### PR TITLE
APP-250: Improve test suite stability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -270,7 +270,7 @@ dependencies {
     implementation("com.facebook.shimmer:shimmer:0.5.0")
 
     // test
-    testImplementation("junit:junit:4.13")
+    testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
     androidTestImplementation("androidx.test:runner:1.3.0")
     androidTestImplementation("androidx.test:rules:1.3.0")

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressNotEligibleTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressNotEligibleTest.kt
@@ -4,7 +4,6 @@ import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
 import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
 import com.hedvig.app.R
 import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
-import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.testdata.feature.changeaddress.BLOCKED_SELF_CHANGE_ELIGIBILITY
 import com.hedvig.app.testdata.feature.changeaddress.UPCOMING_AGREEMENT_NONE
 import com.hedvig.app.util.ApolloCacheClearRule
@@ -19,7 +18,7 @@ import org.junit.Test
 class ChangeAddressNotEligibleTest : TestCase() {
 
     @get:Rule
-    val activityRule = LazyActivityScenarioRule(LoggedInActivity::class.java)
+    val activityRule = LazyActivityScenarioRule(ChangeAddressActivity::class.java)
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/ChangeAddressTest.kt
@@ -4,7 +4,6 @@ import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
 import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
 import com.hedvig.app.R
 import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
-import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.testdata.feature.changeaddress.SELF_CHANGE_ELIGIBILITY
 import com.hedvig.app.testdata.feature.changeaddress.UPCOMING_AGREEMENT_NONE
 import com.hedvig.app.util.ApolloCacheClearRule
@@ -19,7 +18,7 @@ import org.junit.Test
 class ChangeAddressTest : TestCase() {
 
     @get:Rule
-    val activityRule = LazyActivityScenarioRule(LoggedInActivity::class.java)
+    val activityRule = LazyActivityScenarioRule(ChangeAddressActivity::class.java)
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(

--- a/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/UpcomingChangeAddressTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/changeaddress/UpcomingChangeAddressTest.kt
@@ -4,7 +4,6 @@ import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
 import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
 import com.hedvig.app.R
 import com.hedvig.app.feature.home.ui.changeaddress.ChangeAddressActivity
-import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.testdata.feature.changeaddress.SELF_CHANGE_ELIGIBILITY
 import com.hedvig.app.testdata.feature.changeaddress.UPCOMING_AGREEMENT_SWEDISH_HOUSE
 import com.hedvig.app.util.ApolloCacheClearRule
@@ -19,7 +18,7 @@ import org.junit.Test
 class UpcomingChangeAddressTest : TestCase() {
 
     @get:Rule
-    val activityRule = LazyActivityScenarioRule(LoggedInActivity::class.java)
+    val activityRule = LazyActivityScenarioRule(ChangeAddressActivity::class.java)
 
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
@@ -31,7 +30,7 @@ class UpcomingChangeAddressTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldShowManualChangeAddressWhenEligibilityIsBlocked() {
+    fun shouldShowManualChangeAddressWhenEligibilityIsBlocked() = run {
         activityRule.launch(ChangeAddressActivity.newInstance(context()))
 
         ChangeAddressScreen {

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/BackNavigationTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/BackNavigationTest.kt
@@ -32,7 +32,7 @@ class BackNavigationTest : TestCase() {
             EmbarkActivity.newInstance(
                 ApplicationProvider.getApplicationContext(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/EmbarkActivityTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/EmbarkActivityTest.kt
@@ -23,7 +23,7 @@ class EmbarkActivityTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle,
+                "",
             )
         )
         onScreen<EmbarkScreen> {

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/EmbarkMenuTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/EmbarkMenuTest.kt
@@ -53,7 +53,7 @@ class EmbarkMenuTest : TestCase() {
 
     @Test
     fun loginButtonShouldOpenLoginMethod() = run {
-        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle)
+        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, "")
         activityRule.launch(intent)
 
         TextActionScreen {
@@ -71,7 +71,7 @@ class EmbarkMenuTest : TestCase() {
 
     @Test
     fun restartButtonShouldReloadEmbark() = run {
-        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle)
+        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, "")
         activityRule.launch(intent)
 
         TextActionScreen {
@@ -101,7 +101,7 @@ class EmbarkMenuTest : TestCase() {
 
     @Test
     fun appInfoButtonShouldStartMoreOptionsActivity() = run {
-        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle)
+        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, "")
         activityRule.launch(intent)
 
         TextActionScreen {
@@ -119,7 +119,7 @@ class EmbarkMenuTest : TestCase() {
 
     @Test
     fun settingsButtonShouldStartMoreOptionsActivity() = run {
-        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle)
+        val intent = EmbarkActivity.newInstance(context(), this.javaClass.name, "")
         activityRule.launch(intent)
 
         TextActionScreen {

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/MissingActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/MissingActionTest.kt
@@ -33,7 +33,7 @@ class MissingActionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/GraphQLErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/GraphQLErrorTest.kt
@@ -36,7 +36,7 @@ class GraphQLErrorTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/NetworkErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/NetworkErrorTest.kt
@@ -36,7 +36,7 @@ class NetworkErrorTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/SingleVariableTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/SingleVariableTest.kt
@@ -37,7 +37,7 @@ class SingleVariableTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/SuccessTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/SuccessTest.kt
@@ -37,7 +37,7 @@ class SuccessTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/GeneratedVariableTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/GeneratedVariableTest.kt
@@ -40,7 +40,7 @@ class GeneratedVariableTest : TestCase() {
             EmbarkActivity.newInstance(
                 ApplicationProvider.getApplicationContext(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/GraphQLErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/GraphQLErrorTest.kt
@@ -36,7 +36,7 @@ class GraphQLErrorTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/NetworkErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/NetworkErrorTest.kt
@@ -36,7 +36,7 @@ class NetworkErrorTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/SingleVariableTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/SingleVariableTest.kt
@@ -39,7 +39,7 @@ class SingleVariableTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/SuccessTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/SuccessTest.kt
@@ -37,7 +37,7 @@ class SuccessTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/computedvalues/ComputedValuesTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/computedvalues/ComputedValuesTest.kt
@@ -29,7 +29,7 @@ class ComputedValuesTest : TestCase() {
 
     @Test
     fun shouldCorrectlyDisplayComputedValues() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, ""))
 
         step("Enter value in first passage and submit") {
             NumberActionScreen {

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/externalredirect/OfferTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/externalredirect/OfferTest.kt
@@ -29,7 +29,7 @@ class OfferTest : TestCase() {
 
     @Test
     fun shouldOpenWebOfferWhenEncounteringExternalRedirect() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), this::class.java.name, storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), this::class.java.name, ""))
 
         onScreen<EmbarkScreen> {
             offer { stub() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/AndExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/AndExpressionTest.kt
@@ -32,7 +32,7 @@ class AndExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/EqualsExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/EqualsExpressionTest.kt
@@ -32,7 +32,7 @@ class EqualsExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/GreaterThanExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/GreaterThanExpressionTest.kt
@@ -34,7 +34,7 @@ class GreaterThanExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/GreaterThanOrEqualsExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/GreaterThanOrEqualsExpressionTest.kt
@@ -34,7 +34,7 @@ class GreaterThanOrEqualsExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/LessThanExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/LessThanExpressionTest.kt
@@ -34,7 +34,7 @@ class LessThanExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/LessThanOrEqualsExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/LessThanOrEqualsExpressionTest.kt
@@ -34,7 +34,7 @@ class LessThanOrEqualsExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/NotEqualsExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/NotEqualsExpressionTest.kt
@@ -34,7 +34,7 @@ class NotEqualsExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/OrExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/OrExpressionTest.kt
@@ -32,7 +32,7 @@ class OrExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/TemplateValuesTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/TemplateValuesTest.kt
@@ -32,7 +32,7 @@ class TemplateValuesTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/UnaryExpressionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/messages/UnaryExpressionTest.kt
@@ -32,7 +32,7 @@ class UnaryExpressionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/numberaction/NumberActionTest.kt
@@ -31,7 +31,7 @@ class NumberActionTest : TestCase() {
 
     @Test
     fun shouldRenderNumberAction() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, ""))
 
         NumberActionScreen {
             step("Check that labels match data") {
@@ -81,7 +81,7 @@ class NumberActionTest : TestCase() {
 
     @Test
     fun shouldPrefillNumberActionWhenUserReturnsToPassage() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, ""))
 
         NumberActionScreen {
             step("Fill out passage and submit") {

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/previousinsurer/PreviousInsurerTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/previousinsurer/PreviousInsurerTest.kt
@@ -32,7 +32,7 @@ class PreviousInsurerTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/BinaryExpressionRedirectTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/BinaryExpressionRedirectTest.kt
@@ -32,7 +32,7 @@ class BinaryExpressionRedirectTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/MultipleExpressionRedirectTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/MultipleExpressionRedirectTest.kt
@@ -32,7 +32,7 @@ class MultipleExpressionRedirectTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/PassedKeyValueRedirectTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/PassedKeyValueRedirectTest.kt
@@ -32,7 +32,7 @@ class PassedKeyValueRedirectTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/UnaryExpressionRedirectTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/redirects/UnaryExpressionRedirectTest.kt
@@ -32,7 +32,7 @@ class UnaryExpressionRedirectTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/response/CustomSelectActionResponseTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/response/CustomSelectActionResponseTest.kt
@@ -36,7 +36,7 @@ class CustomSelectActionResponseTest : TestCase() {
             EmbarkActivity.newInstance(
                 ApplicationProvider.getApplicationContext(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/response/CustomTextActionResponseTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/response/CustomTextActionResponseTest.kt
@@ -36,7 +36,7 @@ class CustomTextActionResponseTest : TestCase() {
             EmbarkActivity.newInstance(
                 ApplicationProvider.getApplicationContext(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/response/DefaultSelectActionResponseTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/response/DefaultSelectActionResponseTest.kt
@@ -34,7 +34,7 @@ class DefaultSelectActionResponseTest : TestCase() {
             EmbarkActivity.newInstance(
                 ApplicationProvider.getApplicationContext(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/response/DefaultTextActionResponseTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/response/DefaultTextActionResponseTest.kt
@@ -34,7 +34,7 @@ class DefaultTextActionResponseTest : TestCase() {
             EmbarkActivity.newInstance(
                 ApplicationProvider.getApplicationContext(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionScreen.kt
@@ -11,7 +11,7 @@ object TextActionScreen : KScreen<TextActionScreen>() {
     override val layoutId = R.layout.fragment_embark_text_action
     override val viewClass = TextActionFragment::class.java
 
-    val input = KTextInputLayout { withId(R.id.filledTextField) }
+    val input = KTextInputLayout { withId(R.id.textField) }
     val submitButton = KButton { withId(R.id.textActionSubmit) }
     val loginButton = KView { withText(R.string.common_signin_button_text) }
     val appInfoButton = KView { withText(R.string.onboarding_contextual_menu_app_info_label) }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionSetScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionSetScreen.kt
@@ -1,14 +1,9 @@
 package com.hedvig.app.feature.embark.screens
 
-import android.view.View
-import com.agoda.kakao.edit.KTextInputLayout
-import com.agoda.kakao.recycler.KRecyclerItem
-import com.agoda.kakao.recycler.KRecyclerView
 import com.agoda.kakao.text.KButton
 import com.hedvig.app.R
 import com.hedvig.app.feature.embark.passages.textaction.TextActionFragment
 import com.kaspersky.kaspresso.screens.KScreen
-import org.hamcrest.Matcher
 
 object TextActionSetScreen : KScreen<TextActionSetScreen>() {
     override val layoutId = R.layout.fragment_text_action_set

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionSetScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/screens/TextActionSetScreen.kt
@@ -15,13 +15,4 @@ object TextActionSetScreen : KScreen<TextActionSetScreen>() {
     override val viewClass = TextActionFragment::class.java
 
     val submit = KButton { withId(R.id.textActionSubmit) }
-
-    val inputs = KRecyclerView(
-        { withId(R.id.inputRecycler) },
-        { itemType(TextActionSetScreen::Input) }
-    )
-
-    class Input(parent: Matcher<View>) : KRecyclerItem<Input>(parent) {
-        val input = KTextInputLayout { withMatcher(parent) }
-    }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionAppendHyphen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionAppendHyphen.kt
@@ -32,7 +32,7 @@ class TextActionAppendHyphen : TestCase() {
 
     @Test
     fun shouldAddHyphenToInput() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), "Story Name", storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), "Story Name", ""))
 
         Screen.onScreen<EmbarkScreen> {
             textActionSubmit { isDisabled() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionBirthDateReverseMaskTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionBirthDateReverseMaskTest.kt
@@ -54,7 +54,7 @@ class TextActionBirthDateReverseMaskTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 
@@ -81,7 +81,7 @@ class TextActionBirthDateReverseMaskTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.embark.textaction
 
-import androidx.test.espresso.matcher.ViewMatchers
 import com.agoda.kakao.edit.KEditText
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
@@ -13,7 +12,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
-import com.hedvig.app.util.hasPlaceholderText
+import com.hedvig.app.util.withHint
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -30,8 +29,8 @@ class TextActionSetTest : TestCase() {
     @get:Rule
     val apolloCacheClearRule = ApolloCacheClearRule()
 
-    val editText1 = KEditText { withMatcher(ViewMatchers.withHint("First Placeholder"))}
-    val editText2 = KEditText { withMatcher(ViewMatchers.withHint("Second Placeholder"))}
+    val input1 = KEditText { withHint("Placeholder") }
+    val input2 = KEditText { withHint("Second Placeholder") }
 
     @Test
     fun textActionSetTest() = run {
@@ -51,13 +50,11 @@ class TextActionSetTest : TestCase() {
                 hasText("Another test passage")
                 isDisabled()
             }
-            editText1 {
+            input1 {
                 typeText("First Text")
-                hasHint("First Placeholder")
             }
             submit { isDisabled() }
-            editText2 {
-                hasHint("Second Placeholder")
+            input2 {
                 typeText("Second Text")
             }
             submit { click() }
@@ -81,8 +78,8 @@ class TextActionSetTest : TestCase() {
 
         TextActionSetScreen {
             step("Fill in data and submit") {
-                editText1 { replaceText("Test") }
-                editText2 { replaceText("Testerson") }
+                input1 { replaceText("Test") }
+                input2 { replaceText("Testerson") }
                 submit { click() }
             }
             step("Verify that previous passage is no longer shown") {
@@ -96,8 +93,8 @@ class TextActionSetTest : TestCase() {
             }
             step("Go back and verify that the previous answers are prefilled") {
                 pressBack()
-                editText1 { replaceText("Test") }
-                editText2 { replaceText("Testerson") }
+                input1 { replaceText("Test") }
+                input2 { replaceText("Testerson") }
             }
             step("Check that validation passes on prefilled input") {
                 submit { isEnabled() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
@@ -33,7 +33,7 @@ class TextActionSetTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 
@@ -49,7 +49,6 @@ class TextActionSetTest : TestCase() {
                 childAt<TextActionSetScreen.Input>(0) {
                     input {
                         edit {
-
                             typeText("First Text")
                             hasHint("First Placeholder")
                         }
@@ -82,7 +81,7 @@ class TextActionSetTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.hasPlaceholderText
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -48,9 +49,9 @@ class TextActionSetTest : TestCase() {
             inputs {
                 childAt<TextActionSetScreen.Input>(0) {
                     input {
+                        hasPlaceholderText("Placeholder")
                         edit {
                             typeText("First Text")
-                            hasHint("First Placeholder")
                         }
                     }
                 }
@@ -59,8 +60,8 @@ class TextActionSetTest : TestCase() {
             inputs {
                 childAt<TextActionSetScreen.Input>(1) {
                     input {
+                        hasPlaceholderText("Second Placeholder")
                         edit {
-                            hasHint("Second Placeholder")
                             typeText("Second Text")
                         }
                     }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetTest.kt
@@ -1,5 +1,7 @@
 package com.hedvig.app.feature.embark.textaction
 
+import androidx.test.espresso.matcher.ViewMatchers
+import com.agoda.kakao.edit.KEditText
 import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.feature.embark.screens.EmbarkScreen
@@ -28,6 +30,9 @@ class TextActionSetTest : TestCase() {
     @get:Rule
     val apolloCacheClearRule = ApolloCacheClearRule()
 
+    val editText1 = KEditText { withMatcher(ViewMatchers.withHint("First Placeholder"))}
+    val editText2 = KEditText { withMatcher(ViewMatchers.withHint("Second Placeholder"))}
+
     @Test
     fun textActionSetTest() = run {
         activityRule.launch(
@@ -46,26 +51,14 @@ class TextActionSetTest : TestCase() {
                 hasText("Another test passage")
                 isDisabled()
             }
-            inputs {
-                childAt<TextActionSetScreen.Input>(0) {
-                    input {
-                        hasPlaceholderText("Placeholder")
-                        edit {
-                            typeText("First Text")
-                        }
-                    }
-                }
+            editText1 {
+                typeText("First Text")
+                hasHint("First Placeholder")
             }
             submit { isDisabled() }
-            inputs {
-                childAt<TextActionSetScreen.Input>(1) {
-                    input {
-                        hasPlaceholderText("Second Placeholder")
-                        edit {
-                            typeText("Second Text")
-                        }
-                    }
-                }
+            editText2 {
+                hasHint("Second Placeholder")
+                typeText("Second Text")
             }
             submit { click() }
             onScreen<EmbarkScreen> {
@@ -88,14 +81,8 @@ class TextActionSetTest : TestCase() {
 
         TextActionSetScreen {
             step("Fill in data and submit") {
-                inputs {
-                    childAt<TextActionSetScreen.Input>(0) {
-                        input { edit { replaceText("Test") } }
-                    }
-                    childAt<TextActionSetScreen.Input>(1) {
-                        input { edit { replaceText("Testerson") } }
-                    }
-                }
+                editText1 { replaceText("Test") }
+                editText2 { replaceText("Testerson") }
                 submit { click() }
             }
             step("Verify that previous passage is no longer shown") {
@@ -109,14 +96,8 @@ class TextActionSetTest : TestCase() {
             }
             step("Go back and verify that the previous answers are prefilled") {
                 pressBack()
-                inputs {
-                    childAt<TextActionSetScreen.Input>(0) {
-                        input { edit { hasText("Test") } }
-                    }
-                    childAt<TextActionSetScreen.Input>(1) {
-                        input { edit { hasText("Testerson") } }
-                    }
-                }
+                editText1 { replaceText("Test") }
+                editText2 { replaceText("Testerson") }
             }
             step("Check that validation passes on prefilled input") {
                 submit { isEnabled() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.embark.textaction
 
-import androidx.test.espresso.matcher.ViewMatchers
 import com.agoda.kakao.edit.KEditText
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.feature.embark.screens.TextActionSetScreen
@@ -11,7 +10,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
-import com.hedvig.app.util.hasPlaceholderText
+import com.hedvig.app.util.withHint
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -45,18 +44,16 @@ class TextActionSetValidation : TestCase() {
         TextActionSetScreen {
             submit { isDisabled() }
             val editTextPersonalNumber = KEditText {
-                withMatcher(ViewMatchers.withHint("901124-1234"))
+                withHint("901124-1234")
             }
             editTextPersonalNumber {
-                hasHint("901124-1234")
                 typeText("9704071234")
             }
             submit { isDisabled() }
             val editTextEmail = KEditText {
-                withMatcher(ViewMatchers.withHint("Email"))
+                withHint("example@email.com")
             }
             editTextEmail {
-                hasHint("Email")
                 typeText("email@hedvig.com")
             }
             submit { isEnabled() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
@@ -1,5 +1,7 @@
 package com.hedvig.app.feature.embark.textaction
 
+import androidx.test.espresso.matcher.ViewMatchers
+import com.agoda.kakao.edit.KEditText
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.feature.embark.screens.TextActionSetScreen
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
@@ -42,28 +44,20 @@ class TextActionSetValidation : TestCase() {
 
         TextActionSetScreen {
             submit { isDisabled() }
-            inputs {
-                childAt<TextActionSetScreen.Input>(0) {
-                    input {
-                        hasPlaceholderText("901124-1234")
-                        edit {
-                            hasHint("Personal number")
-                            typeText("9704071234")
-                        }
-                    }
-                }
+            val editTextPersonalNumber = KEditText {
+                withMatcher(ViewMatchers.withHint("901124-1234"))
+            }
+            editTextPersonalNumber {
+                hasHint("901124-1234")
+                typeText("9704071234")
             }
             submit { isDisabled() }
-            inputs {
-                childAt<TextActionSetScreen.Input>(1) {
-                    input {
-                        hasPlaceholderText("example@email.com")
-                        edit {
-                            hasHint("Email")
-                            typeText("email@hedvig.com")
-                        }
-                    }
-                }
+            val editTextEmail = KEditText {
+                withMatcher(ViewMatchers.withHint("Email"))
+            }
+            editTextEmail {
+                hasHint("Email")
+                typeText("email@hedvig.com")
             }
             submit { isEnabled() }
         }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
@@ -35,7 +35,7 @@ class TextActionSetValidation : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionSetValidation.kt
@@ -9,6 +9,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.hasPlaceholderText
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -44,8 +45,9 @@ class TextActionSetValidation : TestCase() {
             inputs {
                 childAt<TextActionSetScreen.Input>(0) {
                     input {
+                        hasPlaceholderText("901124-1234")
                         edit {
-                            hasHint("901124-1234")
+                            hasHint("Personal number")
                             typeText("9704071234")
                         }
                     }
@@ -55,6 +57,7 @@ class TextActionSetValidation : TestCase() {
             inputs {
                 childAt<TextActionSetScreen.Input>(1) {
                     input {
+                        hasPlaceholderText("example@email.com")
                         edit {
                             hasHint("Email")
                             typeText("email@hedvig.com")

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
@@ -33,7 +33,7 @@ class TextActionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 
@@ -60,7 +60,7 @@ class TextActionTest : TestCase() {
             EmbarkActivity.newInstance(
                 context(),
                 this.javaClass.name,
-                storyTitle
+                "",
             )
         )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionTest.kt
@@ -41,7 +41,7 @@ class TextActionTest : TestCase() {
             onScreen<EmbarkScreen> {
                 messages { firstChild<EmbarkScreen.MessageRow> { text { hasText("test message") } } }
             }
-            input { hasHint("Test hint") }
+            input { edit { hasHint("Test hint") } }
             submitButton {
                 hasText("Another test passage")
                 isDisabled()

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionValidation.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/textaction/TextActionValidation.kt
@@ -32,7 +32,7 @@ class TextActionValidation : TestCase() {
 
     @Test
     fun buttonShouldOnlyBeEnabledWhenValidEmailIsTyped() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), "Story Name", storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), "Story Name", ""))
 
         Screen.onScreen<EmbarkScreen> {
             textActionSubmit { isDisabled() }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/track/TrackTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/track/TrackTest.kt
@@ -44,7 +44,7 @@ class TrackTest : TestCase() {
 
     @Test
     fun shouldTrackWhenEnteringPassage() = run {
-        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, storyTitle))
+        activityRule.launch(EmbarkActivity.newInstance(context(), this.javaClass.name, ""))
 
         onScreen<EmbarkScreen> {
             step("Check that initial passage-track is tracked") {

--- a/app/src/androidTest/java/com/hedvig/app/feature/onboarding/screens/ChoosePlanScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/onboarding/screens/ChoosePlanScreen.kt
@@ -12,6 +12,8 @@ import com.agoda.kakao.text.KTextView
 import com.hedvig.app.R
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.feature.onboarding.ui.ChoosePlanActivity
+import com.hedvig.app.testdata.feature.onboarding.builders.EmbarkStoryBuilder.Companion.ENGLISH_CONTENTS
+import com.hedvig.app.testdata.feature.onboarding.builders.EmbarkStoryBuilder.Companion.ENGLISH_TRAVEL
 import com.kaspersky.kaspresso.screens.KScreen
 import org.hamcrest.Matcher
 
@@ -29,14 +31,13 @@ object ChoosePlanScreen : KScreen<ChoosePlanScreen>() {
 
     val contents = KIntent {
         IntentMatchers.hasAction(Intent.ACTION_VIEW)
-        hasExtras {
-            hasEntry("WEB_PATH", "/no-en/new-member/contents")
-        }
+        hasComponent(EmbarkActivity::class.java.name)
+        hasExtra(EmbarkActivity.STORY_NAME, ENGLISH_CONTENTS)
     }
 
     val travel = KIntent {
         hasComponent(EmbarkActivity::class.java.name)
-        hasExtra(EmbarkActivity.STORY_NAME, ChoosePlanActivity.NO_ENGLISH_TRAVEL_STORY_NAME)
+        hasExtra(EmbarkActivity.STORY_NAME, ENGLISH_TRAVEL)
     }
 
     class Card(parent: Matcher<View>) : KRecyclerItem<Card>(parent) {

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/CommonTestData.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/CommonTestData.kt
@@ -5,4 +5,5 @@ import com.hedvig.app.util.context
 import com.hedvig.app.util.market
 import org.javamoney.moneta.Money
 
-val defaultAmount = Money.of(349, "SEK").format(context(), market())
+val defaultAmount: String
+    get() = Money.of(349, "SEK").format(context(), market())

--- a/app/src/androidTest/java/com/hedvig/app/feature/splash/NetworkErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/splash/NetworkErrorTest.kt
@@ -1,10 +1,7 @@
 package com.hedvig.app.feature.splash
 
-import com.agoda.kakao.intent.KIntent
 import com.hedvig.android.owldroid.graphql.ContractStatusQuery
-import com.hedvig.app.R
 import com.hedvig.app.SplashActivity
-import com.hedvig.app.feature.marketing.ui.MarketingActivity
 import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyIntentsActivityScenarioRule
@@ -12,8 +9,6 @@ import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.extensions.isLoggedIn
 import com.hedvig.app.util.extensions.setIsLoggedIn
-import com.hedvig.app.util.stub
-import com.kaspersky.kaspresso.screens.KScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.After
 import org.junit.Before
@@ -48,12 +43,5 @@ class NetworkErrorTest : TestCase() {
     @After
     fun teardown() {
         context().setIsLoggedIn(previousLoginStatus)
-    }
-
-    object SplashScreen : KScreen<SplashScreen>() {
-        override val layoutId = R.layout.activity_splash
-        override val viewClass = SplashActivity::class.java
-
-        val marketing = KIntent { hasComponent(MarketingActivity::class.java.name) }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/splash/NetworkErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/splash/NetworkErrorTest.kt
@@ -1,9 +1,8 @@
 package com.hedvig.app.feature.splash
 
 import com.agoda.kakao.intent.KIntent
-import com.agoda.kakao.screen.Screen
-import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.hedvig.android.owldroid.graphql.ContractStatusQuery
+import com.hedvig.app.R
 import com.hedvig.app.SplashActivity
 import com.hedvig.app.feature.marketing.ui.MarketingActivity
 import com.hedvig.app.util.ApolloCacheClearRule
@@ -14,6 +13,7 @@ import com.hedvig.app.util.context
 import com.hedvig.app.util.extensions.isLoggedIn
 import com.hedvig.app.util.extensions.setIsLoggedIn
 import com.hedvig.app.util.stub
+import com.kaspersky.kaspresso.screens.KScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.After
 import org.junit.Before
@@ -43,9 +43,6 @@ class NetworkErrorTest : TestCase() {
     @Test
     fun shouldNotCrashOnNetworkError() = run {
         activityRule.launch()
-        onScreen<SplashScreen> {
-            marketing { stub() }
-        }
     }
 
     @After
@@ -53,7 +50,10 @@ class NetworkErrorTest : TestCase() {
         context().setIsLoggedIn(previousLoginStatus)
     }
 
-    class SplashScreen : Screen<SplashScreen>() {
+    object SplashScreen : KScreen<SplashScreen>() {
+        override val layoutId = R.layout.activity_splash
+        override val viewClass = SplashActivity::class.java
+
         val marketing = KIntent { hasComponent(MarketingActivity::class.java.name) }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/util/ApolloMockServer.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/ApolloMockServer.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.toJson
 import com.hedvig.app.CUSTOM_TYPE_ADAPTERS
 import com.hedvig.app.TestApplication
+import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -54,7 +55,16 @@ fun apolloMockServer(vararg mocks: Pair<String, ApolloResultProvider>) =
             }
 
             private fun handleWebSocket() = MockResponse()
-                .withWebSocketUpgrade(object : WebSocketListener() {})
+                .withWebSocketUpgrade(object : WebSocketListener() {
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        val message = JSONObject(text)
+                        if (message.getString("type") == "connection_init") {
+                            webSocket.send(jsonObjectOf(
+                                "type" to "connection_ack"
+                            ).toString())
+                        }
+                    }
+                })
         }
     }
 

--- a/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
@@ -6,7 +6,9 @@ import android.widget.TextView
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import com.agoda.kakao.bottomnav.KBottomNavigationView
+import com.agoda.kakao.common.builders.ViewBuilder
 import com.agoda.kakao.common.utilities.getResourceString
 import com.agoda.kakao.edit.KTextInputLayout
 import com.agoda.kakao.intent.KIntent
@@ -79,3 +81,5 @@ fun KTextInputLayout.hasHelperText(text: String) {
 }
 
 fun KTextInputLayout.hasHelperText(@StringRes resId: Int) = hasHelperText(getResourceString(resId))
+
+fun ViewBuilder.withHint(hint: String) = withMatcher(ViewMatchers.withHint(hint))

--- a/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/KakaoExtensions.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.util
 
 import android.app.Activity
 import android.app.Instrumentation
+import android.widget.TextView
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.test.espresso.assertion.ViewAssertions
@@ -21,7 +22,16 @@ fun KTextInputLayout.hasError(@StringRes resId: Int, vararg formatArgs: Any) =
 fun KDatePicker.setDate(date: LocalDate) = setDate(date.year, date.monthValue, date.dayOfMonth)
 
 fun KTextView.hasText(@StringRes resId: Int, vararg formatArgs: Any) =
-    hasText(context().getString(resId, *formatArgs))
+    view.check { view, noViewFoundException ->
+        if (view is TextView) {
+            val text = view.resources.getString(resId, *formatArgs)
+            if (text != view.text) {
+                throw AssertionError("Expected view with text: $text, but actual is ${view.text}")
+            }
+        } else {
+            noViewFoundException?.let { throw AssertionError(it) }
+        }
+    }
 
 fun KTextView.hasPluralText(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any) =
     hasText(context().resources.getQuantityString(resId, quantity, *formatArgs))

--- a/app/src/androidTest/java/com/hedvig/app/util/Util.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/Util.kt
@@ -1,10 +1,12 @@
 package com.hedvig.app.util
 
-import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.hedvig.app.feature.settings.Language
 import com.hedvig.app.feature.settings.MarketManager
 import org.koin.java.KoinJavaComponent.getKoin
 
-fun context(): Context = ApplicationProvider.getApplicationContext()
+fun context() = Language
+    .fromSettings(ApplicationProvider.getApplicationContext(), market())
+    .apply(ApplicationProvider.getApplicationContext())
 
 fun market() = getKoin().get<MarketManager>().market

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -88,7 +88,11 @@
 
         <activity android:name=".feature.payment.PaymentMockActivity" />
 
-        <activity android:name=".feature.changeaddress.ChangeAddressMockActivity"  />
+        <activity android:name=".feature.changeaddress.ChangeAddressMockActivity" />
+
+        <meta-data
+            android:name="com.mixpanel.android.MPConfig.DisableEmulatorBindingUI"
+            android:value="true" />
 
     </application>
 

--- a/app/src/engineering/java/com/hedvig/app/feature/marketpicker/MockMarketPickerViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/marketpicker/MockMarketPickerViewModel.kt
@@ -11,13 +11,13 @@ import com.hedvig.app.util.extensions.getLanguage
 class MockMarketPickerViewModel(context: Context, marketManager: MarketManager) : MarketPickerViewModel() {
 
     override fun submitMarketAndReload(market: Market) {
-        _pickerSate.value = _pickerSate.value?.let {
+        _pickerState.value = _pickerState.value?.let {
             PickerState(market, it.language)
         }
     }
 
     override fun submitLanguageAndReload(language: Language) {
-        _pickerSate.value = _pickerSate.value?.let {
+        _pickerState.value = _pickerState.value?.let {
             PickerState(it.market, language)
         }
     }
@@ -32,12 +32,12 @@ class MockMarketPickerViewModel(context: Context, marketManager: MarketManager) 
                     Market.valueOf(GEO_DATA_FI.geo.countryISOCode)
                 }
                 when (market) {
-                    Market.SE -> _pickerSate.postValue(PickerState(market, Language.EN_SE))
-                    Market.NO -> _pickerSate.postValue(PickerState(market, Language.EN_NO))
-                    Market.DK -> _pickerSate.postValue(PickerState(market, Language.EN_DK))
+                    Market.SE -> _pickerState.postValue(PickerState(market, Language.EN_SE))
+                    Market.NO -> _pickerState.postValue(PickerState(market, Language.EN_NO))
+                    Market.DK -> _pickerState.postValue(PickerState(market, Language.EN_DK))
                 }
             } catch (e: Exception) {
-                _pickerSate.postValue(
+                _pickerState.postValue(
                     PickerState(
                         Market.SE, Language.EN_SE
                     )
@@ -45,7 +45,7 @@ class MockMarketPickerViewModel(context: Context, marketManager: MarketManager) 
             }
         } else {
             marketManager.market?.let { market ->
-                _pickerSate.postValue(
+                _pickerState.postValue(
                     PickerState(
                         market, context.getLanguage() ?: market.toLanguage()
                     )

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
@@ -33,9 +33,9 @@ class ChangeAddressViewModelImpl(
     }
 
     private fun fetchDataAndCreateState() {
+        _viewState.postValue(Loading)
         viewModelScope.launch {
-            _viewState.value = Loading
-            _viewState.value = createViewState()
+            _viewState.postValue(createViewState())
         }
     }
 
@@ -45,11 +45,12 @@ class ChangeAddressViewModelImpl(
         )
     }
 
-    private suspend fun getUpComingAgreementState(onNoUpcomingChange: suspend () -> ViewState) = when (val upcomingAgreement = getUpcomingAgreement()) {
-        is UpcomingAgreementResult.NoUpcomingAgreementChange -> onNoUpcomingChange()
-        is UpcomingAgreementResult.UpcomingAgreement -> ChangeAddressInProgress(upcomingAgreement)
-        is UpcomingAgreementResult.Error -> UpcomingAgreementError(upcomingAgreement)
-    }
+    private suspend fun getUpComingAgreementState(onNoUpcomingChange: suspend () -> ViewState) =
+        when (val upcomingAgreement = getUpcomingAgreement()) {
+            is UpcomingAgreementResult.NoUpcomingAgreementChange -> onNoUpcomingChange()
+            is UpcomingAgreementResult.UpcomingAgreement -> ChangeAddressInProgress(upcomingAgreement)
+            is UpcomingAgreementResult.Error -> UpcomingAgreementError(upcomingAgreement)
+        }
 
     private suspend fun getSelfChangeState() = when (val selfChangeEligibility = getSelfChangeEligibility()) {
         SelfChangeEligibilityResult.Eligible -> SelfChangeAddress
@@ -69,6 +70,6 @@ sealed class ViewState {
     data class UpcomingAgreementError(val error: UpcomingAgreementResult.Error) : ViewState()
     data class SelfChangeError(val error: SelfChangeEligibilityResult.Error) : ViewState()
     data class ChangeAddressInProgress(
-        val upcomingAgreementResult: UpcomingAgreementResult.UpcomingAgreement
+        val upcomingAgreementResult: UpcomingAgreementResult.UpcomingAgreement,
     ) : ViewState()
 }

--- a/app/src/main/java/com/hedvig/app/feature/marketpicker/MarketPickerViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketpicker/MarketPickerViewModel.kt
@@ -11,8 +11,8 @@ import com.hedvig.app.feature.settings.MarketManager
 import kotlinx.coroutines.launch
 
 abstract class MarketPickerViewModel : ViewModel() {
-    protected val _pickerSate = MutableLiveData<PickerState>()
-    val pickerState: LiveData<PickerState> = _pickerSate
+    protected val _pickerState = MutableLiveData<PickerState>()
+    val pickerState: LiveData<PickerState> = _pickerState
     abstract fun submitMarketAndReload(market: Market)
     abstract fun submitLanguageAndReload(language: Language)
 }
@@ -26,14 +26,14 @@ class MarketPickerViewModelImpl(
 ) : MarketPickerViewModel() {
 
     override fun submitMarketAndReload(market: Market) {
-        _pickerSate.value = _pickerSate.value?.let {
+        _pickerState.value = _pickerState.value?.let {
             updateState(market, market.toLanguage())
             PickerState(market, market.toLanguage())
         }
     }
 
     override fun submitLanguageAndReload(language: Language) {
-        _pickerSate.value = _pickerSate.value?.let {
+        _pickerState.value = _pickerState.value?.let {
             updateState(it.market, language)
             PickerState(it.market, language)
         }
@@ -56,8 +56,8 @@ class MarketPickerViewModelImpl(
 
     init {
         viewModelScope.launch {
-            val market = marketRepository.getMarket()
-            _pickerSate.value = PickerState(market, market.toLanguage())
+            val market = runCatching { marketRepository.getMarket() }.getOrNull() ?: return@launch
+            _pickerState.value = PickerState(market, market.toLanguage())
             marketManager.market = market
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationActivity.kt
@@ -52,8 +52,6 @@ class SimpleSignAuthenticationActivity : BaseActivity(R.layout.simple_sign_authe
 
         model.authStatus.observe(this) {
             when (it) {
-                AuthState.SUCCESS -> {
-                }
                 AuthState.FAILED -> {
                     showError()
                 }

--- a/app/src/main/res/layout/embark_input_item.xml
+++ b/app/src/main/res/layout/embark_input_item.xml
@@ -9,7 +9,7 @@
         android:id="@+id/input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:importantForAutofill="no"
         android:imeOptions="actionDone"
+        android:importantForAutofill="no"
         android:inputType="textCapWords" />
 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
- Test stability fixes
- Make tests build again
- Update dependency
- Format a file
- Repair some malfunctioning tests
- Fix incorrect resources being loaded on `hasText`-assert
- Prevent app from crashing when `GeoQuery` fails
- Repair tests using WebSocket connections
- Prevent Mixpanel from crashing our tests
- Fix the last test instability issues

<!-- Add when these when applicable. -->
### Checklist

- [X] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
