### PR TITLE
HVG-878: Persist input in Embark between passages

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
@@ -78,4 +78,27 @@ class NumberActionTest : TestCase() {
             }
         }
     }
+
+    @Test
+    fun shouldPrefillNumberActionWhenUserReturnsToPassage() = run {
+        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name))
+
+        NumberActionScreen {
+            step("Fill out passage and submit") {
+                numberInput { edit { typeText("50") } }
+                submit { click() }
+            }
+            step("Verify that the previous passage is no longer shown") {
+                onScreen<EmbarkScreen> {
+                    messages {
+                        childAt<EmbarkScreen.MessageRow>(0) { text { hasText("50 was entered") } }
+                    }
+                }
+            }
+            step("Go back and verify that the previous answer is prefilled") {
+                pressBack()
+                numberInput { edit { hasText("50") } }
+            }
+        }
+    }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
@@ -99,6 +99,9 @@ class NumberActionTest : TestCase() {
                 pressBack()
                 numberInput { edit { hasText("50") } }
             }
+            step("Check that validation passes on prefilled input") {
+                submit { isEnabled() }
+            }
         }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
@@ -39,14 +39,14 @@ class NumberActionTest : TestCase() {
                     isDisabled()
                     hasText("Another test passage")
                 }
-                numberInput {
+                input {
                     hasHint("Co-insured")
                     hasPlaceholderText("1")
                     hasHelperText("other people")
                 }
             }
             step("Test that lower bound does not allow submit") {
-                numberInput {
+                input {
                     edit {
                         typeText("0")
                     }
@@ -54,17 +54,17 @@ class NumberActionTest : TestCase() {
                 submit { isDisabled() }
             }
             step("Test that upper bound does not allow submit") {
-                numberInput { edit { replaceText("100") } }
+                input { edit { replaceText("100") } }
                 submit { isDisabled() }
             }
             step("Moving from valid to empty does not allow submit") {
-                numberInput { edit { replaceText("50") } }
+                input { edit { replaceText("50") } }
                 submit { isEnabled() }
-                numberInput { edit { replaceText("") } }
+                input { edit { replaceText("") } }
                 submit { isDisabled() }
             }
             step("Test that number in range allows submit") {
-                numberInput { edit { replaceText("50") } }
+                input { edit { replaceText("50") } }
                 submit {
                     click()
                 }
@@ -85,7 +85,7 @@ class NumberActionTest : TestCase() {
 
         NumberActionScreen {
             step("Fill out passage and submit") {
-                numberInput { edit { typeText("50") } }
+                input { edit { typeText("50") } }
                 submit { click() }
             }
             step("Verify that the previous passage is no longer shown") {
@@ -97,7 +97,7 @@ class NumberActionTest : TestCase() {
             }
             step("Go back and verify that the previous answer is prefilled") {
                 pressBack()
-                numberInput { edit { hasText("50") } }
+                input { edit { hasText("50") } }
             }
             step("Check that validation passes on prefilled input") {
                 submit { isEnabled() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/NumberActionScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/NumberActionScreen.kt
@@ -11,6 +11,6 @@ object NumberActionScreen : KScreen<NumberActionScreen>() {
     override val layoutId = R.layout.number_action_fragment
     override val viewClass = NumberActionFragment::class.java
 
-    val numberInput = KTextInputLayout { withId(R.id.inputContainer) }
+    val input = KTextInputLayout { withId(R.id.inputContainer) }
     val submit = KButton { withId(R.id.submit) }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionScreen.kt
@@ -1,0 +1,15 @@
+package com.hedvig.app.feature.embark.screens
+
+import com.agoda.kakao.edit.KTextInputLayout
+import com.agoda.kakao.text.KButton
+import com.hedvig.app.R
+import com.hedvig.app.feature.embark.passages.textaction.TextActionFragment
+import com.kaspersky.kaspresso.screens.KScreen
+
+object TextActionScreen : KScreen<TextActionScreen>() {
+    override val layoutId = R.layout.fragment_embark_text_action
+    override val viewClass = TextActionFragment::class.java
+
+    val input = KTextInputLayout { withId(R.id.filledTextField) }
+    val submit = KButton { withId(R.id.textActionSubmit) }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
@@ -72,6 +72,9 @@ class TextActionTest : TestCase() {
                 pressBack()
                 textActionSingleInput { hasText("Foo") }
             }
+            step("Check that validation passes on prefilled input") {
+                textActionSubmit { isEnabled() }
+            }
         }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
@@ -50,4 +50,28 @@ class TextActionTest : TestCase() {
             messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("Test entry was entered") } } }
         }
     }
+
+    @Test
+    fun shouldPrefillTextActionWhenUserReturnsToPassage() = run {
+        activityRule.launch(
+            EmbarkActivity.newInstance(
+                context(),
+                this.javaClass.name
+            )
+        )
+
+        onScreen<EmbarkScreen> {
+            step("Fill out passage and submit") {
+                textActionSingleInput { typeText("Foo") }
+                textActionSubmit { click() }
+            }
+            step("Verify that the previous passage no longer is shown") {
+                messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("Foo was entered") } } }
+            }
+            step("Go back and verify that previous answer is prefilled") {
+                pressBack()
+                textActionSingleInput { hasText("Foo") }
+            }
+        }
+    }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.embark.textaction
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.feature.embark.screens.EmbarkScreen
+import com.hedvig.app.feature.embark.screens.TextActionScreen
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_TEXT_ACTION
 import com.hedvig.app.util.ApolloCacheClearRule
@@ -35,19 +36,20 @@ class TextActionTest : TestCase() {
             )
         )
 
-        onScreen<EmbarkScreen> {
-            messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("test message") } } }
-            textActionSingleInput {
-                isVisible()
-                hasHint("Test hint")
+        TextActionScreen {
+            onScreen<EmbarkScreen> {
+                messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("test message") } } }
             }
-            textActionSubmit { isDisabled() }
-            textActionSingleInput { typeText("Test entry") }
-            textActionSubmit {
+            input { hasHint("Test hint") }
+            submit {
                 hasText("Another test passage")
-                click()
+                isDisabled()
             }
-            messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("Test entry was entered") } } }
+            input { edit { typeText("Test entry") } }
+            submit { click() }
+            onScreen<EmbarkScreen> {
+                messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("Test entry was entered") } } }
+            }
         }
     }
 
@@ -60,20 +62,22 @@ class TextActionTest : TestCase() {
             )
         )
 
-        onScreen<EmbarkScreen> {
+        TextActionScreen {
             step("Fill out passage and submit") {
-                textActionSingleInput { typeText("Foo") }
-                textActionSubmit { click() }
+                input { edit { typeText("Foo") } }
+                submit { click() }
             }
             step("Verify that the previous passage no longer is shown") {
-                messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("Foo was entered") } } }
+                onScreen<EmbarkScreen> {
+                    messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("Foo was entered") } } }
+                }
             }
             step("Go back and verify that previous answer is prefilled") {
                 pressBack()
-                textActionSingleInput { hasText("Foo") }
+                input { edit { hasText("Foo") } }
             }
             step("Check that validation passes on prefilled input") {
-                textActionSubmit { isEnabled() }
+                submit { isEnabled() }
             }
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -55,6 +55,8 @@ abstract class EmbarkViewModel : ViewModel() {
         store[key] = value
     }
 
+    fun getFromStore(key: String) = store[key]
+
     fun navigateToPassage(passageName: String) {
         storyData.embarkStory?.let { story ->
             val nextPassage = story.passages.find { it.name == passageName }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/numberaction/NumberActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/numberaction/NumberActionFragment.kt
@@ -31,7 +31,6 @@ class NumberActionFragment : Fragment(R.layout.number_action_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(binding) {
             messages.adapter = MessageAdapter(data.messages)
-            model.getFromStore(data.key)?.let { input.setText(it) }
             inputContainer.placeholderText = data.placeholder
             data.label?.let { inputContainer.hint = it }
             data.unit?.let { inputContainer.helperText = it }
@@ -39,6 +38,7 @@ class NumberActionFragment : Fragment(R.layout.number_action_fragment) {
                 numberActionViewModel.validate(text)
             }
             numberActionViewModel.valid.observe(viewLifecycleOwner) { submit.isEnabled = it }
+            model.getFromStore(data.key)?.let { input.setText(it) }
             submit.text = data.submitLabel
             submit
                 .hapticClicks()

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/numberaction/NumberActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/numberaction/NumberActionFragment.kt
@@ -31,6 +31,7 @@ class NumberActionFragment : Fragment(R.layout.number_action_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(binding) {
             messages.adapter = MessageAdapter(data.messages)
+            model.getFromStore(data.key)?.let { input.setText(it) }
             inputContainer.placeholderText = data.placeholder
             data.label?.let { inputContainer.hint = it }
             data.unit?.let { inputContainer.helperText = it }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
@@ -70,7 +70,6 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
         binding.apply {
             messages.adapter = MessageAdapter(data.messages)
 
-            model.getFromStore(data.key)?.let { input.setText(it) }
             filledTextField.hint = data.hint
             data.mask?.let { mask ->
                 input.apply {
@@ -89,6 +88,8 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
                         )
                 }
             }
+           
+            model.getFromStore(data.key)?.let { input.setText(it) }
 
             textActionSubmit.text = data.submitLabel
             textActionSubmit

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
@@ -70,6 +70,7 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
         binding.apply {
             messages.adapter = MessageAdapter(data.messages)
 
+            model.getFromStore(data.key)?.let { input.setText(it) }
             filledTextField.hint = data.hint
             data.mask?.let { mask ->
                 input.apply {


### PR DESCRIPTION
- Prefill with previous answer for `TextAction`
- Prefill with previous answer for `NumberAction`
- Validate prefilled data
- Validate prefilled data for `TextAction`
- Opportunistic refactor: Modernize the tests a bit and improve naming

<!-- Add when these when applicable. -->
### Checklist

- [X] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
