### PR TITLE
Offer: Various bug fixes

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferActivity.kt
@@ -58,10 +58,6 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
 
                 val percentage = scrollY.toFloat() / offerToolbar.height
 
-                if (percentage < -1 || percentage > 2) {
-                    return
-                }
-
                 offerToolbar.setBackgroundColor(
                     boundedColorLerp(
                         Color.TRANSPARENT,

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
@@ -59,7 +59,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
                 {
                     tracker.changeDateContinue()
                     offerViewModel.chooseStartDate(data.id, localDate)
-                    dialog?.hide()
+                    dismiss()
                 })
         }
         if (data.hasSwitchableInsurer) {
@@ -68,7 +68,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
             autoSetDateText.setHapticClickListener {
                 tracker.activateOnInsuranceEnd()
                 offerViewModel.removeStartDate(data.id)
-                dialog?.hide()
+                dismiss()
             }
         } else {
             autoSetDateText.text = getString(R.string.ACTIVATE_TODAY_BTN)
@@ -76,7 +76,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
             autoSetDateText.setHapticClickListener {
                 tracker.activateToday()
                 offerViewModel.chooseStartDate(data.id, LocalDate.now())
-                dialog?.hide()
+                dismiss()
             }
         }
     }

--- a/app/src/main/res/layout/offer_header.xml
+++ b/app/src/main/res/layout/offer_header.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/hedvig_black"
-    android:paddingBottom="@dimen/base_margin_quadruple">
+    android:paddingBottom="@dimen/base_margin_quadruple"
+    tools:context=".feature.offer.ui.OfferActivity">
 
     <com.hedvig.app.ui.view.HedvigCardView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/offer_switch.xml
+++ b/app/src/main/res/layout/offer_switch.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?android:colorBackground">
+    android:background="?android:colorBackground"
+    android:paddingBottom="@dimen/base_margin_quadruple">
 
     <TextView
         android:id="@+id/switchTitle"

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -11,9 +11,10 @@
     <style name="Hedvig.Theme.Offer.V27" parent="Hedvig.Theme.Offer.V23">
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:navigationBarColor">@color/hedvig_black</item>
     </style>
 
-    <style name="Hedvig.Theme.Offer" parent="Hedvig.Theme.V27" />
+    <style name="Hedvig.Theme.Offer" parent="Hedvig.Theme.Offer.V27" />
 
     <style name="BottomSheetDialogTheme" parent="BaseBottomSheetDialog">
         <item name="android:statusBarColor">@android:color/transparent</item>

--- a/app/src/main/res/values/button_themes.xml
+++ b/app/src/main/res/values/button_themes.xml
@@ -12,6 +12,7 @@
         <item name="android:padding">@dimen/base_margin_double</item>
         <item name="shapeAppearance">?shapeAppearanceLargeComponent</item>
         <item name="android:textColor">@color/hedvig_large_button_text_color_selector</item>
+        <item name="iconTint">@color/hedvig_large_button_text_color_selector</item>
     </style>
 
     <style name="Hedvig.Button.Text" parent="Widget.MaterialComponents.Button.TextButton">


### PR DESCRIPTION
- `ChangeDateBottomSheet` now dismisses properly
We were accidentally using `hide()`, which caused the bottom sheet to reappear when the activity resumed because the `Dialog` never actually disappeared
- The theme now looks correct on API levels 27 and 28
- Remove background not being continuously applied in all circumstances on `Toolbar`
This remove an issue where the `Toolbar`-background does not get to its correct color when users scroll really, really fast