### PR TITLE
APP-223: LocaleManager

### DIFF
--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -115,8 +115,8 @@ import com.hedvig.app.service.FileService
 import com.hedvig.app.service.LoginStatusService
 import com.hedvig.app.service.push.managers.PaymentNotificationManager
 import com.hedvig.app.terminated.TerminatedTracker
+import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.ApolloTimberLogger
-import com.hedvig.app.util.apollo.defaultLocale
 import com.hedvig.app.util.extensions.getAuthenticationToken
 import com.hedvig.app.util.svg.GlideApp
 import com.hedvig.app.util.svg.SvgSoftwareLayerSetter
@@ -416,6 +416,6 @@ val notificationModule = module {
     single { PaymentNotificationManager(get()) }
 }
 
-val defaultLocaleModule = module {
-    single { defaultLocale(get(), get()) }
+val localeManagerModule = module {
+    single { LocaleManager(get(), get()) }
 }

--- a/app/src/main/java/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/java/com/hedvig/app/HedvigApplication.kt
@@ -70,7 +70,7 @@ open class HedvigApplication : Application() {
                     marketPickerModule,
                     onboardingModule,
                     choosePlanModule,
-                    defaultLocaleModule
+                    localeManagerModule
                 )
             )
         }

--- a/app/src/main/java/com/hedvig/app/feature/claims/data/ClaimsRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claims/data/ClaimsRepository.kt
@@ -6,16 +6,16 @@ import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.CommonClaimQuery
 import com.hedvig.android.owldroid.graphql.TriggerCallMeChatMutation
 import com.hedvig.android.owldroid.graphql.TriggerClaimChatMutation
-import com.hedvig.android.owldroid.type.Locale
 import com.hedvig.android.owldroid.type.TriggerClaimChatInput
+import com.hedvig.app.util.LocaleManager
 
 class ClaimsRepository(
     private val apolloClient: ApolloClient,
-    private val defaultLocale: Locale,
+    private val localeManager: LocaleManager,
 ) {
 
     suspend fun fetchCommonClaims() = apolloClient
-        .query(CommonClaimQuery(defaultLocale)).await()
+        .query(CommonClaimQuery(localeManager.defaultLocale())).await()
 
     suspend fun triggerClaimsChat(claimTypeId: String?) = apolloClient
         .mutate(

--- a/app/src/main/java/com/hedvig/app/feature/home/data/HomeRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/data/HomeRepository.kt
@@ -6,14 +6,13 @@ import com.apollographql.apollo.coroutines.await
 import com.apollographql.apollo.coroutines.toFlow
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers
 import com.hedvig.android.owldroid.graphql.HomeQuery
-import com.hedvig.android.owldroid.type.Locale
-import com.hedvig.app.util.apollo.toLocaleString
+import com.hedvig.app.util.LocaleManager
 
 class HomeRepository(
     private val apolloClient: ApolloClient,
-    defaultLocale: Locale
+    localeManager: LocaleManager
 ) {
-    private val homeQuery = HomeQuery(defaultLocale, defaultLocale.toLocaleString())
+    private val homeQuery = HomeQuery(localeManager.defaultLocale(), localeManager.defaultLocale().rawValue)
 
     fun home() = apolloClient
         .query(homeQuery)

--- a/app/src/main/java/com/hedvig/app/feature/insurance/data/InsuranceRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/data/InsuranceRepository.kt
@@ -3,13 +3,13 @@ package com.hedvig.app.feature.insurance.data
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
-import com.hedvig.android.owldroid.type.Locale
+import com.hedvig.app.util.LocaleManager
 
 class InsuranceRepository(
     private val apolloClient: ApolloClient,
-    private val defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
     suspend fun insurance() = apolloClient
-        .query(InsuranceQuery(defaultLocale))
+        .query(InsuranceQuery(localeManager.defaultLocale()))
         .await()
 }

--- a/app/src/main/java/com/hedvig/app/feature/keygear/data/KeyGearItemsRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/data/KeyGearItemsRepository.kt
@@ -20,12 +20,10 @@ import com.hedvig.android.owldroid.graphql.UploadFileMutation
 import com.hedvig.android.owldroid.graphql.UploadFilesMutation
 import com.hedvig.android.owldroid.type.AddReceiptToKeyGearItemInput
 import com.hedvig.android.owldroid.type.KeyGearItemCategory
-import com.hedvig.android.owldroid.type.Locale
 import com.hedvig.android.owldroid.type.MonetaryAmountV2Input
 import com.hedvig.android.owldroid.type.S3FileInput
 import com.hedvig.app.service.FileService
-import com.hedvig.app.util.apollo.defaultLocale
-import com.hedvig.app.util.apollo.toLocaleString
+import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.extensions.into
 import e
 import kotlinx.coroutines.Dispatchers
@@ -38,14 +36,16 @@ import java.util.UUID
 class KeyGearItemsRepository(
     private val apolloClient: ApolloClient,
     private val fileService: FileService,
-    private val defaultLocale: Locale,
+    localeManager: LocaleManager,
     private val context: Context
 ) {
     private lateinit var keyGearItemsQuery: KeyGearItemsQuery
     private lateinit var keyGearItemQuery: KeyGearItemQuery
 
+    private val locale = localeManager.defaultLocale().rawValue
+
     fun keyGearItems(): Flow<Response<KeyGearItemsQuery.Data>> {
-        keyGearItemsQuery = KeyGearItemsQuery(defaultLocale.toLocaleString())
+        keyGearItemsQuery = KeyGearItemsQuery(locale)
 
         return apolloClient
             .query(keyGearItemsQuery)
@@ -54,7 +54,7 @@ class KeyGearItemsRepository(
     }
 
     fun keyGearItem(id: String): Flow<Response<KeyGearItemQuery.Data>> {
-        keyGearItemQuery = KeyGearItemQuery(id, defaultLocale.toLocaleString())
+        keyGearItemQuery = KeyGearItemQuery(id, locale)
 
         return apolloClient
             .query(keyGearItemQuery)
@@ -150,7 +150,7 @@ class KeyGearItemsRepository(
         val mutation = CreateKeyGearItemMutation(
             category = category,
             photos = files,
-            languageCode = defaultLocale.toLocaleString(),
+            languageCode = locale,
             physicalReferenceHash = Input.fromNullable(physicalReferenceHash),
             name = Input.fromNullable(name)
         )
@@ -229,7 +229,7 @@ class KeyGearItemsRepository(
                         itemId = itemId,
                         file = s3file
                     ),
-                    defaultLocale.toLocaleString()
+                    locale
                 )
             )
             .await()

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInRepository.kt
@@ -3,13 +3,13 @@ package com.hedvig.app.feature.loggedin.ui
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.LoggedInQuery
-import com.hedvig.android.owldroid.type.Locale
+import com.hedvig.app.util.LocaleManager
 
 class LoggedInRepository(
     private val apolloClient: ApolloClient,
-    private val defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
     suspend fun loggedInData() = apolloClient
-        .query(LoggedInQuery(defaultLocale))
+        .query(LoggedInQuery(localeManager.defaultLocale()))
         .await()
 }

--- a/app/src/main/java/com/hedvig/app/feature/marketing/data/MarketingRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/data/MarketingRepository.kt
@@ -3,13 +3,13 @@ package com.hedvig.app.feature.marketing.data
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.MarketingBackgroundQuery
-import com.hedvig.android.owldroid.type.Locale
+import com.hedvig.app.util.LocaleManager
 
 class MarketingRepository(
     private val apolloClient: ApolloClient,
-    private val defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
     suspend fun marketingBackground() = apolloClient
-        .query(MarketingBackgroundQuery(defaultLocale.rawValue))
+        .query(MarketingBackgroundQuery(localeManager.defaultLocale().rawValue))
         .await()
 }

--- a/app/src/main/java/com/hedvig/app/feature/marketpicker/LanguageRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketpicker/LanguageRepository.kt
@@ -10,6 +10,7 @@ import com.hedvig.android.owldroid.type.Locale
 import com.hedvig.app.feature.settings.Language
 import com.hedvig.app.feature.settings.MarketManager
 import com.hedvig.app.makeLocaleString
+import com.hedvig.app.util.LocaleManager
 import e
 import i
 
@@ -17,13 +18,13 @@ class LanguageRepository(
     private val apolloClient: ApolloClient,
     private val marketManager: MarketManager,
     private val context: Context,
-    private val defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
 
     fun uploadLanguage(language: Language) {
         language.apply(context).let {
             val acceptLanguage = makeLocaleString(it, marketManager.market)
-            uploadLanguage(acceptLanguage, defaultLocale)
+            uploadLanguage(acceptLanguage, localeManager.defaultLocale())
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferRepository.kt
@@ -14,15 +14,15 @@ import com.hedvig.android.owldroid.graphql.RemoveStartDateMutation
 import com.hedvig.android.owldroid.graphql.SignOfferMutation
 import com.hedvig.android.owldroid.graphql.SignStatusQuery
 import com.hedvig.android.owldroid.graphql.SignStatusSubscription
-import com.hedvig.android.owldroid.type.Locale
+import com.hedvig.app.util.LocaleManager
 import e
 import java.time.LocalDate
 
 class OfferRepository(
     private val apolloClient: ApolloClient,
-    defaultLocale: Locale
+    localeManager: LocaleManager
 ) {
-    private val offerQuery = OfferQuery(defaultLocale)
+    private val offerQuery = OfferQuery(localeManager.defaultLocale())
 
     fun offer() = apolloClient
         .query(offerQuery)

--- a/app/src/main/java/com/hedvig/app/feature/onboarding/ChoosePlanRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/onboarding/ChoosePlanRepository.kt
@@ -1,17 +1,18 @@
 package com.hedvig.app.feature.onboarding
 
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.ChoosePlanQuery
-import com.hedvig.android.owldroid.type.Locale
-import com.hedvig.app.util.apollo.toLocaleString
+import com.hedvig.app.util.LocaleManager
 
 class ChoosePlanRepository(
     private val apolloClient: ApolloClient,
-    defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
-    private val locale = defaultLocale.toLocaleString()
-
-    suspend fun bundles() =
-        apolloClient.query(ChoosePlanQuery(locale)).await()
+    suspend fun bundles(): Response<ChoosePlanQuery.Data> {
+        val locale = localeManager.defaultLocale().rawValue
+        val choosePlanQuery = ChoosePlanQuery(locale)
+        return apolloClient.query(choosePlanQuery).await()
+    }
 }

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -8,7 +8,6 @@ import androidx.core.view.doOnLayout
 import androidx.core.view.marginBottom
 import androidx.fragment.app.Fragment
 import com.google.android.material.transition.MaterialFadeThrough
-import com.hedvig.android.owldroid.type.Locale
 import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentReferralsBinding
@@ -18,6 +17,7 @@ import com.hedvig.app.feature.referrals.service.ReferralsTracker
 import com.hedvig.app.feature.referrals.ui.tab.ReferralsAdapter.Companion.LOADING_STATE
 import com.hedvig.app.feature.settings.MarketManager
 import com.hedvig.app.ui.animator.ViewHolderReusingDefaultItemAnimator
+import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.apollo.toMonetaryAmount
 import com.hedvig.app.util.apollo.toWebLocaleTag
@@ -37,7 +37,7 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
     private val referralsViewModel: ReferralsViewModel by viewModel()
     private val tracker: ReferralsTracker by inject()
     private val marketManager: MarketManager by inject()
-    private val defaultLocale: Locale by inject()
+    private val localeManager: LocaleManager by inject()
 
     private val binding by viewBinding(FragmentReferralsBinding::bind)
 
@@ -155,7 +155,7 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
                                     "${
                                     BuildConfig.WEB_BASE_URL
                                     }/${
-                                    defaultLocale.toWebLocaleTag()
+                                    localeManager.defaultLocale().toWebLocaleTag()
                                     }/forever/${
                                     Uri.encode(
                                         code

--- a/app/src/main/java/com/hedvig/app/feature/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/settings/SettingsActivity.kt
@@ -12,7 +12,6 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.google.firebase.iid.FirebaseInstanceId
-import com.hedvig.android.owldroid.type.Locale
 import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivitySettingsBinding
@@ -20,6 +19,7 @@ import com.hedvig.app.feature.chat.viewmodel.UserViewModel
 import com.hedvig.app.feature.marketing.ui.MarketingActivity
 import com.hedvig.app.makeLocaleString
 import com.hedvig.app.service.LoginStatusService
+import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.extensions.compatDrawable
 import com.hedvig.app.util.extensions.setAuthenticationToken
 import com.hedvig.app.util.extensions.setIsLoggedIn
@@ -53,7 +53,7 @@ class SettingsActivity : BaseActivity(R.layout.activity_settings) {
         private val marketManager: MarketManager by inject()
         private val userViewModel: UserViewModel by sharedViewModel()
         private val model: SettingsViewModel by viewModel()
-        private val defaultLocale: Locale by inject()
+        private val localeManager: LocaleManager by inject()
 
         @SuppressLint("ApplySharedPref")
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -132,7 +132,7 @@ class SettingsActivity : BaseActivity(R.layout.activity_settings) {
                         Language
                             .from(v)
                             .apply(requireContext()).let { ctx ->
-                                model.save(makeLocaleString(ctx, marketManager.market), defaultLocale)
+                                model.save(makeLocaleString(ctx, marketManager.market), localeManager.defaultLocale())
                             }
                         LocalBroadcastManager
                             .getInstance(requireContext())

--- a/app/src/main/java/com/hedvig/app/feature/webonboarding/WebOnboardingActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/webonboarding/WebOnboardingActivity.kt
@@ -18,6 +18,7 @@ import com.hedvig.app.feature.settings.Market
 import com.hedvig.app.feature.settings.MarketManager
 import com.hedvig.app.feature.settings.SettingsActivity
 import com.hedvig.app.makeUserAgent
+import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.extensions.getAuthenticationToken
 import com.hedvig.app.util.extensions.setIsLoggedIn
 import com.hedvig.app.util.extensions.view.setHapticClickListener
@@ -28,7 +29,7 @@ import java.net.URLEncoder
 class WebOnboardingActivity : BaseActivity(R.layout.activity_web_onboarding) {
     private val binding by viewBinding(ActivityWebOnboardingBinding::bind)
     private val marketManager: MarketManager by inject()
-    private val defaultLocale: Locale by inject()
+    private val localeManager: LocaleManager by inject()
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -87,7 +88,7 @@ class WebOnboardingActivity : BaseActivity(R.layout.activity_web_onboarding) {
 
             val encodedToken = URLEncoder.encode(getAuthenticationToken(), UTF_8)
 
-            val localePath = when (defaultLocale) {
+            val localePath = when (localeManager.defaultLocale()) {
                 Locale.NB_NO -> "/no"
                 Locale.EN_NO -> "/no-en"
                 Locale.DA_DK -> "/dk"

--- a/app/src/main/java/com/hedvig/app/feature/welcome/WelcomeRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/welcome/WelcomeRepository.kt
@@ -3,13 +3,13 @@ package com.hedvig.app.feature.welcome
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.WelcomeQuery
-import com.hedvig.android.owldroid.type.Locale
+import com.hedvig.app.util.LocaleManager
 
 class WelcomeRepository(
     private val apolloClient: ApolloClient,
-    private val defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
     suspend fun fetchWelcomeScreens() = apolloClient
-        .query(WelcomeQuery(defaultLocale))
+        .query(WelcomeQuery(localeManager.defaultLocale()))
         .await()
 }

--- a/app/src/main/java/com/hedvig/app/feature/whatsnew/WhatsNewRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/whatsnew/WhatsNewRepository.kt
@@ -4,18 +4,18 @@ import android.content.Context
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.hedvig.android.owldroid.graphql.WhatsNewQuery
-import com.hedvig.android.owldroid.type.Locale
 import com.hedvig.app.BuildConfig
+import com.hedvig.app.util.LocaleManager
 
 class WhatsNewRepository(
     private val apolloClient: ApolloClient,
     private val context: Context,
-    private val defaultLocale: Locale
+    private val localeManager: LocaleManager
 ) {
     suspend fun whatsNew(sinceVersion: String? = null) =
         apolloClient.query(
             WhatsNewQuery(
-                locale = defaultLocale,
+                locale = localeManager.defaultLocale(),
                 sinceVersion = sinceVersion ?: latestSeenNews()
             )
         ).await()

--- a/app/src/main/java/com/hedvig/app/util/LocaleManager.kt
+++ b/app/src/main/java/com/hedvig/app/util/LocaleManager.kt
@@ -1,0 +1,26 @@
+package com.hedvig.app.util
+
+import android.content.Context
+import com.hedvig.android.owldroid.type.Locale
+import com.hedvig.app.feature.settings.Language
+import com.hedvig.app.feature.settings.MarketManager
+import com.hedvig.app.getLocale
+
+class LocaleManager(
+    private val marketManager: MarketManager,
+    private val context: Context
+) {
+    fun defaultLocale(): Locale {
+        val localeFromSettings = Language.fromSettings(context, marketManager.market).apply(context)
+        val locale = getLocale(localeFromSettings, marketManager.market)
+        return when (locale.toString()) {
+            "en_NO" -> Locale.EN_NO
+            "nb_NO" -> Locale.NB_NO
+            "sv_SE" -> Locale.SV_SE
+            "en_SE" -> Locale.EN_SE
+            "da_DK" -> Locale.DA_DK
+            "en_DK" -> Locale.EN_DK
+            else -> Locale.EN_SE
+        }
+    }
+}

--- a/app/src/main/java/com/hedvig/app/util/apollo/GraphQLUtils.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/GraphQLUtils.kt
@@ -13,17 +13,6 @@ import java.text.NumberFormat
 import java.util.Currency
 import javax.money.MonetaryAmount
 
-fun defaultLocale(context: Context, marketManager: MarketManager) =
-    when (getLocale(Language.fromSettings(context, marketManager.market).apply(context), marketManager.market).toString()) {
-        "en_NO" -> Locale.EN_NO
-        "nb_NO" -> Locale.NB_NO
-        "sv_SE" -> Locale.SV_SE
-        "en_SE" -> Locale.EN_SE
-        "da_DK" -> Locale.DA_DK
-        "en_DK" -> Locale.EN_DK
-        else -> Locale.EN_SE
-    }
-
 fun Locale.toLocaleString() = when (this) {
     Locale.EN_SE -> "en_SE"
     Locale.SV_SE -> "sv_SE"


### PR DESCRIPTION
Use a LocaleManager in order to fetch a locale instead of creating the locale when initialising the dependency graph. When initialising the locale in the dependency graph, changes will not be reflected when setting a new locale. Use `defaultLocale()` in LocaleManager to get the most recent locale and avoid stale data.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
