### PR TITLE
HVG-897: Charity: Switch from `paragraph` to `description`.

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/cashback.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/cashback.graphql
@@ -1,5 +1,5 @@
 fragment CashbackFragment on Cashback {
   name
   imageUrl
-  paragraph
+  description
 }

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/charity/CharityActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/charity/CharityActivity.kt
@@ -66,7 +66,7 @@ class CharityActivity : BaseActivity(R.layout.activity_charity) {
                 .into(selectedCharityBanner)
 
             selectedCharityCardTitle.text = cashback.name
-            selectedCharityCardParagraph.text = cashback.paragraph
+            selectedCharityCardParagraph.text = cashback.description
             charitySelectedHowDoesItWorkButton.setHapticClickListener {
                 tracker.howDoesItWorkClick()
                 CharityExplanationBottomSheet.newInstance()

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/profile/builders/ProfileDataBuilder.kt
@@ -35,7 +35,7 @@ data class ProfileDataBuilder(
                 CashbackFragment(
                     name = "Example Charity",
                     imageUrl = null,
-                    paragraph = null
+                    description = null
                 )
             )
         ),


### PR DESCRIPTION
Reason: `paragraph` and `description` contained similar data,
but `description` is used by iOS and `paragraph`
is missing for some charities.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
