### PR TITLE
Forever: URL Encode codes before placing them inside URLs

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ReferralTabScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ReferralTabScreen.kt
@@ -1,10 +1,8 @@
 package com.hedvig.app.feature.referrals.tab
 
-import android.content.Intent
 import android.view.View
 import com.agoda.kakao.common.views.KView
 import com.agoda.kakao.image.KImageView
-import com.agoda.kakao.intent.KIntent
 import com.agoda.kakao.recycler.KRecyclerItem
 import com.agoda.kakao.recycler.KRecyclerView
 import com.agoda.kakao.screen.Screen
@@ -18,9 +16,6 @@ import org.hamcrest.Matcher
 class ReferralTabScreen : Screen<ReferralTabScreen>() {
     val moreInfo = KButton { withId(R.id.referralMoreInfo) }
     val share = KButton { withId(R.id.share) }
-    val shareIntent = KIntent {
-        hasAction(Intent.ACTION_CHOOSER)
-    }
 
     val codeCopied = KSnackbar()
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ShareTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ShareTest.kt
@@ -2,8 +2,12 @@ package com.hedvig.app.feature.referrals.tab
 
 import android.app.Activity
 import android.app.Instrumentation
+import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.matcher.IntentMatchers.isInternal
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -13,9 +17,13 @@ import com.hedvig.android.owldroid.graphql.ReferralsQuery
 import com.hedvig.app.ApolloClientWrapper
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
+import com.hedvig.app.testdata.feature.referrals.COMPLEX_REFERRAL_CODE
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED
-import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNTS
+import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_COMPLEX_CODE
 import com.hedvig.app.util.apolloMockServer
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Rule
@@ -23,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.koin.core.inject
 import org.koin.test.KoinTest
+import java.net.URLEncoder
 
 @RunWith(AndroidJUnit4::class)
 class ShareTest : KoinTest {
@@ -42,7 +51,7 @@ class ShareTest : KoinTest {
     fun shouldOpenShareWhenClickingShare() {
         apolloMockServer(
             LoggedInQuery.OPERATION_NAME to { LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED },
-            ReferralsQuery.OPERATION_NAME to { REFERRALS_DATA_WITH_NO_DISCOUNTS }
+            ReferralsQuery.OPERATION_NAME to { REFERRALS_DATA_WITH_COMPLEX_CODE }
         ).use { webServer ->
             webServer.start(8080)
 
@@ -65,8 +74,23 @@ class ShareTest : KoinTest {
                     isVisible()
                     click()
                 }
-                shareIntent { intended() }
             }
+
+            intended(
+                allOf(
+                    hasAction(Intent.ACTION_CHOOSER),
+                    hasExtra(
+                        equalTo(Intent.EXTRA_INTENT),
+                        allOf(
+                            hasAction(Intent.ACTION_SEND),
+                            hasExtra(
+                                equalTo(Intent.EXTRA_TEXT),
+                                containsString(URLEncoder.encode(COMPLEX_REFERRAL_CODE, "UTF-8"))
+                            )
+                        )
+                    )
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -27,6 +27,7 @@ import kotlinx.android.synthetic.main.fragment_referrals.*
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
+import java.net.URLEncoder
 
 class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
     private val loggedInViewModel: LoggedInViewModel by sharedViewModel()
@@ -100,7 +101,10 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
                             requireContext().getString(
                                 R.string.REFERRAL_SMS_MESSAGE,
                                 incentive.format(requireContext()),
-                                "${BuildConfig.WEB_BASE_URL}${defaultLocale(requireContext()).toWebLocaleTag()}/forever/${code}"
+                                "${BuildConfig.WEB_BASE_URL}${defaultLocale(requireContext()).toWebLocaleTag()}/forever/${URLEncoder.encode(
+                                    code,
+                                    UTF_8
+                                )}"
                             )
                         )
                         intent.type = "text/plain"
@@ -156,5 +160,9 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
     private fun applyInsets() {
         share.updateMargin(bottom = shareInitialBottomMargin + bottomTabInset)
         invites.updatePadding(bottom = invitesInitialBottomPadding + bottomTabInset + shareHeight)
+    }
+
+    companion object {
+        private const val UTF_8 = "UTF-8"
     }
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/referrals/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/referrals/Data.kt
@@ -62,6 +62,12 @@ val REFERRALS_DATA_WITH_ONE_REFEREE_AND_OTHER_DISCOUNT = ReferralsDataBuilder(
     )
 ).build()
 
+const val COMPLEX_REFERRAL_CODE = "CODE $ \uD83E\uDD11"
+
+val REFERRALS_DATA_WITH_COMPLEX_CODE = ReferralsDataBuilder(
+    code = COMPLEX_REFERRAL_CODE
+).build()
+
 val REFERRALS_DATA_WITH_MULTIPLE_REFERRALS_IN_DIFFERENT_STATES = ReferralsDataBuilder(
     insuranceCost = CostBuilder(
         discountAmount = "10.00",


### PR DESCRIPTION
I've decided against using `Kakao`s support for `Intent`s, as it is too limiting.