### PR TITLE
APP-243: Market selected preferences

### DIFF
--- a/app/src/engineering/java/com/hedvig/app/feature/marketpicker/MarketPickerMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/marketpicker/MarketPickerMockActivity.kt
@@ -27,16 +27,11 @@ class MarketPickerMockActivity : MockActivity() {
         }
     )
     private var originalMarket: Market? = null
-    private var originalShouldOpenMarketSelected = false
-
     private val marketManager by inject<MarketManager>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pref = PreferenceManager.getDefaultSharedPreferences(this)
         originalMarket = marketManager.market
-        originalShouldOpenMarketSelected =
-            pref.getBoolean(MarketingActivity.HAS_SELECTED_MARKET, false)
     }
 
     @SuppressLint("ApplySharedPref") // Needed
@@ -46,7 +41,6 @@ class MarketPickerMockActivity : MockActivity() {
         clickableItem("Market: SE /w Swedish") {
             marketManager.market = Market.SE
             setLanguage(Language.SV_SE)
-            storeBoolean(MarketingActivity.HAS_SELECTED_MARKET, true)
             startActivity(
                 MarketingActivity.newInstance(this@MarketPickerMockActivity)
             )
@@ -54,7 +48,6 @@ class MarketPickerMockActivity : MockActivity() {
         clickableItem("Market: NO /w Norwegian") {
             marketManager.market = Market.NO
             MockMarketPickerViewModel.AVAILABLE_GEO_MARKET = true
-            storeBoolean(MarketingActivity.HAS_SELECTED_MARKET, true)
             setLanguage(Language.NB_NO)
             startActivity(
                 MarketingActivity.newInstance(this@MarketPickerMockActivity)
@@ -63,7 +56,6 @@ class MarketPickerMockActivity : MockActivity() {
         clickableItem("Market: not selected. SE IP Address") {
             marketManager.market = null
             removeLanguage()
-            pref.edit().remove(MarketingActivity.HAS_SELECTED_MARKET).commit()
             MockMarketPickerViewModel.AVAILABLE_GEO_MARKET = true
             startActivity(
                 MarketingActivity.newInstance(this@MarketPickerMockActivity)
@@ -72,7 +64,6 @@ class MarketPickerMockActivity : MockActivity() {
         clickableItem("Preselected geo market not avalible") {
             marketManager.market = null
             removeLanguage()
-            pref.edit().remove(MarketingActivity.HAS_SELECTED_MARKET).commit()
             MockMarketPickerViewModel.AVAILABLE_GEO_MARKET = false
             startActivity(
                 MarketingActivity.newInstance(this@MarketPickerMockActivity)
@@ -111,9 +102,5 @@ class MarketPickerMockActivity : MockActivity() {
         originalMarket?.let {
             marketManager.market = it
         }
-        storeBoolean(
-            MarketingActivity.HAS_SELECTED_MARKET,
-            originalShouldOpenMarketSelected
-        )
     }
 }

--- a/app/src/main/java/com/hedvig/app/SplashActivity.kt
+++ b/app/src/main/java/com/hedvig/app/SplashActivity.kt
@@ -136,14 +136,8 @@ class SplashActivity : BaseActivity(R.layout.activity_splash) {
         val market = sharedPreferences.getString(Market.MARKET_SHARED_PREF, null)
         when (loginStatus) {
             LoginStatus.ONBOARDING -> {
-                if (market == null) {
-                    runSplashAnimation {
-                        startActivity(MarketingActivity.newInstance(this))
-                    }
-                } else {
-                    runSplashAnimation {
-                        startActivity(MarketingActivity.newInstance(this))
-                    }
+                runSplashAnimation {
+                    startActivity(MarketingActivity.newInstance(this))
                 }
             }
             LoginStatus.IN_OFFER -> {

--- a/app/src/main/java/com/hedvig/app/feature/settings/MarketManager.kt
+++ b/app/src/main/java/com/hedvig/app/feature/settings/MarketManager.kt
@@ -57,5 +57,5 @@ class MarketManagerImpl(
     }
 
     override fun hasSelectedMarket() = sharedPreferences
-        .getBoolean(MarketingActivity.HAS_SELECTED_MARKET, false)
+        .getString(Market.MARKET_SHARED_PREF, null) != null
 }

--- a/app/src/main/java/com/hedvig/app/feature/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/settings/SettingsActivity.kt
@@ -90,10 +90,6 @@ class SettingsActivity : BaseActivity(R.layout.activity_settings) {
                         negativeLabel = R.string.SETTINGS_ALERT_CHANGE_MARKET_CANCEL,
                         positiveAction = {
                             marketManager.market = null
-                            requireContext().storeBoolean(
-                                MarketingActivity.HAS_SELECTED_MARKET,
-                                false
-                            )
                             userViewModel.logout {
                                 requireContext().storeBoolean(
                                     LoginStatusService.IS_VIEWING_OFFER,


### PR DESCRIPTION
Check market shared string preference to determine if market has been selected instead of using separate boolean preference

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
