### PR TITLE
HVG-738 Add states for adyen and bank account connections

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/profile.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/profile.graphql
@@ -7,15 +7,23 @@ query Profile {
     phoneNumber
   }
   insuranceCost {
-    ... CostFragment
+    ...CostFragment
     freeUntil
   }
   cashback {
-    ... CashbackFragment
+    ...CashbackFragment
   }
   cashbackOptions {
     id
     name
     paragraph
+  }
+  bankAccount {
+    directDebitStatus
+  }
+  activePaymentMethods {
+    storedPaymentMethodsDetails {
+      id
+    }
   }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenConnectedTest.kt
@@ -9,14 +9,11 @@ import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
 import com.hedvig.app.feature.marketpicker.Market
 import com.hedvig.app.feature.marketpicker.MarketProvider
 import com.hedvig.app.marketProviderModule
-import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
 import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_CONNECTED
-import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_NOT_CONNECTED
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
-import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
@@ -33,11 +30,7 @@ class AdyenConnectedTest : TestCase() {
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
-        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
-            success(
-                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
-            )
-        },
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse { success(LOGGED_IN_DATA_WITH_REFERRALS_ENABLED) },
         ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA_ADYEN_CONNECTED) }
     )
 
@@ -55,7 +48,7 @@ class AdyenConnectedTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldShowDirectDebitNotConnected() = run {
+    fun shouldShowCardConnected() = run {
         every {
             marketProvider.market
         } returns Market.NO

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenConnectedTest.kt
@@ -1,0 +1,83 @@
+package com.hedvig.app.feature.profile
+
+import androidx.test.rule.ActivityTestRule
+import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.android.owldroid.graphql.ProfileQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
+import com.hedvig.app.feature.marketpicker.Market
+import com.hedvig.app.feature.marketpicker.MarketProvider
+import com.hedvig.app.marketProviderModule
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_CONNECTED
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_NOT_CONNECTED
+import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.KoinMockModuleRule
+import com.hedvig.app.util.apollo.format
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.hedvig.app.util.hasText
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.every
+import io.mockk.mockk
+import org.javamoney.moneta.Money
+import org.junit.Rule
+import org.junit.Test
+import org.koin.dsl.module
+
+class AdyenConnectedTest : TestCase() {
+    @get:Rule
+    val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
+            success(
+                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+            )
+        },
+        ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA_ADYEN_CONNECTED) }
+    )
+
+    private val marketProvider = mockk<MarketProvider>(relaxed = true)
+
+    @get:Rule
+    val koinMockModuleRule = KoinMockModuleRule(
+        listOf(marketProviderModule),
+        listOf(module {
+            single { marketProvider }
+        })
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldShowDirectDebitNotConnected() = run {
+        every {
+            marketProvider.market
+        } returns Market.NO
+
+        activityRule.launchActivity(
+            LoggedInActivity.newInstance(
+                context(),
+                initialTab = LoggedInTabs.PROFILE
+            )
+        )
+
+        ProfileTabScreen {
+            recycler {
+                childAt<ProfileTabScreen.Row>(3) {
+                    caption {
+                        hasText(R.string.Card_Connected,
+                            Money.of(349, "SEK").format(context()))
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenConnectedTest.kt
@@ -23,7 +23,6 @@ import com.hedvig.app.util.hasText
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.every
 import io.mockk.mockk
-import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
 import org.koin.dsl.module
@@ -72,8 +71,7 @@ class AdyenConnectedTest : TestCase() {
             recycler {
                 childAt<ProfileTabScreen.Row>(3) {
                     caption {
-                        hasText(R.string.Card_Connected,
-                            Money.of(349, "SEK").format(context()))
+                        hasText(R.string.Card_Connected, defaultAmount)
                     }
                 }
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenNotConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenNotConnectedTest.kt
@@ -23,7 +23,6 @@ import com.hedvig.app.util.hasText
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.every
 import io.mockk.mockk
-import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
 import org.koin.dsl.module
@@ -72,8 +71,7 @@ class AdyenNotConnectedTest : TestCase() {
             recycler {
                 childAt<ProfileTabScreen.Row>(3) {
                     caption {
-                        hasText(R.string.Card_Not_Connected,
-                            Money.of(349, "SEK").format(context()))
+                        hasText(R.string.Card_Not_Connected, defaultAmount)
                     }
                 }
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenNotConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenNotConnectedTest.kt
@@ -9,14 +9,11 @@ import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
 import com.hedvig.app.feature.marketpicker.Market
 import com.hedvig.app.feature.marketpicker.MarketProvider
 import com.hedvig.app.marketProviderModule
-import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
-import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_CONNECTED
 import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_NOT_CONNECTED
 import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
-import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
@@ -33,15 +30,14 @@ class AdyenNotConnectedTest : TestCase() {
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
-        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
-            success(
-                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
-            )
-        },
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse { success(LOGGED_IN_DATA_WITH_REFERRALS_ENABLED) },
         ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA_ADYEN_NOT_CONNECTED) }
     )
 
     private val marketProvider = mockk<MarketProvider>(relaxed = true)
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
 
     @get:Rule
     val koinMockModuleRule = KoinMockModuleRule(
@@ -51,11 +47,8 @@ class AdyenNotConnectedTest : TestCase() {
         })
     )
 
-    @get:Rule
-    val apolloCacheClearRule = ApolloCacheClearRule()
-
     @Test
-    fun shouldShowDirectDebitNotConnected() = run {
+    fun shouldShowCardNotConnected() = run {
         every {
             marketProvider.market
         } returns Market.NO

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenNotConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/AdyenNotConnectedTest.kt
@@ -1,0 +1,83 @@
+package com.hedvig.app.feature.profile
+
+import androidx.test.rule.ActivityTestRule
+import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.android.owldroid.graphql.ProfileQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
+import com.hedvig.app.feature.marketpicker.Market
+import com.hedvig.app.feature.marketpicker.MarketProvider
+import com.hedvig.app.marketProviderModule
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_CONNECTED
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_NOT_CONNECTED
+import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.KoinMockModuleRule
+import com.hedvig.app.util.apollo.format
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.hedvig.app.util.hasText
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.every
+import io.mockk.mockk
+import org.javamoney.moneta.Money
+import org.junit.Rule
+import org.junit.Test
+import org.koin.dsl.module
+
+class AdyenNotConnectedTest : TestCase() {
+    @get:Rule
+    val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
+            success(
+                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+            )
+        },
+        ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA_ADYEN_NOT_CONNECTED) }
+    )
+
+    private val marketProvider = mockk<MarketProvider>(relaxed = true)
+
+    @get:Rule
+    val koinMockModuleRule = KoinMockModuleRule(
+        listOf(marketProviderModule),
+        listOf(module {
+            single { marketProvider }
+        })
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldShowDirectDebitNotConnected() = run {
+        every {
+            marketProvider.market
+        } returns Market.NO
+
+        activityRule.launchActivity(
+            LoggedInActivity.newInstance(
+                context(),
+                initialTab = LoggedInTabs.PROFILE
+            )
+        )
+
+        ProfileTabScreen {
+            recycler {
+                childAt<ProfileTabScreen.Row>(3) {
+                    caption {
+                        hasText(R.string.Card_Not_Connected,
+                            Money.of(349, "SEK").format(context()))
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/CommonTestData.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/CommonTestData.kt
@@ -1,0 +1,7 @@
+package com.hedvig.app.feature.profile
+
+import com.hedvig.app.util.apollo.format
+import com.hedvig.app.util.context
+import org.javamoney.moneta.Money
+
+val defaultAmount = Money.of(349, "SEK").format(context())

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitConnectedTest.kt
@@ -33,11 +33,7 @@ class DirectDebitConnectedTest : TestCase() {
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
-        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
-            success(
-                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
-            )
-        },
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse { success(LOGGED_IN_DATA_WITH_REFERRALS_ENABLED) },
         ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA_BANK_ACCOUNT_ACTIVE) }
     )
 
@@ -55,7 +51,7 @@ class DirectDebitConnectedTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldShowDirectDebitNotConnected() = run {
+    fun shouldShowDirectDebitConnected() = run {
         every {
             marketProvider.market
         } returns Market.SE

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitConnectedTest.kt
@@ -71,8 +71,7 @@ class DirectDebitConnectedTest : TestCase() {
             recycler {
                 childAt<ProfileTabScreen.Row>(3) {
                     caption {
-                        hasText(R.string.Direct_Debit_Connected,
-                            Money.of(349, "SEK").format(context()))
+                        hasText(R.string.Direct_Debit_Connected, defaultAmount)
                     }
                 }
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitConnectedTest.kt
@@ -1,0 +1,82 @@
+package com.hedvig.app.feature.profile
+
+import androidx.test.rule.ActivityTestRule
+import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.android.owldroid.graphql.ProfileQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
+import com.hedvig.app.feature.marketpicker.Market
+import com.hedvig.app.feature.marketpicker.MarketProvider
+import com.hedvig.app.marketProviderModule
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_BANK_ACCOUNT_ACTIVE
+import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.KoinMockModuleRule
+import com.hedvig.app.util.apollo.format
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.hedvig.app.util.hasText
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.every
+import io.mockk.mockk
+import org.javamoney.moneta.Money
+import org.junit.Rule
+import org.junit.Test
+import org.koin.dsl.module
+
+class DirectDebitConnectedTest : TestCase() {
+    @get:Rule
+    val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
+            success(
+                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
+            )
+        },
+        ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA_BANK_ACCOUNT_ACTIVE) }
+    )
+
+    private val marketProvider = mockk<MarketProvider>(relaxed = true)
+
+    @get:Rule
+    val koinMockModuleRule = KoinMockModuleRule(
+        listOf(marketProviderModule),
+        listOf(module {
+            single { marketProvider }
+        })
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldShowDirectDebitNotConnected() = run {
+        every {
+            marketProvider.market
+        } returns Market.SE
+
+        activityRule.launchActivity(
+            LoggedInActivity.newInstance(
+                context(),
+                initialTab = LoggedInTabs.PROFILE
+            )
+        )
+
+        ProfileTabScreen {
+            recycler {
+                childAt<ProfileTabScreen.Row>(3) {
+                    caption {
+                        hasText(R.string.Direct_Debit_Connected,
+                            Money.of(349, "SEK").format(context()))
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitNotConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitNotConnectedTest.kt
@@ -26,7 +26,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.koin.dsl.module
 
-class SuccessTest : TestCase() {
+class DirectDebitNotConnectedTest : TestCase() {
     @get:Rule
     val activityRule = ActivityTestRule(LoggedInActivity::class.java, false, false)
 
@@ -54,7 +54,7 @@ class SuccessTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldSuccessfullyLoadProfileTab() = run {
+    fun shouldShowDirectDebitNotConnected() = run {
         every {
             marketProvider.market
         } returns Market.SE
@@ -68,36 +68,14 @@ class SuccessTest : TestCase() {
 
         ProfileTabScreen {
             recycler {
-                childAt<ProfileTabScreen.Title>(0) {
-                    isVisible()
-                }
-                childAt<ProfileTabScreen.Row>(1) {
-                    caption { hasText("Test Testerson") }
-                }
-                childAt<ProfileTabScreen.Row>(2) {
-                    caption { hasText("Example Charity") }
-                }
                 childAt<ProfileTabScreen.Row>(3) {
                     caption {
-                        hasText(
-                            R.string.Direct_Debit_Not_Connected,
-                            Money.of(349, "SEK").format(context())
-                        )
+                        hasText(R.string.Direct_Debit_Not_Connected,
+                            Money.of(349, "SEK").format(context()))
                     }
-                }
-                childAt<ProfileTabScreen.Subtitle>(4) {
-                    isVisible()
-                }
-                childAt<ProfileTabScreen.Row>(5) {
-                    isVisible()
-                }
-                childAt<ProfileTabScreen.Row>(6) {
-                    isVisible()
-                }
-                childAt<ProfileTabScreen.Logout>(7) {
-                    isVisible()
                 }
             }
         }
     }
 }
+

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitNotConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitNotConnectedTest.kt
@@ -14,7 +14,6 @@ import com.hedvig.app.testdata.feature.referrals.LOGGED_IN_DATA_WITH_REFERRALS_E
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.KoinMockModuleRule
-import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
@@ -31,11 +30,7 @@ class DirectDebitNotConnectedTest : TestCase() {
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
-        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
-            success(
-                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
-            )
-        },
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse { success(LOGGED_IN_DATA_WITH_REFERRALS_ENABLED) },
         ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA) }
     )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitNotConnectedTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/DirectDebitNotConnectedTest.kt
@@ -21,7 +21,6 @@ import com.hedvig.app.util.hasText
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.every
 import io.mockk.mockk
-import org.javamoney.moneta.Money
 import org.junit.Rule
 import org.junit.Test
 import org.koin.dsl.module
@@ -70,8 +69,7 @@ class DirectDebitNotConnectedTest : TestCase() {
             recycler {
                 childAt<ProfileTabScreen.Row>(3) {
                     caption {
-                        hasText(R.string.Direct_Debit_Not_Connected,
-                            Money.of(349, "SEK").format(context()))
+                        hasText(R.string.Direct_Debit_Not_Connected, defaultAmount)
                     }
                 }
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/ProfileTabScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/ProfileTabScreen.kt
@@ -1,0 +1,34 @@
+package com.hedvig.app.feature.profile
+
+import android.view.View
+import com.agoda.kakao.recycler.KRecyclerItem
+import com.agoda.kakao.recycler.KRecyclerView
+import com.agoda.kakao.screen.Screen
+import com.agoda.kakao.text.KTextView
+import com.hedvig.app.R
+import org.hamcrest.Matcher
+
+object ProfileTabScreen : Screen<ProfileTabScreen>() {
+    val recycler = KRecyclerView({ withId(R.id.recycler) }, {
+        itemType(::Title)
+        itemType(::Row)
+        itemType(::Subtitle)
+        itemType(::Logout)
+    })
+
+    class Title(parent: Matcher<View>) : KRecyclerItem<Title>(parent) {
+        val text = KTextView(parent) { withMatcher(parent) }
+    }
+
+    class Row(parent: Matcher<View>) : KRecyclerItem<Row>(parent) {
+        val caption = KTextView(parent) { withId(R.id.caption) }
+    }
+
+    class Subtitle(parent: Matcher<View>) : KRecyclerItem<Subtitle>(parent) {
+        val text = KTextView(parent) { withMatcher(parent) }
+    }
+
+    class Logout(parent: Matcher<View>) : KRecyclerItem<Logout>(parent) {
+
+    }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/SuccessTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/SuccessTest.kt
@@ -32,11 +32,7 @@ class SuccessTest : TestCase() {
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
-        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
-            success(
-                LOGGED_IN_DATA_WITH_REFERRALS_ENABLED
-            )
-        },
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse { success(LOGGED_IN_DATA_WITH_REFERRALS_ENABLED) },
         ProfileQuery.QUERY_DOCUMENT to apolloResponse { success(PROFILE_DATA) }
     )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/SuccessTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/SuccessTest.kt
@@ -79,10 +79,7 @@ class SuccessTest : TestCase() {
                 }
                 childAt<ProfileTabScreen.Row>(3) {
                     caption {
-                        hasText(
-                            R.string.Direct_Debit_Not_Connected,
-                            Money.of(349, "SEK").format(context())
-                        )
+                        hasText(R.string.Direct_Debit_Not_Connected, defaultAmount)
                     }
                 }
                 childAt<ProfileTabScreen.Subtitle>(4) {

--- a/app/src/engineering/java/com/hedvig/app/feature/profile/ProfileMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/profile/ProfileMockActivity.kt
@@ -1,20 +1,26 @@
 package com.hedvig.app.feature.profile
 
 import com.hedvig.app.MockActivity
+import com.hedvig.app.mocks.MockMarketProvider
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
+import com.hedvig.app.feature.marketpicker.MarketProvider
 import com.hedvig.app.feature.profile.ui.ProfileViewModel
 import com.hedvig.app.genericDevelopmentAdapter
+import com.hedvig.app.marketProviderModule
 import com.hedvig.app.profileModule
 import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_CONNECTED
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_ADYEN_NOT_CONNECTED
 import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_BANK_ACCOUNT_ACTIVE
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 class ProfileMockActivity : MockActivity() {
-    override val original = listOf(profileModule)
+    override val original = listOf(profileModule, marketProviderModule)
     override val mocks = listOf(module {
         viewModel<ProfileViewModel> { MockProfileViewModel() }
+        single<MarketProvider> { MockMarketProvider() }
     })
 
     override fun adapter() = genericDevelopmentAdapter {
@@ -27,6 +33,16 @@ class ProfileMockActivity : MockActivity() {
             MockProfileViewModel.profileData = PROFILE_DATA_BANK_ACCOUNT_ACTIVE
             startLoggedInActivity()
         }
+        clickableItem("Adyen connected") {
+            MockProfileViewModel.profileData = PROFILE_DATA_ADYEN_CONNECTED
+            startLoggedInActivity()
+        }
+        clickableItem("Adyen not connected") {
+            MockProfileViewModel.profileData = PROFILE_DATA_ADYEN_NOT_CONNECTED
+            startLoggedInActivity()
+        }
+
+        marketSpinner { MockMarketProvider.mockedMarket = it }
     }
 
     private fun startLoggedInActivity() {

--- a/app/src/engineering/java/com/hedvig/app/feature/profile/ProfileMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/profile/ProfileMockActivity.kt
@@ -7,6 +7,7 @@ import com.hedvig.app.feature.profile.ui.ProfileViewModel
 import com.hedvig.app.genericDevelopmentAdapter
 import com.hedvig.app.profileModule
 import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
+import com.hedvig.app.testdata.feature.profile.PROFILE_DATA_BANK_ACCOUNT_ACTIVE
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
@@ -18,14 +19,22 @@ class ProfileMockActivity : MockActivity() {
 
     override fun adapter() = genericDevelopmentAdapter {
         header("Tab")
-        clickableItem("Success") {
+        clickableItem("Bank account not connected") {
             MockProfileViewModel.profileData = PROFILE_DATA
-            startActivity(
-                LoggedInActivity.newInstance(
-                    this@ProfileMockActivity,
-                    initialTab = LoggedInTabs.PROFILE
-                )
-            )
+            startLoggedInActivity()
         }
+        clickableItem("Bank account connected") {
+            MockProfileViewModel.profileData = PROFILE_DATA_BANK_ACCOUNT_ACTIVE
+            startLoggedInActivity()
+        }
+    }
+
+    private fun startLoggedInActivity() {
+        startActivity(
+            LoggedInActivity.newInstance(
+                this@ProfileMockActivity,
+                initialTab = LoggedInTabs.PROFILE
+            )
+        )
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
@@ -138,19 +138,21 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
 
     private fun getPriceCaption(data: ProfileQuery.Data, monetaryMonthlyNet: String) =
         when (marketProvider.market) {
-            Market.SE -> {
-                when (data.bankAccount?.directDebitStatus) {
-                    DirectDebitStatus.ACTIVE -> getString(R.string.Direct_Debit_Connected, monetaryMonthlyNet)
-                    DirectDebitStatus.NEEDS_SETUP,
-                    DirectDebitStatus.PENDING,
-                    DirectDebitStatus.UNKNOWN__,
-                    null,
-                    -> getString(R.string.Direct_Debit_Not_Connected, monetaryMonthlyNet)
-                }
+            Market.SE -> when (data.bankAccount?.directDebitStatus) {
+                DirectDebitStatus.ACTIVE -> getString(R.string.Direct_Debit_Connected, monetaryMonthlyNet)
+                DirectDebitStatus.NEEDS_SETUP,
+                DirectDebitStatus.PENDING,
+                DirectDebitStatus.UNKNOWN__,
+                null,
+                -> getString(R.string.Direct_Debit_Not_Connected, monetaryMonthlyNet)
             }
-            Market.NO -> TODO()
-            Market.DK -> TODO()
-            null -> TODO()
+            Market.DK,
+            Market.NO -> if (data.activePaymentMethods == null) {
+                getString(R.string.Card_Not_Connected, monetaryMonthlyNet)
+            } else {
+                getString(R.string.Card_Connected, monetaryMonthlyNet)
+            }
+            null -> ""
         }
 
     companion object {

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
@@ -140,9 +140,7 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
         when (marketProvider.market) {
             Market.SE -> {
                 when (data.bankAccount?.directDebitStatus) {
-                    DirectDebitStatus.ACTIVE -> {
-                        getString(R.string.Direct_Debit_Connected, monetaryMonthlyNet)
-                    }
+                    DirectDebitStatus.ACTIVE -> getString(R.string.Direct_Debit_Connected, monetaryMonthlyNet)
                     DirectDebitStatus.NEEDS_SETUP,
                     DirectDebitStatus.PENDING,
                     DirectDebitStatus.UNKNOWN__,

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
@@ -5,10 +5,15 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.google.android.material.transition.MaterialFadeThrough
+import com.hedvig.android.owldroid.fragment.CostFragment
+import com.hedvig.android.owldroid.graphql.ProfileQuery
+import com.hedvig.android.owldroid.type.DirectDebitStatus
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ProfileFragmentBinding
 import com.hedvig.app.feature.loggedin.ui.LoggedInViewModel
 import com.hedvig.app.feature.loggedin.ui.ScrollPositionListener
+import com.hedvig.app.feature.marketpicker.Market
+import com.hedvig.app.feature.marketpicker.MarketProvider
 import com.hedvig.app.feature.profile.service.ProfileTracker
 import com.hedvig.app.feature.profile.ui.ProfileViewModel
 import com.hedvig.app.feature.profile.ui.aboutapp.AboutAppActivity
@@ -22,6 +27,7 @@ import com.hedvig.app.util.extensions.view.updatePadding
 import com.hedvig.app.util.extensions.viewBinding
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.sharedViewModel
+import javax.money.MonetaryAmount
 
 class ProfileFragment : Fragment(R.layout.profile_fragment) {
     private val binding by viewBinding(ProfileFragmentBinding::bind)
@@ -29,6 +35,7 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
     private val loggedInViewModel: LoggedInViewModel by sharedViewModel()
     private var scroll = 0
     private val tracker: ProfileTracker by inject()
+    private val marketProvider: MarketProvider by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -99,13 +106,8 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
                 },
                 ProfileModel.Row(
                     getString(R.string.PROFILE_ROW_PAYMENT_TITLE),
-                    data.insuranceCost?.fragments?.costFragment?.monthlyNet?.fragments?.monetaryAmountFragment?.toMonetaryAmount()
-                        ?.let { monthlyNet ->
-                            getString(
-                                R.string.PROFILE_ROW_PAYMENT_DESCRIPTION,
-                                monthlyNet.format(requireContext())
-                            )
-                        } ?: "",
+                    getPriceCaption(data, data.insuranceCost?.fragments?.costFragment?.monetaryMonthlyNet?.format(requireContext())
+                        ?: ""),
                     R.drawable.ic_payment
                 ) {
                     tracker.paymentRow()
@@ -132,6 +134,32 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
             )
             )
         }
+    }
+
+    private fun getPriceCaption(data: ProfileQuery.Data, monetaryMonthlyNet: String) =
+        when (marketProvider.market) {
+            Market.SE -> {
+                when (data.bankAccount?.directDebitStatus) {
+                    DirectDebitStatus.ACTIVE -> {
+                        getString(R.string.Direct_Debit_Connected, monetaryMonthlyNet)
+                    }
+                    DirectDebitStatus.NEEDS_SETUP,
+                    DirectDebitStatus.PENDING,
+                    DirectDebitStatus.UNKNOWN__,
+                    null,
+                    -> getString(R.string.Direct_Debit_Not_Connected, monetaryMonthlyNet)
+                }
+            }
+            Market.NO -> TODO()
+            Market.DK -> TODO()
+            null -> TODO()
+        }
+
+    companion object {
+        val CostFragment.monetaryMonthlyNet: MonetaryAmount
+            get() {
+                return monthlyNet.fragments.monetaryAmountFragment.toMonetaryAmount()
+            }
     }
 }
 

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/Data.kt
@@ -1,5 +1,8 @@
 package com.hedvig.app.testdata.feature.profile
 
+import com.hedvig.android.owldroid.type.DirectDebitStatus
 import com.hedvig.app.testdata.feature.profile.builders.ProfileDataBuilder
 
 val PROFILE_DATA = ProfileDataBuilder().build()
+
+val PROFILE_DATA_BANK_ACCOUNT_ACTIVE = ProfileDataBuilder(directDebitStatus = DirectDebitStatus.ACTIVE).build()

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/Data.kt
@@ -6,3 +6,6 @@ import com.hedvig.app.testdata.feature.profile.builders.ProfileDataBuilder
 val PROFILE_DATA = ProfileDataBuilder().build()
 
 val PROFILE_DATA_BANK_ACCOUNT_ACTIVE = ProfileDataBuilder(directDebitStatus = DirectDebitStatus.ACTIVE).build()
+
+val PROFILE_DATA_ADYEN_CONNECTED = ProfileDataBuilder(adyenConnected = true).build()
+val PROFILE_DATA_ADYEN_NOT_CONNECTED = ProfileDataBuilder(adyenConnected = false).build()

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
@@ -5,7 +5,6 @@ import com.hedvig.android.owldroid.fragment.CostFragment
 import com.hedvig.android.owldroid.graphql.ProfileQuery
 import com.hedvig.android.owldroid.type.DirectDebitStatus
 import com.hedvig.app.testdata.common.builders.CostBuilder
-import java.time.LocalDate
 
 data class ProfileDataBuilder(
     private val memberId: String = "123",
@@ -14,6 +13,7 @@ data class ProfileDataBuilder(
     private val email: String? = "test@example.com",
     private val phoneNumber: String? = "07012345678",
     private val directDebitStatus: DirectDebitStatus = DirectDebitStatus.NEEDS_SETUP,
+    private val adyenConnected: Boolean = false,
     private val cost: CostFragment = CostBuilder().build(),
 ) {
     fun build() = ProfileQuery.Data(
@@ -41,6 +41,10 @@ data class ProfileDataBuilder(
         ),
         cashbackOptions = emptyList(),
         bankAccount = ProfileQuery.BankAccount(directDebitStatus = directDebitStatus),
-        activePaymentMethods = null,
+        activePaymentMethods = if (adyenConnected) {
+            ProfileQuery.ActivePaymentMethods(storedPaymentMethodsDetails = ProfileQuery.StoredPaymentMethodsDetails(id = "test"))
+        } else {
+            null
+        },
     )
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
@@ -13,6 +13,7 @@ data class ProfileDataBuilder(
     private val lastName: String? = "Testerson",
     private val email: String? = "test@example.com",
     private val phoneNumber: String? = "07012345678",
+    private val directDebitStatus: DirectDebitStatus = DirectDebitStatus.NEEDS_SETUP,
     private val cost: CostFragment = CostBuilder().build(),
 ) {
     fun build() = ProfileQuery.Data(
@@ -39,7 +40,7 @@ data class ProfileDataBuilder(
             )
         ),
         cashbackOptions = emptyList(),
-        bankAccount = ProfileQuery.BankAccount(directDebitStatus = DirectDebitStatus.NEEDS_SETUP),
+        bankAccount = ProfileQuery.BankAccount(directDebitStatus = directDebitStatus),
         activePaymentMethods = null,
     )
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.testdata.feature.profile.builders
 import com.hedvig.android.owldroid.fragment.CashbackFragment
 import com.hedvig.android.owldroid.fragment.CostFragment
 import com.hedvig.android.owldroid.graphql.ProfileQuery
+import com.hedvig.android.owldroid.type.DirectDebitStatus
 import com.hedvig.app.testdata.common.builders.CostBuilder
 import java.time.LocalDate
 
@@ -38,5 +39,7 @@ data class ProfileDataBuilder(
             )
         ),
         cashbackOptions = emptyList(),
-   )
+        bankAccount = ProfileQuery.BankAccount(directDebitStatus = DirectDebitStatus.NEEDS_SETUP),
+        activePaymentMethods = null,
+    )
 }


### PR DESCRIPTION
- Add bankAccount and activePaymentMethods to profile query. Only show direct debit connected if bankAccount has status active.
- Add test for direct debit connected. Add clickable item in ProfileMockActivity.
- Add Adyen connected and not connected tests. Add clickable items in ProfileMockActivity. Extract MockMarketProvider to separate file.

### Checklist

- [X] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
