### PR TITLE
HVG-904: Restart embark from more options

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/EmbarkActivityTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/EmbarkActivityTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.embark
 
-import android.app.Activity
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.app.feature.embark.screens.EmbarkScreen
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
@@ -8,7 +7,6 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.context
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -32,11 +30,5 @@ class EmbarkActivityTest : TestCase() {
                 isVisible()
             }
         }
-    }
-
-    @Test
-    fun endsActivityIfNoStoryNameIsProvided() = run {
-        activityRule.launch()
-        assertTrue(activityRule.scenario.result.resultCode == Activity.RESULT_CANCELED)
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -42,6 +42,7 @@ abstract class EmbarkViewModel : ViewModel() {
     private var totalSteps: Int = 0
 
     protected fun setInitialState() {
+        store.clear()
         storyData.embarkStory?.let { story ->
             val firstPassage = story.passages.first { it.id == story.startPassage }
             totalSteps = getPassagesLeft(firstPassage)

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.embark.ui
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -27,25 +26,19 @@ import com.hedvig.app.feature.embark.passages.textactionset.TextActionSetFragmen
 import com.hedvig.app.feature.embark.passages.textactionset.TextActionSetParameter
 import com.hedvig.app.util.extensions.view.remove
 import com.hedvig.app.util.extensions.viewBinding
-import e
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
     private val model: EmbarkViewModel by viewModel()
     private val binding by viewBinding(ActivityEmbarkBinding::bind)
 
+    private val storyName: String by lazy {
+        // TODO: Implement error UI that design must provide
+        intent.getStringExtra(STORY_NAME) ?: throw IllegalArgumentException("Programmer error: STORY_NAME not provided to ${this.javaClass.name}")
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val storyName = intent.getStringExtra(STORY_NAME)
-
-        if (storyName == null) {
-            // TODO: Implement error UI that design must provide
-            e { "Programmer error: STORY_NAME not provided to ${this.javaClass.name}" }
-            setResult(Activity.RESULT_CANCELED)
-            finish()
-            return
-        }
 
         model.load(storyName)
 
@@ -59,7 +52,7 @@ class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
                 setOnMenuItemClickListener { menuItem ->
                     when (menuItem.itemId) {
                         R.id.moreOptions -> {
-                            startActivity(MoreOptionsActivity.newInstance(this@EmbarkActivity))
+                            startActivityForResult(MoreOptionsActivity.newInstance(this@EmbarkActivity), REQUEST_MORE_OPTIONS)
                             true
                         }
                         R.id.tooltip -> {
@@ -181,9 +174,18 @@ class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
         }
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == REQUEST_MORE_OPTIONS && resultCode == RESULT_CANCELED) {
+            model.load(storyName)
+        } else {
+            super.onActivityResult(requestCode, resultCode, data)
+        }
+    }
+
     companion object {
         private const val SHARED_AXIS = MaterialSharedAxis.X
         internal const val STORY_NAME = "STORY_NAME"
+        internal const val REQUEST_MORE_OPTIONS = 1
 
         fun newInstance(context: Context, storyName: String) =
             Intent(context, EmbarkActivity::class.java).apply {

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
@@ -33,7 +33,6 @@ class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
     private val binding by viewBinding(ActivityEmbarkBinding::bind)
 
     private val storyName: String by lazy {
-        // TODO: Implement error UI that design must provide
         intent.getStringExtra(STORY_NAME) ?: throw IllegalArgumentException("Programmer error: STORY_NAME not provided to ${this.javaClass.name}")
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
@@ -45,7 +45,7 @@ class MoreOptionsActivity : BaseActivity(R.layout.activity_more_options) {
                 showLogin()
             }
 
-            restart.setOnClickListener {
+            restart.setHapticClickListener {
                 restartOffer()
             }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
@@ -1,5 +1,6 @@
 package com.hedvig.app.feature.embark.ui
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -44,6 +45,10 @@ class MoreOptionsActivity : BaseActivity(R.layout.activity_more_options) {
                 showLogin()
             }
 
+            restart.setOnClickListener {
+                restartOffer()
+            }
+
             viewModel.data.observe(this@MoreOptionsActivity) { result ->
                 if (result.isFailure) {
                     (recycler.adapter as MoreOptionsAdapter).submitList(
@@ -72,6 +77,11 @@ class MoreOptionsActivity : BaseActivity(R.layout.activity_more_options) {
 
     private fun showLogin() {
         marketProvider.market?.openAuth(this, supportFragmentManager)
+    }
+
+    private fun restartOffer() {
+        setResult(Activity.RESULT_CANCELED)
+        finish()
     }
 
     companion object {

--- a/app/src/main/java/com/hedvig/app/feature/onboarding/ui/ChoosePlanActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/onboarding/ui/ChoosePlanActivity.kt
@@ -26,6 +26,7 @@ import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import dev.chrisbanes.insetter.setEdgeToEdgeSystemUiFlags
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
+import timber.log.Timber
 
 class ChoosePlanActivity : BaseActivity(R.layout.activity_choose_plan) {
     private val binding by viewBinding(ActivityChoosePlanBinding::bind)
@@ -56,8 +57,7 @@ class ChoosePlanActivity : BaseActivity(R.layout.activity_choose_plan) {
                     "Web Onboarding NO - English Travel", "Web Onboarding NO - Norwegian Travel" -> {
                         startActivity(EmbarkActivity.newInstance(this@ChoosePlanActivity, storyName))
                     }
-                    null -> {
-                    }
+                    null -> Timber.e("Could not start embark activity - null story name")
                     else -> {
                         startActivity(
                             WebOnboardingActivity.newNoInstance(


### PR DESCRIPTION
Any idea how we can simulate a press on the overflow menu button in the progress toolbar? Couldn't figure out how to do that, which is need if we want to write an integration test for this.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
