### PR TITLE
HVG-890: Improve embark transitions

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/numberaction/NumberActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/numberaction/NumberActionFragment.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.embark.passages.numberaction
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.core.view.doOnNextLayout
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
@@ -29,6 +30,8 @@ class NumberActionFragment : Fragment(R.layout.number_action_fragment) {
     private val numberActionViewModel: NumberActionViewModel by viewModel { parametersOf(data) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        postponeEnterTransition()
+
         with(binding) {
             messages.adapter = MessageAdapter(data.messages)
             inputContainer.placeholderText = data.placeholder
@@ -53,6 +56,10 @@ class NumberActionFragment : Fragment(R.layout.number_action_fragment) {
                     model.navigateToPassage(data.link)
                 }
                 .launchIn(viewLifecycleScope)
+
+            messages.doOnNextLayout {
+                startPostponedEnterTransition()
+            }
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/previousinsurer/PreviousInsurerFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/previousinsurer/PreviousInsurerFragment.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.feature.embark.passages.previousinsurer
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
 import com.hedvig.app.databinding.PreviousInsurerFragmentBinding
@@ -24,6 +25,9 @@ class PreviousInsurerFragment : Fragment(R.layout.previous_insurer_fragment) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        postponeEnterTransition()
+
         binding.apply {
             messages.adapter = MessageAdapter(insurerData.messages)
             currentInsurerContainer.setHapticClickListener {
@@ -38,6 +42,10 @@ class PreviousInsurerFragment : Fragment(R.layout.previous_insurer_fragment) {
                 if (selectedInsurer?.isNotEmpty() == true) {
                     currentInsurerLabel.text = selectedInsurer
                 }
+            }
+
+            messages.doOnNextLayout {
+                startPostponedEnterTransition()
             }
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/selectaction/SelectActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/selectaction/SelectActionFragment.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.embark.passages.selectaction
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
+import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentEmbarkSelectActionBinding
@@ -24,6 +25,7 @@ class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        postponeEnterTransition()
         val data = requireArguments().getParcelable<SelectActionParameter>(DATA)
 
         if (data == null) {
@@ -42,6 +44,10 @@ class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
                 submitList(data.actions)
             }
             actions.addItemDecoration(SelectActionDecoration())
+
+            messages.doOnNextLayout {
+                startPostponedEnterTransition()
+            }
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.embark.passages.textaction
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
 import android.view.View
+import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentEmbarkTextActionBinding
@@ -41,6 +42,7 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        postponeEnterTransition()
 
         val data = requireArguments().getParcelable<TextActionParameter>(DATA)
 
@@ -77,7 +79,7 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
                     setValidationFormatter(mask)
                 }
             }
-
+    
             input.onChange { text ->
                 if (data.mask == null) {
                     textActionSubmit.isEnabled = text.isNotEmpty()
@@ -108,6 +110,10 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
                 }
                 .onEach { model.navigateToPassage(data.link) }
                 .launchIn(viewLifecycleScope)
+
+            messages.doOnNextLayout {
+                startPostponedEnterTransition()
+            }
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/textactionset/TextActionSetFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/textactionset/TextActionSetFragment.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.feature.embark.passages.textactionset
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentTextActionSetBinding
@@ -28,6 +29,9 @@ class TextActionSetFragment : Fragment(R.layout.fragment_text_action_set) {
     private val binding by viewBinding(FragmentTextActionSetBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        postponeEnterTransition()
+
         binding.apply {
             messages.adapter = MessageAdapter(data.messages)
             inputRecycler.adapter = TextInputSetAdapter(textActionSetViewModel).also {
@@ -43,6 +47,10 @@ class TextActionSetFragment : Fragment(R.layout.fragment_text_action_set) {
                     model.navigateToPassage(data.link)
                 }
                 .launchIn(viewLifecycleScope)
+
+            messages.doOnNextLayout {
+                startPostponedEnterTransition()
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_embark_select_action.xml
+++ b/app/src/main/res/layout/fragment_embark_select_action.xml
@@ -23,6 +23,8 @@
         android:id="@+id/response"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/base_margin_double"
+        android:layout_marginEnd="@dimen/base_margin_double"
         android:alpha="0"
         android:textAppearance="?textAppearanceSubtitle1"
         android:theme="@style/ThemeOverlay.Hedvig.Embark.Chat.Self"

--- a/app/src/main/res/layout/fragment_embark_text_action.xml
+++ b/app/src/main/res/layout/fragment_embark_text_action.xml
@@ -24,6 +24,8 @@
         android:id="@+id/response"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/base_margin_double"
+        android:layout_marginEnd="@dimen/base_margin_double"
         android:alpha="0"
         android:textAppearance="?textAppearanceSubtitle1"
         android:theme="@style/ThemeOverlay.Hedvig.Embark.Chat.Self"

--- a/app/src/main/res/layout/number_action_fragment.xml
+++ b/app/src/main/res/layout/number_action_fragment.xml
@@ -24,6 +24,8 @@
         android:id="@+id/response"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/base_margin_double"
+        android:layout_marginEnd="@dimen/base_margin_double"
         android:alpha="0"
         android:textAppearance="?textAppearanceSubtitle1"
         android:theme="@style/ThemeOverlay.Hedvig.Embark.Chat.Self"

--- a/app/src/main/res/layout/previous_insurer_fragment.xml
+++ b/app/src/main/res/layout/previous_insurer_fragment.xml
@@ -23,6 +23,8 @@
         android:id="@+id/response"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/base_margin_double"
+        android:layout_marginEnd="@dimen/base_margin_double"
         android:alpha="0"
         android:textAppearance="?textAppearanceSubtitle1"
         android:theme="@style/ThemeOverlay.Hedvig.Embark.Chat.Self"
@@ -53,9 +55,9 @@
                 android:layout_marginTop="@dimen/base_margin_triple"
                 android:layout_marginEnd="@dimen/base_margin_quadruple"
                 android:layout_marginBottom="@dimen/base_margin_double"
-                app:drawableEndCompat="@drawable/ic_chevron_down"
                 android:text="@string/onboarding_norway_current_insurer.bottom_sheet_title"
-                android:textAppearance="?textAppearanceBody1" />
+                android:textAppearance="?textAppearanceBody1"
+                app:drawableEndCompat="@drawable/ic_chevron_down" />
 
             <View
                 android:layout_width="match_parent"


### PR DESCRIPTION
Postpone enter transitions to allow smoother animations when navigating between embark screens. Add margins to response text view.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
