### PR TITLE
Show error on `fail` instead of `failure` in Simple Sign-authentication screen

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/zignsec/ui/ZignSecWebViewFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/zignsec/ui/ZignSecWebViewFragment.kt
@@ -44,7 +44,7 @@ class ZignSecWebViewFragment : Fragment(R.layout.activity_zign_sec_authenticatio
                         if (request?.url?.toString()?.contains("success") == true) {
                             return true
                         }
-                        if (request?.url?.toString()?.contains("failure") == true) {
+                        if (request?.url?.toString()?.contains("fail") == true) {
                             model.authFailed()
                             return true
                         }


### PR DESCRIPTION
I swear it used to redirect to an URL containing `failure`, not `fail`.
Whatever.
