### PR TITLE
APP-374: Support Expression-based responses

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/embarkStory.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/embarkStory.graphql
@@ -23,6 +23,12 @@ query EmbarkStory($name: String!, $locale: String!) {
       }
       response {
         ...MessageFragment
+        ... on EmbarkResponseExpression {
+          text
+          expressions {
+            ...ExpressionFragment
+          }
+        }
       }
       redirects {
         ... on EmbarkRedirectUnaryExpression {
@@ -45,7 +51,7 @@ query EmbarkStory($name: String!, $locale: String!) {
           passedExpressionKey
           passedExpressionValue
           subExpressions {
-            ...SubExpressionFragment
+            ...ExpressionFragment
           }
         }
       }

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/embarkStory.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/embarkStory.graphql
@@ -171,28 +171,12 @@ fragment EmbarkLinkFragment on EmbarkLink {
 
 fragment MessageFragment on EmbarkMessage {
   expressions {
-    ... on EmbarkExpressionUnary {
-      unaryType: type
-      text
-    }
-    ... on EmbarkExpressionBinary {
-      binaryType: type
-      key
-      value
-      text
-    }
-    ... on EmbarkExpressionMultiple {
-      multipleType: type
-      text
-      subExpressions {
-        ...SubExpressionFragment
-      }
-    }
+    ...ExpressionFragment
   }
   text
 }
 
-fragment SubExpressionFragment on EmbarkExpression {
+fragment BasicExpressionFragment on EmbarkExpression {
   ... on EmbarkExpressionUnary {
     unaryType: type
     text
@@ -203,20 +187,15 @@ fragment SubExpressionFragment on EmbarkExpression {
     value
     text
   }
+}
+
+fragment ExpressionFragment on EmbarkExpression {
+  ...BasicExpressionFragment
   ... on EmbarkExpressionMultiple {
     multipleType: type
     text
     subExpressions {
-      ... on EmbarkExpressionUnary {
-        unaryType: type
-        text
-      }
-      ... on EmbarkExpressionBinary {
-        binaryType: type
-        key
-        value
-        text
-      }
+      ...BasicExpressionFragment
     }
   }
 }

--- a/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkMockActivity.kt
@@ -26,6 +26,7 @@ import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_MANY_TOOLTIP
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_MULTIPLE_REDIRECTS
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_NOT_EQUALS_EXPRESSION
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_NUMBER_ACTION
+import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_NUMBER_ACTION_AND_CUSTOM_RESPONSE
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_OR_EXPRESSION
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_PASSED_KEY_VALUE
 import com.hedvig.app.testdata.feature.embark.data.STORY_WITH_SELECT_ACTION_AND_CUSTOM_RESPONSE
@@ -99,6 +100,13 @@ class EmbarkMockActivity : MockActivity() {
             }
             startActivity(EmbarkActivity.newInstance(context, this.javaClass.name, "Number Action"))
         }
+        clickableItem("Custom response") {
+            MockEmbarkViewModel.apply {
+                shouldLoad = true
+                mockedData = STORY_WITH_NUMBER_ACTION_AND_CUSTOM_RESPONSE
+            }
+            startActivity(EmbarkActivity.newInstance(context, this.javaClass.name, "Custom Response"))
+        }
         header("Text Action")
         clickableItem("Regular") {
             MockEmbarkViewModel.apply {
@@ -154,7 +162,13 @@ class EmbarkMockActivity : MockActivity() {
                 shouldLoad = true
                 mockedData = STORY_WITH_INCOMPATIBLE_ACTION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Incompatible Action"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Incompatible Action",
+                )
+            )
         }
         header("Template Values")
         clickableItem("Open") {
@@ -189,63 +203,117 @@ class EmbarkMockActivity : MockActivity() {
                 shouldLoad = true
                 mockedData = STORY_WITH_UNARY_EXPRESSIONS
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Equals (==)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_EQUALS_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Not Equals (!=)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_NOT_EQUALS_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Greater Than (>)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_GREATER_THAN_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Greater Than or Equals (>=)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_GREATER_THAN_OR_EQUALS_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Less Than (<)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_LESS_THAN_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Less Than or Equals (<=)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_LESS_THAN_OR_EQUALS_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("Or (||)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_OR_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         clickableItem("And (&&)") {
             MockEmbarkViewModel.apply {
                 shouldLoad = true
                 mockedData = STORY_WITH_OR_EXPRESSION
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Message Expressions"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Message Expressions",
+                )
+            )
         }
         header("Redirects")
         clickableItem("Unary") {
@@ -283,7 +351,13 @@ class EmbarkMockActivity : MockActivity() {
                 mockedData = STORY_WITH_GRAPHQL_QUERY_API
                 graphQLQueryResponse = jsonObjectOf("hello" to "world")
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "GraphQL Query"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "GraphQL Query",
+                )
+            )
         }
         header("More Options")
         clickableItem("More Options Error") {
@@ -297,7 +371,13 @@ class EmbarkMockActivity : MockActivity() {
                 mockedData = PROGRESSABLE_STORY
                 shouldLoad = true
             }
-            startActivity(EmbarkActivity.newInstance(this@EmbarkMockActivity, this.javaClass.name, "Story with progress"))
+            startActivity(
+                EmbarkActivity.newInstance(
+                    this@EmbarkMockActivity,
+                    this.javaClass.name,
+                    "Story with progress",
+                )
+            )
         }
     }
 }

--- a/app/src/engineering/java/com/hedvig/app/feature/embark/MockEmbarkViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/MockEmbarkViewModel.kt
@@ -5,6 +5,9 @@ import com.hedvig.app.util.jsonObjectOf
 import org.json.JSONObject
 
 class MockEmbarkViewModel(tracker: EmbarkTracker) : EmbarkViewModel(tracker, ValueStoreImpl()) {
+    init {
+        fetchStory("")
+    }
 
     override fun fetchStory(name: String) {
         if (!shouldLoad) {

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -281,6 +281,19 @@ abstract class EmbarkViewModel(
         response.fragments.messageFragment?.let { message ->
             preProcessMessage(message)?.let { return it.text }
         }
+
+        response.asEmbarkResponseExpression?.let { exp ->
+            preProcessMessage(
+                MessageFragment(
+                    text = exp.text,
+                    expressions = exp.expressions.map {
+                        MessageFragment.Expression(
+                            fragments = MessageFragment.Expression.Fragments(it.fragments.expressionFragment)
+                        )
+                    }
+                )
+            )?.let { return it.text }
+        }
         return null
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -5,9 +5,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hedvig.android.owldroid.fragment.ApiFragment
+import com.hedvig.android.owldroid.fragment.BasicExpressionFragment
+import com.hedvig.android.owldroid.fragment.ExpressionFragment
 import com.hedvig.android.owldroid.fragment.GraphQLVariablesFragment
 import com.hedvig.android.owldroid.fragment.MessageFragment
-import com.hedvig.android.owldroid.fragment.SubExpressionFragment
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.android.owldroid.type.EmbarkAPIGraphQLSingleVariableCasting
 import com.hedvig.android.owldroid.type.EmbarkAPIGraphQLVariableGeneratedType
@@ -325,7 +326,7 @@ abstract class EmbarkViewModel(
 
         val expressionText = message
             .expressions
-            .map(::evaluateExpression)
+            .map { evaluateExpression(it.fragments.expressionFragment) }
             .filterIsInstance<ExpressionResult.True>()
             .firstOrNull()
             ?.resultValue
@@ -336,15 +337,15 @@ abstract class EmbarkViewModel(
         )
     }
 
-    private fun evaluateExpression(expression: MessageFragment.Expression): ExpressionResult {
-        expression.asEmbarkExpressionUnary?.let { unaryExpression ->
+    private fun evaluateExpression(expression: ExpressionFragment): ExpressionResult {
+        expression.fragments.basicExpressionFragment.asEmbarkExpressionUnary?.let { unaryExpression ->
             return when (unaryExpression.unaryType) {
                 EmbarkExpressionTypeUnary.ALWAYS -> ExpressionResult.True(unaryExpression.text)
                 EmbarkExpressionTypeUnary.NEVER -> ExpressionResult.False
                 else -> ExpressionResult.False
             }
         }
-        expression.asEmbarkExpressionBinary?.let { binaryExpression ->
+        expression.fragments.basicExpressionFragment.asEmbarkExpressionBinary?.let { binaryExpression ->
             when (binaryExpression.binaryType) {
                 EmbarkExpressionTypeBinary.EQUALS -> {
                     if (valueStore.get(binaryExpression.key) == binaryExpression.value) {
@@ -387,7 +388,12 @@ abstract class EmbarkViewModel(
         }
         expression.asEmbarkExpressionMultiple?.let { multipleExpression ->
             val results =
-                multipleExpression.subExpressions.map { evaluateExpression(it.fragments.subExpressionFragment.into()) }
+                multipleExpression.subExpressions.map {
+                    evaluateExpression(ExpressionFragment(
+                        fragments = ExpressionFragment.Fragments(it.fragments.basicExpressionFragment),
+                        asEmbarkExpressionMultiple = null,
+                    ))
+                }
             when (multipleExpression.multipleType) {
                 EmbarkExpressionTypeMultiple.AND -> {
                     if (results.all { it is ExpressionResult.True }) {
@@ -420,77 +426,33 @@ abstract class EmbarkViewModel(
 
         private fun Result<JSONObject?>.hasErrors() = getOrNull()?.has("errors") == true
 
-        private fun SubExpressionFragment.into(): MessageFragment.Expression =
-            MessageFragment.Expression(
-                asEmbarkExpressionUnary = asEmbarkExpressionUnary?.let {
-                    MessageFragment.AsEmbarkExpressionUnary(
-                        unaryType = it.unaryType,
-                        text = it.text
-                    )
-                },
-                asEmbarkExpressionBinary = asEmbarkExpressionBinary?.let {
-                    MessageFragment.AsEmbarkExpressionBinary(
-                        binaryType = it.binaryType,
-                        key = it.key,
-                        value = it.value,
-                        text = it.text
-                    )
-                },
-                asEmbarkExpressionMultiple = asEmbarkExpressionMultiple?.let {
-                    MessageFragment.AsEmbarkExpressionMultiple(
-                        multipleType = it.multipleType,
-                        text = it.text,
-                        subExpressions = it.subExpressions.map { se -> se.into() }
-                    )
-                }
-            )
-
-        private fun SubExpressionFragment.SubExpression.into(): MessageFragment.SubExpression =
-            MessageFragment.SubExpression(
-                fragments = MessageFragment.SubExpression.Fragments(
-                    SubExpressionFragment(
-                        asEmbarkExpressionUnary = asEmbarkExpressionUnary1?.let {
-                            SubExpressionFragment.AsEmbarkExpressionUnary(
+        private fun EmbarkStoryQuery.Redirect.into(): ExpressionFragment =
+            ExpressionFragment(
+                fragments = ExpressionFragment.Fragments(
+                    BasicExpressionFragment(
+                        asEmbarkExpressionUnary = asEmbarkRedirectUnaryExpression?.let {
+                            BasicExpressionFragment.AsEmbarkExpressionUnary(
                                 unaryType = it.unaryType,
-                                text = it.text
+                                text = null
                             )
                         },
-                        asEmbarkExpressionBinary = asEmbarkExpressionBinary1?.let {
-                            SubExpressionFragment.AsEmbarkExpressionBinary(
+                        asEmbarkExpressionBinary = asEmbarkRedirectBinaryExpression?.let {
+                            BasicExpressionFragment.AsEmbarkExpressionBinary(
                                 binaryType = it.binaryType,
                                 key = it.key,
                                 value = it.value,
-                                text = it.text
+                                text = null
                             )
                         },
-                        asEmbarkExpressionMultiple = null
                     )
-                )
-            )
-
-        private fun EmbarkStoryQuery.Redirect.into(): MessageFragment.Expression =
-            MessageFragment.Expression(
-                asEmbarkExpressionUnary = asEmbarkRedirectUnaryExpression?.let {
-                    MessageFragment.AsEmbarkExpressionUnary(
-                        unaryType = it.unaryType,
-                        text = null
-                    )
-                },
-                asEmbarkExpressionBinary = asEmbarkRedirectBinaryExpression?.let {
-                    MessageFragment.AsEmbarkExpressionBinary(
-                        binaryType = it.binaryType,
-                        key = it.key,
-                        value = it.value,
-                        text = null
-                    )
-                },
+                ),
                 asEmbarkExpressionMultiple = asEmbarkRedirectMultipleExpressions?.let {
-                    MessageFragment.AsEmbarkExpressionMultiple(
+                    ExpressionFragment.AsEmbarkExpressionMultiple(
                         multipleType = it.multipleExpressionType,
                         text = null,
                         subExpressions = it.subExpressions.map { se ->
-                            MessageFragment.SubExpression(
-                                fragments = MessageFragment.SubExpression.Fragments(se.fragments.subExpressionFragment)
+                            ExpressionFragment.SubExpression(
+                                fragments = ExpressionFragment.SubExpression.Fragments(se.fragments.expressionFragment.fragments.basicExpressionFragment)
                             )
                         }
                     )

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/ExpressionBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/ExpressionBuilder.kt
@@ -1,7 +1,7 @@
 package com.hedvig.app.testdata.feature.embark.builders
 
-import com.hedvig.android.owldroid.fragment.MessageFragment
-import com.hedvig.android.owldroid.fragment.SubExpressionFragment
+import com.hedvig.android.owldroid.fragment.BasicExpressionFragment
+import com.hedvig.android.owldroid.fragment.ExpressionFragment
 import com.hedvig.android.owldroid.type.EmbarkExpressionTypeBinary
 import com.hedvig.android.owldroid.type.EmbarkExpressionTypeMultiple
 import com.hedvig.android.owldroid.type.EmbarkExpressionTypeUnary
@@ -11,41 +11,45 @@ data class ExpressionBuilder(
     private val text: String = "test message",
     private val key: String = "",
     private val value: String = "",
-    private val subExpressions: List<SubExpressionFragment> = emptyList()
+    private val subExpressions: List<ExpressionFragment> = emptyList(),
 ) {
-    fun build() = MessageFragment.Expression(
-        asEmbarkExpressionUnary = if (type == ExpressionType.ALWAYS || type == ExpressionType.NEVER) {
-            MessageFragment.AsEmbarkExpressionUnary(
-                unaryType = when (type) {
-                    ExpressionType.ALWAYS -> EmbarkExpressionTypeUnary.ALWAYS
-                    ExpressionType.NEVER -> EmbarkExpressionTypeUnary.NEVER
-                    else -> throw Error("Unreachable")
+    fun build() = ExpressionFragment(
+        fragments = ExpressionFragment.Fragments(
+            BasicExpressionFragment(
+                asEmbarkExpressionUnary = if (type == ExpressionType.ALWAYS || type == ExpressionType.NEVER) {
+                    BasicExpressionFragment.AsEmbarkExpressionUnary(
+                        unaryType = when (type) {
+                            ExpressionType.ALWAYS -> EmbarkExpressionTypeUnary.ALWAYS
+                            ExpressionType.NEVER -> EmbarkExpressionTypeUnary.NEVER
+                            else -> throw Error("Unreachable")
+                        },
+                        text = text
+                    )
+                } else {
+                    null
                 },
-                text = text
-            )
-        } else {
-            null
-        },
-        asEmbarkExpressionBinary = if (type == ExpressionType.EQUALS || type == ExpressionType.NOT_EQUALS || type == ExpressionType.GREATER_THAN || type == ExpressionType.GREATER_THAN_OR_EQUALS || type == ExpressionType.LESS_THAN || type == ExpressionType.LESS_THAN_OR_EQUALS || type == ExpressionType.NOT_EQUALS) {
-            MessageFragment.AsEmbarkExpressionBinary(
-                binaryType = when (type) {
-                    ExpressionType.EQUALS -> EmbarkExpressionTypeBinary.EQUALS
-                    ExpressionType.NOT_EQUALS -> EmbarkExpressionTypeBinary.NOT_EQUALS
-                    ExpressionType.GREATER_THAN -> EmbarkExpressionTypeBinary.MORE_THAN
-                    ExpressionType.GREATER_THAN_OR_EQUALS -> EmbarkExpressionTypeBinary.MORE_THAN_OR_EQUALS
-                    ExpressionType.LESS_THAN -> EmbarkExpressionTypeBinary.LESS_THAN
-                    ExpressionType.LESS_THAN_OR_EQUALS -> EmbarkExpressionTypeBinary.LESS_THAN_OR_EQUALS
-                    else -> throw Error("Unreachable")
+                asEmbarkExpressionBinary = if (type == ExpressionType.EQUALS || type == ExpressionType.NOT_EQUALS || type == ExpressionType.GREATER_THAN || type == ExpressionType.GREATER_THAN_OR_EQUALS || type == ExpressionType.LESS_THAN || type == ExpressionType.LESS_THAN_OR_EQUALS || type == ExpressionType.NOT_EQUALS) {
+                    BasicExpressionFragment.AsEmbarkExpressionBinary(
+                        binaryType = when (type) {
+                            ExpressionType.EQUALS -> EmbarkExpressionTypeBinary.EQUALS
+                            ExpressionType.NOT_EQUALS -> EmbarkExpressionTypeBinary.NOT_EQUALS
+                            ExpressionType.GREATER_THAN -> EmbarkExpressionTypeBinary.MORE_THAN
+                            ExpressionType.GREATER_THAN_OR_EQUALS -> EmbarkExpressionTypeBinary.MORE_THAN_OR_EQUALS
+                            ExpressionType.LESS_THAN -> EmbarkExpressionTypeBinary.LESS_THAN
+                            ExpressionType.LESS_THAN_OR_EQUALS -> EmbarkExpressionTypeBinary.LESS_THAN_OR_EQUALS
+                            else -> throw Error("Unreachable")
+                        },
+                        key = key,
+                        value = value,
+                        text = text
+                    )
+                } else {
+                    null
                 },
-                key = key,
-                value = value,
-                text = text
             )
-        } else {
-            null
-        },
+        ),
         asEmbarkExpressionMultiple = if (type == ExpressionType.AND || type == ExpressionType.OR) {
-            MessageFragment.AsEmbarkExpressionMultiple(
+            ExpressionFragment.AsEmbarkExpressionMultiple(
                 multipleType = when (type) {
                     ExpressionType.AND -> EmbarkExpressionTypeMultiple.AND
                     ExpressionType.OR -> EmbarkExpressionTypeMultiple.OR
@@ -53,21 +57,15 @@ data class ExpressionBuilder(
                 },
                 text = text,
                 subExpressions = subExpressions.map {
-                    MessageFragment.SubExpression(
-                        fragments = MessageFragment.SubExpression.Fragments(
-                            it
-                        )
+                    ExpressionFragment.SubExpression(
+                        fragments = ExpressionFragment.SubExpression.Fragments(it.fragments.basicExpressionFragment)
                     )
-                }
+                },
             )
         } else {
             null
         }
     )
-
-    fun buildSubExpression() = build().intoSubExpression()
-
-    fun buildSubSubExpression() = build().intoSubExpression().intoSubSubExpression()
 
     enum class ExpressionType {
         ALWAYS,
@@ -82,44 +80,3 @@ data class ExpressionBuilder(
         OR
     }
 }
-
-fun MessageFragment.Expression.intoSubExpression() = SubExpressionFragment(
-    asEmbarkExpressionUnary = this.asEmbarkExpressionUnary?.let {
-        SubExpressionFragment.AsEmbarkExpressionUnary(
-            unaryType = it.unaryType,
-            text = it.text
-        )
-    },
-    asEmbarkExpressionBinary = this.asEmbarkExpressionBinary?.let {
-        SubExpressionFragment.AsEmbarkExpressionBinary(
-            binaryType = it.binaryType,
-            key = it.key,
-            value = it.value,
-            text = it.text
-        )
-    },
-    asEmbarkExpressionMultiple = this.asEmbarkExpressionMultiple?.let {
-        SubExpressionFragment.AsEmbarkExpressionMultiple(
-            multipleType = it.multipleType,
-            text = it.text,
-            subExpressions = it.subExpressions.map { se -> se.fragments.subExpressionFragment.intoSubSubExpression() }
-        )
-    }
-)
-
-fun SubExpressionFragment.intoSubSubExpression() = SubExpressionFragment.SubExpression(
-    asEmbarkExpressionUnary1 = this.asEmbarkExpressionUnary?.let {
-        SubExpressionFragment.AsEmbarkExpressionUnary1(
-            unaryType = it.unaryType,
-            text = it.text
-        )
-    },
-    asEmbarkExpressionBinary1 = this.asEmbarkExpressionBinary?.let {
-        SubExpressionFragment.AsEmbarkExpressionBinary1(
-            binaryType = it.binaryType,
-            key = it.key,
-            value = it.value,
-            text = it.text
-        )
-    }
-)

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/MessageBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/MessageBuilder.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.testdata.feature.embark.builders
 
 import com.hedvig.android.owldroid.fragment.ExpressionFragment
 import com.hedvig.android.owldroid.fragment.MessageFragment
+import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 
 data class MessageBuilder(
     private val text: String,
@@ -10,5 +11,20 @@ data class MessageBuilder(
     fun build() = MessageFragment(
         expressions = expressions.map { MessageFragment.Expression(fragments = MessageFragment.Expression.Fragments(it)) },
         text = text
+    )
+
+    fun buildMessageResponse() = EmbarkStoryQuery.Response(
+        fragments = EmbarkStoryQuery.Response.Fragments(build()),
+        asEmbarkResponseExpression = null,
+    )
+
+    fun buildExpressionResponse() = EmbarkStoryQuery.Response(
+        fragments = EmbarkStoryQuery.Response.Fragments(null),
+        asEmbarkResponseExpression = EmbarkStoryQuery.AsEmbarkResponseExpression(
+            text = text,
+            expressions = expressions.map {
+                EmbarkStoryQuery.Expression(fragments = EmbarkStoryQuery.Expression.Fragments(it))
+            }
+        )
     )
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/MessageBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/MessageBuilder.kt
@@ -1,13 +1,14 @@
 package com.hedvig.app.testdata.feature.embark.builders
 
+import com.hedvig.android.owldroid.fragment.ExpressionFragment
 import com.hedvig.android.owldroid.fragment.MessageFragment
 
 data class MessageBuilder(
     private val text: String,
-    private val expressions: List<MessageFragment.Expression> = emptyList()
+    private val expressions: List<ExpressionFragment> = emptyList(),
 ) {
     fun build() = MessageFragment(
-        expressions = expressions,
+        expressions = expressions.map { MessageFragment.Expression(fragments = MessageFragment.Expression.Fragments(it)) },
         text = text
     )
 }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/PassageBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/PassageBuilder.kt
@@ -9,7 +9,7 @@ data class PassageBuilder(
     private val name: String,
     private val id: String,
     private val messages: List<MessageFragment> = emptyList(),
-    private val response: MessageFragment = MessageBuilder(text = "").build(),
+    private val response: EmbarkStoryQuery.Response = MessageBuilder(text = "").buildMessageResponse(),
     private val redirects: List<EmbarkStoryQuery.Redirect> = emptyList(),
     private val action: EmbarkStoryQuery.Action,
     private val api: EmbarkStoryQuery.Api? = null,
@@ -17,7 +17,7 @@ data class PassageBuilder(
     private val links: List<EmbarkLinkFragment> = emptyList(),
     private val tracks: List<EmbarkStoryQuery.Track> = emptyList(),
     private val externalRedirect: EmbarkExternalRedirectLocation? = null,
-    private val offerRedirectKeys: List<String> = emptyList()
+    private val offerRedirectKeys: List<String> = emptyList(),
 ) {
     fun build() = EmbarkStoryQuery.Passage(
         name = name,
@@ -29,11 +29,7 @@ data class PassageBuilder(
                 )
             )
         },
-        response = EmbarkStoryQuery.Response(
-            fragments = EmbarkStoryQuery.Response.Fragments(
-                response
-            )
-        ),
+        response = response,
         tooltips = tooltip,
         redirects = redirects,
         action = action,

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/RedirectBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/builders/RedirectBuilder.kt
@@ -1,16 +1,16 @@
 package com.hedvig.app.testdata.feature.embark.builders
 
-import com.hedvig.android.owldroid.fragment.MessageFragment
+import com.hedvig.android.owldroid.fragment.ExpressionFragment
 import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 
 data class RedirectBuilder(
     private val to: String,
-    private val expression: MessageFragment.Expression,
+    private val expression: ExpressionFragment,
     private val passedExpressionKey: String? = null,
-    private val passedExpressionValue: String? = null
+    private val passedExpressionValue: String? = null,
 ) {
     fun build() = EmbarkStoryQuery.Redirect(
-        asEmbarkRedirectUnaryExpression = expression.asEmbarkExpressionUnary?.let {
+        asEmbarkRedirectUnaryExpression = expression.fragments.basicExpressionFragment.asEmbarkExpressionUnary?.let {
             EmbarkStoryQuery.AsEmbarkRedirectUnaryExpression(
                 unaryType = it.unaryType,
                 to = to,
@@ -18,7 +18,7 @@ data class RedirectBuilder(
                 passedExpressionValue = passedExpressionValue
             )
         },
-        asEmbarkRedirectBinaryExpression = expression.asEmbarkExpressionBinary?.let {
+        asEmbarkRedirectBinaryExpression = expression.fragments.basicExpressionFragment.asEmbarkExpressionBinary?.let {
             EmbarkStoryQuery.AsEmbarkRedirectBinaryExpression(
                 binaryType = it.binaryType,
                 to = to,
@@ -36,7 +36,12 @@ data class RedirectBuilder(
                 passedExpressionValue = passedExpressionValue,
                 subExpressions = it.subExpressions.map { se ->
                     EmbarkStoryQuery.SubExpression(
-                        fragments = EmbarkStoryQuery.SubExpression.Fragments(se.fragments.subExpressionFragment)
+                        fragments = EmbarkStoryQuery.SubExpression.Fragments(
+                            ExpressionFragment(
+                                fragments = ExpressionFragment.Fragments(se.fragments.basicExpressionFragment),
+                                asEmbarkExpressionMultiple = null
+                            )
+                        )
                     )
                 }
             )

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
@@ -67,7 +67,7 @@ val STANDARD_FIRST_PASSAGE_BUILDER =
         id = "1",
         response = MessageBuilder(
             text = "{TestPassageResult}"
-        ).build(),
+        ).buildMessageResponse(),
         messages = listOf(
             STANDARD_FIRST_MESSAGE
         ),
@@ -477,7 +477,7 @@ val STORY_WITH_TEXT_ACTION_AND_CUSTOM_RESPONSE = EmbarkStoryDataBuilder(
     passages = listOf(
         STANDARD_FIRST_PASSAGE_BUILDER
             .copy(
-                response = MessageBuilder(text = "{BAR} response").build(),
+                response = MessageBuilder(text = "{BAR} response").buildMessageResponse(),
                 action = TextActionBuilder(
                     key = "BAR", link = STANDARD_FIRST_LINK
                 ).build()
@@ -491,7 +491,7 @@ val STORY_WITH_SELECT_ACTION_AND_CUSTOM_RESPONSE = EmbarkStoryDataBuilder(
     passages = listOf(
         STANDARD_FIRST_PASSAGE_BUILDER
             .copy(
-                response = MessageBuilder(text = "{FOO} response").build(),
+                response = MessageBuilder(text = "{FOO} response").buildMessageResponse(),
                 action = SelectActionBuilder(
                     options = listOf(
                         SelectOptionBuilder(
@@ -1290,7 +1290,31 @@ val STORY_WITH_NUMBER_ACTION = EmbarkStoryDataBuilder(
                     maxValue = 75,
                     minValue = 1,
                     link = STANDARD_FIRST_LINK,
-                ).build()
+                ).build(),
+            )
+            .build(),
+        STANDARD_SECOND_PASSAGE_BUILDER.copy(
+            messages = listOf(
+                MessageBuilder("{BAR} was entered")
+                    .build()
+            )
+        ).build()
+    )
+).build()
+
+val STORY_WITH_NUMBER_ACTION_AND_CUSTOM_RESPONSE = EmbarkStoryDataBuilder(
+    passages = listOf(
+        STANDARD_FIRST_PASSAGE_BUILDER
+            .copy(
+                action = NumberActionBuilder(
+                    unit = "other people",
+                    placeholder = "1",
+                    label = "Co-insured",
+                    maxValue = 75,
+                    minValue = 1,
+                    link = STANDARD_FIRST_LINK,
+                ).build(),
+                response = MessageBuilder("custom response").buildExpressionResponse(),
             )
             .build(),
         STANDARD_SECOND_PASSAGE_BUILDER.copy(
@@ -1426,7 +1450,7 @@ val STORY_WITH_COMPUTED_VALUE = EmbarkStoryDataBuilder(
             id = "1",
             response = MessageBuilder(
                 text = "{TestPassageResult}"
-            ).build(),
+            ).buildMessageResponse(),
             messages = listOf(
                 MessageFragment(
                     text = "Text on input in next passage will have added 3 to your input",
@@ -1443,7 +1467,7 @@ val STORY_WITH_COMPUTED_VALUE = EmbarkStoryDataBuilder(
             id = "2",
             response = MessageBuilder(
                 text = "{TestPassageResult}"
-            ).build(),
+            ).buildMessageResponse(),
             messages = listOf(
                 MessageBuilder(
                     text = "Computed value is previous input + 3 = {BAR}"

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/embark/data/Data.kt
@@ -779,10 +779,10 @@ val STORY_WITH_OR_EXPRESSION = EmbarkStoryDataBuilder(
                                 subExpressions = listOf(
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.ALWAYS
-                                    ).buildSubExpression(),
+                                    ).build(),
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.NEVER
-                                    ).buildSubExpression()
+                                    ).build()
                                 )
                             ).build()
                         )
@@ -796,10 +796,10 @@ val STORY_WITH_OR_EXPRESSION = EmbarkStoryDataBuilder(
                                 subExpressions = listOf(
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.NEVER
-                                    ).buildSubExpression(),
+                                    ).build(),
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.NEVER
-                                    ).buildSubExpression()
+                                    ).build()
                                 )
                             ).build()
                         )
@@ -826,10 +826,10 @@ val STORY_WITH_AND_EXPRESSION = EmbarkStoryDataBuilder(
                                 subExpressions = listOf(
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.ALWAYS
-                                    ).buildSubExpression(),
+                                    ).build(),
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.ALWAYS
-                                    ).buildSubExpression()
+                                    ).build()
                                 )
                             ).build()
                         )
@@ -843,10 +843,10 @@ val STORY_WITH_AND_EXPRESSION = EmbarkStoryDataBuilder(
                                 subExpressions = listOf(
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.ALWAYS
-                                    ).buildSubExpression(),
+                                    ).build(),
                                     ExpressionBuilder(
                                         type = ExpressionBuilder.ExpressionType.NEVER
-                                    ).buildSubExpression()
+                                    ).build()
                                 )
                             ).build()
                         )
@@ -992,8 +992,8 @@ val STORY_WITH_MULTIPLE_REDIRECTS = EmbarkStoryDataBuilder(
                         expression = ExpressionBuilder(
                             type = ExpressionBuilder.ExpressionType.AND,
                             subExpressions = listOf(
-                                ExpressionBuilder(type = ExpressionBuilder.ExpressionType.ALWAYS).buildSubExpression(),
-                                ExpressionBuilder(type = ExpressionBuilder.ExpressionType.ALWAYS).buildSubExpression()
+                                ExpressionBuilder(type = ExpressionBuilder.ExpressionType.ALWAYS).build(),
+                                ExpressionBuilder(type = ExpressionBuilder.ExpressionType.ALWAYS).build(),
                             )
                         ).build()
                     ).build()


### PR DESCRIPTION
As it turns out, these are functionally equivalent to `EmbarkMessage`.
However, we need to support both.

I also did some opportunistic refactoring. Nice!

- Kill SubExpression in favor of BasicExpression
- Make the MockEmbarkViewModel work again
- Support `EmbarkResponseExpression`

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
