### PR TITLE
APP-353: Embark lifecycle

### DIFF
--- a/app/src/engineering/java/com/hedvig/app/feature/embark/MockEmbarkViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/MockEmbarkViewModel.kt
@@ -5,7 +5,8 @@ import com.hedvig.app.util.jsonObjectOf
 import org.json.JSONObject
 
 class MockEmbarkViewModel(tracker: EmbarkTracker) : EmbarkViewModel(tracker, ValueStoreImpl()) {
-    override fun load(name: String) {
+
+    override fun fetchStory(name: String) {
         if (!shouldLoad) {
             return
         }

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -340,7 +340,7 @@ val adyenModule = module {
 }
 
 val embarkModule = module {
-    viewModel<EmbarkViewModel> { EmbarkViewModelImpl(get(), get(), get()) }
+    viewModel<EmbarkViewModel> { (storyName: String) -> EmbarkViewModelImpl(get(), get(), get(), storyName) }
 }
 
 val valueStoreModule = module {

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -37,7 +37,7 @@ abstract class EmbarkViewModel(
     protected val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> = _errorMessage
 
-    abstract fun load(name: String)
+    abstract fun fetchStory(name: String)
 
     abstract suspend fun callGraphQL(query: String, variables: JSONObject? = null): JSONObject?
 
@@ -528,14 +528,18 @@ abstract class EmbarkViewModel(
 class EmbarkViewModelImpl(
     private val embarkRepository: EmbarkRepository,
     tracker: EmbarkTracker,
-    valueStore: ValueStore
+    valueStore: ValueStore,
+    storyName: String
 ) : EmbarkViewModel(tracker, valueStore) {
 
-    override fun load(name: String) {
+    init {
+        fetchStory(storyName)
+    }
+
+    override fun fetchStory(name: String) {
         viewModelScope.launch {
             val result = runCatching {
-                embarkRepository
-                    .embarkStory(name)
+                embarkRepository.embarkStory(name)
             }
             if (result.isFailure) {
                 _errorMessage.value = result.getOrNull()?.errors?.toString() ?: result.exceptionOrNull()?.message

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
@@ -40,26 +40,26 @@ import com.hedvig.app.util.whenApiVersion
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
 
 class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
-    private val model: EmbarkViewModel by viewModel()
-    private val binding by viewBinding(ActivityEmbarkBinding::bind)
-    private val marketManager: MarketManager by inject()
-
-    private val storyName: String by lazy {
-        intent.getStringExtra(STORY_NAME)
-            ?: throw IllegalArgumentException("Programmer error: STORY_NAME not provided to ${this.javaClass.name}")
-    }
 
     private val storyTitle: String by lazy {
         intent.getStringExtra(STORY_TITLE)
             ?: throw IllegalArgumentException("Programmer error: STORY_TITLE not provided to ${this.javaClass.name}")
     }
 
+    private val storyName: String by lazy {
+        intent.getStringExtra(STORY_NAME)
+            ?: throw IllegalArgumentException("Programmer error: STORY_NAME not provided to ${this.javaClass.name}")
+    }
+
+    private val model: EmbarkViewModel by viewModel { parametersOf(storyName) }
+    private val binding by viewBinding(ActivityEmbarkBinding::bind)
+    private val marketManager: MarketManager by inject()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        model.load(storyName)
 
         binding.apply {
 
@@ -145,7 +145,7 @@ class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
         MaterialAlertDialogBuilder(this)
             .setTitle(R.string.settings_alert_restart_onboarding_title)
             .setMessage(R.string.settings_alert_restart_onboarding_description)
-            .setPositiveButton(R.string.ALERT_OK) { _, _ -> model.load(storyName) }
+            .setPositiveButton(R.string.ALERT_OK) { _, _ -> model.fetchStory(storyName) }
             .setNegativeButton(R.string.ALERT_CANCEL) { dialog, _ -> dialog.dismiss() }
             .show()
     }

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/MaterialProgressToolbar.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/MaterialProgressToolbar.kt
@@ -26,10 +26,12 @@ class MaterialProgressToolbar @JvmOverloads constructor(
     }
 
     fun setProgress(progress: Percent) {
-        TransitionManager.beginDelayedTransition(this)
-        binding.progress.layoutParams = FrameLayout.LayoutParams(
-            (this.width * progress.toFraction()).toInt(),
-            binding.progress.layoutParams.height
-        )
+        binding.progress.post {
+            TransitionManager.beginDelayedTransition(this)
+            binding.progress.layoutParams = FrameLayout.LayoutParams(
+                (this.width * progress.toFraction()).toInt(),
+                binding.progress.layoutParams.height
+            )
+        }
     }
 }


### PR DESCRIPTION
Initiate embark data in viewmodel init to avoid reload when recreating activity. Wait for progressbar to be laid out by using post.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
