### PR TITLE
HVG-379: Show terminated contracts on tab screen if there are only terminated contracts

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/adyen/ConnectPayinNorwayTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/adyen/ConnectPayinNorwayTest.kt
@@ -19,6 +19,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Rule
@@ -59,7 +60,7 @@ class ConnectPayinNorwayTest {
 
     @Test
     fun shouldOpenConnectPayinAdyen() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         Screen.onScreen<HomeTabScreen> {
             recycler {
                 childAt<HomeTabScreen.InfoCardItem>(3) {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveInFutureAndTerminatedInFutureTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveInFutureAndTerminatedInFutureTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_FE
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +47,7 @@ class ActiveInFutureAndTerminatedInFutureTest {
 
     @Test
     fun shouldShowMessageWhenUserHasAllContractsInActiveInFutureStateOrActiveInFutureAndTerminatedInFutureState() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)
 
         onScreen<HomeTabScreen> {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveInFutureTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveInFutureTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_FE
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +43,7 @@ class ActiveInFutureTest {
 
     @Test
     fun shouldShowMessageWhenUserHasAllContractsInActiveInFutureState() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)
 
         onScreen<HomeTabScreen> {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveInfoCardsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveInfoCardsTest.kt
@@ -20,6 +20,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import com.hedvig.app.util.stubExternalIntents
 import io.mockk.every
@@ -62,7 +63,7 @@ class ActiveInfoCardsTest {
 
     @Test
     fun shouldShowTitleClaimButtonAndCommonClaimsWhenUserHasOneActiveContract() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         stubExternalIntents()
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveTest.kt
@@ -17,6 +17,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +43,7 @@ class ActiveTest {
 
     @Test
     fun shouldShowTitleClaimButtonAndCommonClaimsWhenUserHasOneActiveContract() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveWithMultiplePSAsAndConnectPayment.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/ActiveWithMultiplePSAsAndConnectPayment.kt
@@ -25,6 +25,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.stubExternalIntents
 import io.mockk.every
 import io.mockk.mockk
@@ -66,7 +67,7 @@ class ActiveWithMultiplePSAsAndConnectPayment {
 
     @Test
     fun shouldOpenPSALinksAndConnectPayment() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         stubExternalIntents()
         Screen.onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/GraphQLErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/GraphQLErrorTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -48,7 +49,7 @@ class GraphQLErrorTest {
 
     @Test
     fun shouldShowErrorWhenGraphQLErrorOccurs() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/NoFirstNameErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/NoFirstNameErrorTest.kt
@@ -15,6 +15,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -49,7 +50,7 @@ class NoFirstNameErrorTest {
 
     @Test
     fun shouldShowErrorWhenUserHasNoFirstName() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/NoFutureInceptionErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/NoFutureInceptionErrorTest.kt
@@ -15,6 +15,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_FE
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -49,7 +50,7 @@ class NoFutureInceptionErrorTest {
 
     @Test
     fun shouldShowErrorWhenUserHasNoFutureInception() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/PendingTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -39,7 +40,7 @@ class PendingTest {
 
     @Test
     fun shouldShowMessageWhenUserHasAllContractsInPendingState() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/TerminatedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/TerminatedTest.kt
@@ -15,6 +15,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -40,7 +41,7 @@ class TerminatedTest {
 
     @Test
     fun shouldShowMessageWhenUserHasAllContractsInTerminatedState() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/TerminatedTodayTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/TerminatedTodayTest.kt
@@ -18,6 +18,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
 import org.junit.Rule
 import org.junit.Test
@@ -43,7 +44,7 @@ class TerminatedTodayTest {
 
     @Test
     fun shouldShowTitleClaimButtonAndCommonClaimsWhenUserHasOneContractInTerminatedTodayState() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/UpcomingRenewalTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/UpcomingRenewalTest.kt
@@ -22,6 +22,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.stubExternalIntents
 import io.mockk.every
 import io.mockk.mockk
@@ -50,7 +51,7 @@ class UpcomingRenewalTest {
 
     @Test
     fun shouldOpenPSALinksAndConnectPayment() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         stubExternalIntents()
         Screen.onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/howclaimswork/HowClaimsWorkTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/howclaimswork/HowClaimsWorkTest.kt
@@ -17,6 +17,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,7 +42,7 @@ class HowClaimsWorkTest {
 
     @Test
     fun shouldOpenClaimFromHowClaimsWork() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         Intents.init()
         onScreen<HomeTabScreen> {
             recycler {

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/ErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/ErrorTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_AN
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,7 +50,7 @@ class ErrorTest {
     @Test
     fun shouldShowErrorOnGraphQLError() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.INSURANCE
         )
         activityRule.launchActivity(intent)

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/InsuranceStudentCardTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/InsuranceStudentCardTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_AN
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,7 +45,7 @@ class InsuranceStudentCardTest {
     @Test
     fun showsCorrectContentOnStudentContract() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.INSURANCE
         )
         activityRule.launchActivity(intent)

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/OnlyTerminatedContractsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/OnlyTerminatedContractsTest.kt
@@ -1,27 +1,25 @@
 package com.hedvig.app.feature.insurance.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.android.owldroid.graphql.LoggedInQuery
-import com.hedvig.app.R
 import com.hedvig.app.feature.insurance.screens.InsuranceScreen
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
-import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED
+import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_TERMINATED
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_AND_REFERRAL_FEATURE_ENABLED
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
-import com.hedvig.app.util.hasPluralText
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class TerminatedContractsTest {
+class OnlyTerminatedContractsTest {
 
     @get:Rule
     val activityRule = IntentsTestRule(LoggedInActivity::class.java, false, false)
@@ -34,7 +32,7 @@ class TerminatedContractsTest {
             )
         },
         InsuranceQuery.QUERY_DOCUMENT to apolloResponse {
-            success(INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED)
+            success(INSURANCE_DATA_TERMINATED)
         }
     )
 
@@ -42,24 +40,20 @@ class TerminatedContractsTest {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldShowTerminatedContractsRowWhenUserHasTerminatedContracts() {
+    fun shouldShowTerminatedContractsOnTabWhenUserHasOnlyTerminatedContracts() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.INSURANCE
         )
         activityRule.launchActivity(intent)
 
         onScreen<InsuranceScreen> {
             insuranceRecycler {
-                childAt<InsuranceScreen.TerminatedContractsHeader>(2) { text { hasText(R.string.insurances_tab_more_title) } }
-                childAt<InsuranceScreen.TerminatedContracts>(3) {
-                    caption {
-                        hasPluralText(R.plurals.insurances_tab_terminated_insurance_subtitile, 1, 1)
-                    }
-                    click()
+                hasSize(2)
+                childAt<InsuranceScreen.ContractCard>(1) {
+                    contractName { isVisible() }
                 }
             }
-            terminatedContractsScreen { intended() }
         }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/TerminatedAndActiveContractsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/TerminatedAndActiveContractsTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.insurance.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -52,6 +51,9 @@ class TerminatedAndActiveContractsTest {
 
         onScreen<InsuranceScreen> {
             insuranceRecycler {
+                childAt<InsuranceScreen.ContractCard>(1) {
+                    firstStatusPill { isGone() }
+                }
                 childAt<InsuranceScreen.TerminatedContractsHeader>(2) { text { hasText(R.string.insurances_tab_more_title) } }
                 childAt<InsuranceScreen.TerminatedContracts>(3) {
                     caption {

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/TerminatedAndActiveContractsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/TerminatedAndActiveContractsTest.kt
@@ -6,21 +6,23 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.app.R
 import com.hedvig.app.feature.insurance.screens.InsuranceScreen
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
-import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_ACTIVE_AND_TERMINATED
+import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_AND_REFERRAL_FEATURE_ENABLED
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.hasPluralText
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class InsuranceActiveAndTerminatedInFutureCardTest {
+class TerminatedAndActiveContractsTest {
 
     @get:Rule
     val activityRule = IntentsTestRule(LoggedInActivity::class.java, false, false)
@@ -33,9 +35,7 @@ class InsuranceActiveAndTerminatedInFutureCardTest {
             )
         },
         InsuranceQuery.QUERY_DOCUMENT to apolloResponse {
-            success(
-                INSURANCE_DATA_ACTIVE_AND_TERMINATED
-            )
+            success(INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED)
         }
     )
 
@@ -43,7 +43,7 @@ class InsuranceActiveAndTerminatedInFutureCardTest {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun showsCorrectContentOnSActivatedAndTerminatedInFeatureContract() {
+    fun shouldShowTerminatedContractsRowWhenUserHasTerminatedContracts() {
         val intent = LoggedInActivity.newInstance(
             context(),
             initialTab = LoggedInTabs.INSURANCE
@@ -52,15 +52,15 @@ class InsuranceActiveAndTerminatedInFutureCardTest {
 
         onScreen<InsuranceScreen> {
             insuranceRecycler {
-                childAt<InsuranceScreen.ContractCard>(1) {
-                    firstStatusPill {
-                        hasAnyText()
+                childAt<InsuranceScreen.TerminatedContractsHeader>(2) { text { hasText(R.string.insurances_tab_more_title) } }
+                childAt<InsuranceScreen.TerminatedContracts>(3) {
+                    caption {
+                        hasPluralText(R.plurals.insurances_tab_terminated_insurance_subtitile, 1, 1)
                     }
-                    secondStatusPill{
-                        hasAnyText()
-                    }
+                    click()
                 }
             }
+            terminatedContractsScreen { intended() }
         }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NavBarKeyGearAndReferralsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NavBarKeyGearAndReferralsTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_AN
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasNumberOfMenuItems
 import org.junit.Rule
 import org.junit.Test
@@ -36,7 +37,7 @@ class NavBarKeyGearAndReferralsTest {
 
     @Test
     fun shouldAllIconsIncludingKeyGear() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<LoggedInScreen> {
             bottomTabs {

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NavBarKeyGearEnabledTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NavBarKeyGearEnabledTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_FE
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasNumberOfMenuItems
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +35,7 @@ class NavBarKeyGearEnabledTest {
 
     @Test
     fun shouldAllIconsExcludingReferrals() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         Screen.onScreen<LoggedInScreen> {
             bottomTabs {

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NavBarReferralsEnabledTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NavBarReferralsEnabledTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasNumberOfMenuItems
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +35,7 @@ class NavBarReferralsEnabledTest {
 
     @Test
     fun shouldAllIconsExcludingKeyGear() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         Screen.onScreen<LoggedInScreen> {
             bottomTabs {

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NotTerminatedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/NotTerminatedTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,7 +35,7 @@ class NotTerminatedTest {
 
     @Test
     fun shouldOpenWithHomeTabWhenUserIsNotTerminated() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<LoggedInScreen> {
             root { isVisible() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/PostSignTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,7 +42,7 @@ class PostSignTest {
     @Test
     fun shouldOpenWelcomeWhenNavigatingFromOnboarding() {
         activityRule.launchActivity(
-            LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext())
+            LoggedInActivity.newInstance(context())
                 .apply { putExtra(EXTRA_IS_FROM_ONBOARDING, true) })
 
         onScreen<WelcomeScreen> {

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/ProfileToolbarMenuTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/ProfileToolbarMenuTest.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,7 +39,7 @@ class ProfileToolbarMenuTest {
 
     @Test
     fun shouldOpenChatWhenClickingToolbarActionOnProfileTab() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<LoggedInScreen> {
             root { isVisible() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/loggedin/WhatsNewTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/loggedin/WhatsNewTest.kt
@@ -16,6 +16,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,7 +43,7 @@ class WhatsNewTest {
 
     @Test
     fun shouldOpenWhatsNew() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
 
         onScreen<WelcomeScreen> {
             close {

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/activated/FeatureActivatedNotificationTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/activated/FeatureActivatedNotificationTest.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,7 +38,7 @@ class FeatureActivatedNotificationTest {
     @Test
     fun shouldOpenLoggedInScreenWithReferralsShownWhenOpeningReferralsFeatureActivatedNotification() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/activated/ReferralsActivatedActivityTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/activated/ReferralsActivatedActivityTest.kt
@@ -15,6 +15,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.javamoney.moneta.Money
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -58,7 +59,7 @@ class ReferralsActivatedActivityTest {
             body {
                 isVisible()
                 containsText(
-                    Money.of(10, "SEK").format(ApplicationProvider.getApplicationContext())
+                    Money.of(10, "SEK").format(context())
                 )
             }
         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/deeplinks/ForeverDeepLinkTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/deeplinks/ForeverDeepLinkTest.kt
@@ -19,6 +19,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.extensions.isLoggedIn
 import com.hedvig.app.util.extensions.setIsLoggedIn
 import org.awaitility.Duration
@@ -54,11 +55,9 @@ class ForeverDeepLinkTest {
 
     @Before
     fun setup() {
-        previousLoginStatus = ApplicationProvider.getApplicationContext<Context>().isLoggedIn()
+        previousLoginStatus = context().isLoggedIn()
 
-        ApplicationProvider
-            .getApplicationContext<Context>()
-            .setIsLoggedIn(true)
+        context().setIsLoggedIn(true)
     }
 
     @Test
@@ -66,10 +65,7 @@ class ForeverDeepLinkTest {
         activityRule.launchActivity(
             Intent(Intent.ACTION_VIEW).apply {
                 data = Uri.parse(
-                    "https://${
-                        ApplicationProvider.getApplicationContext<Context>()
-                            .getString(R.string.FIREBASE_LINK_DOMAIN)
-                    }/forever"
+                    "https://${context().getString(R.string.FIREBASE_LINK_DOMAIN)}/forever"
                 )
             }
         )
@@ -92,6 +88,6 @@ class ForeverDeepLinkTest {
 
     @After
     fun teardown() {
-        ApplicationProvider.getApplicationContext<Context>().setIsLoggedIn(previousLoginStatus)
+        context().setIsLoggedIn(previousLoginStatus)
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeAlreadyTakenTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeAlreadyTakenTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.testdata.feature.referrals.EDIT_CODE_DATA_ALREADY_TAKEN
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -37,7 +38,7 @@ class CodeAlreadyTakenTest {
     fun shouldShowAlreadyTakenErrorWhenCodeIsAlreadyTaken() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooLongErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooLongErrorTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.testdata.feature.referrals.EDIT_CODE_DATA_TOO_LONG
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -37,7 +38,7 @@ class CodeTooLongErrorTest {
     fun shouldShowErrorWhenCodeIsTooLong() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooLongValidationTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooLongValidationTest.kt
@@ -6,6 +6,7 @@ import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.app.R
 import com.hedvig.app.feature.referrals.ui.editcode.ReferralsEditCodeActivity
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -21,7 +22,7 @@ class CodeTooLongValidationTest {
     fun shouldNotAllowSubmitWhenCodeIsTooLongAndShowAnError() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooShortErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooShortErrorTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -11,6 +10,7 @@ import com.hedvig.app.testdata.feature.referrals.EDIT_CODE_DATA_TOO_SHORT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -38,7 +38,7 @@ class CodeTooShortErrorTest {
     fun shouldShowGenericErrorWhenCodeIsTooShort() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooShortValidationTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/CodeTooShortValidationTest.kt
@@ -1,10 +1,10 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.app.feature.referrals.ui.editcode.ReferralsEditCodeActivity
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +19,7 @@ class CodeTooShortValidationTest {
     fun shouldNotAllowSubmitWhenCodeFieldIsBlank() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/ConfirmDismissDirtyTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/ConfirmDismissDirtyTest.kt
@@ -1,10 +1,10 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.app.feature.referrals.ui.editcode.ReferralsEditCodeActivity
+import com.hedvig.app.util.context
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -20,7 +20,7 @@ class ConfirmDismissDirtyTest {
     fun shouldShowConfirmDismissWhenFormIsDirty() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/ConfirmDismissNotDirtyTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/ConfirmDismissNotDirtyTest.kt
@@ -1,10 +1,10 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.hedvig.app.feature.referrals.ui.editcode.ReferralsEditCodeActivity
+import com.hedvig.app.util.context
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -20,7 +20,7 @@ class ConfirmDismissNotDirtyTest {
     fun shouldNotShowConfirmDismissWhenFormIsNotDirty() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/GenericErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/GenericErrorTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -10,6 +9,7 @@ import com.hedvig.app.feature.referrals.ui.editcode.ReferralsEditCodeActivity
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -35,7 +35,7 @@ class GenericErrorTest {
     fun shouldShowErrorWhenNetworkErrorOccurs() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/MaxChangesErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/MaxChangesErrorTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -11,6 +10,7 @@ import com.hedvig.app.testdata.feature.referrals.EDIT_CODE_DATA_TOO_MANY_CHANGES
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -37,7 +37,7 @@ class MaxChangesErrorTest {
     fun shouldShowErrorWhenTooManyCodeChangesHaveBeenPerformed() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/SubmitUsingImeTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/SubmitUsingImeTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -16,6 +15,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +48,7 @@ class SubmitUsingImeTest {
     fun shouldSubmitCorrectlyUsingImeSubmit() {
         activityRule.launchActivity(
             LoggedInActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 initialTab = LoggedInTabs.REFERRALS
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/SuccessTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/SuccessTest.kt
@@ -16,6 +16,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +49,7 @@ class SuccessTest {
     fun shouldUpdateCodeWhenCodeIsAccepted() {
         activityRule.launchActivity(
             LoggedInActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 initialTab = LoggedInTabs.REFERRALS
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/UnknownResultErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/UnknownResultErrorTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.editcode
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -11,6 +10,7 @@ import com.hedvig.app.testdata.feature.referrals.EDIT_CODE_DATA_UNKNOWN_RESULT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import com.hedvig.app.util.hasError
 import org.junit.Rule
 import org.junit.Test
@@ -38,7 +38,7 @@ class UnknownResultErrorTest {
     fun shouldShowGenericErrorWhenResultTypeIsNotKnown() {
         activityRule.launchActivity(
             ReferralsEditCodeActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 "TEST123"
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/moreinfo/ReferralsInformationActivityTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/moreinfo/ReferralsInformationActivityTest.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.feature.referrals.moreinfo
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.isInternal
 import androidx.test.espresso.intent.rule.IntentsTestRule
@@ -23,6 +22,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.hamcrest.CoreMatchers.not
 import org.javamoney.moneta.Money
 import org.junit.Rule
@@ -50,7 +50,7 @@ class ReferralsInformationActivityTest {
     @Test
     fun shouldOpenInformationActivityWhenClickingMoreInformationAction() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 
@@ -70,7 +70,7 @@ class ReferralsInformationActivityTest {
         onScreen<ReferralsInformationScreen> {
             body {
                 containsText(
-                    Money.of(10, "SEK").format(ApplicationProvider.getApplicationContext())
+                    Money.of(10, "SEK").format(context())
                 )
             }
             termsAndConditions { click() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/CodeSnackbarTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/CodeSnackbarTest.kt
@@ -1,9 +1,7 @@
 package com.hedvig.app.feature.referrals.tab
 
 import android.content.ClipboardManager
-import android.content.Context
 import androidx.core.content.getSystemService
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import assertk.assertThat
@@ -18,6 +16,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -45,7 +44,7 @@ class CodeSnackbarTest {
     @Before
     fun setup() {
         runCatching {
-            ApplicationProvider.getApplicationContext<Context>()
+            context()
                 .getSystemService<ClipboardManager>()
                 ?.clearPrimaryClip()
         }
@@ -54,7 +53,7 @@ class CodeSnackbarTest {
     @Test
     fun shouldShowSnackbarWhenClickingCode() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 
@@ -79,7 +78,7 @@ class CodeSnackbarTest {
         }
 
         activityRule.runOnUiThread {
-            val clipboardContent = ApplicationProvider.getApplicationContext<Context>()
+            val clipboardContent = context()
                 .getSystemService<ClipboardManager>()?.primaryClip?.getItemAt(0)?.text
             assertThat(clipboardContent).isEqualTo("TEST123")
         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/EmptyTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/EmptyTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
@@ -41,7 +42,7 @@ class EmptyTest {
     @Test
     fun shouldShowEmptyStateWhenLoadedWithNoItems() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 
@@ -56,7 +57,7 @@ class EmptyTest {
                         isVisible()
                         hasText(
                             Money.of(349, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthPlaceholder { isGone() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ErrorTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -12,6 +11,7 @@ import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_KEY_GEAR_FEATURE_ENABLED
 import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNTS
 import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.context
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -68,7 +68,7 @@ class ErrorTest {
             webServer.start(8080)
 
             val intent = LoggedInActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 initialTab = LoggedInTabs.REFERRALS
             )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/MultipleReferralsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/MultipleReferralsTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen
@@ -15,6 +14,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +46,7 @@ class MultipleReferralsTest {
     @Test
     fun shouldShowActiveStateWhenUserHasMultipleReferrals() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 
@@ -61,7 +61,7 @@ class MultipleReferralsTest {
                         isVisible()
                         hasText(
                             Money.of(349, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthPlaceholder { isGone() }
@@ -70,14 +70,14 @@ class MultipleReferralsTest {
                         isVisible()
                         hasText(
                             Money.of(-10, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     newPrice {
                         isVisible()
                         hasText(
                             Money.of(339, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthLabel { isVisible() }
@@ -105,7 +105,7 @@ class MultipleReferralsTest {
                     status {
                         hasText(
                             Money.of(-10, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/OneRefereeTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/OneRefereeTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -15,6 +14,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +42,7 @@ class OneRefereeTest {
     @Test
     fun shouldShowActiveStateWhenUserHasOneReferee() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 
@@ -57,7 +57,7 @@ class OneRefereeTest {
                         isVisible()
                         hasText(
                             Money.of(349, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthPlaceholder { isGone() }
@@ -66,14 +66,14 @@ class OneRefereeTest {
                         isVisible()
                         hasText(
                             Money.of(-10, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     newPrice {
                         isVisible()
                         hasText(
                             Money.of(339, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthLabel { isVisible() }
@@ -107,7 +107,7 @@ class OneRefereeTest {
                     status {
                         hasText(
                             Money.of(-10, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/OpenEditCodeTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/OpenEditCodeTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -14,6 +13,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,7 +41,7 @@ class OpenEditCodeTest {
     fun shouldOpenEditCodeScreenWhenPressingEdit() {
         activityRule.launchActivity(
             LoggedInActivity.newInstance(
-                ApplicationProvider.getApplicationContext(),
+                context(),
                 initialTab = LoggedInTabs.REFERRALS
             )
         )

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/OtherDiscountTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/OtherDiscountTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen.Companion.onScreen
@@ -15,6 +14,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +46,7 @@ class OtherDiscountTest {
     @Test
     fun shouldShowOtherDiscountWhenUserHasNonReferralDiscounts() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 
@@ -61,7 +61,7 @@ class OtherDiscountTest {
                         isVisible()
                         hasText(
                             Money.of(349, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthPlaceholder { isGone() }
@@ -70,14 +70,14 @@ class OtherDiscountTest {
                         isVisible()
                         hasText(
                             Money.of(-10, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     newPrice {
                         isVisible()
                         hasText(
                             Money.of(339, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                     discountPerMonthLabel { isVisible() }
@@ -111,7 +111,7 @@ class OtherDiscountTest {
                     status {
                         hasText(
                             Money.of(-10, "SEK")
-                                .format(ApplicationProvider.getApplicationContext())
+                                .format(context())
                         )
                     }
                 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ShareTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/ShareTest.kt
@@ -4,10 +4,11 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import android.net.Uri
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
-import androidx.test.espresso.intent.matcher.IntentMatchers.*
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.espresso.intent.matcher.IntentMatchers.isInternal
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.agoda.kakao.screen.Screen
@@ -21,7 +22,11 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_COMPLEX_COD
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
-import org.hamcrest.Matchers.*
+import com.hedvig.app.util.context
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +53,7 @@ class ShareTest {
     @Test
     fun shouldOpenShareWhenClickingShare() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
         activityRule.launchActivity(intent)

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshNewDataTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshNewDataTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen
@@ -14,6 +13,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_ONE_REFEREE
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,7 +49,7 @@ class SwipeToRefreshNewDataTest {
     @Test
     fun shouldRefreshDataWhenSwipingDownToRefreshWithWhenDataHasChanged() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshSameDataTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/tab/SwipeToRefreshSameDataTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.referrals.tab
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.screen.Screen
@@ -13,6 +12,7 @@ import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,7 +39,7 @@ class SwipeToRefreshSameDataTest {
     @Test
     fun shouldRefreshDataWhenSwipingDownToRefreshWhenDataHasNotChanged() {
         val intent = LoggedInActivity.newInstance(
-            ApplicationProvider.getApplicationContext(),
+            context(),
             initialTab = LoggedInTabs.REFERRALS
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/trustly/ConnectPayinSwedenTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/trustly/ConnectPayinSwedenTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.trustly
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.agoda.kakao.screen.Screen
@@ -19,6 +18,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Rule
@@ -59,7 +59,7 @@ class ConnectPayinSwedenTest {
 
     @Test
     fun shouldOpenConnectPayinTrustly() {
-        activityRule.launchActivity(LoggedInActivity.newInstance(ApplicationProvider.getApplicationContext()))
+        activityRule.launchActivity(LoggedInActivity.newInstance(context()))
         Screen.onScreen<HomeTabScreen> {
             recycler {
                 childAt<HomeTabScreen.InfoCardItem>(3) {

--- a/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
@@ -12,15 +12,15 @@ import com.agoda.kakao.text.KTextView
 import java.time.LocalDate
 
 fun KTextInputLayout.hasError(@StringRes resId: Int) =
-    hasError(ApplicationProvider.getApplicationContext<Context>().getString(resId))
+    hasError(context().getString(resId))
 
 fun KTextInputLayout.hasError(@StringRes resId: Int, vararg formatArgs: Any) =
-    hasError(ApplicationProvider.getApplicationContext<Context>().getString(resId, *formatArgs))
+    hasError(context().getString(resId, *formatArgs))
 
 fun KDatePicker.setDate(date: LocalDate) = setDate(date.year, date.monthValue, date.dayOfMonth)
 
 fun KTextView.hasText(@StringRes resId: Int, vararg formatArgs: Any) =
-    hasText(ApplicationProvider.getApplicationContext<Context>().getString(resId, *formatArgs))
+    hasText(context().getString(resId, *formatArgs))
 
 fun KTextView.hasPluralText(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any) =
     hasText(context().resources.getQuantityString(resId, quantity, *formatArgs))

--- a/app/src/engineering/java/com/hedvig/app/feature/insurance/InsuranceMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/insurance/InsuranceMockActivity.kt
@@ -19,6 +19,7 @@ import com.hedvig.app.insuranceModule
 import com.hedvig.app.loggedInModule
 import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_ACTIVE_AND_TERMINATED
 import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED
+import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_TERMINATED
 import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_STUDENT
 import com.hedvig.app.testdata.feature.insurance.INSURANCE_DATA_NORWEGIAN_HOME_CONTENTS
 import com.hedvig.app.testdata.feature.insurance.INSURANCE_DATA_NORWEGIAN_TRAVEL
@@ -142,6 +143,18 @@ class InsuranceMockActivity : MockActivity() {
         clickableItem("One Active + One Terminated") {
             MockInsuranceViewModel.apply {
                 insuranceMockData = INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED
+                shouldError = false
+            }
+            startActivity(
+                LoggedInActivity.newInstance(
+                    context,
+                    initialTab = LoggedInTabs.INSURANCE
+                )
+            )
+        }
+        clickableItem("Terminated") {
+            MockInsuranceViewModel.apply {
+                insuranceMockData = INSURANCE_DATA_TERMINATED
                 shouldError = false
             }
             startActivity(

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceFragment.kt
@@ -87,11 +87,11 @@ class InsuranceFragment : Fragment(R.layout.fragment_insurance) {
 
         val successData = data.getOrNull() ?: return
 
-        val contracts = successData.contracts.mapNotNull {
-            if (it.status.fragments.contractStatusFragment.asTerminatedStatus == null) {
-                InsuranceModel.Contract(it)
+        val contracts = successData.contracts.map(InsuranceModel::Contract).let { contractModels ->
+            if (hasNotOnlyTerminatedContracts(successData.contracts)) {
+                contractModels.filter { it.inner.status.fragments.contractStatusFragment.asTerminatedStatus != null }
             } else {
-                null
+                contractModels
             }
         }
 
@@ -112,7 +112,7 @@ class InsuranceFragment : Fragment(R.layout.fragment_insurance) {
 
     private fun terminatedRow(contracts: List<InsuranceQuery.Contract>): List<InsuranceModel> {
         val terminatedContracts = amountOfTerminatedContracts(contracts)
-        return if (terminatedContracts > 0) {
+        return if (hasNotOnlyTerminatedContracts(contracts)) {
             listOf(
                 InsuranceModel.TerminatedContractsHeader,
                 InsuranceModel.TerminatedContracts(terminatedContracts)
@@ -148,5 +148,10 @@ class InsuranceFragment : Fragment(R.layout.fragment_insurance) {
 
         fun amountOfTerminatedContracts(contracts: List<InsuranceQuery.Contract>) =
             contracts.filter { it.status.fragments.contractStatusFragment.asTerminatedStatus != null }.size
+
+        fun hasNotOnlyTerminatedContracts(contracts: List<InsuranceQuery.Contract>): Boolean {
+            val terminatedContracts = amountOfTerminatedContracts(contracts)
+            return (terminatedContracts > 0 && contracts.size != terminatedContracts)
+        }
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceFragment.kt
@@ -89,7 +89,7 @@ class InsuranceFragment : Fragment(R.layout.fragment_insurance) {
 
         val contracts = successData.contracts.map(InsuranceModel::Contract).let { contractModels ->
             if (hasNotOnlyTerminatedContracts(successData.contracts)) {
-                contractModels.filter { it.inner.status.fragments.contractStatusFragment.asTerminatedStatus != null }
+                contractModels.filter { it.inner.status.fragments.contractStatusFragment.asTerminatedStatus == null }
             } else {
                 contractModels
             }

--- a/testdata/src/main/java/com/hedvig/app/testdata/dashboard/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/dashboard/Data.kt
@@ -21,3 +21,6 @@ val INSURANCE_DATA_ACTIVE_AND_TERMINATED =
 val INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED = InsuranceDataBuilder(
     contracts = listOf(ContractStatus.ACTIVE, ContractStatus.TERMINATED)
 ).build()
+val INSURANCE_DATA_TERMINATED = InsuranceDataBuilder(
+    contracts = listOf(ContractStatus.TERMINATED)
+).build()


### PR DESCRIPTION
Bonus: migrate all old calls to `ApplicationProvider.getApplicationContext()` to `context()`
### Checklist

- [X] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
