### PR TITLE
HVG-392: Attempt to fix Trustly-related crashes

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
@@ -16,8 +16,8 @@ import com.google.android.material.transition.MaterialFadeThrough
 import com.google.android.material.transition.MaterialSharedAxis
 import com.hedvig.app.R
 import com.hedvig.app.databinding.TrustlyConnectFragmentBinding
-import com.hedvig.app.feature.connectpayin.ConnectPaymentScreenState
 import com.hedvig.app.feature.connectpayin.ConnectPayinType
+import com.hedvig.app.feature.connectpayin.ConnectPaymentScreenState
 import com.hedvig.app.feature.connectpayin.ConnectPaymentViewModel
 import com.hedvig.app.feature.connectpayin.TransitionType
 import com.hedvig.app.feature.connectpayin.showConfirmCloseDialog
@@ -27,7 +27,10 @@ import org.koin.android.viewmodel.ext.android.sharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
-    private val binding by viewBinding(TrustlyConnectFragmentBinding::bind)
+    private val binding by viewBinding(TrustlyConnectFragmentBinding::bind, cleanup = {
+        root.removeView(trustly)
+        trustly.destroy()
+    })
     private val trustlyViewModel: TrustlyViewModel by viewModel()
     private val connectPaymentViewModel: ConnectPaymentViewModel by sharedViewModel()
 

--- a/app/src/main/java/com/hedvig/app/util/extensions/ViewBindingExtensions.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/ViewBindingExtensions.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
+import com.hedvig.app.util.safeLet
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -28,8 +29,9 @@ inline fun <T : ViewBinding> ViewGroup.viewBinding(crossinline binder: (View) ->
     }
 
 class FragmentViewBindingDelegate<T : ViewBinding>(
-    val fragment: Fragment,
-    val viewBindingFactory: (View) -> T
+    private val fragment: Fragment,
+    private val viewBindingFactory: (View) -> T,
+    private val cleanup: (T.() -> Unit)? = null
 ) : ReadOnlyProperty<Fragment, T> {
     private var binding: T? = null
 
@@ -39,6 +41,7 @@ class FragmentViewBindingDelegate<T : ViewBinding>(
                 fragment.viewLifecycleOwnerLiveData.observe(fragment) { viewLifecycleOwner ->
                     viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
                         override fun onDestroy(owner: LifecycleOwner) {
+                            safeLet(binding, cleanup) { binding, cleanup -> cleanup(binding) }
                             binding = null
                         }
                     })
@@ -62,5 +65,5 @@ class FragmentViewBindingDelegate<T : ViewBinding>(
     }
 }
 
-fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
-    FragmentViewBindingDelegate(this, viewBindingFactory)
+fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T, cleanup: (T.() -> Unit)? = null) =
+    FragmentViewBindingDelegate(this, viewBindingFactory, cleanup)


### PR DESCRIPTION
Should hopefully fix cases where the `WebViewClient`
causes crashes by attempting to access by trying to access
the `ViewModel`/`ViewBinding` after the `TrustlyConnectFragment`-view is destroyed.
