### PR TITLE
App Navigation: Home Tab, Pending

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/home.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/home.graphql
@@ -1,4 +1,7 @@
 query HomeQuery {
+  member {
+    firstName
+  }
   contracts {
     switchedFromInsuranceProvider
     status {

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/home.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/home.graphql
@@ -1,0 +1,10 @@
+query HomeQuery {
+  contracts {
+    switchedFromInsuranceProvider
+    status {
+      ... on PendingStatus {
+        pendingSince
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
@@ -43,7 +43,7 @@ class PendingTest {
         onScreen<HomeTabScreen> {
             recycler {
                 childAt<HomeTabScreen.BigTextItem>(0) {
-                    text { hasText("TODO") }
+                    text { hasText("Test TODO") }
                 }
             }
         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
@@ -17,6 +17,7 @@ import com.hedvig.app.testdata.feature.home.HOME_DATA_PENDING
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.hasText
 import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test
@@ -43,10 +44,10 @@ class PendingTest {
         onScreen<HomeTabScreen> {
             recycler {
                 childAt<HomeTabScreen.BigTextItem>(0) {
-                    text { hasText("Test TODO") }
+                    text { hasText(R.string.home_tab_pending_nonswitchable_welcome_title, "Test") }
                 }
                 childAt<HomeTabScreen.BodyTextItem>(1) {
-                    text { hasText(R.string.home_tab_pending_switchable_body) }
+                    text { hasText(R.string.home_tab_pending_nonswitchable_body) }
                 }
             }
         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
@@ -1,47 +1,61 @@
-package com.hedvig.app.feature.loggedin
+package com.hedvig.app.feature.home
 
+import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import com.agoda.kakao.bottomnav.KBottomNavigationView
-import com.agoda.kakao.common.views.KView
+import com.agoda.kakao.recycler.KRecyclerItem
+import com.agoda.kakao.recycler.KRecyclerView
 import com.agoda.kakao.screen.Screen
 import com.agoda.kakao.screen.Screen.Companion.onScreen
+import com.agoda.kakao.text.KTextView
+import com.hedvig.android.owldroid.graphql.HomeQuery
 import com.hedvig.android.owldroid.graphql.LoggedInQuery
 import com.hedvig.app.R
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.testdata.feature.home.HOME_DATA_PENDING
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
+import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class NotTerminatedTest {
+class PendingTest {
     @get:Rule
     val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
-        LoggedInQuery.OPERATION_NAME to { LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED }
+        LoggedInQuery.OPERATION_NAME to { LOGGED_IN_DATA_WITH_REFERRALS_FEATURE_ENABLED },
+        HomeQuery.OPERATION_NAME to { HOME_DATA_PENDING }
     )
 
     @get:Rule
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldOpenWithHomeTabWhenUserIsNotTerminated() {
+    fun shouldShowMessageWhenUserHasAllContractsInPendingState() {
         activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
 
-        onScreen<LoggedInScreen> {
-            root { isVisible() }
-            bottomTabs { hasSelectedItem(R.id.home) }
+        onScreen<HomeTabScreen> {
+            recycler {
+                childAt<HomeTabScreen.BigTextItem>(0) {
+                    text { hasText("TODO") }
+                }
+            }
         }
     }
 }
 
-class LoggedInScreen : Screen<LoggedInScreen>() {
-    val root = KView { withId(R.id.loggedInRoot) }
-    val bottomTabs = KBottomNavigationView { withId(R.id.bottomNavigation) }
+class HomeTabScreen : Screen<HomeTabScreen>() {
+    val recycler = KRecyclerView({ withId(R.id.recycler) }, {
+        itemType(::BigTextItem)
+    })
+
+    class BigTextItem(parent: Matcher<View>) : KRecyclerItem<BigTextItem>(parent) {
+        val text = KTextView { withMatcher(parent) }
+    }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
@@ -45,6 +45,9 @@ class PendingTest {
                 childAt<HomeTabScreen.BigTextItem>(0) {
                     text { hasText("Test TODO") }
                 }
+                childAt<HomeTabScreen.BodyTextItem>(1) {
+                    text { hasText(R.string.home_tab_pending_switchable_body) }
+                }
             }
         }
     }
@@ -53,9 +56,14 @@ class PendingTest {
 class HomeTabScreen : Screen<HomeTabScreen>() {
     val recycler = KRecyclerView({ withId(R.id.recycler) }, {
         itemType(::BigTextItem)
+        itemType(::BodyTextItem)
     })
 
     class BigTextItem(parent: Matcher<View>) : KRecyclerItem<BigTextItem>(parent) {
+        val text = KTextView { withMatcher(parent) }
+    }
+
+    class BodyTextItem(parent: Matcher<View>) : KRecyclerItem<BodyTextItem>(parent) {
         val text = KTextView { withMatcher(parent) }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import androidx.test.core.app.ApplicationProvider
 import com.agoda.kakao.edit.KTextInputLayout
 import com.agoda.kakao.picker.date.KDatePicker
+import com.agoda.kakao.text.KTextView
 import java.time.LocalDate
 
 fun KTextInputLayout.hasError(@StringRes resId: Int) =
@@ -14,3 +15,6 @@ fun KTextInputLayout.hasError(@StringRes resId: Int, vararg formatArgs: Any) =
     hasError(ApplicationProvider.getApplicationContext<Context>().getString(resId, *formatArgs))
 
 fun KDatePicker.setDate(date: LocalDate) = setDate(date.year, date.monthValue, date.dayOfMonth)
+
+fun KTextView.hasText(@StringRes resId: Int, vararg formatArgs: Any) =
+    hasText(ApplicationProvider.getApplicationContext<Context>().getString(resId, *formatArgs))

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -44,6 +44,11 @@
             android:label="Offer Mock Screen"
             android:theme="@style/Hedvig.Theme" />
 
+        <activity
+            android:name=".feature.home.HomeMockActivity"
+            android:label="Home Mock Screen"
+            android:theme="@style/Hedvig.Theme" />
+
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/hedvig/app/DevelopmentActivity.kt
+++ b/app/src/debug/java/com/hedvig/app/DevelopmentActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.hedvig.app.feature.chat.ChatMockActivity
+import com.hedvig.app.feature.home.HomeMockActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.feature.offer.OfferMockActivity
 import com.hedvig.app.feature.referrals.ReferralsMockActivity
@@ -36,6 +37,9 @@ class DevelopmentActivity : AppCompatActivity(R.layout.activity_development) {
                 },
                 DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Offer") {
                     startActivity(Intent(this, OfferMockActivity::class.java))
+                },
+                DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Home") {
+                    startActivity(Intent(this, HomeMockActivity::class.java))
                 },
                 DevelopmentScreenAdapter.DevelopmentScreenItem.Row("`VectorDrawable`-gallery") {
                     startActivity(Intent(this, VectorDrawableGalleryActivity::class.java))

--- a/app/src/debug/java/com/hedvig/app/GenericDevelopmentAdapter.kt
+++ b/app/src/debug/java/com/hedvig/app/GenericDevelopmentAdapter.kt
@@ -64,3 +64,23 @@ class GenericDevelopmentAdapter(
         ) : Item()
     }
 }
+
+class GenericDevelopmentAdapterBuilder {
+    val items = mutableListOf<GenericDevelopmentAdapter.Item>()
+
+    fun header(label: String) {
+        items.add(GenericDevelopmentAdapter.Item.Header(label))
+    }
+
+    fun clickableItem(label: String, onClick: () -> Unit) {
+        items.add(GenericDevelopmentAdapter.Item.ClickableItem(label, onClick))
+    }
+}
+
+inline fun genericDevelopmentAdapter(
+    crossinline function: GenericDevelopmentAdapterBuilder.() -> Unit
+): GenericDevelopmentAdapter {
+    val builder = GenericDevelopmentAdapterBuilder()
+    function(builder)
+    return GenericDevelopmentAdapter(builder.items)
+}

--- a/app/src/debug/java/com/hedvig/app/feature/home/HomeMockActivity.kt
+++ b/app/src/debug/java/com/hedvig/app/feature/home/HomeMockActivity.kt
@@ -1,0 +1,51 @@
+package com.hedvig.app.feature.home
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.hedvig.app.R
+import com.hedvig.app.databinding.ActivityGenericDevelopmentBinding
+import com.hedvig.app.feature.home.ui.HomeViewModel
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInViewModel
+import com.hedvig.app.feature.referrals.MockLoggedInViewModel
+import com.hedvig.app.genericDevelopmentAdapter
+import com.hedvig.app.homeModule
+import com.hedvig.app.loggedInModule
+import com.hedvig.app.testdata.feature.home.HOME_DATA_PENDING
+import com.hedvig.app.util.extensions.viewBinding
+import org.koin.android.viewmodel.dsl.viewModel
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.unloadKoinModules
+import org.koin.dsl.module
+
+class HomeMockActivity : AppCompatActivity(R.layout.activity_generic_development) {
+    private val binding by viewBinding(ActivityGenericDevelopmentBinding::bind)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        unloadKoinModules(
+            listOf(
+                loggedInModule,
+                homeModule
+            )
+        )
+
+        loadKoinModules(MOCK_MODULE)
+
+        binding.root.adapter = genericDevelopmentAdapter {
+            header("Tab Screen")
+            clickableItem("Pending") {
+                MockHomeViewModel.mockData = HOME_DATA_PENDING
+                startActivity(LoggedInActivity.newInstance(this@HomeMockActivity))
+            }
+        }
+    }
+
+    companion object {
+        private val MOCK_MODULE = module {
+            viewModel<LoggedInViewModel> { MockLoggedInViewModel() }
+            viewModel<HomeViewModel> { MockHomeViewModel() }
+        }
+    }
+}

--- a/app/src/debug/java/com/hedvig/app/feature/home/MockHomeViewModel.kt
+++ b/app/src/debug/java/com/hedvig/app/feature/home/MockHomeViewModel.kt
@@ -1,0 +1,14 @@
+package com.hedvig.app.feature.home
+
+import com.hedvig.app.feature.home.ui.HomeViewModel
+import com.hedvig.app.testdata.feature.home.HOME_DATA_PENDING
+
+class MockHomeViewModel : HomeViewModel() {
+    init {
+        _data.postValue(mockData)
+    }
+
+    companion object {
+        var mockData = HOME_DATA_PENDING
+    }
+}

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -30,6 +30,9 @@ import com.hedvig.app.feature.dashboard.ui.contractcoverage.ContractCoverageView
 import com.hedvig.app.feature.dashboard.ui.contractcoverage.ContractCoverageViewModelImpl
 import com.hedvig.app.feature.dashboard.ui.contractdetail.ContractDetailViewModel
 import com.hedvig.app.feature.dashboard.ui.contractdetail.ContractDetailViewModelImpl
+import com.hedvig.app.feature.home.data.HomeRepository
+import com.hedvig.app.feature.home.ui.HomeViewModel
+import com.hedvig.app.feature.home.ui.HomeViewModelImpl
 import com.hedvig.app.feature.keygear.KeyGearTracker
 import com.hedvig.app.feature.keygear.KeyGearValuationViewModel
 import com.hedvig.app.feature.keygear.KeyGearValuationViewModelImpl
@@ -254,6 +257,10 @@ val referralsModule = module {
     viewModel<ReferralsEditCodeViewModel> { ReferralsEditCodeViewModelImpl(get()) }
 }
 
+val homeModule = module {
+    viewModel<HomeViewModel> { HomeViewModelImpl(get()) }
+}
+
 val serviceModule = module {
     single { FileService(get()) }
     single { LoginStatusService(get(), get()) }
@@ -284,6 +291,7 @@ val repositoriesModule = module {
     single { AdyenRepository(get(), get()) }
     single { ReferralsRepository(get()) }
     single { LoggedInRepository(get(), get()) }
+    single { HomeRepository(get()) }
 }
 
 val trackerModule = module {

--- a/app/src/main/java/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/java/com/hedvig/app/HedvigApplication.kt
@@ -62,6 +62,7 @@ open class HedvigApplication : Application() {
                     languageAndMarketModule,
                     adyenModule,
                     referralsModule,
+                    homeModule,
                     serviceModule,
                     repositoriesModule,
                     trackerModule

--- a/app/src/main/java/com/hedvig/app/feature/home/data/HomeRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/data/HomeRepository.kt
@@ -1,0 +1,14 @@
+package com.hedvig.app.feature.home.data
+
+import com.apollographql.apollo.coroutines.toDeferred
+import com.hedvig.android.owldroid.graphql.HomeQuery
+import com.hedvig.app.ApolloClientWrapper
+
+class HomeRepository(
+    private val apolloClientWrapper: ApolloClientWrapper
+) {
+    fun homeAsync() = apolloClientWrapper
+        .apolloClient
+        .query(HomeQuery())
+        .toDeferred()
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.hedvig.app.R
 import com.hedvig.app.databinding.HomeBigTextBinding
+import com.hedvig.app.databinding.HomeBodyTextBinding
 import com.hedvig.app.util.GenericDiffUtilCallback
 import com.hedvig.app.util.extensions.inflate
 import com.hedvig.app.util.extensions.viewBinding
@@ -26,12 +27,14 @@ class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
         R.layout.home_big_text -> ViewHolder.BigText(parent)
+        R.layout.home_body_text -> ViewHolder.BodyText(parent)
         else -> throw Error("Invalid view type")
     }
 
     override fun getItemCount() = items.size
     override fun getItemViewType(position: Int) = when (items[position]) {
         is HomeModel.BigText -> R.layout.home_big_text
+        is HomeModel.BodyText -> R.layout.home_body_text
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -61,6 +64,18 @@ class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
                         root.text = "${data.name} TODO"
                     }
                 }
+            }
+        }
+
+        class BodyText(parent: ViewGroup) : ViewHolder(parent.inflate(R.layout.home_body_text)) {
+            private val binding by viewBinding(HomeBodyTextBinding::bind)
+
+            override fun bind(data: HomeModel) = with(binding) {
+                if (data !is HomeModel.BodyText) {
+                    return invalid(data)
+                }
+
+                root.setText(R.string.home_tab_pending_switchable_body)
             }
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
@@ -61,7 +61,10 @@ class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
 
                 when (data) {
                     is HomeModel.BigText.Pending -> {
-                        root.text = "${data.name} TODO"
+                        root.text = root.resources.getString(
+                            R.string.home_tab_pending_nonswitchable_welcome_title,
+                            data.name
+                        )
                     }
                 }
             }
@@ -75,7 +78,7 @@ class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
                     return invalid(data)
                 }
 
-                root.setText(R.string.home_tab_pending_switchable_body)
+                root.setText(R.string.home_tab_pending_nonswitchable_body)
             }
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
@@ -1,0 +1,66 @@
+package com.hedvig.app.feature.home.ui
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.hedvig.app.R
+import com.hedvig.app.databinding.HomeBigTextBinding
+import com.hedvig.app.util.extensions.inflate
+import com.hedvig.app.util.extensions.viewBinding
+import e
+
+class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
+    var items: List<HomeModel> = emptyList()
+        set(value) {
+            val diff = DiffUtil.calculateDiff(
+                GenericDiffUtilCallback(
+                    field,
+                    value
+                )
+            )
+            field = value
+            diff.dispatchUpdatesTo(this)
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
+        R.layout.home_big_text -> ViewHolder.BigText(parent)
+        else -> throw Error("Invalid view type")
+    }
+
+    override fun getItemCount() = items.size
+    override fun getItemViewType(position: Int) = when (items[position]) {
+        is HomeModel.BigText -> R.layout.home_big_text
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    sealed class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        abstract fun bind(data: HomeModel): Any?
+
+        fun invalid(data: HomeModel) {
+            e { "Invalid data passed to ${this.javaClass.name}::bind - type is ${data.javaClass.name}" }
+        }
+
+        class BigText(parent: ViewGroup) : ViewHolder(
+            parent.inflate(
+                R.layout.home_big_text
+            )
+        ) {
+            private val binding by viewBinding(HomeBigTextBinding::bind)
+            override fun bind(data: HomeModel) = with(binding) {
+                if (data !is HomeModel.BigText) {
+                    return invalid(data)
+                }
+
+                when (data) {
+                    is HomeModel.BigText.Pending -> {
+                        root.text = "TODO"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.hedvig.app.R
 import com.hedvig.app.databinding.HomeBigTextBinding
+import com.hedvig.app.util.GenericDiffUtilCallback
 import com.hedvig.app.util.extensions.inflate
 import com.hedvig.app.util.extensions.viewBinding
 import e
@@ -57,7 +58,7 @@ class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
 
                 when (data) {
                     is HomeModel.BigText.Pending -> {
-                        root.text = "TODO"
+                        root.text = "${data.name} TODO"
                     }
                 }
             }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -1,0 +1,55 @@
+package com.hedvig.app.feature.home.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.observe
+import androidx.recyclerview.widget.DiffUtil
+import com.hedvig.android.owldroid.graphql.HomeQuery
+import com.hedvig.app.R
+import com.hedvig.app.databinding.HomeFragmentBinding
+import com.hedvig.app.util.extensions.viewBinding
+import org.koin.android.viewmodel.ext.android.viewModel
+
+class HomeFragment : Fragment(R.layout.home_fragment) {
+    private val model: HomeViewModel by viewModel()
+    private val binding by viewBinding(HomeFragmentBinding::bind)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding.recycler.adapter = HomeAdapter()
+
+        model.data.observe(viewLifecycleOwner) { data ->
+            if (isPending(data.contracts)) {
+                (binding.recycler.adapter as? HomeAdapter)?.items = listOf(
+                    HomeModel.BigText.Pending("TODO")
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun isPending(contracts: List<HomeQuery.Contract>) =
+            contracts.all { it.status.asPendingStatus != null }
+    }
+}
+
+sealed class HomeModel {
+    sealed class BigText : HomeModel() {
+        data class Pending(
+            val name: String
+        ) : BigText()
+    }
+}
+
+class GenericDiffUtilCallback<T>(
+    private val old: List<T>,
+    private val new: List<T>
+) : DiffUtil.Callback() {
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+        old[oldItemPosition] == new[newItemPosition]
+
+    override fun getOldListSize() = old.size
+    override fun getNewListSize() = new.size
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+        old[oldItemPosition] == new[newItemPosition]
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.observe
-import androidx.recyclerview.widget.DiffUtil
 import com.hedvig.android.owldroid.graphql.HomeQuery
 import com.hedvig.app.R
 import com.hedvig.app.databinding.HomeFragmentBinding
@@ -21,7 +20,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
         model.data.observe(viewLifecycleOwner) { data ->
             if (isPending(data.contracts)) {
                 (binding.recycler.adapter as? HomeAdapter)?.items = listOf(
-                    HomeModel.BigText.Pending("TODO")
+                    HomeModel.BigText.Pending(data.member.firstName ?: "")
                 )
             }
         }
@@ -33,23 +32,3 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
     }
 }
 
-sealed class HomeModel {
-    sealed class BigText : HomeModel() {
-        data class Pending(
-            val name: String
-        ) : BigText()
-    }
-}
-
-class GenericDiffUtilCallback<T>(
-    private val old: List<T>,
-    private val new: List<T>
-) : DiffUtil.Callback() {
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-        old[oldItemPosition] == new[newItemPosition]
-
-    override fun getOldListSize() = old.size
-    override fun getNewListSize() = new.size
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-        old[oldItemPosition] == new[newItemPosition]
-}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -20,7 +20,8 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
         model.data.observe(viewLifecycleOwner) { data ->
             if (isPending(data.contracts)) {
                 (binding.recycler.adapter as? HomeAdapter)?.items = listOf(
-                    HomeModel.BigText.Pending(data.member.firstName ?: "")
+                    HomeModel.BigText.Pending(data.member.firstName ?: ""),
+                    HomeModel.BodyText.Pending
                 )
             }
         }
@@ -31,4 +32,3 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
             contracts.all { it.status.asPendingStatus != null }
     }
 }
-

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeModel.kt
@@ -1,0 +1,9 @@
+package com.hedvig.app.feature.home.ui
+
+sealed class HomeModel {
+    sealed class BigText : HomeModel() {
+        data class Pending(
+            val name: String
+        ) : BigText()
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeModel.kt
@@ -6,4 +6,8 @@ sealed class HomeModel {
             val name: String
         ) : BigText()
     }
+
+    sealed class BodyText : HomeModel() {
+        object Pending : BodyText()
+    }
 }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeViewModel.kt
@@ -1,0 +1,30 @@
+package com.hedvig.app.feature.home.ui
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hedvig.android.owldroid.graphql.HomeQuery
+import com.hedvig.app.feature.home.data.HomeRepository
+import kotlinx.coroutines.launch
+
+abstract class HomeViewModel : ViewModel() {
+    protected val _data = MutableLiveData<HomeQuery.Data>()
+    val data: LiveData<HomeQuery.Data> = _data
+}
+
+class HomeViewModelImpl(
+    private val homeRepository: HomeRepository
+) : HomeViewModel() {
+    init {
+        viewModelScope.launch {
+            val result = runCatching { homeRepository.homeAsync().await() }
+            if (result.isFailure) {
+                TODO("Present error to user")
+            }
+
+            result.getOrNull()?.data?.let { _data.postValue(it) }
+        }
+    }
+}
+

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -47,7 +47,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
 
     private val binding by viewBinding(ActivityLoggedInBinding::bind)
 
-    private var lastLoggedInTab = LoggedInTabs.DASHBOARD
+    private var lastLoggedInTab = LoggedInTabs.HOME
 
     private lateinit var referralTermsUrl: String
     private lateinit var referralsIncentive: MonetaryAmount
@@ -111,9 +111,9 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         when (LoggedInTabs.fromId(binding.bottomNavigation.selectedItemId)) {
-            LoggedInTabs.DASHBOARD,
+            LoggedInTabs.HOME,
             LoggedInTabs.KEY_GEAR,
-            LoggedInTabs.CLAIMS -> {
+            LoggedInTabs.INSURANCE -> {
                 menuInflater.inflate(R.menu.base_tab_menu, menu)
             }
             LoggedInTabs.PROFILE -> {
@@ -131,9 +131,9 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (LoggedInTabs.fromId(binding.bottomNavigation.selectedItemId)) {
-            LoggedInTabs.DASHBOARD,
+            LoggedInTabs.HOME,
             LoggedInTabs.KEY_GEAR,
-            LoggedInTabs.CLAIMS -> {
+            LoggedInTabs.INSURANCE -> {
                 claimsViewModel.triggerFreeTextChat {
                     startClosableChat()
                 }
@@ -179,7 +179,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                     }
                     binding.bottomNavigation.inflateMenu(menuId)
                     val initialTab = intent.extras?.getSerializable(INITIAL_TAB) as? LoggedInTabs
-                        ?: LoggedInTabs.DASHBOARD
+                        ?: LoggedInTabs.HOME
                     binding.bottomNavigation.selectedItemId = initialTab.id()
                     setupToolBar(LoggedInTabs.fromId(binding.bottomNavigation.selectedItemId))
                     binding.loggedInRoot.show()
@@ -223,7 +223,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
         fun newInstance(
             context: Context,
             withoutHistory: Boolean = false,
-            initialTab: LoggedInTabs = LoggedInTabs.DASHBOARD
+            initialTab: LoggedInTabs = LoggedInTabs.HOME
         ) =
             Intent(context, LoggedInActivity::class.java).apply {
                 if (withoutHistory) {

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInTabs.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInTabs.kt
@@ -4,16 +4,16 @@ import androidx.annotation.IdRes
 import com.hedvig.app.R
 
 enum class LoggedInTabs {
-    DASHBOARD,
-    CLAIMS,
+    HOME,
+    INSURANCE,
     KEY_GEAR,
     REFERRALS,
     PROFILE;
 
     @IdRes
     fun id() = when (this) {
-        DASHBOARD -> R.id.dashboard
-        CLAIMS -> R.id.claims
+        HOME -> R.id.home
+        INSURANCE -> R.id.insurance
         KEY_GEAR -> R.id.key_gear
         REFERRALS -> R.id.referrals
         PROFILE -> R.id.profile
@@ -21,8 +21,8 @@ enum class LoggedInTabs {
 
     companion object {
         fun fromId(@IdRes id: Int) = when (id) {
-            R.id.dashboard -> DASHBOARD
-            R.id.claims -> CLAIMS
+            R.id.home -> HOME
+            R.id.insurance -> INSURANCE
             R.id.key_gear -> KEY_GEAR
             R.id.referrals -> REFERRALS
             R.id.profile -> PROFILE

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/TabPagerAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/TabPagerAdapter.kt
@@ -3,8 +3,8 @@ package com.hedvig.app.feature.loggedin.ui
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-import com.hedvig.app.feature.claims.ui.ClaimsFragment
 import com.hedvig.app.feature.dashboard.ui.DashboardFragment
+import com.hedvig.app.feature.home.ui.HomeFragment
 import com.hedvig.app.feature.keygear.ui.tab.KeyGearFragment
 import com.hedvig.app.feature.profile.ui.ProfileFragment
 import com.hedvig.app.feature.referrals.ui.tab.ReferralsFragment
@@ -13,8 +13,8 @@ import com.hedvig.app.util.extensions.byOrdinal
 class TabPagerAdapter(fragmentManager: FragmentManager) :
     FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
     override fun getItem(page: Int): Fragment = when (byOrdinal<LoggedInTabs>(page)) {
-        LoggedInTabs.DASHBOARD -> DashboardFragment()
-        LoggedInTabs.CLAIMS -> ClaimsFragment()
+        LoggedInTabs.HOME -> HomeFragment()
+        LoggedInTabs.INSURANCE -> DashboardFragment()
         LoggedInTabs.KEY_GEAR -> KeyGearFragment()
         LoggedInTabs.REFERRALS -> ReferralsFragment()
         LoggedInTabs.PROFILE -> ProfileFragment()

--- a/app/src/main/java/com/hedvig/app/util/GenericDiffUtilCallback.kt
+++ b/app/src/main/java/com/hedvig/app/util/GenericDiffUtilCallback.kt
@@ -1,0 +1,16 @@
+package com.hedvig.app.util
+
+import androidx.recyclerview.widget.DiffUtil
+
+class GenericDiffUtilCallback<T>(
+    private val old: List<T>,
+    private val new: List<T>
+) : DiffUtil.Callback() {
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+        old[oldItemPosition] == new[newItemPosition]
+
+    override fun getOldListSize() = old.size
+    override fun getNewListSize() = new.size
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+        old[oldItemPosition] == new[newItemPosition]
+}

--- a/app/src/main/java/com/hedvig/app/util/extensions/ViewBindingExtensions.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/ViewBindingExtensions.kt
@@ -3,9 +3,60 @@ package com.hedvig.app.util.extensions
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.observe
+import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
 
 inline fun <T : ViewBinding> AppCompatActivity.viewBinding(crossinline binder: (View) -> T) =
     lazy(LazyThreadSafetyMode.NONE) {
         binder(findViewById<ViewGroup>(android.R.id.content).getChildAt(0))
     }
+
+inline fun <T : ViewBinding> RecyclerView.ViewHolder.viewBinding(crossinline binder: (View) -> T) =
+    lazy(LazyThreadSafetyMode.NONE) {
+        binder(itemView)
+    }
+
+class FragmentViewBindingDelegate<T : ViewBinding>(
+    val fragment: Fragment,
+    val viewBindingFactory: (View) -> T
+) : ReadOnlyProperty<Fragment, T> {
+    private var binding: T? = null
+
+    init {
+        fragment.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
+                fragment.viewLifecycleOwnerLiveData.observe(fragment) { viewLifecycleOwner ->
+                    viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+                        override fun onDestroy(owner: LifecycleOwner) {
+                            binding = null
+                        }
+                    })
+                }
+            }
+        })
+    }
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+        val binding = binding
+        if (binding != null) {
+            return binding
+        }
+
+        val lifecycle = fragment.viewLifecycleOwner.lifecycle
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+            throw IllegalStateException("Should not attempt to get bindings when Fragment views are destroyed.")
+        }
+
+        return viewBindingFactory(thisRef.requireView()).also { this.binding = it }
+    }
+}
+
+fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
+    FragmentViewBindingDelegate(this, viewBindingFactory)

--- a/app/src/main/res/layout/home_big_text.xml
+++ b/app/src/main/res/layout/home_big_text.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginStart="@dimen/base_margin_triple"
+    android:layout_marginTop="@dimen/base_margin_octuple"
+    android:layout_marginEnd="@dimen/base_margin_triple"
+    android:textAppearance="?textAppearanceHeadline4"
+    tools:text="Welcome Zak, we’re contacting your old insurer to find out your start date" />

--- a/app/src/main/res/layout/home_body_text.xml
+++ b/app/src/main/res/layout/home_body_text.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?><!-- TODO: Should we choose different keys although they contain the same copy? Hmm. -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/base_margin_triple"
+    android:layout_marginTop="@dimen/base_margin_triple"
+    android:layout_marginEnd="@dimen/base_margin_triple"
+    android:textAlignment="center"
+    android:textAppearance="?textAppearanceBody1"
+    tools:text="@string/home_tab.pending_switchable_body" />

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/recycler"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    tools:context=".feature.home.ui.HomeFragment"
+    tools:itemCount="1"
+    tools:listitem="@layout/home_big_text" />

--- a/app/src/main/res/menu/logged_in_menu.xml
+++ b/app/src/main/res/menu/logged_in_menu.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/dashboard"
+        android:id="@+id/home"
         android:icon="@drawable/ic_home"
         android:title="@string/TAB_TITLE_HOME" />
 
     <item
-        android:id="@+id/claims"
+        android:id="@+id/insurance"
         android:icon="@drawable/ic_claims"
         android:title="@string/TAB_TITLE_CLAIM" />
 

--- a/app/src/main/res/menu/logged_in_menu_key_gear.xml
+++ b/app/src/main/res/menu/logged_in_menu_key_gear.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/dashboard"
+        android:id="@+id/home"
         android:icon="@drawable/ic_home"
         android:title="@string/TAB_TITLE_HOME" />
 
     <item
-        android:id="@+id/claims"
+        android:id="@+id/insurance"
         android:icon="@drawable/ic_claims"
         android:title="@string/TAB_TITLE_CLAIM" />
 

--- a/app/src/main/res/menu/logged_in_menu_no_referrals.xml
+++ b/app/src/main/res/menu/logged_in_menu_no_referrals.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/dashboard"
+        android:id="@+id/home"
         android:icon="@drawable/ic_home"
         android:title="@string/TAB_TITLE_HOME" />
 
     <item
-        android:id="@+id/claims"
+        android:id="@+id/insurance"
         android:icon="@drawable/ic_claims"
         android:title="@string/TAB_TITLE_CLAIM" />
 

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/home/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/home/Data.kt
@@ -1,0 +1,5 @@
+package com.hedvig.app.testdata.feature.home
+
+import com.hedvig.app.testdata.feature.home.builders.HomeDataBuilder
+
+val HOME_DATA_PENDING = HomeDataBuilder(listOf(HomeDataBuilder.Status.PENDING)).build()

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/home/builders/HomeDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/home/builders/HomeDataBuilder.kt
@@ -3,9 +3,13 @@ package com.hedvig.app.testdata.feature.home.builders
 import com.hedvig.android.owldroid.graphql.HomeQuery
 
 data class HomeDataBuilder(
-    private val contracts: List<Status> = emptyList()
+    private val contracts: List<Status> = emptyList(),
+    private val firstName: String = "Test"
 ) {
     fun build() = HomeQuery.Data(
+        member = HomeQuery.Member(
+            firstName = firstName
+        ),
         contracts = contracts.map { c ->
             HomeQuery.Contract(
                 switchedFromInsuranceProvider = null,

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/home/builders/HomeDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/home/builders/HomeDataBuilder.kt
@@ -1,0 +1,28 @@
+package com.hedvig.app.testdata.feature.home.builders
+
+import com.hedvig.android.owldroid.graphql.HomeQuery
+
+data class HomeDataBuilder(
+    private val contracts: List<Status> = emptyList()
+) {
+    fun build() = HomeQuery.Data(
+        contracts = contracts.map { c ->
+            HomeQuery.Contract(
+                switchedFromInsuranceProvider = null,
+                status = HomeQuery.Status(
+                    asPendingStatus = if (c == Status.PENDING) {
+                        HomeQuery.AsPendingStatus(
+                            pendingSince = null
+                        )
+                    } else {
+                        null
+                    }
+                )
+            )
+        }
+    )
+
+    enum class Status {
+        PENDING
+    }
+}


### PR DESCRIPTION
- Home tab is now shown by default instead of the old insurance tab
- If all contracts are pending, show a Big Text item (copy pending)
- Test and mock-infra for Home tab are in place

Also included:

- Ergonomic `viewBinding`-delegates
- A type-safe builder for `GenericDevelopmentAdapter`

Missing for now:

- API support for insurance switching. We're pretending that everyone is non-switchable for the time being.