### PR TITLE
Fix: Weird activity recreate-related navigation behaviours

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
@@ -3,8 +3,6 @@ package com.hedvig.app.feature.loggedin
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import com.agoda.kakao.image.KImageView
-import com.agoda.kakao.screen.Screen
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.LoggedInQuery
 import com.hedvig.android.owldroid.graphql.WelcomeQuery
@@ -62,6 +60,3 @@ class PostSignTest {
     }
 }
 
-class WelcomeScreen : Screen<WelcomeScreen>() {
-    val close = KImageView { withId(R.id.close) }
-}

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
@@ -16,10 +16,6 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
-import org.awaitility.Duration.TWO_SECONDS
-import org.awaitility.kotlin.atMost
-import org.awaitility.kotlin.await
-import org.awaitility.kotlin.untilAsserted
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,19 +46,17 @@ class PostSignTest {
             LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext())
                 .apply { putExtra(EXTRA_IS_FROM_ONBOARDING, true) })
 
-        await atMost TWO_SECONDS untilAsserted {
-            onScreen<WelcomeScreen> {
-                close {
-                    isVisible()
-                    click()
-                }
+        onScreen<WelcomeScreen> {
+            close {
+                isVisible()
+                click()
             }
-            onScreen<LoggedInScreen> {
-                pressBack()
-                root { isVisible() }
-                bottomTabs {
-                    hasSelectedItem(R.id.home)
-                }
+        }
+        onScreen<LoggedInScreen> {
+            pressBack()
+            root { isVisible() }
+            bottomTabs {
+                hasSelectedItem(R.id.home)
             }
         }
     }

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
@@ -1,0 +1,73 @@
+package com.hedvig.app.feature.loggedin
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.agoda.kakao.image.KImageView
+import com.agoda.kakao.screen.Screen
+import com.agoda.kakao.screen.Screen.Companion.onScreen
+import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.android.owldroid.graphql.WelcomeQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity.Companion.EXTRA_IS_FROM_ONBOARDING
+import com.hedvig.app.testdata.feature.loggedin.WELCOME_DATA_ONE_PAGE
+import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.apolloResponse
+import org.awaitility.Duration.TWO_SECONDS
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PostSignTest {
+    @get:Rule
+    val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
+            success(
+                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+            )
+        },
+        WelcomeQuery.QUERY_DOCUMENT to apolloResponse {
+            success(WELCOME_DATA_ONE_PAGE)
+        }
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldOpenWelcomeWhenNavigatingFromOnboarding() {
+        activityRule.launchActivity(
+            LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext())
+                .apply { putExtra(EXTRA_IS_FROM_ONBOARDING, true) })
+
+        await atMost TWO_SECONDS untilAsserted {
+            onScreen<WelcomeScreen> {
+                close {
+                    isVisible()
+                    click()
+                }
+            }
+            onScreen<LoggedInScreen> {
+                pressBack()
+                root { isVisible() }
+                bottomTabs {
+                    hasSelectedItem(R.id.home)
+                }
+            }
+        }
+    }
+}
+
+class WelcomeScreen : Screen<WelcomeScreen>() {
+    val close = KImageView { withId(R.id.close) }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/WelcomeScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/WelcomeScreen.kt
@@ -1,0 +1,9 @@
+package com.hedvig.app.feature.loggedin
+
+import com.agoda.kakao.image.KImageView
+import com.agoda.kakao.screen.Screen
+import com.hedvig.app.R
+
+class WelcomeScreen : Screen<WelcomeScreen>() {
+    val close = KImageView { withId(R.id.close) }
+}

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -12,7 +12,6 @@ import androidx.dynamicanimation.animation.SpringAnimation
 import androidx.dynamicanimation.animation.SpringForce
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
-import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.android.owldroid.type.Feature
 import com.hedvig.app.BaseActivity
 import com.hedvig.app.HedvigApplication
@@ -20,7 +19,6 @@ import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityLoggedInBinding
 import com.hedvig.app.feature.claims.ui.ClaimsViewModel
 import com.hedvig.app.feature.dismissiblepager.DismissiblePagerModel
-import com.hedvig.app.feature.insurance.ui.InsuranceViewModel
 import com.hedvig.app.feature.profile.ui.ProfileViewModel
 import com.hedvig.app.feature.referrals.ui.ReferralsInformationActivity
 import com.hedvig.app.feature.welcome.WelcomeDialog

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -132,7 +132,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 intent.removeExtra(EXTRA_IS_FROM_ONBOARDING)
             }
 
-
             bindData()
             setupToolBar(LoggedInTabs.fromId(bottomNavigation.selectedItemId))
         }
@@ -240,7 +239,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
 
     private fun setupToolBar(id: LoggedInTabs?) {
         if (lastLoggedInTab != id) {
-            binding.bottomNavigation.elevation = 0f
             invalidateOptionsMenu()
         }
         if (id != null) {

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -49,7 +49,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
     private val whatsNewViewModel: WhatsNewViewModel by viewModel()
     private val profileViewModel: ProfileViewModel by viewModel()
     private val welcomeViewModel: WelcomeViewModel by viewModel()
-    private val insuranceViewModel: InsuranceViewModel by viewModel()
     private val loggedInViewModel: LoggedInViewModel by viewModel()
 
     private val loggedInTracker: LoggedInTracker by inject()
@@ -319,9 +318,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 }
                 putExtra(INITIAL_TAB, initialTab)
             }
-
-        fun isTerminated(contracts: List<InsuranceQuery.Contract>) =
-            contracts.isNotEmpty() && contracts.all { it.status.fragments.contractStatusFragment.asTerminatedStatus != null }
 
         const val EXTRA_IS_FROM_REFERRALS_NOTIFICATION = "extra_is_from_referrals_notification"
         const val EXTRA_IS_FROM_ONBOARDING = "extra_is_from_onboarding"

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -90,6 +90,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
             setSupportActionBar(toolbar)
             supportActionBar?.setDisplayShowTitleEnabled(false)
 
+            bottomNavigation.itemIconTintList = null
             bottomNavigation.setOnNavigationItemSelectedListener { menuItem ->
                 val id = LoggedInTabs.fromId(menuItem.itemId)
                 if (id == null) {
@@ -104,11 +105,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 setupToolBar(id)
                 animateGradient(id)
                 true
-            }
-
-            if (intent.getBooleanExtra(EXTRA_IS_FROM_REFERRALS_NOTIFICATION, false)) {
-                bottomNavigation.selectedItemId = R.id.referrals
-                intent.removeExtra(EXTRA_IS_FROM_REFERRALS_NOTIFICATION)
             }
 
             if (intent.getBooleanExtra(EXTRA_IS_FROM_ONBOARDING, false)) {
@@ -136,7 +132,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 intent.removeExtra(EXTRA_IS_FROM_ONBOARDING)
             }
 
-            bottomNavigation.itemIconTintList = null
 
             bindData()
             setupToolBar(LoggedInTabs.fromId(bottomNavigation.selectedItemId))
@@ -317,7 +312,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 putExtra(INITIAL_TAB, initialTab)
             }
 
-        const val EXTRA_IS_FROM_REFERRALS_NOTIFICATION = "extra_is_from_referrals_notification"
         const val EXTRA_IS_FROM_ONBOARDING = "extra_is_from_onboarding"
 
         private val evaluator = ArgbEvaluator()

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/loggedin/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/loggedin/Data.kt
@@ -2,8 +2,10 @@ package com.hedvig.app.testdata.feature.loggedin
 
 import com.hedvig.app.testdata.common.ContractStatus
 import com.hedvig.app.testdata.feature.loggedin.builders.ContractStatusDataBuilder
+import com.hedvig.app.testdata.feature.loggedin.builders.WelcomeDataBuilder
 
 val CONTRACT_STATUS_DATA_ONE_TERMINATED_CONTRACT = ContractStatusDataBuilder(
     listOf(ContractStatus.TERMINATED)
 ).build()
 
+val WELCOME_DATA_ONE_PAGE = WelcomeDataBuilder().build()

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/loggedin/builders/WelcomeDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/loggedin/builders/WelcomeDataBuilder.kt
@@ -1,0 +1,38 @@
+package com.hedvig.app.testdata.feature.loggedin.builders
+
+import com.hedvig.android.owldroid.fragment.IconVariantsFragment
+import com.hedvig.android.owldroid.graphql.WelcomeQuery
+
+data class WelcomeDataBuilder(
+    val pages: List<WelcomeQuery.Welcome> = listOf(
+        WelcomePageBuilder().build()
+    )
+) {
+    fun build() = WelcomeQuery.Data(pages)
+}
+
+data class WelcomePageBuilder(
+    val lightUrl: String = "/app-content-service/welcome_welcome.svg",
+    val darkUrl: String = "/app-content-service/welcome_welcome_dark.svg",
+    val paragraph: String = "test",
+    val title: String = "test"
+) {
+    fun build() = WelcomeQuery.Welcome(
+        illustration = WelcomeQuery.Illustration(
+            variants = WelcomeQuery.Variants(
+                fragments = WelcomeQuery.Variants.Fragments(
+                    IconVariantsFragment(
+                        dark = IconVariantsFragment.Dark(
+                            svgUrl = darkUrl
+                        ),
+                        light = IconVariantsFragment.Light(
+                            svgUrl = lightUrl
+                        )
+                    )
+                )
+            )
+        ),
+        paragraph = paragraph,
+        title = title
+    )
+}


### PR DESCRIPTION
- Opportunistic cleanup
- Add a test to ensure post sign-behaviour
- Remove some unused await-statements
- Remove some unused code
- Remove some purposeless code (?)
- The correct tab is now shown after activity recreation, and the toolbar inset is also correct after such an event

