### PR TITLE
Forever: Fix swipe to refresh not moving to `not loading`-state when underlying data on the screen has not changed

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshNewDataTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshNewDataTest.kt
@@ -21,7 +21,7 @@ import org.koin.core.inject
 import org.koin.test.KoinTest
 
 @RunWith(AndroidJUnit4::class)
-class SwipeToRefreshTest : KoinTest {
+class SwipeToRefreshNewDataTest : KoinTest {
     private val apolloClientWrapper: ApolloClientWrapper by inject()
 
     @get:Rule
@@ -35,7 +35,7 @@ class SwipeToRefreshTest : KoinTest {
     }
 
     @Test
-    fun shouldRefreshDataWhenSwipingDownToRefresh() {
+    fun shouldRefreshDataWhenSwipingDownToRefreshWithWhenDataHasChanged() {
         var firstLoadFlag = false
         apolloMockServer(
             LoggedInQuery.OPERATION_NAME to { LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED },

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshSameDataTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshSameDataTest.kt
@@ -1,0 +1,63 @@
+package com.hedvig.app.feature.referrals.tab
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.agoda.kakao.screen.Screen
+import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.android.owldroid.graphql.ReferralsQuery
+import com.hedvig.app.ApolloClientWrapper
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
+import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED
+import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNTS
+import com.hedvig.app.util.apolloMockServer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.inject
+import org.koin.test.KoinTest
+
+@RunWith(AndroidJUnit4::class)
+class SwipeToRefreshSameDataTest : KoinTest {
+    private val apolloClientWrapper: ApolloClientWrapper by inject()
+
+    @get:Rule
+    val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
+
+    @Before
+    fun setup() {
+        apolloClientWrapper
+            .apolloClient
+            .clearNormalizedCache()
+    }
+
+    @Test
+    fun shouldRefreshDataWhenSwipingDownToRefreshWhenDataHasNotChanged() {
+        apolloMockServer(
+            LoggedInQuery.OPERATION_NAME to { LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED },
+            ReferralsQuery.OPERATION_NAME to { REFERRALS_DATA_WITH_NO_DISCOUNTS }
+        ).use { webServer ->
+            webServer.start(8080)
+
+            val intent = LoggedInActivity.newInstance(
+                ApplicationProvider.getApplicationContext(),
+                initialTab = LoggedInTabs.REFERRALS
+            )
+
+            activityRule.launchActivity(intent)
+
+            Screen.onScreen<ReferralTabScreen> {
+                share { isVisible() }
+                recycler {
+                    hasSize(3)
+                }
+                swipeToRefresh { swipeDown() }
+                recycler { hasSize(3) }
+                swipeToRefresh { isNotRefreshing() }
+            }
+        }
+    }
+}
+

--- a/app/src/debug/java/com/hedvig/app/feature/referrals/MockReferralsViewModel.kt
+++ b/app/src/debug/java/com/hedvig/app/feature/referrals/MockReferralsViewModel.kt
@@ -1,14 +1,10 @@
 package com.hedvig.app.feature.referrals
 
 import android.os.Handler
-import androidx.lifecycle.MutableLiveData
-import com.hedvig.android.owldroid.graphql.ReferralsQuery
 import com.hedvig.app.feature.referrals.ui.tab.ReferralsViewModel
 import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNTS
 
 class MockReferralsViewModel : ReferralsViewModel() {
-    override val data = MutableLiveData<Result<ReferralsQuery.Data>>()
-
     init {
         if (loadInitially) {
             load()
@@ -20,15 +16,16 @@ class MockReferralsViewModel : ReferralsViewModel() {
             Handler().postDelayed({
                 if (!hasLoadedOnce) {
                     hasLoadedOnce = true
-                    data.postValue(Result.success(referralsData))
+                    _data.postValue(Result.success(referralsData))
                 } else {
-                    data.postValue(Result.success(afterRefreshData))
+                    _data.postValue(Result.success(afterRefreshData))
                 }
             }, 1000)
         } else {
             shouldSucceed = true
-            data.postValue(Result.failure(Error("Something went wrong")))
+            _data.postValue(Result.failure(Error("Something went wrong")))
         }
+        _isRefreshing.postValue(false)
     }
 
     companion object {

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -64,15 +64,18 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
         }, tracker)
 
         swipeToRefresh.setOnRefreshListener {
+            referralsViewModel.setRefreshing(true)
             referralsViewModel.load()
+        }
+
+        referralsViewModel.isRefreshing.observe(viewLifecycleOwner) { isRefreshing ->
+            isRefreshing?.let { swipeToRefresh.isRefreshing = it }
         }
 
         referralsViewModel.data.observe(viewLifecycleOwner) { data ->
             if (data == null) {
                 return@observe
             }
-
-            swipeToRefresh.isRefreshing = false
 
             if (data.isFailure) {
                 (invites.adapter as? ReferralsAdapter)?.items = listOf(


### PR DESCRIPTION
…even if the data has not actually changed