### PR TITLE
HVG-941: computed store values

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,6 +52,8 @@ jobs:
         run: ./gradlew app:downloadStrings
       - name: Generate License-report
         run: ./gradlew licenseReleaseReport
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest
       - name: Instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/embarkStory.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/embarkStory.graphql
@@ -1,6 +1,10 @@
 query EmbarkStory($name: String!, $locale: String!) {
   embarkStory(name: $name, locale: $locale) {
     startPassage
+    computedStoreValues {
+      key
+      value
+    }
     passages {
       name
       id

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -273,6 +273,8 @@ dependencies {
     implementation("com.facebook.shimmer:shimmer:0.5.0")
 
     // test
+    testImplementation("junit:junit:4.13")
+    testImplementation("com.google.truth:truth:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
     androidTestImplementation("androidx.test:runner:1.3.0")
     androidTestImplementation("androidx.test:rules:1.3.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -274,7 +274,6 @@ dependencies {
 
     // test
     testImplementation("junit:junit:4.13")
-    testImplementation("com.google.truth:truth:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
     androidTestImplementation("androidx.test:runner:1.3.0")
     androidTestImplementation("androidx.test:rules:1.3.0")
@@ -285,6 +284,7 @@ dependencies {
     androidTestImplementation(
         "com.apollographql.apollo:apollo-idling-resource:${Dependencies.Versions.apollo}"
     )
+    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.22")
     androidTestImplementation("com.willowtreeapps.assertk:assertk-jvm:0.22")
     androidTestImplementation("org.koin:koin-test:$koin_version")
     androidTestImplementation("org.awaitility:awaitility:4.0.2")

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/computedvalues/ComputedValuesTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/computedvalues/ComputedValuesTest.kt
@@ -1,6 +1,8 @@
 package com.hedvig.app.feature.embark.computedvalues
 
+import com.agoda.kakao.screen.Screen
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
+import com.hedvig.app.feature.embark.screens.EmbarkScreen
 import com.hedvig.app.feature.embark.screens.NumberActionScreen
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_COMPUTED_VALUE
@@ -29,8 +31,8 @@ class ComputedValuesTest : TestCase() {
     fun shouldCorrectlyDisplayComputedValues() = run {
         activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name))
 
-        NumberActionScreen {
-            step("Enter value in first passage and submit") {
+        step("Enter value in first passage and submit") {
+            NumberActionScreen {
                 input {
                     edit {
                         typeText("1334")
@@ -38,11 +40,13 @@ class ComputedValuesTest : TestCase() {
                 }
                 submit { click() }
             }
+        }
 
-            step("Verify that computed value has been correctly parsed") {
-                input {
-                    edit {
-                        hasText("1337")
+        step("Verify that computed value has been correctly parsed") {
+            Screen.onScreen<EmbarkScreen> {
+                messages {
+                    firstChild<EmbarkScreen.MessageRow> {
+                        text { hasText("Computed value is previous input + 3 = 1337") }
                     }
                 }
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/computedvalues/ComputedValuesTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/computedvalues/ComputedValuesTest.kt
@@ -1,0 +1,51 @@
+package com.hedvig.app.feature.embark.computedvalues
+
+import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
+import com.hedvig.app.feature.embark.screens.NumberActionScreen
+import com.hedvig.app.feature.embark.ui.EmbarkActivity
+import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_COMPUTED_VALUE
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Rule
+import org.junit.Test
+
+class ComputedValuesTest : TestCase() {
+    @get:Rule
+    val activityRule = LazyActivityScenarioRule(EmbarkActivity::class.java)
+
+    @get:Rule
+    val apolloMockServerRule = ApolloMockServerRule(
+        EmbarkStoryQuery.QUERY_DOCUMENT to apolloResponse { success(STORY_WITH_COMPUTED_VALUE) }
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldCorrectlyDisplayComputedValues() = run {
+        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name))
+
+        NumberActionScreen {
+            step("Enter value in first passage and submit") {
+                input {
+                    edit {
+                        typeText("1334")
+                    }
+                }
+                submit { click() }
+            }
+
+            step("Verify that computed value has been correctly parsed") {
+                input {
+                    edit {
+                        hasText("1337")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/EmbarkScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/EmbarkScreen.kt
@@ -13,7 +13,7 @@ import com.agoda.kakao.text.KTextView
 import com.hedvig.app.R
 import org.hamcrest.Matcher
 
-class EmbarkScreen : Screen<EmbarkScreen>() {
+object EmbarkScreen : Screen<EmbarkScreen>() {
     val spinner = KView { withId(R.id.loadingSpinner) }
     val messages = KRecyclerView({ withId(R.id.messages) }, { itemType(::MessageRow) })
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/EmbarkScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/EmbarkScreen.kt
@@ -13,7 +13,7 @@ import com.agoda.kakao.text.KTextView
 import com.hedvig.app.R
 import org.hamcrest.Matcher
 
-object EmbarkScreen : Screen<EmbarkScreen>() {
+class EmbarkScreen : Screen<EmbarkScreen>() {
     val spinner = KView { withId(R.id.loadingSpinner) }
     val messages = KRecyclerView({ withId(R.id.messages) }, { itemType(::MessageRow) })
 

--- a/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkMockActivity.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.testdata.feature.embark.data.PREVIOUS_INSURER_STORY
 import com.hedvig.app.testdata.feature.embark.data.PROGRESSABLE_STORY
 import com.hedvig.app.testdata.feature.embark.data.STANDARD_STORY
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_BINARY_REDIRECT
+import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_COMPUTED_VALUE
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_EQUALS_EXPRESSION
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_FOUR_TOOLTIP
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_GRAPHQL_QUERY_API
@@ -53,6 +54,11 @@ class EmbarkMockActivity : MockActivity() {
     })
 
     override fun adapter() = genericDevelopmentAdapter {
+        header("Computed Value")
+        clickableItem("Computed Value") {
+            MockEmbarkViewModel.mockedData = STORY_WITH_COMPUTED_VALUE
+            startActivity(EmbarkActivity.newInstance(context, this.javaClass.name))
+        }
         header("Previous Insurer")
         clickableItem("Previous Insurer") {
             MockEmbarkViewModel.mockedData = PREVIOUS_INSURER_STORY

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkStoryExt.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkStoryExt.kt
@@ -1,0 +1,7 @@
+package com.hedvig.app.feature.embark
+
+import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
+
+fun EmbarkStoryQuery.EmbarkStory.getComputedValues() = computedStoreValues
+    ?.associateBy({ it.key }, { it.value })
+    ?: emptyMap()

--- a/app/src/main/java/com/hedvig/app/feature/embark/ValueStore.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ValueStore.kt
@@ -1,0 +1,24 @@
+package com.hedvig.app.feature.embark
+
+import com.hedvig.app.feature.embark.computedvalues.TemplateExpressionCalculator
+
+class ValueStore(
+    private val computedValues: Map<String, String>
+) {
+
+    private val storedValues = HashMap<String, String>()
+
+    fun put(key: String, value: String) {
+        storedValues[key] = value
+    }
+
+    fun get(key: String): String? {
+        return computedValues[key]?.let {
+            TemplateExpressionCalculator.evaluateTemplateExpression(it, storedValues)
+        } ?: storedValues[key]
+    }
+
+    fun toMap(): Map<String, String> {
+        return storedValues.toMap()
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/embark/computedvalues/TemplateExpressionCalculator.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/computedvalues/TemplateExpressionCalculator.kt
@@ -1,0 +1,188 @@
+package com.hedvig.app.feature.embark.computedvalues
+
+class TemplateExpressionCalculator {
+
+    private val tokenCheckers: List<Pair<TokenType, Regex>> = listOf(
+        TokenType.BINARY_OPERATOR to BIN_OPERATOR_EXPR,
+        TokenType.STORE_KEY to STORE_KEY_EXPR,
+        TokenType.NUMBER_CONSTANT to NUMBER_CONSTANT_EXPR,
+        TokenType.STRING_CONSTANT to DOUBLE_QUOTE_STRING_CONSTANT_EXPR,
+        TokenType.STRING_CONSTANT to SINGLE_QUOTE_STRING_CONSTANT_EXPR,
+    )
+
+    fun evaluateTemplateExpression(expression: String, store: HashMap<String, String>): String = try {
+        val tokenStream = parseTokenStream(expression)
+        val abstractExpression = parseAbstractExpression(tokenStream)
+        evaluateAbstractExpression(abstractExpression, store)
+    } catch (e: Exception) {
+        e.message.toString()
+    }
+
+    private fun parseTokenStream(expression: String): List<Token> {
+        var cursor = 0
+        val tokenStream = mutableListOf<Token>()
+
+        while (cursor < expression.length) {
+            val subExpr = expression.substring(cursor, expression.length)
+            if (VOID_EXPR.containsMatchIn(subExpr)) {
+                cursor += VOID_EXPR.find(subExpr)?.groups?.get(0)?.value?.length ?: subExpr.length
+                continue
+            }
+
+            val matchingTokenChecker = tokenCheckers.find {
+                val regex = it.second
+                regex.containsMatchIn(subExpr)
+            } ?: throw NoValidTokenCheckerException("Invalid expression from $subExpr")
+
+            val matchResult = matchingTokenChecker.second.find(subExpr)
+
+            tokenStream.add(Token(
+                matchingTokenChecker.first,
+                payload = matchResult?.value ?: ""
+            ))
+
+            cursor += matchResult?.groups?.get(0)?.value?.length ?: subExpr.length
+        }
+
+        return tokenStream
+    }
+
+    private fun parseAbstractExpression(tokenStream: List<Token>): Expression {
+        var tokenStreamCursor = 0
+        var abstractExpression: Expression? = null
+
+        while (tokenStreamCursor < tokenStream.size) {
+            val token = tokenStream[tokenStreamCursor]
+
+            when (token.type) {
+                TokenType.BINARY_OPERATOR -> {
+                    if (abstractExpression == null) {
+                        throw UnexpectedTokenOperator("Unexpected token operator ${token.payload}")
+                    }
+
+                    abstractExpression = Expression.BinaryOperatorExpression(
+                        operatorField = token.payload,
+                        left = abstractExpression,
+                        right = null
+                    )
+                }
+                TokenType.STORE_KEY -> {
+                    val storeKeyExpression = Expression.StoreKeyExpression(key = token.payload)
+
+                    abstractExpression = if (abstractExpression != null) {
+                        if (abstractExpression is Expression.BinaryOperatorExpression) {
+                            abstractExpression.copy(right = storeKeyExpression)
+                        } else {
+                            throw UnexpectedTokenOperator("Unexpected token ${token.payload}")
+                        }
+                    } else {
+                        storeKeyExpression
+                    }
+                }
+                TokenType.NUMBER_CONSTANT -> {
+                    val numberExpression = Expression.NumberConstantExpression(token.payload.toFloat())
+
+                    abstractExpression = if (abstractExpression != null) {
+                        if (abstractExpression is Expression.BinaryOperatorExpression) {
+                            abstractExpression.copy(right = numberExpression)
+                        } else {
+                            throw UnexpectedTokenOperator("Unexpected number constant \"${token.payload}\"")
+                        }
+                    } else {
+                        numberExpression
+                    }
+                }
+                TokenType.STRING_CONSTANT -> {
+                    val stringConstantExpression = Expression.StringConstantExpression(constant = token.payload)
+
+                    abstractExpression = if (abstractExpression != null) {
+                        if (abstractExpression is Expression.BinaryOperatorExpression) {
+                            abstractExpression.copy(right = stringConstantExpression)
+                        } else {
+                            throw UnexpectedTokenOperator("Unexpected string constant ${token.payload}")
+                        }
+                    } else {
+                        stringConstantExpression
+                    }
+                }
+            }
+
+            tokenStreamCursor += 1
+        }
+
+        return abstractExpression
+            ?: throw NoExpressionMatch("Could not create an abstract expression from $tokenStream")
+    }
+
+    private fun evaluateAbstractExpression(expression: Expression, store: HashMap<String, String>): String = when (expression) {
+        is Expression.StoreKeyExpression -> store[expression.key] ?: ""
+        is Expression.NumberConstantExpression -> expression.constant.toBigDecimal().stripTrailingZeros().toString()
+        is Expression.StringConstantExpression -> expression.constant
+        is Expression.BinaryOperatorExpression -> {
+            if (expression.left == null || expression.right == null) {
+                throw InvalidOperator("Invalid use of operator \"${expression.operatorField}\", must have expressions on both sides")
+            } else {
+                val left: Expression = expression.left
+                val right: Expression = expression.right
+                when (expression.operatorField) {
+                    "+" -> (evaluateAbstractExpression(left, store).toFloat() + evaluateAbstractExpression(right, store).toFloat())
+                        .toBigDecimal()
+                        .stripTrailingZeros()
+                        .toString()
+                    "-" -> (evaluateAbstractExpression(left, store).toFloat() - evaluateAbstractExpression(right, store).toFloat())
+                        .toBigDecimal()
+                        .stripTrailingZeros()
+                        .toString()
+                    "++" -> (evaluateAbstractExpression(left, store) + evaluateAbstractExpression(right, store))
+                        .replace("\"", "")
+                        .replace("\'", "")
+                    else -> throw InvalidOperator(expression.operatorField)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val VOID_EXPR = Regex("^\\s+")
+        private val BIN_OPERATOR_EXPR = Regex("^(-|\\+\\+|\\+)")
+        private val STORE_KEY_EXPR = Regex("^([a-zA-Z][\\w\\d]*)")
+        private val NUMBER_CONSTANT_EXPR = Regex("^(\\d+(\\.\\d+)?)")
+        private val DOUBLE_QUOTE_STRING_CONSTANT_EXPR = Regex("^\"([^\"]*)\"")
+        private val SINGLE_QUOTE_STRING_CONSTANT_EXPR = Regex("^'([^']*)'")
+    }
+
+    enum class TokenType {
+        BINARY_OPERATOR, STORE_KEY, STRING_CONSTANT, NUMBER_CONSTANT
+    }
+
+    data class Token(
+        val type: TokenType,
+        val payload: String
+    )
+
+    sealed class Expression {
+
+        data class BinaryOperatorExpression(
+            val left: Expression?,
+            val right: Expression?,
+            val operatorField: String
+        ) : Expression()
+
+        data class StringConstantExpression(
+            val constant: String
+        ) : Expression()
+
+        data class NumberConstantExpression(
+            val constant: Float
+        ) : Expression()
+
+        data class StoreKeyExpression(
+            val key: String
+        ) : Expression()
+    }
+
+    class NoValidTokenCheckerException(override val message: String) : Exception(message)
+    class UnexpectedTokenOperator(override val message: String) : Exception(message)
+    class InvalidOperator(override val message: String) : Exception(message)
+    class NoExpressionMatch(override val message: String) : Exception(message)
+}

--- a/app/src/main/java/com/hedvig/app/feature/embark/computedvalues/TemplateExpressionCalculator.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/computedvalues/TemplateExpressionCalculator.kt
@@ -1,6 +1,13 @@
 package com.hedvig.app.feature.embark.computedvalues
 
-class TemplateExpressionCalculator {
+object TemplateExpressionCalculator {
+
+    private val VOID_EXPR = Regex("^\\s+")
+    private val BIN_OPERATOR_EXPR = Regex("^(-|\\+\\+|\\+)")
+    private val STORE_KEY_EXPR = Regex("^([a-zA-Z][\\w\\d]*)")
+    private val NUMBER_CONSTANT_EXPR = Regex("^(\\d+(\\.\\d+)?)")
+    private val DOUBLE_QUOTE_STRING_CONSTANT_EXPR = Regex("^\"([^\"]*)\"")
+    private val SINGLE_QUOTE_STRING_CONSTANT_EXPR = Regex("^'([^']*)'")
 
     private val tokenCheckers: List<Pair<TokenType, Regex>> = listOf(
         TokenType.BINARY_OPERATOR to BIN_OPERATOR_EXPR,
@@ -140,15 +147,6 @@ class TemplateExpressionCalculator {
                 }
             }
         }
-    }
-
-    companion object {
-        private val VOID_EXPR = Regex("^\\s+")
-        private val BIN_OPERATOR_EXPR = Regex("^(-|\\+\\+|\\+)")
-        private val STORE_KEY_EXPR = Regex("^([a-zA-Z][\\w\\d]*)")
-        private val NUMBER_CONSTANT_EXPR = Regex("^(\\d+(\\.\\d+)?)")
-        private val DOUBLE_QUOTE_STRING_CONSTANT_EXPR = Regex("^\"([^\"]*)\"")
-        private val SINGLE_QUOTE_STRING_CONSTANT_EXPR = Regex("^'([^']*)'")
     }
 
     enum class TokenType {

--- a/app/src/test/java/com/hedvig/app/ComputedValuesTest.kt
+++ b/app/src/test/java/com/hedvig/app/ComputedValuesTest.kt
@@ -1,6 +1,7 @@
 package com.hedvig.app
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.hedvig.app.feature.embark.computedvalues.TemplateExpressionCalculator
 import org.junit.Test
 
@@ -78,14 +79,20 @@ class ComputedValuesTest {
     @Test
     fun testReferenceStoreKey() {
         val expression = "myKey"
-        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "my value"))
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(
+            expression,
+            hashMapOf("myKey" to "my value")
+        )
         assertThat(result).isEqualTo("my value")
     }
 
     @Test
     fun testCalculateWithStoreReference() {
         val expression = "myKey + 1"
-        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "41"))
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(
+            expression,
+            hashMapOf("myKey" to "41")
+        )
         assertThat(result).isEqualTo("42")
     }
 

--- a/app/src/test/java/com/hedvig/app/ComputedValuesTest.kt
+++ b/app/src/test/java/com/hedvig/app/ComputedValuesTest.kt
@@ -1,0 +1,114 @@
+package com.hedvig.app
+
+import com.google.common.truth.Truth.assertThat
+import com.hedvig.app.feature.embark.computedvalues.TemplateExpressionCalculator
+import org.junit.Test
+
+class ComputedValuesTest {
+
+    private val templateExpressionCalculator = TemplateExpressionCalculator()
+    private val emptyStore = hashMapOf<String, String>()
+
+    @Test
+    fun testSubstitutingANumber() {
+        val expression = "2"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("2")
+    }
+
+    @Test
+    fun testCalculateTwoIntegers() {
+        val expression = "41+1"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("42")
+
+        val expressionWithSpace = "41 + 1"
+        val result2 = templateExpressionCalculator.evaluateTemplateExpression(expressionWithSpace, emptyStore)
+        assertThat(result2).isEqualTo("42")
+    }
+
+    @Test
+    fun testCalculateMultipleIntegersWithAdditionAndSubtraction() {
+        val expression = "1 +2 + 3 -1 "
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("5")
+    }
+
+    @Test
+    fun testCalculateWithFloats() {
+        val expression = "13.17 + 0.2"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("13.37")
+    }
+
+    @Test
+    fun testCalculateWithFloatAndInt() {
+        val expression = "13 + 0.37"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("13.37")
+    }
+
+    @Test
+    fun testCalculateAnEvenFloatAndIntToBeAnInt() {
+        val expression = "1337 + 1.0"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("1338")
+    }
+
+    @Test
+    fun testConcatenateDoubleQuoteStrings() {
+        val expression = "\"133\" ++ \"7\""
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("1337")
+    }
+
+    @Test
+    fun testConcatenateSingleQuoteStrings() {
+        val expression = "\'133\' ++ \'7\'"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("1337")
+    }
+
+    @Test
+    fun testConcatenateSingleAndDoubleQuoteStrings() {
+        val expression = "\"133\" ++ \'7\'"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("1337")
+    }
+
+    @Test
+    fun testReferenceStoreKey() {
+        val expression = "myKey"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "my value"))
+        assertThat(result).isEqualTo("my value")
+    }
+
+    @Test
+    fun testCalculateWithStoreReference() {
+        val expression = "myKey + 1"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "41"))
+        assertThat(result).isEqualTo("42")
+    }
+
+    @Test
+    fun testStringConcatenationWithStoreReference() {
+        val expression = "\"foo\" ++ \" \"++ myKey ++ ' '++\"baz\""
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "bar"))
+        assertThat(result).isEqualTo("foo bar baz")
+    }
+
+    @Test
+    fun failsWhenUsingMultipleOperatorsInSuccession() {
+        val expression = "\"foo\" ++ ++ \"bar\""
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("Invalid use of operator \"++\", must have expressions on both sides")
+    }
+
+    @Test
+    fun twoNumbersShouldGenerateError() {
+        val expression = "42 1337"
+        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        assertThat(result).isEqualTo("Unexpected number constant \"1337\"")
+    }
+
+}

--- a/app/src/test/java/com/hedvig/app/ComputedValuesTest.kt
+++ b/app/src/test/java/com/hedvig/app/ComputedValuesTest.kt
@@ -6,108 +6,107 @@ import org.junit.Test
 
 class ComputedValuesTest {
 
-    private val templateExpressionCalculator = TemplateExpressionCalculator()
     private val emptyStore = hashMapOf<String, String>()
 
     @Test
     fun testSubstitutingANumber() {
         val expression = "2"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("2")
     }
 
     @Test
     fun testCalculateTwoIntegers() {
         val expression = "41+1"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("42")
 
         val expressionWithSpace = "41 + 1"
-        val result2 = templateExpressionCalculator.evaluateTemplateExpression(expressionWithSpace, emptyStore)
+        val result2 = TemplateExpressionCalculator.evaluateTemplateExpression(expressionWithSpace, emptyStore)
         assertThat(result2).isEqualTo("42")
     }
 
     @Test
     fun testCalculateMultipleIntegersWithAdditionAndSubtraction() {
         val expression = "1 +2 + 3 -1 "
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("5")
     }
 
     @Test
     fun testCalculateWithFloats() {
         val expression = "13.17 + 0.2"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("13.37")
     }
 
     @Test
     fun testCalculateWithFloatAndInt() {
         val expression = "13 + 0.37"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("13.37")
     }
 
     @Test
     fun testCalculateAnEvenFloatAndIntToBeAnInt() {
         val expression = "1337 + 1.0"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("1338")
     }
 
     @Test
     fun testConcatenateDoubleQuoteStrings() {
         val expression = "\"133\" ++ \"7\""
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("1337")
     }
 
     @Test
     fun testConcatenateSingleQuoteStrings() {
         val expression = "\'133\' ++ \'7\'"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("1337")
     }
 
     @Test
     fun testConcatenateSingleAndDoubleQuoteStrings() {
         val expression = "\"133\" ++ \'7\'"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("1337")
     }
 
     @Test
     fun testReferenceStoreKey() {
         val expression = "myKey"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "my value"))
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "my value"))
         assertThat(result).isEqualTo("my value")
     }
 
     @Test
     fun testCalculateWithStoreReference() {
         val expression = "myKey + 1"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "41"))
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "41"))
         assertThat(result).isEqualTo("42")
     }
 
     @Test
     fun testStringConcatenationWithStoreReference() {
         val expression = "\"foo\" ++ \" \"++ myKey ++ ' '++\"baz\""
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "bar"))
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, hashMapOf("myKey" to "bar"))
         assertThat(result).isEqualTo("foo bar baz")
     }
 
     @Test
     fun failsWhenUsingMultipleOperatorsInSuccession() {
         val expression = "\"foo\" ++ ++ \"bar\""
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("Invalid use of operator \"++\", must have expressions on both sides")
     }
 
     @Test
     fun twoNumbersShouldGenerateError() {
         val expression = "42 1337"
-        val result = templateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
+        val result = TemplateExpressionCalculator.evaluateTemplateExpression(expression, emptyStore)
         assertThat(result).isEqualTo("Unexpected number constant \"1337\"")
     }
 

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/EmbarkStoryDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/EmbarkStoryDataBuilder.kt
@@ -4,12 +4,14 @@ import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 
 data class EmbarkStoryDataBuilder(
     private val startPassage: String = "1",
-    private val passages: List<EmbarkStoryQuery.Passage> = emptyList()
+    private val passages: List<EmbarkStoryQuery.Passage> = emptyList(),
+    private val computedStoreValues: List<EmbarkStoryQuery.ComputedStoreValue> = emptyList()
 ) {
     fun build() = EmbarkStoryQuery.Data(
         embarkStory = EmbarkStoryQuery.EmbarkStory(
             startPassage = startPassage,
-            passages = passages
+            passages = passages,
+            computedStoreValues = computedStoreValues
         )
     )
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.testdata.feature.embark.data
 import com.hedvig.android.owldroid.fragment.EmbarkLinkFragment
 import com.hedvig.android.owldroid.fragment.GraphQLErrorsFragment
 import com.hedvig.android.owldroid.fragment.GraphQLResultsFragment
+import com.hedvig.android.owldroid.fragment.MessageFragment
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.android.owldroid.type.EmbarkAPIGraphQLSingleVariableCasting
 import com.hedvig.android.owldroid.type.EmbarkAPIGraphQLVariableGeneratedType
@@ -502,19 +503,19 @@ val STORY_WITH_UNARY_EXPRESSIONS = EmbarkStoryDataBuilder(
                 messages = listOf(
                     MessageBuilder(
                         text = "Unary true test", expressions = listOf(
-                            ExpressionBuilder(
-                                type = ExpressionBuilder.ExpressionType.ALWAYS,
-                                text = "Unary true test"
-                            ).build()
-                        )
+                        ExpressionBuilder(
+                            type = ExpressionBuilder.ExpressionType.ALWAYS,
+                            text = "Unary true test"
+                        ).build()
+                    )
                     ).build(),
                     MessageBuilder(
                         text = "Unary false test", expressions = listOf(
-                            ExpressionBuilder(
-                                type = ExpressionBuilder.ExpressionType.NEVER,
-                                text = "Unary false test"
-                            ).build()
-                        )
+                        ExpressionBuilder(
+                            type = ExpressionBuilder.ExpressionType.NEVER,
+                            text = "Unary false test"
+                        ).build()
+                    )
                     ).build()
                 )
             )
@@ -1328,6 +1329,45 @@ val STORY_WITH_TRACK = EmbarkStoryDataBuilder(
                 )
             )
             .build()
+    )
+).build()
+
+val STORY_WITH_COMPUTED_VALUE = EmbarkStoryDataBuilder(
+    computedStoreValues = listOf(
+        EmbarkStoryQuery.ComputedStoreValue(key = "BAR", value = "FOO + 3")
+    ),
+    passages = listOf(
+        PassageBuilder(
+            name = "TestPassage",
+            id = "1",
+            response = MessageBuilder(
+                text = "{TestPassageResult}"
+            ).build(),
+            messages = listOf(
+                MessageFragment(
+                    text = "Text on input in next passage will have added 3 to your input",
+                    expressions = emptyList()
+                )
+            ),
+            action = NumberActionBuilder(
+                "FOO",
+                link = STANDARD_FIRST_LINK
+            ).build()
+        ).build(),
+        PassageBuilder(
+            name = "TestPassage2",
+            id = "2",
+            response = MessageBuilder(
+                text = "{TestPassageResult}"
+            ).build(),
+            messages = listOf(
+                STANDARD_FIRST_MESSAGE
+            ),
+            action = TextActionBuilder(
+                link = STANDARD_SECOND_LINK,
+                key = "BAR"
+            ).build()
+        ).build(),
     )
 ).build()
 

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
@@ -1361,7 +1361,9 @@ val STORY_WITH_COMPUTED_VALUE = EmbarkStoryDataBuilder(
                 text = "{TestPassageResult}"
             ).build(),
             messages = listOf(
-                STANDARD_FIRST_MESSAGE
+                MessageBuilder(
+                    text = "Computed value is previous input + 3 = {BAR}"
+                ).build()
             ),
             action = TextActionBuilder(
                 link = STANDARD_SECOND_LINK,


### PR DESCRIPTION
Adds support for computed store values in embark. 

Whats not included: 
Support for computed store values in responses. Please point me in the right direction on where I should implement this, `preProcessResponse` perhaps? Thanks

I also had problems verifying a `KTextInputLayout` - the test framework could not find the view for some reason. Please take a look in `ComputedValuesTest` 🙏 

<!-- Add when these when applicable. -->
### Checklist

- [x] Functionality is covered by an integration test
- [x] Functionality is accessible in engineering mode
