### PR TITLE
APP-264: Embark email autofill

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/TextValidationUtil.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/TextValidationUtil.kt
@@ -1,10 +1,13 @@
 package com.hedvig.app.feature.embark
 
+import android.os.Build
 import android.text.Editable
 import android.text.InputType
 import android.text.TextWatcher
 import android.text.method.DigitsKeyListener
+import android.view.View.AUTOFILL_HINT_EMAIL_ADDRESS
 import com.google.android.material.textfield.TextInputEditText
+import com.hedvig.app.util.whenApiVersion
 import java.util.regex.Pattern
 
 const val PERSONAL_NUMBER = "PersonalNumber"
@@ -35,6 +38,9 @@ fun validationCheck(mask: String, text: String) = when (mask) {
 fun TextInputEditText.setInputType(mask: String) {
     if (mask == EMAIL) {
         inputType = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+        whenApiVersion(Build.VERSION_CODES.O) {
+            setAutofillHints(AUTOFILL_HINT_EMAIL_ADDRESS)
+        }
     } else if (mask == BIRTH_DATE ||
         mask == BIRTH_DATE_REVERSE ||
         mask == PERSONAL_NUMBER ||

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
@@ -92,7 +92,7 @@ class TextActionFragment : Fragment(R.layout.fragment_embark_text_action) {
 
             messages.adapter = MessageAdapter(data.messages)
 
-            filledTextField.hint = data.hint
+            input.hint = data.hint
             data.mask?.let { mask ->
                 input.apply {
                     setInputType(mask)


### PR DESCRIPTION
Show email autofill hints in embark. Use input hint instead of text field hint.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [x] Functionality is accessible in engineering mode
