### PR TITLE
Forever: Replace `URLEncoder.encode` with `Uri.encode`

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ShareTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ShareTest.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.referrals.tab
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
+import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -31,7 +32,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.koin.core.inject
 import org.koin.test.KoinTest
-import java.net.URLEncoder
 
 @RunWith(AndroidJUnit4::class)
 class ShareTest : KoinTest {
@@ -85,7 +85,7 @@ class ShareTest : KoinTest {
                             hasAction(Intent.ACTION_SEND),
                             hasExtra(
                                 equalTo(Intent.EXTRA_TEXT),
-                                containsString(URLEncoder.encode(COMPLEX_REFERRAL_CODE, "UTF-8"))
+                                containsString(Uri.encode(COMPLEX_REFERRAL_CODE))
                             )
                         )
                     )

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -1,6 +1,7 @@
 package com.hedvig.app.feature.referrals.ui.tab
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.doOnLayout
@@ -27,7 +28,6 @@ import kotlinx.android.synthetic.main.fragment_referrals.*
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
-import java.net.URLEncoder
 
 class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
     private val loggedInViewModel: LoggedInViewModel by sharedViewModel()
@@ -101,9 +101,8 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
                             requireContext().getString(
                                 R.string.REFERRAL_SMS_MESSAGE,
                                 incentive.format(requireContext()),
-                                "${BuildConfig.WEB_BASE_URL}${defaultLocale(requireContext()).toWebLocaleTag()}/forever/${URLEncoder.encode(
-                                    code,
-                                    UTF_8
+                                "${BuildConfig.WEB_BASE_URL}${defaultLocale(requireContext()).toWebLocaleTag()}/forever/${Uri.encode(
+                                    code
                                 )}"
                             )
                         )


### PR DESCRIPTION
This one behaves as expected with regards to spaces, encoding them as `%20` instead of `+`.

For shame, `URLEncoder`. For shame.