### PR TITLE
APP-372: Start embark from moving flow intro 

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/addressFragment.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/addressFragment.graphql
@@ -1,0 +1,5 @@
+fragment AddressFragment on Address {
+  street
+  postalCode
+  city
+}

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
@@ -68,9 +68,3 @@ query InsuranceQuery($locale: Locale!) {
     }
   }
 }
-
-fragment AddressFragment on Address {
-  street
-  postalCode
-  city
-}

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/selfChangeEligibility.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/selfChangeEligibility.graphql
@@ -1,5 +1,5 @@
 query SelfChangeEligibility {
   selfChangeEligibility {
-    blockers
+    embarkStoryId
   }
 }

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/upcomingAgreement.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/upcomingAgreement.graphql
@@ -24,42 +24,34 @@ fragment UpcomingAgreementFragment on UpcomingAgreementChange {
   newAgreement {
     ... on SwedishApartmentAgreement {
       address {
-        street
-        postalCode
-        city
+        ...AddressFragment
       }
       squareMeters
       activeFrom
-      type
+      saType: type
     }
     ... on SwedishHouseAgreement {
       address {
-        street
-        postalCode
-        city
+        ...AddressFragment
       }
       squareMeters
       activeFrom
     }
     ... on NorwegianHomeContentAgreement {
       address {
-        street
-        postalCode
-        city
+        ...AddressFragment
       }
       squareMeters
       activeFrom
-      type
+      nhcType: type
     }
     ... on DanishHomeContentAgreement {
       address {
-        street
-        postalCode
-        city
+        ...AddressFragment
       }
       squareMeters
       activeFrom
-      type
+      dhcType: type
     }
   }
 }

--- a/app/src/engineering/java/com/hedvig/app/feature/changeaddress/ChangeAddressMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/changeaddress/ChangeAddressMockActivity.kt
@@ -23,7 +23,7 @@ class ChangeAddressMockActivity : MockActivity() {
     override fun adapter() = genericDevelopmentAdapter {
         header("Change address")
         clickableItem("Eligible") {
-            MockChangeAddressViewModel.mockedState = MutableLiveData(ViewState.SelfChangeAddress)
+            MockChangeAddressViewModel.mockedState = MutableLiveData(ViewState.SelfChangeAddress("embarkTestId"))
             startActivity(ChangeAddressActivity.newInstance(context))
         }
         clickableItem("Error") {

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ChangeAddressActivityBinding
 import com.hedvig.app.feature.chat.ui.ChatActivity
+import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.GeneralError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.NoContractsError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement
@@ -76,13 +77,20 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
             binding.spinner.loadingSpinner.show()
             binding.contentScrollView.remove()
         }
-        SelfChangeAddress -> setContent(
+        is SelfChangeAddress -> setContent(
             titleText = getString(R.string.moving_intro_title),
             subtitleText = getString(R.string.moving_intro_description),
             buttonText = getString(R.string.moving_intro_open_flow_button_text),
             buttonIcon = null,
-            // TODO: Start Embark
-            onContinue = { }
+            onContinue = {
+                startActivity(
+                    EmbarkActivity.newInstance(
+                        context = this,
+                        storyName = viewState.embarkStoryId,
+                        storyTitle = "Change address"
+                    )
+                )
+            }
         )
         ManualChangeAddress -> setContent(
             titleText = getString(R.string.moving_intro_title),

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
@@ -53,7 +53,7 @@ class ChangeAddressViewModelImpl(
         }
 
     private suspend fun getSelfChangeState() = when (val selfChangeEligibility = getSelfChangeEligibility()) {
-        SelfChangeEligibilityResult.Eligible -> SelfChangeAddress
+        is SelfChangeEligibilityResult.Eligible -> SelfChangeAddress(selfChangeEligibility.embarkStoryId)
         is SelfChangeEligibilityResult.Blocked -> ManualChangeAddress
         is SelfChangeEligibilityResult.Error -> SelfChangeError(selfChangeEligibility)
     }
@@ -65,7 +65,7 @@ class ChangeAddressViewModelImpl(
 
 sealed class ViewState {
     object Loading : ViewState()
-    object SelfChangeAddress : ViewState()
+    data class SelfChangeAddress(val embarkStoryId: String) : ViewState()
     object ManualChangeAddress : ViewState()
     data class UpcomingAgreementError(val error: UpcomingAgreementResult.Error) : ViewState()
     data class SelfChangeError(val error: SelfChangeEligibilityResult.Error) : ViewState()

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetUpcomingAgreementUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetUpcomingAgreementUseCase.kt
@@ -38,20 +38,20 @@ class GetUpcomingAgreementUseCase(
         return asSwedishApartmentAgreement?.let {
             UpcomingAgreement(
                 address = UpcomingAgreement.Address(
-                    street = it.address.street,
-                    postalCode = it.address.postalCode,
-                    city = it.address.city
+                    street = it.address.fragments.addressFragment.street,
+                    postalCode = it.address.fragments.addressFragment.postalCode,
+                    city = it.address.fragments.addressFragment.city
                 ),
                 squareMeters = it.squareMeters,
                 activeFrom = it.activeFrom,
-                addressType = it.type.stringRes()
+                addressType = it.saType.stringRes()
             )
         } ?: asSwedishHouseAgreement?.let {
             UpcomingAgreement(
                 address = UpcomingAgreement.Address(
-                    street = it.address.street,
-                    postalCode = it.address.postalCode,
-                    city = it.address.city
+                    street = it.address.fragments.addressFragment.street,
+                    postalCode = it.address.fragments.addressFragment.postalCode,
+                    city = it.address.fragments.addressFragment.city
                 ),
                 squareMeters = it.squareMeters,
                 activeFrom = it.activeFrom,
@@ -60,24 +60,24 @@ class GetUpcomingAgreementUseCase(
         } ?: asNorwegianHomeContentAgreement?.let {
             UpcomingAgreement(
                 address = UpcomingAgreement.Address(
-                    street = it.address.street,
-                    postalCode = it.address.postalCode,
-                    city = it.address.city
+                    street = it.address.fragments.addressFragment.street,
+                    postalCode = it.address.fragments.addressFragment.postalCode,
+                    city = it.address.fragments.addressFragment.city
                 ),
                 squareMeters = it.squareMeters,
                 activeFrom = it.activeFrom,
-                addressType = it.type?.stringRes()
+                addressType = it.nhcType?.stringRes()
             )
         } ?: asDanishHomeContentAgreement?.let {
             UpcomingAgreement(
                 address = UpcomingAgreement.Address(
-                    street = it.address.street,
-                    postalCode = it.address.postalCode,
-                    city = it.address.city
+                    street = it.address.fragments.addressFragment.street,
+                    postalCode = it.address.fragments.addressFragment.postalCode,
+                    city = it.address.fragments.addressFragment.city
                 ),
                 squareMeters = it.squareMeters,
                 activeFrom = it.activeFrom,
-                addressType = it.type?.stringRes()
+                addressType = it.dhcType?.stringRes()
             )
         }
     }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/Data.kt
@@ -2,7 +2,6 @@ package com.hedvig.app.testdata.feature.changeaddress
 
 import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
 import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
-import com.hedvig.android.owldroid.type.SelfChangeBlocker
 import com.hedvig.app.testdata.feature.changeaddress.builders.SelfChangeEligibilityBuilder
 import com.hedvig.app.testdata.feature.changeaddress.builders.UpcomingAgreementBuilder
 
@@ -32,10 +31,11 @@ val UPCOMING_AGREEMENT_SWEDISH_HOUSE = UpcomingAgreementQuery.Data(
     )
 )
 
-val SELF_CHANGE_ELIGIBILITY = SelfChangeEligibilityQuery.Data(SelfChangeEligibilityBuilder().build())
+val SELF_CHANGE_ELIGIBILITY = SelfChangeEligibilityQuery.Data(
+    SelfChangeEligibilityBuilder(
+        embarkStoryId = "testId").build()
+)
 
 val BLOCKED_SELF_CHANGE_ELIGIBILITY = SelfChangeEligibilityQuery.Data(
-    SelfChangeEligibilityBuilder(
-        blockers = listOf(SelfChangeBlocker.COINSURED_MISMATCH)
-    ).build()
+    SelfChangeEligibilityBuilder().build()
 )

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/SelfChangeEligibilityBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/SelfChangeEligibilityBuilder.kt
@@ -1,13 +1,12 @@
 package com.hedvig.app.testdata.feature.changeaddress.builders
 
 import com.hedvig.android.owldroid.graphql.SelfChangeEligibilityQuery
-import com.hedvig.android.owldroid.type.SelfChangeBlocker
 
 class SelfChangeEligibilityBuilder(
-    private val blockers: List<SelfChangeBlocker> = emptyList()
+    val embarkStoryId: String? = null
 ) {
 
     fun build() = SelfChangeEligibilityQuery.SelfChangeEligibility(
-        blockers = blockers
+        embarkStoryId = embarkStoryId
     )
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/UpcomingAgreementBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/UpcomingAgreementBuilder.kt
@@ -1,5 +1,6 @@
 package com.hedvig.app.testdata.feature.changeaddress.builders
 
+import com.hedvig.android.owldroid.fragment.AddressFragment
 import com.hedvig.android.owldroid.fragment.UpcomingAgreementFragment
 import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
 import com.hedvig.android.owldroid.type.SwedishApartmentLineOfBusiness
@@ -13,13 +14,17 @@ class UpcomingAgreementBuilder {
                 newAgreement = UpcomingAgreementFragment.NewAgreement(
                     asSwedishApartmentAgreement = UpcomingAgreementFragment.AsSwedishApartmentAgreement(
                         address = UpcomingAgreementFragment.Address(
-                            street = "Test Street 123",
-                            postalCode = "123 TEST",
-                            city = "Test City"
+                            fragments = UpcomingAgreementFragment.Address.Fragments(
+                                addressFragment = AddressFragment(
+                                    street = "Test Street 123",
+                                    postalCode = "123 TEST",
+                                    city = "Test City"
+                                )
+                            )
                         ),
                         squareMeters = 50,
                         activeFrom = LocalDate.of(2021, 4, 11),
-                        type = SwedishApartmentLineOfBusiness.RENT
+                        saType = SwedishApartmentLineOfBusiness.RENT
                     ),
                     asDanishHomeContentAgreement = null,
                     asNorwegianHomeContentAgreement = null,


### PR DESCRIPTION
Use updated schema to query an embark story id and use in order to start embark for moving flow. Note that the current id is not the final story to be used. 

### Checklist

- [ ] Functionality is covered by an integration test
- [x] Functionality is accessible in engineering mode
