### PR TITLE
HVG-757 Fix select action crash

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/SelectActionAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/SelectActionAdapter.kt
@@ -1,5 +1,6 @@
 package com.hedvig.app.feature.embark.passages
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -7,17 +8,16 @@ import com.hedvig.app.R
 import com.hedvig.app.databinding.EmbarkSelectActionItemBinding
 import com.hedvig.app.util.GenericDiffUtilItemCallback
 import com.hedvig.app.util.extensions.inflate
-import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.viewBinding
 
 class SelectActionAdapter(
-    private val onActionSelected: (SelectAction) -> Unit
+    private val bindClicks: (SelectAction, View) -> Unit
 ) : ListAdapter<SelectAction, SelectActionAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ViewHolder(parent)
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position), onActionSelected)
+        holder.bind(getItem(position), bindClicks)
     }
 
     class ViewHolder(parent: ViewGroup) :
@@ -25,11 +25,11 @@ class SelectActionAdapter(
         private val binding by viewBinding(EmbarkSelectActionItemBinding::bind)
         fun bind(
             item: SelectAction,
-            onActionSelected: (SelectAction) -> Unit
+            onActionSelected: (SelectAction, View) -> Unit
         ) {
             binding.apply {
                 text.text = item.label
-                root.setHapticClickListener { onActionSelected(item) }
+                onActionSelected(item, root)
             }
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/SelectActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/SelectActionFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentEmbarkSelectActionBinding
@@ -11,11 +12,15 @@ import com.hedvig.app.feature.embark.EmbarkViewModel
 import com.hedvig.app.util.extensions.viewBinding
 import e
 import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 
 class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
     private val model: EmbarkViewModel by sharedViewModel()
     private val binding by viewBinding(FragmentEmbarkSelectActionBinding::bind)
+
+    private var job: Job? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -36,7 +41,9 @@ class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
                 }
                 model.putInStore("${data.passageName}Result", selectAction.label)
                 val responseText = model.preProcessResponse(data.passageName) ?: selectAction.label
-                animateResponse(response, responseText) {
+                job?.cancel()
+                job = lifecycleScope.launch {
+                    animateResponse(response, responseText)
                     model.navigateToPassage(selectAction.link)
                 }
             }.apply {

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/TextActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/TextActionFragment.kt
@@ -2,9 +2,9 @@ package com.hedvig.app.feature.embark.passages
 
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.InputType
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentEmbarkTextActionBinding
@@ -23,11 +23,15 @@ import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.viewBinding
 import e
 import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 
 class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
     private val model: EmbarkViewModel by sharedViewModel()
     private val binding by viewBinding(FragmentEmbarkTextActionBinding::bind)
+
+    private var job: Job? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -83,7 +87,9 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
                 model.putInStore("${data.passageName}Result", inputText)
                 model.putInStore(data.key, inputText)
                 val responseText = model.preProcessResponse(data.passageName) ?: inputText
-                animateResponse(response, responseText) {
+                job?.cancel()
+                job = lifecycleScope.launch {
+                    animateResponse(response, responseText)
                     model.navigateToPassage(data.link)
                 }
             }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/TextActionSetFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/TextActionSetFragment.kt
@@ -10,12 +10,14 @@ import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentTextActionSetBinding
 import com.hedvig.app.feature.embark.EmbarkViewModel
-import com.hedvig.app.util.extensions.view.setHapticClickListener
+import com.hedvig.app.util.extensions.view.hapticClicks
 import com.hedvig.app.util.extensions.viewBinding
 import e
 import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onEach
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
 
@@ -23,8 +25,6 @@ class TextActionSetFragment : Fragment(R.layout.fragment_text_action_set) {
     private val model: EmbarkViewModel by sharedViewModel()
     private val textActionSetViewModel: TextActionSetViewModel by viewModel()
     private val binding by viewBinding(FragmentTextActionSetBinding::bind)
-
-    private var job: Job? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val data = requireArguments().getParcelable<TextActionSetData>(DATA)
@@ -47,23 +47,24 @@ class TextActionSetFragment : Fragment(R.layout.fragment_text_action_set) {
                     textActionSubmit.isEnabled = hashMap.all { it.value }
                 }
             }
-            textActionSubmit.setHapticClickListener {
-                val allInput = ""
-                for ((index, key) in data.keys.withIndex()) {
-                    val input =
-                        inputRecycler.getChildAt(index).findViewById<TextInputEditText>(R.id.input)
-                    key?.let { model.putInStore(it, input.text.toString()) }
-                    allInput.plus("${input.text.toString()} ")
-                }
-                val responseText =
-                    model.preProcessResponse(data.passageName) ?: allInput
-                job?.cancel()
-                job = lifecycleScope.launch {
-                    animateResponse(response, responseText)
-                    model.navigateToPassage(data.link)
-                }
-            }
+            textActionSubmit
+                .hapticClicks()
+                .mapLatest { animateSubmission(data) }
+                .onEach { model.navigateToPassage(data.link) }
+                .launchIn(lifecycleScope)
         }
+    }
+
+    private suspend fun FragmentTextActionSetBinding.animateSubmission(data: TextActionSetData) {
+        val allInput = ""
+        for ((index, key) in data.keys.withIndex()) {
+            val input =
+                inputRecycler.getChildAt(index).findViewById<TextInputEditText>(R.id.input)
+            key?.let { model.putInStore(it, input.text.toString()) }
+            allInput.plus("${input.text.toString()} ")
+        }
+        val responseText = model.preProcessResponse(data.passageName) ?: allInput
+        animateResponse(response, responseText)
     }
 
     private fun textFieldData(data: TextActionSetData): MutableList<TextFieldData> {

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/TextActionSetFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/TextActionSetFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.textfield.TextInputEditText
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.R
@@ -13,6 +14,8 @@ import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.viewBinding
 import e
 import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
 
@@ -20,6 +23,8 @@ class TextActionSetFragment : Fragment(R.layout.fragment_text_action_set) {
     private val model: EmbarkViewModel by sharedViewModel()
     private val textActionSetViewModel: TextActionSetViewModel by viewModel()
     private val binding by viewBinding(FragmentTextActionSetBinding::bind)
+
+    private var job: Job? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val data = requireArguments().getParcelable<TextActionSetData>(DATA)
@@ -52,7 +57,9 @@ class TextActionSetFragment : Fragment(R.layout.fragment_text_action_set) {
                 }
                 val responseText =
                     model.preProcessResponse(data.passageName) ?: allInput
-                animateResponse(response, responseText) {
+                job?.cancel()
+                job = lifecycleScope.launch {
+                    animateResponse(response, responseText)
                     model.navigateToPassage(data.link)
                 }
             }

--- a/app/src/main/java/com/hedvig/app/util/extensions/view/ViewExtensions.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/view/ViewExtensions.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
+import androidx.annotation.CheckResult
 import androidx.annotation.Dimension
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
@@ -16,6 +17,12 @@ import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import com.hedvig.app.util.extensions.compatDrawable
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
 
 fun View.show(): View {
     if (visibility != View.VISIBLE) {
@@ -287,3 +294,11 @@ val View.centerX: Int
 
 val View.centerY: Int
     get() = (y + height / 2).toInt()
+
+fun View.hapticClicks(): Flow<Unit> = callbackFlow {
+    setOnClickListener {
+        performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+        runCatching { offer(Unit) }.getOrDefault(false)
+    }
+    awaitClose { setOnClickListener(null) }
+}.conflate()


### PR DESCRIPTION
- Refactor animateResponse to suspend function and start a coroutine from fragments to avoid crashing.
- Add view extension to create callbackFlow for click listeners. Use when animating views in embark.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [x] Functionality is accessible in engineering mode
