### PR TITLE
APP-10: Moving flow intro

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/selfChangeEligibility.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/selfChangeEligibility.graphql
@@ -1,0 +1,5 @@
+query SelfChangeEligibility {
+  selfChangeEligibility {
+    blockers
+  }
+}

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/upcomingAgreement.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/upcomingAgreement.graphql
@@ -1,0 +1,65 @@
+query UpcomingAgreement {
+  contracts {
+    status {
+      ... on ActiveStatus {
+        upcomingAgreementChange {
+          ... UpcomingAgreementFragment
+        }
+      }
+      ... on TerminatedInFutureStatus {
+        upcomingAgreementChange {
+          ... UpcomingAgreementFragment
+        }
+      }
+      ... on TerminatedTodayStatus {
+        upcomingAgreementChange {
+          ... UpcomingAgreementFragment
+        }
+      }
+    }
+  }
+}
+
+fragment UpcomingAgreementFragment on UpcomingAgreementChange {
+  newAgreement {
+    ... on SwedishApartmentAgreement {
+      address {
+        street
+        postalCode
+        city
+      }
+      squareMeters
+      activeFrom
+      type
+    }
+    ... on SwedishHouseAgreement {
+      address {
+        street
+        postalCode
+        city
+      }
+      squareMeters
+      activeFrom
+    }
+    ... on NorwegianHomeContentAgreement {
+      address {
+        street
+        postalCode
+        city
+      }
+      squareMeters
+      activeFrom
+      type
+    }
+    ... on DanishHomeContentAgreement {
+      address {
+        street
+        postalCode
+        city
+      }
+      squareMeters
+      activeFrom
+      type
+    }
+  }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressNotEligibleTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressNotEligibleTest.kt
@@ -1,0 +1,51 @@
+package com.hedvig.app.feature.changeaddress
+
+import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.testdata.feature.changeaddress.BLOCKED_SELF_CHANGE_ELIGIBILITY
+import com.hedvig.app.testdata.feature.changeaddress.UPCOMING_AGREEMENT_NONE
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Rule
+import org.junit.Test
+
+class ChangeAddressNotEligibleTest: TestCase() {
+
+    @get:Rule
+    val activityRule = LazyActivityScenarioRule(LoggedInActivity::class.java)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        UpcomingAgreementQuery.QUERY_DOCUMENT to apolloResponse { success(UPCOMING_AGREEMENT_NONE) },
+        SelfChangeEligibilityQuery.QUERY_DOCUMENT to apolloResponse { success(BLOCKED_SELF_CHANGE_ELIGIBILITY) }
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldShowManualChangeAddressWhenEligibilityIsBlocked() {
+        activityRule.launch(ChangeAddressActivity.newInstance(context()))
+
+        ChangeAddressScreen {
+            title {
+                hasText(R.string.moving_intro_title)
+            }
+
+            subtitle {
+                hasText(R.string.moving_intro_manual_handling_description)
+            }
+
+            continueButton {
+                hasText(R.string.moving_intro_manual_handling_button_text)
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressScreen.kt
@@ -1,0 +1,18 @@
+package com.hedvig.app.feature.changeaddress
+
+import com.agoda.kakao.screen.Screen
+import com.agoda.kakao.text.KButton
+import com.agoda.kakao.text.KTextView
+import com.hedvig.app.R
+
+object ChangeAddressScreen : Screen<ChangeAddressScreen>() {
+    val title = KTextView { withId(R.id.title) }
+    val subtitle = KTextView { withId(R.id.subtitle) }
+    val continueButton = KButton { withId(R.id.continueButton) }
+
+    val address = KTextView { withId(R.id.address_label) }
+    val postalCode = KTextView { withId(R.id.postal_code_label) }
+    val type = KTextView { withId(R.id.type_label) }
+    val livingSpace = KTextView { withId(R.id.living_space_label) }
+    val date = KTextView { withId(R.id.date_label) }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressScreen.kt
@@ -1,11 +1,15 @@
 package com.hedvig.app.feature.changeaddress
 
-import com.agoda.kakao.screen.Screen
 import com.agoda.kakao.text.KButton
 import com.agoda.kakao.text.KTextView
 import com.hedvig.app.R
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
+import com.kaspersky.kaspresso.screens.KScreen
 
-object ChangeAddressScreen : Screen<ChangeAddressScreen>() {
+object ChangeAddressScreen : KScreen<ChangeAddressScreen>() {
+    override val layoutId = R.layout.change_address_activity
+    override val viewClass = ChangeAddressActivity::class.java
+
     val title = KTextView { withId(R.id.title) }
     val subtitle = KTextView { withId(R.id.subtitle) }
     val continueButton = KButton { withId(R.id.continueButton) }

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressTest.kt
@@ -1,0 +1,51 @@
+package com.hedvig.app.feature.changeaddress
+
+import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.testdata.feature.changeaddress.SELF_CHANGE_ELIGIBILITY
+import com.hedvig.app.testdata.feature.changeaddress.UPCOMING_AGREEMENT_NONE
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Rule
+import org.junit.Test
+
+class ChangeAddressTest: TestCase() {
+
+    @get:Rule
+    val activityRule = LazyActivityScenarioRule(LoggedInActivity::class.java)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        UpcomingAgreementQuery.QUERY_DOCUMENT to apolloResponse { success(UPCOMING_AGREEMENT_NONE) },
+        SelfChangeEligibilityQuery.QUERY_DOCUMENT to apolloResponse { success(SELF_CHANGE_ELIGIBILITY) }
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldShowChangeAddressWhenNoUpcomingAgreementAndSelfChangePossible() {
+        activityRule.launch(ChangeAddressActivity.newInstance(context()))
+
+        ChangeAddressScreen {
+            title {
+                hasText(R.string.moving_intro_title)
+            }
+
+            subtitle {
+                hasText(R.string.moving_intro_description)
+            }
+
+            continueButton {
+                hasText(R.string.moving_intro_open_flow_button_text)
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/UpcomingChangeAddressTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/UpcomingChangeAddressTest.kt
@@ -1,0 +1,71 @@
+package com.hedvig.app.feature.changeaddress
+
+import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+import com.hedvig.app.R
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.testdata.feature.changeaddress.SELF_CHANGE_ELIGIBILITY
+import com.hedvig.app.testdata.feature.changeaddress.UPCOMING_AGREEMENT_SWEDISH_HOUSE
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.context
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Rule
+import org.junit.Test
+
+class UpcomingChangeAddressTest: TestCase() {
+
+    @get:Rule
+    val activityRule = LazyActivityScenarioRule(LoggedInActivity::class.java)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        UpcomingAgreementQuery.QUERY_DOCUMENT to apolloResponse { success(UPCOMING_AGREEMENT_SWEDISH_HOUSE) },
+        SelfChangeEligibilityQuery.QUERY_DOCUMENT to apolloResponse { success(SELF_CHANGE_ELIGIBILITY) }
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun shouldShowManualChangeAddressWhenEligibilityIsBlocked() {
+        activityRule.launch(ChangeAddressActivity.newInstance(context()))
+
+        ChangeAddressScreen {
+            title {
+                hasText(R.string.moving_intro_existing_move_title)
+            }
+
+            subtitle {
+                hasText(R.string.moving_intro_existing_move_description)
+            }
+
+            continueButton {
+                hasText(R.string.moving_intro_manual_handling_button_text)
+            }
+
+            address {
+                hasText("Test Street 123")
+            }
+
+            postalCode {
+                hasText("123 TEST")
+            }
+
+            livingSpace {
+                hasText("50 sqm")
+            }
+
+            type {
+                hasText("Rental")
+            }
+
+            date {
+                hasText("2021-04-11")
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/DanishHomeContentsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/DanishHomeContentsTest.kt
@@ -5,11 +5,11 @@ import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.android.owldroid.type.DanishHomeContentLineOfBusiness
 import com.hedvig.app.R
 import com.hedvig.app.feature.insurance.ui.detail.ContractDetailActivity
-import com.hedvig.app.feature.insurance.ui.detail.yourinfo.YourInfoFragment.Companion.displayName
 import com.hedvig.app.testdata.dashboard.INSURANCE_DATA_DANISH_HOME_CONTENTS
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apollo.stringRes
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
@@ -61,9 +61,7 @@ class DanishHomeContentsTest : TestCase() {
                             label { hasText(R.string.CONTRACT_DETAIL_HOME_TYPE) }
                             content {
                                 hasText(
-                                    DanishHomeContentLineOfBusiness.RENT.displayName(
-                                        context()
-                                    )
+                                    DanishHomeContentLineOfBusiness.RENT.stringRes()?.let(context()::getString) ?: ""
                                 )
                             }
                         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/NorwegianHomeContentsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/NorwegianHomeContentsTest.kt
@@ -5,11 +5,11 @@ import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.android.owldroid.type.NorwegianHomeContentLineOfBusiness
 import com.hedvig.app.R
 import com.hedvig.app.feature.insurance.ui.detail.ContractDetailActivity
-import com.hedvig.app.feature.insurance.ui.detail.yourinfo.YourInfoFragment.Companion.displayName
 import com.hedvig.app.testdata.feature.insurance.INSURANCE_DATA_NORWEGIAN_HOME_CONTENTS
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apollo.stringRes
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
@@ -61,9 +61,7 @@ class NorwegianHomeContentsTest : TestCase() {
                             label { hasText(R.string.CONTRACT_DETAIL_HOME_TYPE) }
                             content {
                                 hasText(
-                                    NorwegianHomeContentLineOfBusiness.RENT.displayName(
-                                        context()
-                                    )
+                                    NorwegianHomeContentLineOfBusiness.RENT.stringRes()?.let(context()::getString) ?: ""
                                 )
                             }
                         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/SwedishApartmentTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/SwedishApartmentTest.kt
@@ -5,11 +5,11 @@ import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.android.owldroid.type.SwedishApartmentLineOfBusiness
 import com.hedvig.app.R
 import com.hedvig.app.feature.insurance.ui.detail.ContractDetailActivity
-import com.hedvig.app.feature.insurance.ui.detail.yourinfo.YourInfoFragment.Companion.displayName
 import com.hedvig.app.testdata.feature.insurance.INSURANCE_DATA_SWEDISH_APARTMENT
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
+import com.hedvig.app.util.apollo.stringRes
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
@@ -57,9 +57,7 @@ class SwedishApartmentTest : TestCase() {
                             label { hasText(R.string.CONTRACT_DETAIL_HOME_TYPE) }
                             content {
                                 hasText(
-                                    SwedishApartmentLineOfBusiness.RENT.displayName(
-                                        context()
-                                    )
+                                    SwedishApartmentLineOfBusiness.RENT.stringRes()?.let(context()::getString) ?: ""
                                 )
                             }
                         }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -88,6 +88,11 @@
 
         <activity android:name=".feature.payment.PaymentMockActivity" />
 
+        <activity
+            android:name=".feature.changeaddress.ChangeAddressMockActivity"
+            android:label="Change Address Mock Screen"
+            android:theme="@style/Hedvig.Theme" />
+
     </application>
 
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -88,10 +88,7 @@
 
         <activity android:name=".feature.payment.PaymentMockActivity" />
 
-        <activity
-            android:name=".feature.changeaddress.ChangeAddressMockActivity"
-            android:label="Change Address Mock Screen"
-            android:theme="@style/Hedvig.Theme" />
+        <activity android:name=".feature.changeaddress.ChangeAddressMockActivity"  />
 
     </application>
 

--- a/app/src/engineering/java/com/hedvig/app/DevelopmentActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/DevelopmentActivity.kt
@@ -5,10 +5,10 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.hedvig.app.databinding.ActivityDevelopmentBinding
 import com.hedvig.app.feature.adyen.AdyenMockActivity
+import com.hedvig.app.feature.changeaddress.ChangeAddressMockActivity
 import com.hedvig.app.feature.chat.ChatMockActivity
 import com.hedvig.app.feature.embark.EmbarkMockActivity
 import com.hedvig.app.feature.home.HomeMockActivity
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
 import com.hedvig.app.feature.insurance.InsuranceMockActivity
 import com.hedvig.app.feature.loggedin.LoggedInMockActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
@@ -33,12 +33,10 @@ class DevelopmentActivity : AppCompatActivity(R.layout.activity_development) {
                 listOf(
                     DevelopmentScreenAdapter.DevelopmentScreenItem.Header,
                     DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Change address intro") {
-                        startActivity(Intent(this, ChangeAddressActivity::class.java))
+                        startActivity(Intent(this, ChangeAddressMockActivity::class.java))
                     },
                     DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Logged in without welcome-screen") {
-                        startActivity(
-                            LoggedInActivity.newInstance(this)
-                        )
+                        startActivity(LoggedInActivity.newInstance(this))
                     },
                     DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Embark") {
                         startActivity(Intent(this, EmbarkMockActivity::class.java))

--- a/app/src/engineering/java/com/hedvig/app/feature/changeaddress/ChangeAddressMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/changeaddress/ChangeAddressMockActivity.kt
@@ -1,0 +1,64 @@
+package com.hedvig.app.feature.changeaddress
+
+import androidx.lifecycle.MutableLiveData
+import com.hedvig.app.MockActivity
+import com.hedvig.app.R
+import com.hedvig.app.changeAddressModule
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel
+import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState
+import com.hedvig.app.genericDevelopmentAdapter
+import org.koin.android.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+import java.time.LocalDate
+
+class ChangeAddressMockActivity : MockActivity() {
+    override val original = listOf(changeAddressModule)
+    override val mocks = listOf(
+        module { viewModel<ChangeAddressViewModel> { MockChangeAddressViewModel() } }
+    )
+
+    override fun adapter() = genericDevelopmentAdapter {
+        header("Change address")
+        clickableItem("Eligible") {
+            MockChangeAddressViewModel.mockedState = MutableLiveData(ViewState.SelfChangeAddress)
+            startActivity(ChangeAddressActivity.newInstance(context))
+        }
+        clickableItem("Error") {
+            MockChangeAddressViewModel.mockedState = MutableLiveData(
+                ViewState.SelfChangeError(
+                    GetSelfChangeEligibilityUseCase.SelfChangeEligibilityResult.Error(
+                        message = "Test error message, this can happen because of no internet connection, backend errors etc."
+                    )
+                )
+            )
+            startActivity(ChangeAddressActivity.newInstance(context))
+        }
+        clickableItem("Blocked (manual change, chat)") {
+            MockChangeAddressViewModel.mockedState = MutableLiveData(ViewState.ManualChangeAddress)
+            startActivity(ChangeAddressActivity.newInstance(context))
+        }
+        clickableItem("Upcoming address change") {
+            MockChangeAddressViewModel.mockedState = MutableLiveData(ViewState.ChangeAddressInProgress(
+                GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement(
+                    address = GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement.Address(
+                        "Test street 1 ",
+                        postalCode = "Test 123 Postal code",
+                        city = "City of Test"
+                    ),
+                    squareMeters = 123,
+                    activeFrom = LocalDate.of(2021, 3, 15),
+                    addressType = R.string.NORWEIGIAN_HOME_CONTENT_LOB_RENT
+                )
+            ))
+            startActivity(ChangeAddressActivity.newInstance(context))
+        }
+        clickableItem("Loading") {
+            MockChangeAddressViewModel.mockedState = MutableLiveData(ViewState.Loading)
+            startActivity(ChangeAddressActivity.newInstance(context))
+        }
+    }
+
+}

--- a/app/src/engineering/java/com/hedvig/app/feature/changeaddress/MockChangeAddressViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/changeaddress/MockChangeAddressViewModel.kt
@@ -1,0 +1,28 @@
+package com.hedvig.app.feature.changeaddress
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class MockChangeAddressViewModel : ChangeAddressViewModel() {
+
+    override val viewState: LiveData<ViewState>
+        get() = mockedState
+
+    override fun reload() {
+        viewModelScope.launch {
+            val tempValue = mockedState.value
+            mockedState.value = ViewState.Loading
+            delay(2000)
+            mockedState.value = tempValue
+        }
+    }
+
+    companion object {
+        var mockedState: MutableLiveData<ViewState> = MutableLiveData()
+    }
+}

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -42,6 +42,9 @@ import com.hedvig.app.feature.home.data.HomeRepository
 import com.hedvig.app.feature.home.service.HomeTracker
 import com.hedvig.app.feature.home.ui.HomeViewModel
 import com.hedvig.app.feature.home.ui.HomeViewModelImpl
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel
+import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase
 import com.hedvig.app.feature.insurance.data.InsuranceRepository
 import com.hedvig.app.feature.insurance.service.InsuranceTracker
 import com.hedvig.app.feature.insurance.ui.InsuranceViewModel
@@ -280,6 +283,7 @@ val viewModelModule = module {
     viewModel { ZignSecAuthViewModel(get(), get()) }
     viewModel { SettingsViewModel(get()) }
     viewModel { DatePickerViewModel() }
+    viewModel { ChangeAddressViewModel(get(), get()) }
 }
 
 val choosePlanModule = module {
@@ -453,4 +457,9 @@ val embarkTrackerModule = module { single<EmbarkTracker> { EmbarkTrackerImpl(get
 
 val localeManagerModule = module {
     single { LocaleManager(get(), get()) }
+}
+
+val useCaseModule = module {
+    single { GetUpcomingAgreementUseCase(get()) }
+    single { GetSelfChangeEligibilityUseCase(get()) }
 }

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -43,6 +43,7 @@ import com.hedvig.app.feature.home.service.HomeTracker
 import com.hedvig.app.feature.home.ui.HomeViewModel
 import com.hedvig.app.feature.home.ui.HomeViewModelImpl
 import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModelImpl
 import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase
 import com.hedvig.app.feature.insurance.data.InsuranceRepository
@@ -283,7 +284,6 @@ val viewModelModule = module {
     viewModel { ZignSecAuthViewModel(get(), get()) }
     viewModel { SettingsViewModel(get()) }
     viewModel { DatePickerViewModel() }
-    viewModel { ChangeAddressViewModel(get(), get()) }
 }
 
 val choosePlanModule = module {
@@ -375,6 +375,10 @@ val connectPaymentModule = module {
 
 val trustlyModule = module {
     viewModel<TrustlyViewModel> { TrustlyViewModelImpl(get()) }
+}
+
+val changeAddressModule = module {
+    viewModel<ChangeAddressViewModel> { ChangeAddressViewModelImpl(get(), get()) }
 }
 
 val serviceModule = module {

--- a/app/src/main/java/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/java/com/hedvig/app/HedvigApplication.kt
@@ -77,6 +77,7 @@ open class HedvigApplication : Application() {
                     clockModule,
                     embarkTrackerModule,
                     localeManagerModule,
+                    changeAddressModule,
                     useCaseModule,
                 )
             )

--- a/app/src/main/java/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/java/com/hedvig/app/HedvigApplication.kt
@@ -76,7 +76,8 @@ open class HedvigApplication : Application() {
                     choosePlanModule,
                     clockModule,
                     embarkTrackerModule,
-                    localeManagerModule
+                    localeManagerModule,
+                    useCaseModule,
                 )
             )
         }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeAdapter.kt
@@ -28,6 +28,7 @@ import com.hedvig.app.feature.claims.ui.pledge.HonestyPledgeBottomSheet
 import com.hedvig.app.feature.dismissiblepager.DismissiblePagerModel
 import com.hedvig.app.feature.home.service.HomeTracker
 import com.hedvig.app.feature.home.ui.HomeModel.HowClaimsWork
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
 import com.hedvig.app.feature.settings.MarketManager
 import com.hedvig.app.util.GenericDiffUtilItemCallback
 import com.hedvig.app.util.apollo.ThemedIconUrls
@@ -424,6 +425,7 @@ class HomeAdapter(
                 marketManager: MarketManager,
             ): Any? = with(binding) {
                 changeAddressButton.setHapticClickListener {
+                    root.context.startActivity(ChangeAddressActivity.newInstance(root.context))
                 }
             }
         }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -182,7 +182,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
                         )
                     )
                     if (FeatureFlag.MOVING_FLOW.enabled) {
-                        add(HomeModel.Header("Change address"))
+                        add(HomeModel.Header("Make changes"))
                         add(HomeModel.ChangeAddress)
                     }
                 }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -155,7 +155,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
                     add(HomeModel.StartClaimOutlined)
                     add(HomeModel.HowClaimsWork(successData.howClaimsWork))
                     if (FeatureFlag.MOVING_FLOW.enabled) {
-                        add(HomeModel.Header("Change address"))
+                        add(HomeModel.Header(getString(R.string.home_tab_editing_section_title)))
                         add(HomeModel.ChangeAddress)
                     }
                 }
@@ -182,7 +182,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
                         )
                     )
                     if (FeatureFlag.MOVING_FLOW.enabled) {
-                        add(HomeModel.Header("Make changes"))
+                        add(HomeModel.Header(getString(R.string.home_tab_editing_section_title)))
                         add(HomeModel.ChangeAddress)
                     }
                 }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.transition.TransitionManager
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
@@ -63,11 +65,15 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
     }
 
     private fun setViewState(viewState: ViewState): Any = when (viewState) {
-        Loading -> binding.spinner.loadingSpinner.show()
+        Loading -> {
+            binding.spinner.loadingSpinner.show()
+            binding.contentScrollView.remove()
+        }
         SelfChangeAddress -> setContent(
             titleText = getString(R.string.moving_intro_title),
             subtitleText = getString(R.string.moving_intro_description),
             buttonText = getString(R.string.moving_intro_open_flow_button_text),
+            buttonIcon = null,
             // TODO: Start Embark
             onContinue = { }
         )
@@ -75,12 +81,14 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
             titleText = getString(R.string.moving_intro_title),
             subtitleText = getString(R.string.moving_intro_manual_handling_description),
             buttonText = getString(R.string.moving_intro_manual_handling_button_text),
+            buttonIcon = R.drawable.ic_chat_white,
             onContinue = { openChat() }
         )
         is ChangeAddressInProgress -> setUpcomingChangeContent(
             titleText = getString(R.string.moving_intro_existing_move_title),
             subtitleText = getString(R.string.moving_intro_existing_move_description),
             buttonText = getString(R.string.moving_intro_manual_handling_button_text),
+            buttonIcon = R.drawable.ic_chat_white,
             onContinue = { openChat() },
             viewState.upcomingAgreementResult
         )
@@ -91,12 +99,14 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
                 is GeneralError -> viewState.error.message ?: "Could not continue, please try again later"
             },
             buttonText = "Try again",
+            buttonIcon = null,
             onContinue = { viewModel.reload() }
         )
         is SelfChangeError -> setContent(
             titleText = getString(R.string.error_dialog_title),
             subtitleText = viewState.error.message ?: "Could not continue, please try again later",
             buttonText = "Try again",
+            buttonIcon = null,
             onContinue = { viewModel.reload() }
         )
     }
@@ -107,9 +117,11 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         titleText: String,
         subtitleText: String,
         buttonText: String?,
+        @DrawableRes buttonIcon: Int?,
         onContinue: () -> Unit
     ) = with(binding) {
         spinner.loadingSpinner.remove()
+        contentScrollView.show()
         image.show()
         title.text = titleText
         title.show()
@@ -117,6 +129,7 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         subtitle.show()
         continueButton.text = buttonText
         continueButton.setOnClickListener { onContinue() }
+        continueButton.icon = buttonIcon?.let { ContextCompat.getDrawable(this@ChangeAddressActivity, it) }
         continueButton.isVisible = buttonText != null
     }
 
@@ -124,10 +137,12 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         titleText: String,
         subtitleText: String,
         buttonText: String?,
+        @DrawableRes buttonIcon: Int?,
         onContinue: () -> Unit,
         upcomingAgreementResult: UpcomingAgreement
     ) = with(binding) {
         spinner.loadingSpinner.remove()
+        contentScrollView.show()
         image.remove()
 
         title.text = titleText
@@ -138,6 +153,7 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         continueButton.text = buttonText
         continueButton.setOnClickListener { onContinue() }
         continueButton.isVisible = buttonText != null
+        continueButton.icon = buttonIcon?.let { ContextCompat.getDrawable(this@ChangeAddressActivity, it) }
 
         upcomingAddressLayout.upcomingAddressLayoutRoot.show()
         upcomingAddressLayout.addressLabel.text = upcomingAgreementResult.address.street

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -3,19 +3,35 @@ package com.hedvig.app.feature.home.ui.changeaddress
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.transition.TransitionManager
+import androidx.core.view.isVisible
 import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ChangeAddressActivityBinding
-import com.hedvig.app.util.extensions.view.setHapticClickListener
+import com.hedvig.app.feature.chat.ui.ChatActivity
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.ChangeAddressInProgress
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.Loading
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.ManualChangeAddress
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.SelfChangeAddress
+import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.UpcomingAgreementError
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.GeneralError
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.NoContractsError
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement
+import com.hedvig.app.util.extensions.view.remove
+import com.hedvig.app.util.extensions.view.show
 import com.hedvig.app.util.extensions.view.updateMargin
 import com.hedvig.app.util.extensions.view.updatePadding
 import com.hedvig.app.util.extensions.viewBinding
 import dev.chrisbanes.insetter.Insetter
 import dev.chrisbanes.insetter.setEdgeToEdgeSystemUiFlags
+import org.koin.android.viewmodel.ext.android.viewModel
+import java.time.format.DateTimeFormatter
 
 class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
 
     private val binding by viewBinding(ChangeAddressActivityBinding::bind)
+    private val viewModel: ChangeAddressViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,11 +50,101 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
             toolbar.setNavigationOnClickListener {
                 onBackPressed()
             }
-
-            continueButton.setHapticClickListener {
-                // TODO Start embark for moving flow
-            }
         }
+
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        viewModel.viewState.observe(this) { viewState ->
+            TransitionManager.beginDelayedTransition(binding.root)
+            setViewState(viewState)
+        }
+    }
+
+    private fun setViewState(viewState: ViewState): Any = when (viewState) {
+        Loading -> binding.spinner.loadingSpinner.show()
+        SelfChangeAddress -> setContent(
+            titleText = getString(R.string.moving_intro_title),
+            subtitleText = getString(R.string.moving_intro_description),
+            buttonText = getString(R.string.moving_intro_open_flow_button_text),
+            // TODO: Start Embark
+            onContinue = { }
+        )
+        ManualChangeAddress -> setContent(
+            titleText = getString(R.string.moving_intro_title),
+            subtitleText = getString(R.string.moving_intro_manual_handling_description),
+            buttonText = getString(R.string.moving_intro_manual_handling_button_text),
+            onContinue = { openChat() }
+        )
+        is ChangeAddressInProgress -> setUpcomingChangeContent(
+            titleText = getString(R.string.moving_intro_existing_move_title),
+            subtitleText = getString(R.string.moving_intro_existing_move_description),
+            buttonText = getString(R.string.moving_intro_manual_handling_button_text),
+            onContinue = { openChat() },
+            viewState.upcomingAgreementResult
+        )
+        is UpcomingAgreementError -> setContent(
+            titleText = getString(R.string.error_dialog_title),
+            subtitleText = when (viewState.error) {
+                NoContractsError -> "You do not have any contracts eligible for address change"
+                is GeneralError -> viewState.error.message ?: "Could not continue, please try again later"
+            },
+            buttonText = "Try again",
+            onContinue = { viewModel.reload() }
+        )
+        is ViewState.SelfChangeError -> setContent(
+            titleText = getString(R.string.error_dialog_title),
+            subtitleText = viewState.error.message ?: "Could not continue, please try again later",
+            buttonText = "Try again",
+            onContinue = { viewModel.reload() }
+        )
+    }
+
+    private fun openChat() = startActivity(ChatActivity.newInstance(this, true))
+
+    private fun setContent(
+        titleText: String,
+        subtitleText: String,
+        buttonText: String?,
+        onContinue: () -> Unit
+    ) = with(binding) {
+        spinner.loadingSpinner.remove()
+        image.show()
+        title.text = titleText
+        title.show()
+        subtitle.text = subtitleText
+        subtitle.show()
+        continueButton.text = buttonText
+        continueButton.setOnClickListener { onContinue() }
+        continueButton.isVisible = buttonText != null
+    }
+
+    private fun setUpcomingChangeContent(
+        titleText: String,
+        subtitleText: String,
+        buttonText: String?,
+        onContinue: () -> Unit,
+        upcomingAgreementResult: UpcomingAgreement
+    ) = with(binding) {
+        spinner.loadingSpinner.remove()
+        image.remove()
+
+        title.text = titleText
+        title.show()
+        subtitle.text = subtitleText
+        subtitle.show()
+
+        continueButton.text = buttonText
+        continueButton.setOnClickListener { onContinue() }
+        continueButton.isVisible = buttonText != null
+
+        upcomingAddressLayout.upcomingAddressLayoutRoot.show()
+        upcomingAddressLayout.addressLabel.text = upcomingAgreementResult.address.street
+        upcomingAddressLayout.postalCodeLabel.text = upcomingAgreementResult.address.postalCode
+        upcomingAddressLayout.typeLabel.text = upcomingAgreementResult.addressType?.let(::getString) ?: "-"
+        upcomingAddressLayout.livingSpaceLabel.text = getString(R.string.HOUSE_INFO_BIYTA_SQUAREMETERS, upcomingAgreementResult.squareMeters)
+        upcomingAddressLayout.dateLabel.text = upcomingAgreementResult.activeFrom?.format(DateTimeFormatter.ISO_DATE)
     }
 
     companion object {

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -9,15 +9,15 @@ import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ChangeAddressActivityBinding
 import com.hedvig.app.feature.chat.ui.ChatActivity
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.ChangeAddressInProgress
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.Loading
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.ManualChangeAddress
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.SelfChangeAddress
-import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressViewModel.ViewState.UpcomingAgreementError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.GeneralError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.NoContractsError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ChangeAddressInProgress
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.Loading
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ManualChangeAddress
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeAddress
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeError
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.UpcomingAgreementError
 import com.hedvig.app.util.extensions.view.remove
 import com.hedvig.app.util.extensions.view.show
 import com.hedvig.app.util.extensions.view.updateMargin
@@ -93,7 +93,7 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
             buttonText = "Try again",
             onContinue = { viewModel.reload() }
         )
-        is ViewState.SelfChangeError -> setContent(
+        is SelfChangeError -> setContent(
             titleText = getString(R.string.error_dialog_title),
             subtitleText = viewState.error.message ?: "Could not continue, please try again later",
             buttonText = "Try again",

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.transition.TransitionManager
 import androidx.annotation.DrawableRes
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
@@ -20,7 +19,9 @@ import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ManualChangeAddres
 import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeAddress
 import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeError
 import com.hedvig.app.feature.home.ui.changeaddress.ViewState.UpcomingAgreementError
+import com.hedvig.app.util.extensions.compatDrawable
 import com.hedvig.app.util.extensions.view.remove
+import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.view.show
 import com.hedvig.app.util.extensions.view.updateMargin
 import com.hedvig.app.util.extensions.view.updatePadding
@@ -128,8 +129,8 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         subtitle.text = subtitleText
         subtitle.show()
         continueButton.text = buttonText
-        continueButton.setOnClickListener { onContinue() }
-        continueButton.icon = buttonIcon?.let { ContextCompat.getDrawable(this@ChangeAddressActivity, it) }
+        continueButton.setHapticClickListener { onContinue() }
+        continueButton.icon = buttonIcon?.let { compatDrawable(it) }
         continueButton.isVisible = buttonText != null
     }
 
@@ -151,9 +152,9 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         subtitle.show()
 
         continueButton.text = buttonText
-        continueButton.setOnClickListener { onContinue() }
+        continueButton.setHapticClickListener { onContinue() }
         continueButton.isVisible = buttonText != null
-        continueButton.icon = buttonIcon?.let { ContextCompat.getDrawable(this@ChangeAddressActivity, it) }
+        continueButton.icon = buttonIcon?.let { compatDrawable(it) }
 
         upcomingAddressLayout.upcomingAddressLayoutRoot.show()
         upcomingAddressLayout.addressLabel.text = upcomingAgreementResult.address.street

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
@@ -1,0 +1,64 @@
+package com.hedvig.app.feature.home.ui.changeaddress
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase.SelfChangeEligibilityResult
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult
+import kotlinx.coroutines.launch
+
+class ChangeAddressViewModel(
+    private val getUpcomingAgreement: GetUpcomingAgreementUseCase,
+    private val getSelfChangeEligibility: GetSelfChangeEligibilityUseCase,
+) : ViewModel() {
+
+    val viewState: LiveData<ViewState>
+        get() = _viewState
+
+    private val _viewState = MutableLiveData<ViewState>()
+
+    init {
+        fetchDataAndCreateState()
+    }
+
+    private fun fetchDataAndCreateState() {
+        viewModelScope.launch {
+            _viewState.value = ViewState.Loading
+            _viewState.value = createViewState()
+        }
+    }
+
+    private suspend fun createViewState(): ViewState {
+        return getUpComingAgreementState(
+            onNoUpcomingChange = ::getSelfChangeState
+        )
+    }
+
+    private suspend fun getUpComingAgreementState(onNoUpcomingChange: suspend () -> ViewState) = when (val upcomingAgreement = getUpcomingAgreement()) {
+        is UpcomingAgreementResult.NoUpcomingAgreementChange -> onNoUpcomingChange()
+        is UpcomingAgreementResult.UpcomingAgreement -> ViewState.ChangeAddressInProgress(upcomingAgreement)
+        is UpcomingAgreementResult.Error -> ViewState.UpcomingAgreementError(upcomingAgreement)
+    }
+
+    private suspend fun getSelfChangeState() = when (val selfChangeEligibility = getSelfChangeEligibility()) {
+        SelfChangeEligibilityResult.Eligible -> ViewState.SelfChangeAddress
+        is SelfChangeEligibilityResult.Blocked -> ViewState.ManualChangeAddress
+        is SelfChangeEligibilityResult.Error -> ViewState.SelfChangeError(selfChangeEligibility)
+    }
+
+    fun reload() {
+        fetchDataAndCreateState()
+    }
+
+    sealed class ViewState {
+        object Loading : ViewState()
+        object SelfChangeAddress : ViewState()
+        object ManualChangeAddress : ViewState()
+        data class UpcomingAgreementError(val error: UpcomingAgreementResult.Error) : ViewState()
+        data class SelfChangeError(val error: SelfChangeEligibilityResult.Error) : ViewState()
+        data class ChangeAddressInProgress(
+            val upcomingAgreementResult: UpcomingAgreementResult.UpcomingAgreement
+        ) : ViewState()
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
@@ -15,6 +15,7 @@ import com.hedvig.app.feature.home.ui.changeaddress.ViewState.UpcomingAgreementE
 import kotlinx.coroutines.launch
 
 abstract class ChangeAddressViewModel: ViewModel() {
+    protected val _viewState = MutableLiveData<ViewState>()
     abstract val viewState: LiveData<ViewState>
     abstract fun reload()
 }
@@ -26,8 +27,6 @@ class ChangeAddressViewModelImpl(
 
     override val viewState: LiveData<ViewState>
         get() = _viewState
-
-    private val _viewState = MutableLiveData<ViewState>()
 
     init {
         fetchDataAndCreateState()

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetSelfChangeEligibilityUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetSelfChangeEligibilityUseCase.kt
@@ -1,0 +1,35 @@
+package com.hedvig.app.feature.home.ui.changeaddress
+
+import com.apollographql.apollo.ApolloClient
+import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
+import com.hedvig.android.owldroid.type.SelfChangeBlocker
+import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase.SelfChangeEligibilityResult.Blocked
+import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase.SelfChangeEligibilityResult.Eligible
+import com.hedvig.app.feature.home.ui.changeaddress.GetSelfChangeEligibilityUseCase.SelfChangeEligibilityResult.Error
+import com.hedvig.app.util.apollo.QueryResult
+import com.hedvig.app.util.apollo.safeQuery
+
+class GetSelfChangeEligibilityUseCase(
+    private val apolloClient: ApolloClient,
+) {
+
+    suspend operator fun invoke(): SelfChangeEligibilityResult {
+        return when (val result = apolloClient.query(SelfChangeEligibilityQuery()).safeQuery()) {
+            is QueryResult.Success -> {
+                val blockers = result.data?.selfChangeEligibility?.blockers
+                if (!blockers.isNullOrEmpty()) {
+                    Blocked(blockers)
+                } else {
+                    Eligible
+                }
+            }
+            is QueryResult.Error -> Error(result.message)
+        }
+    }
+
+    sealed class SelfChangeEligibilityResult {
+        object Eligible: SelfChangeEligibilityResult()
+        data class Blocked(val blockers: List<SelfChangeBlocker>?) : SelfChangeEligibilityResult()
+        data class Error(val message: String?) : SelfChangeEligibilityResult()
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetUpcomingAgreementUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetUpcomingAgreementUseCase.kt
@@ -1,0 +1,107 @@
+package com.hedvig.app.feature.home.ui.changeaddress
+
+import androidx.annotation.StringRes
+import com.apollographql.apollo.ApolloClient
+import com.hedvig.android.owldroid.fragment.UpcomingAgreementFragment
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.NoUpcomingAgreementChange
+import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement
+import com.hedvig.app.util.apollo.QueryResult
+import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.stringRes
+import java.time.LocalDate
+
+class GetUpcomingAgreementUseCase(
+    private val apolloClient: ApolloClient,
+) {
+
+    suspend operator fun invoke(): UpcomingAgreementResult {
+        return when (val response = apolloClient.query(UpcomingAgreementQuery()).safeQuery()) {
+            is QueryResult.Success -> {
+                val contracts = response.data?.contracts
+                if (contracts.isNullOrEmpty()) {
+                    Error.NoContractsError
+                } else {
+                    contracts
+                        .firstOrNull { it.upcomingAgreementChange() != null }
+                        ?.upcomingAgreementChange()
+                        ?.let { it.newAgreement.toUpComingAgreement() ?: Error.NoContractsError }
+                        ?: NoUpcomingAgreementChange
+                }
+            }
+            is QueryResult.Error -> Error.GeneralError(response.message)
+        }
+    }
+
+    private fun UpcomingAgreementFragment.NewAgreement.toUpComingAgreement(): UpcomingAgreement? {
+        return asSwedishApartmentAgreement?.let {
+            UpcomingAgreement(
+                address = UpcomingAgreement.Address(
+                    street = it.address.street,
+                    postalCode = it.address.postalCode,
+                    city = it.address.city
+                ),
+                squareMeters = it.squareMeters,
+                activeFrom = it.activeFrom,
+                addressType = it.type.stringRes()
+            )
+        } ?: asSwedishHouseAgreement?.let {
+            UpcomingAgreement(
+                address = UpcomingAgreement.Address(
+                    street = it.address.street,
+                    postalCode = it.address.postalCode,
+                    city = it.address.city
+                ),
+                squareMeters = it.squareMeters,
+                activeFrom = it.activeFrom,
+                addressType = null
+            )
+        } ?: asNorwegianHomeContentAgreement?.let {
+            UpcomingAgreement(
+                address = UpcomingAgreement.Address(
+                    street = it.address.street,
+                    postalCode = it.address.postalCode,
+                    city = it.address.city
+                ),
+                squareMeters = it.squareMeters,
+                activeFrom = it.activeFrom,
+                addressType = it.type?.stringRes()
+            )
+        } ?: asDanishHomeContentAgreement?.let {
+            UpcomingAgreement(
+                address = UpcomingAgreement.Address(
+                    street = it.address.street,
+                    postalCode = it.address.postalCode,
+                    city = it.address.city
+                ),
+                squareMeters = it.squareMeters,
+                activeFrom = it.activeFrom,
+                addressType = it.type?.stringRes()
+            )
+        }
+    }
+
+    sealed class UpcomingAgreementResult {
+        data class UpcomingAgreement(
+            val address: Address,
+            val squareMeters: Int,
+            val activeFrom: LocalDate?,
+            @StringRes
+            val addressType: Int?
+        ) : UpcomingAgreementResult() {
+            data class Address(
+                val street: String,
+                val postalCode: String,
+                val city: String?,
+            )
+        }
+
+        object NoUpcomingAgreementChange : UpcomingAgreementResult()
+
+        sealed class Error : UpcomingAgreementResult() {
+            object NoContractsError : Error()
+            data class GeneralError(val message: String?) : Error()
+        }
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/UpcomingAgreementQueryExt.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/UpcomingAgreementQueryExt.kt
@@ -1,0 +1,10 @@
+package com.hedvig.app.feature.home.ui.changeaddress
+
+import com.hedvig.android.owldroid.fragment.UpcomingAgreementFragment
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+
+fun UpcomingAgreementQuery.Contract.upcomingAgreementChange(): UpcomingAgreementFragment? {
+    return status.asActiveStatus?.upcomingAgreementChange?.fragments?.upcomingAgreementFragment
+        ?: status.asTerminatedInFutureStatus?.upcomingAgreementChange?.fragments?.upcomingAgreementFragment
+        ?: status.asTerminatedTodayStatus?.upcomingAgreementChange?.fragments?.upcomingAgreementFragment
+}

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoFragment.kt
@@ -1,16 +1,13 @@
 package com.hedvig.app.feature.insurance.ui.detail.yourinfo
 
-import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.hedvig.android.owldroid.fragment.AddressFragment
-import com.hedvig.android.owldroid.type.DanishHomeContentLineOfBusiness
-import com.hedvig.android.owldroid.type.NorwegianHomeContentLineOfBusiness
-import com.hedvig.android.owldroid.type.SwedishApartmentLineOfBusiness
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ContractDetailYourInfoFragmentBinding
 import com.hedvig.app.feature.insurance.ui.detail.ContractDetailViewModel
+import com.hedvig.app.util.apollo.stringRes
 import com.hedvig.app.util.extensions.view.updatePadding
 import com.hedvig.app.util.extensions.viewBinding
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
@@ -33,7 +30,7 @@ class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
                         (adapter as? YourInfoAdapter)?.submitList(
                             homeSection(
                                 it.address.fragments.addressFragment,
-                                it.saType.displayName(requireContext()),
+                                it.saType.stringRes()?.let(::getString) ?: "",
                                 it.squareMeters
                             ) + coinsuredSection(it.numberCoInsured) +
                                 changeSection()
@@ -56,7 +53,7 @@ class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
                         (adapter as? YourInfoAdapter)?.submitList(
                             homeSection(
                                 it.address.fragments.addressFragment,
-                                it.nhcType?.displayName(requireContext()) ?: "",
+                                it.nhcType?.stringRes()?.let(::getString) ?: "",
                                 it.squareMeters
                             ) + coinsuredSection(it.numberCoInsured) +
                                 changeSection()
@@ -67,7 +64,7 @@ class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
                         (adapter as? YourInfoAdapter)?.submitList(
                             homeSection(
                                 it.address.fragments.addressFragment,
-                                it.dhcType?.displayName(requireContext()) ?: "",
+                                it.dhcType?.stringRes()?.let(::getString) ?: "",
                                 it.squareMeters
                             ) + coinsuredSection(it.numberCoInsured) +
                                 changeSection()
@@ -139,43 +136,4 @@ class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
         YourInfoModel.ChangeParagraph,
         YourInfoModel.OpenChatButton
     )
-
-    companion object {
-
-        internal fun SwedishApartmentLineOfBusiness.displayName(context: Context) = when (this) {
-            SwedishApartmentLineOfBusiness.RENT -> context.getString(R.string.SWEDISH_APARTMENT_LOB_RENT)
-            SwedishApartmentLineOfBusiness.BRF -> context.getString(R.string.SWEDISH_APARTMENT_LOB_BRF)
-            SwedishApartmentLineOfBusiness.STUDENT_RENT -> context.getString(
-                R.string.SWEDISH_APARTMENT_LOB_STUDENT_RENT
-            )
-            SwedishApartmentLineOfBusiness.STUDENT_BRF -> context.getString(R.string.SWEDISH_APARTMENT_LOB_STUDENT_BRF)
-            SwedishApartmentLineOfBusiness.UNKNOWN__ -> ""
-        }
-
-        internal fun NorwegianHomeContentLineOfBusiness.displayName(context: Context) =
-            when (this) {
-                NorwegianHomeContentLineOfBusiness.RENT -> context.getString(R.string.NORWEIGIAN_HOME_CONTENT_LOB_RENT)
-                NorwegianHomeContentLineOfBusiness.OWN -> context.getString(R.string.NORWEIGIAN_HOME_CONTENT_LOB_OWN)
-                NorwegianHomeContentLineOfBusiness.YOUTH_RENT -> context.getString(
-                    R.string.NORWEIGIAN_HOME_CONTENT_LOB_STUDENT_RENT
-                )
-                NorwegianHomeContentLineOfBusiness.YOUTH_OWN -> context.getString(
-                    R.string.NORWEIGIAN_HOME_CONTENT_LOB_STUDENT_OWN
-                )
-                NorwegianHomeContentLineOfBusiness.UNKNOWN__ -> ""
-            }
-
-        internal fun DanishHomeContentLineOfBusiness.displayName(context: Context) =
-            when (this) {
-                DanishHomeContentLineOfBusiness.RENT -> context.getString(R.string.DANISH_HOME_CONTENT_LOB_RENT)
-                DanishHomeContentLineOfBusiness.OWN -> context.getString(R.string.DANISH_HOME_CONTENT_LOB_OWN)
-                DanishHomeContentLineOfBusiness.STUDENT_RENT -> context.getString(
-                    R.string.DANISH_HOME_CONTENT_LOB_STUDENT_RENT
-                )
-                DanishHomeContentLineOfBusiness.STUDENT_OWN -> context.getString(
-                    R.string.DANISH_HOME_CONTENT_LOB_STUDENT_OWN
-                )
-                DanishHomeContentLineOfBusiness.UNKNOWN__ -> ""
-            }
-    }
 }

--- a/app/src/main/java/com/hedvig/app/util/apollo/LineOfBusinessExt.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/LineOfBusinessExt.kt
@@ -1,0 +1,31 @@
+package com.hedvig.app.util.apollo
+
+import com.hedvig.android.owldroid.type.DanishHomeContentLineOfBusiness
+import com.hedvig.android.owldroid.type.NorwegianHomeContentLineOfBusiness
+import com.hedvig.android.owldroid.type.SwedishApartmentLineOfBusiness
+import com.hedvig.app.R
+
+fun SwedishApartmentLineOfBusiness.stringRes() = when (this) {
+    SwedishApartmentLineOfBusiness.RENT -> R.string.SWEDISH_APARTMENT_LOB_RENT
+    SwedishApartmentLineOfBusiness.BRF -> R.string.SWEDISH_APARTMENT_LOB_BRF
+    SwedishApartmentLineOfBusiness.STUDENT_RENT -> R.string.SWEDISH_APARTMENT_LOB_STUDENT_RENT
+    SwedishApartmentLineOfBusiness.STUDENT_BRF -> R.string.SWEDISH_APARTMENT_LOB_STUDENT_BRF
+    SwedishApartmentLineOfBusiness.UNKNOWN__ -> null
+}
+
+fun NorwegianHomeContentLineOfBusiness.stringRes() = when (this) {
+    NorwegianHomeContentLineOfBusiness.RENT -> R.string.NORWEIGIAN_HOME_CONTENT_LOB_RENT
+    NorwegianHomeContentLineOfBusiness.OWN -> R.string.NORWEIGIAN_HOME_CONTENT_LOB_OWN
+    NorwegianHomeContentLineOfBusiness.YOUTH_RENT -> R.string.NORWEIGIAN_HOME_CONTENT_LOB_STUDENT_RENT
+    NorwegianHomeContentLineOfBusiness.YOUTH_OWN -> R.string.NORWEIGIAN_HOME_CONTENT_LOB_STUDENT_OWN
+    NorwegianHomeContentLineOfBusiness.UNKNOWN__ -> null
+}
+
+fun DanishHomeContentLineOfBusiness.stringRes() = when (this) {
+    DanishHomeContentLineOfBusiness.RENT -> R.string.DANISH_HOME_CONTENT_LOB_RENT
+    DanishHomeContentLineOfBusiness.OWN -> R.string.DANISH_HOME_CONTENT_LOB_OWN
+    DanishHomeContentLineOfBusiness.STUDENT_RENT -> R.string.DANISH_HOME_CONTENT_LOB_STUDENT_RENT
+    DanishHomeContentLineOfBusiness.STUDENT_OWN -> R.string.DANISH_HOME_CONTENT_LOB_STUDENT_OWN
+    DanishHomeContentLineOfBusiness.UNKNOWN__ -> null
+}
+

--- a/app/src/main/java/com/hedvig/app/util/apollo/SafeQuery.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/SafeQuery.kt
@@ -1,0 +1,34 @@
+package com.hedvig.app.util.apollo
+
+import com.apollographql.apollo.ApolloCall
+import com.apollographql.apollo.coroutines.await
+import com.apollographql.apollo.exception.ApolloException
+
+suspend fun <T> ApolloCall<T>.safeQuery(): QueryResult<T> {
+    return try {
+        val response = await()
+        val data = response.data
+        when {
+            response.hasErrors() -> QueryResult.Error.QueryError(response.errors?.first()?.message)
+            data != null -> QueryResult.Success(data)
+            else -> QueryResult.Error.NoDataError("No data")
+        }
+    } catch (apolloException: ApolloException) {
+        QueryResult.Error.NetworkError(apolloException.localizedMessage)
+    } catch (throwable: Throwable) {
+        QueryResult.Error.GeneralError(throwable.localizedMessage)
+    }
+}
+
+sealed class QueryResult<T> {
+    data class Success<T>(val data: T): QueryResult<T>()
+    sealed class Error<T> : QueryResult<T>() {
+
+        abstract val message: String?
+
+        data class NoDataError<T>(override val message: String?) : Error<T>()
+        data class GeneralError<T>(override val message: String?) : Error<T>()
+        data class QueryError<T>(override val message: String?) : Error<T>()
+        data class NetworkError<T>(override val message: String?) : Error<T>()
+    }
+}

--- a/app/src/main/res/drawable/ic_chat_white.xml
+++ b/app/src/main/res/drawable/ic_chat_white.xml
@@ -1,3 +1,10 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="32dp" android:height="32dp" android:viewportWidth="32" android:viewportHeight="32">
-    <path android:pathData="M23.84 7.2c1.904 0 3.36 1.443 3.36 3.333v8.89a3.355 3.355 0 0 1-3.36 3.33V27.2l-4.48-4.446H8.16a3.355 3.355 0 0 1-3.36-3.332v-8.889C4.8 8.643 6.256 7.2 8.16 7.2h15.68zM8.16 11.644v1.667h15.68v-1.667H8.16zm0 4.445v1.667H21.6v-1.667H8.16z" android:fillColor="#FFF" android:fillType="evenOdd"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19.5,3.25L4.5617,3.25C3.5287,3.25 2.5528,3.6981 1.844,4.4711C1.1371,5.242 0.75,6.2746 0.75,7.3391V14.497L0.75,14.4991C0.7529,15.5621 1.1408,16.5923 1.8466,17.362C2.5544,18.1339 3.5279,18.5827 4.5592,18.5861L4.5617,18.5861H5.3134L5.3133,20.8402L5.3135,20.8524C5.318,21.1318 5.3929,21.4085 5.5349,21.6524C5.677,21.8967 5.8834,22.1025 6.1382,22.2394C6.3937,22.3767 6.6842,22.4368 6.976,22.4081C7.2675,22.3794 7.5395,22.2641 7.7632,22.0833L7.7768,22.0723L11.7017,18.5861L19.5,18.586L19.5024,18.586C20.5337,18.5827 21.5073,18.1339 22.215,17.362C22.9208,16.5923 23.3088,15.5621 23.3117,14.4991L23.3117,7.3291L23.3117,7.327C23.3087,6.2646 22.9203,5.235 22.2137,4.4668C21.5052,3.6963 20.5309,3.25 19.5,3.25ZM17,13.75H4V12.25H17V13.75ZM4,9.5H20V8H4V9.5Z"
+      android:fillColor="#FAFAFA"
+      android:fillType="evenOdd"/>
 </vector>

--- a/app/src/main/res/layout/change_address_activity.xml
+++ b/app/src/main/res/layout/change_address_activity.xml
@@ -1,62 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_close" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toStartOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:navigationIcon="@drawable/ic_close" />
+            android:paddingBottom="150dp">
 
-    <ImageView
-            android:id="@+id/image"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginBottom="200dp"
-            android:src="@drawable/ic_notifications" />
+            <ImageView
+                android:id="@+id/image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="150dp"
+                android:src="@drawable/ic_notifications"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription"
+                tools:visibility="visible" />
 
-    <TextView
-            android:id="@+id/title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Are you moving? We'll join"
-            android:layout_marginTop="@dimen/base_margin_quintuple"
-            android:textAppearance="?textAppearanceHeadline5"
-            app:layout_constraintTop_toBottomOf="@id/image"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/base_margin_quintuple"
+                android:textAppearance="?textAppearanceHeadline5"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/image"
+                tools:text="Are you moving? We'll join"
+                tools:visibility="visible" />
 
-    <TextView
-            android:id="@+id/subtitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="You’ll get a few question about your new place to calculate your new price and coverage."
-            android:layout_marginTop="@dimen/base_margin_double"
-            android:layout_marginHorizontal="@dimen/base_margin_double"
-            android:textAppearance="?textAppearanceBody1"
-            app:layout_constraintTop_toBottomOf="@id/title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <TextView
+                android:id="@+id/subtitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/base_margin_double"
+                android:layout_marginTop="@dimen/base_margin_double"
+                android:gravity="center"
+                android:textAppearance="?textAppearanceBody1"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                tools:text="You’ll get a few question about your new place to calculate your new price and coverage."
+                tools:visibility="visible" />
+
+            <include
+                android:id="@+id/upcoming_address_layout"
+                layout="@layout/upcoming_address_change_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/base_margin_double"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/subtitle" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+    <include
+        android:id="@+id/spinner"
+        layout="@layout/loading_spinner" />
 
     <Button
-            android:id="@+id/continueButton"
-            style="?materialButtonContainedLargeStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginBottom="@dimen/base_margin_double"
-            android:layout_marginHorizontal="@dimen/base_margin_double"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:text="Continue to questions" />
+        android:id="@+id/continueButton"
+        style="?materialButtonContainedLargeStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/base_margin_double"
+        android:layout_marginBottom="@dimen/base_margin_double"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Continue to questions"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/change_address_activity.xml
+++ b/app/src/main/res/layout/change_address_activity.xml
@@ -15,6 +15,7 @@
         app:navigationIcon="@drawable/ic_close" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/content_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
@@ -85,7 +86,7 @@
         android:id="@+id/spinner"
         layout="@layout/loading_spinner" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/continueButton"
         style="?materialButtonContainedLargeStyle"
         android:layout_width="match_parent"
@@ -93,6 +94,7 @@
         android:layout_marginHorizontal="@dimen/base_margin_double"
         android:layout_marginBottom="@dimen/base_margin_double"
         android:visibility="gone"
+        app:iconGravity="textStart"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/home_change_address.xml
+++ b/app/src/main/res/layout/home_change_address.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:foreground="?selectableItemBackground"
-        android:padding="@dimen/base_margin_double"
-        android:id="@+id/change_address_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:drawableStartCompat="@drawable/ic_apartment"
-        android:drawablePadding="@dimen/base_margin_double"
-        android:textAppearance="@style/Hedvig.TextAppearance.Subtitle1"
-        android:text="@string/home_tab.editing_section_change_address_label" />
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/change_address_button"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:drawablePadding="@dimen/base_margin_double"
+    android:foreground="?selectableItemBackground"
+    android:padding="@dimen/base_margin_double"
+    android:text="@string/home_tab.editing_section_change_address_label"
+    android:textAppearance="@style/Hedvig.TextAppearance.Subtitle1"
+    app:drawableStartCompat="@drawable/ic_apartment" />

--- a/app/src/main/res/layout/home_change_address.xml
+++ b/app/src/main/res/layout/home_change_address.xml
@@ -8,5 +8,5 @@
     android:foreground="?selectableItemBackground"
     android:padding="@dimen/base_margin_double"
     android:text="@string/home_tab.editing_section_change_address_label"
-    android:textAppearance="@style/Hedvig.TextAppearance.Subtitle1"
+    android:textAppearance="?textAppearanceSubtitle1"
     app:drawableStartCompat="@drawable/ic_apartment" />

--- a/app/src/main/res/layout/upcoming_address_change_layout.xml
+++ b/app/src/main/res/layout/upcoming_address_change_layout.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/upcoming_address_layout_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/base_margin_double">
+
+    <TextView
+        android:id="@+id/address_change_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:text="@string/moving_intro.existing_move.upcoming_address_change_title"
+        android:textAppearance="?textAppearanceHeadline6"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/address_title"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:text="@string/CONTRACT_DETAIL_HOME_ADDRESS"
+        android:textAppearance="?textAppearanceBody1"
+        android:textColor="?android:textColorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/address_change_title" />
+
+    <TextView
+        android:id="@+id/address_label"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:gravity="end"
+        android:textAppearance="?textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/address_title"
+        app:layout_constraintTop_toBottomOf="@id/address_change_title"
+        tools:text="Askergatan 128 B" />
+
+    <TextView
+        android:id="@+id/postal_code_title"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:text="@string/CONTRACT_DETAIL_HOME_POSTCODE"
+        android:textAppearance="?textAppearanceBody1"
+        android:textColor="?android:textColorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/address_label" />
+
+    <TextView
+        android:id="@+id/postal_code_label"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:gravity="end"
+        android:textAppearance="?textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/address_title"
+        app:layout_constraintTop_toBottomOf="@id/address_label"
+        tools:text="113 89" />
+
+    <TextView
+        android:id="@+id/type_title"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:text="@string/CONTRACT_DETAIL_HOME_TYPE"
+        android:textAppearance="?textAppearanceBody1"
+        android:textColor="?android:textColorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/postal_code_label" />
+
+    <TextView
+        android:id="@+id/type_label"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:gravity="end"
+        android:textAppearance="?textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/address_title"
+        app:layout_constraintTop_toBottomOf="@id/postal_code_label"
+        tools:text="Rental" />
+
+    <TextView
+        android:id="@+id/living_space_title"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:text="@string/CONTRACT_DETAIL_HOME_SIZE"
+        android:textAppearance="?textAppearanceBody1"
+        android:textColor="?android:textColorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/type_label" />
+
+    <TextView
+        android:id="@+id/living_space_label"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:gravity="end"
+        android:textAppearance="?textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/address_title"
+        app:layout_constraintTop_toBottomOf="@id/type_label"
+        tools:text="48 sqm" />
+
+    <TextView
+        android:id="@+id/date_title"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:text="NO_LOKALISE_KEY"
+        android:textAppearance="?textAppearanceBody1"
+        android:textColor="?android:textColorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/living_space_label" />
+
+    <TextView
+        android:id="@+id/date_label"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:gravity="end"
+        android:textAppearance="?textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/address_title"
+        app:layout_constraintTop_toBottomOf="@id/living_space_label"
+        tools:text="2020-03-4" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/Data.kt
@@ -1,0 +1,38 @@
+package com.hedvig.app.testdata.feature.changeaddress
+
+import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+import com.hedvig.android.owldroid.type.SelfChangeBlocker
+import com.hedvig.app.testdata.feature.changeaddress.builders.SelfChangeEligibilityBuilder
+import com.hedvig.app.testdata.feature.changeaddress.builders.UpcomingAgreementBuilder
+
+val UPCOMING_AGREEMENT_NONE = UpcomingAgreementQuery.Data(
+    contracts = listOf(UpcomingAgreementQuery.Contract(
+        status = UpcomingAgreementQuery.Status(
+            asActiveStatus = null,
+            asTerminatedInFutureStatus = null,
+            asTerminatedTodayStatus = null,
+        )
+    ))
+)
+
+val UPCOMING_AGREEMENT_SWEDISH_HOUSE = UpcomingAgreementQuery.Data(
+    contracts = listOf(UpcomingAgreementQuery.Contract(
+        status = UpcomingAgreementQuery.Status(
+            asActiveStatus = UpcomingAgreementQuery.AsActiveStatus(
+                upcomingAgreementChange = UpcomingAgreementBuilder().build()
+            ),
+            asTerminatedInFutureStatus = null,
+            asTerminatedTodayStatus = null,
+        )
+    ))
+)
+
+val SELF_CHANGE_ELIGIBILITY = SelfChangeEligibilityQuery.Data(SelfChangeEligibilityBuilder().build())
+
+val BLOCKED_SELF_CHANGE_ELIGIBILITY = SelfChangeEligibilityQuery.Data(
+    SelfChangeEligibilityBuilder(
+        blockers = listOf(SelfChangeBlocker.COINSURED_MISMATCH)
+    ).build()
+)
+

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/SelfChangeEligibilityBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/SelfChangeEligibilityBuilder.kt
@@ -1,0 +1,13 @@
+package com.hedvig.app.testdata.feature.changeaddress.builders
+
+import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
+import com.hedvig.android.owldroid.type.SelfChangeBlocker
+
+class SelfChangeEligibilityBuilder(
+    private val blockers: List<SelfChangeBlocker> = emptyList()
+) {
+
+    fun build() = SelfChangeEligibilityQuery.SelfChangeEligibility(
+        blockers = blockers
+    )
+}

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/UpcomingAgreementBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/UpcomingAgreementBuilder.kt
@@ -1,0 +1,31 @@
+package com.hedvig.app.testdata.feature.changeaddress.builders
+
+import com.hedvig.android.owldroid.fragment.UpcomingAgreementFragment
+import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
+import com.hedvig.android.owldroid.type.SwedishApartmentLineOfBusiness
+import java.time.LocalDate
+
+class UpcomingAgreementBuilder {
+
+    fun build() = UpcomingAgreementQuery.UpcomingAgreementChange(
+        fragments = UpcomingAgreementQuery.UpcomingAgreementChange.Fragments(
+            upcomingAgreementFragment = UpcomingAgreementFragment(
+                newAgreement = UpcomingAgreementFragment.NewAgreement(
+                    asSwedishApartmentAgreement = UpcomingAgreementFragment.AsSwedishApartmentAgreement(
+                        address = UpcomingAgreementFragment.Address(
+                            street = "Test Street 123",
+                            postalCode = "123 TEST",
+                            city = "Test City"
+                        ),
+                        squareMeters = 50,
+                        activeFrom = LocalDate.of(2021, 4, 11),
+                        type = SwedishApartmentLineOfBusiness.RENT
+                    ),
+                    asDanishHomeContentAgreement = null,
+                    asNorwegianHomeContentAgreement = null,
+                    asSwedishHouseAgreement = null
+                )
+            )
+        )
+    )
+}


### PR DESCRIPTION
This PR contains the view shown when entering the moving flow (https://www.figma.com/file/Ds2hXzDbnUt9ZNhg4HSWH3/Moving-Flow-Android?node-id=94%3A0). 

We first check if the user has any upcoming agreement changes by querying `upcomingAgreementChange` (see `upcomingAgreement.graphql`). This is done in `GetUpcomingAgreementUseCase`, where we return a `UpcomingAgreementResult` with data suitable for the view to use. We populate the view with data from this query if an upcoming agreement is found.

If no upcoming agreement is found - we query `selfChangeEligibility` (`selfChangeEligibility.graphql`). If we receive blockers we show an error state. Otherwise we let the user continue with the moving flow by opening embark. 

Not present in this PR: 
* Starting embark when pressing "Continue to questions"
* Mock activity for testing in engineering mode (WIP)
* Some string resources missing for error states


<!-- Add when these when applicable. -->
### Checklist

- [x] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
