### PR TITLE
Add CODEOWNERS to enable automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@HedvigInsurance/android


### PR DESCRIPTION
Automatically add the Android team as reviewers on PRs. 