### PR TITLE
Offer view state

### DIFF
--- a/app/src/engineering/java/com/hedvig/app/feature/offer/MockOfferViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/offer/MockOfferViewModel.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.feature.offer
 
 import android.os.Handler
 import android.os.Looper.getMainLooper
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.hedvig.android.owldroid.fragment.CostFragment
 import com.hedvig.android.owldroid.fragment.IncentiveFragment
@@ -17,7 +18,11 @@ import com.hedvig.app.testdata.feature.offer.OFFER_DATA_SWEDISH_APARTMENT
 import java.time.LocalDate
 
 class MockOfferViewModel : OfferViewModel() {
-    override val data = MutableLiveData<OfferQuery.Data>()
+
+    private val _viewState = MutableLiveData<ViewState>()
+    override val viewState: LiveData<ViewState>
+        get() = _viewState
+
     override val autoStartToken = MutableLiveData<SignOfferMutation.Data>()
     override val signStatus = MutableLiveData<SignStatusFragment>()
     override val signError = MutableLiveData<Boolean>()
@@ -25,7 +30,8 @@ class MockOfferViewModel : OfferViewModel() {
     init {
         Handler(getMainLooper()).postDelayed(
             {
-                data.postValue(mockData)
+                val items = OfferItemsBuilder.createItems(mockData)
+                _viewState.postValue(ViewState.OfferItems(items))
             },
             500
         )
@@ -38,27 +44,37 @@ class MockOfferViewModel : OfferViewModel() {
     override fun clearPreviousErrors() = Unit
     override fun manuallyRecheckSignStatus() = Unit
     override fun chooseStartDate(id: String, date: LocalDate) {
-        data.postValue(
-            mockData.copy(
-                lastQuoteOfMember = mockData.lastQuoteOfMember.copy(
-                    asCompleteQuote = mockData.lastQuoteOfMember.asCompleteQuote!!.copy(
-                        startDate = date
+        _viewState.postValue(
+            ViewState.OfferItems(
+                OfferItemsBuilder.createItems(mockData.copy(
+                    lastQuoteOfMember = mockData.lastQuoteOfMember.copy(
+                        asCompleteQuote = mockData.lastQuoteOfMember.asCompleteQuote!!.copy(
+                            startDate = date
+                        )
                     )
+                )
                 )
             )
         )
     }
 
     override fun removeStartDate(id: String) {
-        data.postValue(
-            mockData.copy(
-                lastQuoteOfMember = mockData.lastQuoteOfMember.copy(
-                    asCompleteQuote = mockData.lastQuoteOfMember.asCompleteQuote!!.copy(
-                        startDate = null
+        _viewState.postValue(
+            ViewState.OfferItems(
+                OfferItemsBuilder.createItems(mockData.copy(
+                    lastQuoteOfMember = mockData.lastQuoteOfMember.copy(
+                        asCompleteQuote = mockData.lastQuoteOfMember.asCompleteQuote!!.copy(
+                            startDate = null
+                        )
                     )
+                )
                 )
             )
         )
+    }
+
+    override fun trackUserSign() {
+
     }
 
     companion object {

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -319,7 +319,7 @@ val marketingModule = module {
 }
 
 val offerModule = module {
-    viewModel<OfferViewModel> { OfferViewModelImpl(get()) }
+    viewModel<OfferViewModel> { OfferViewModelImpl(get(), get()) }
 }
 
 val profileModule = module {

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferExt.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferExt.kt
@@ -1,0 +1,17 @@
+package com.hedvig.app.feature.offer
+
+import com.apollographql.apollo.api.Response
+import com.hedvig.android.owldroid.graphql.OfferQuery
+
+fun Response<OfferQuery.Data>.priceOrNull() = data
+    ?.lastQuoteOfMember
+    ?.asCompleteQuote
+    ?.insuranceCost
+    ?.fragments
+    ?.costFragment
+    ?.monthlyNet
+    ?.fragments
+    ?.monetaryAmountFragment
+    ?.amount
+    ?.toBigDecimal()
+    ?.toDouble()

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferItemsBuilder.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferItemsBuilder.kt
@@ -1,0 +1,27 @@
+package com.hedvig.app.feature.offer
+
+import com.hedvig.android.owldroid.graphql.OfferQuery
+import com.hedvig.app.feature.offer.ui.OfferModel
+
+class OfferItemsBuilder {
+
+    companion object {
+        fun createItems(data: OfferQuery.Data): List<OfferModel> {
+            return listOfNotNull(
+                OfferModel.Header(data),
+                OfferModel.Info,
+                OfferModel.Facts(data),
+                OfferModel.Perils(data),
+                OfferModel.Terms(data),
+                data.lastQuoteOfMember.asCompleteQuote?.currentInsurer?.let { currentInsurer ->
+                    if (currentInsurer.switchable == true) {
+                        OfferModel.Switcher(currentInsurer.displayName)
+                    } else {
+                        null
+                    }
+                },
+                OfferModel.Footer
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferSignDialog.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferSignDialog.kt
@@ -28,7 +28,6 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 class OfferSignDialog : DialogFragment() {
     private val model: OfferViewModel by sharedViewModel()
     private val binding by viewBinding(DialogSignBinding::bind)
-    private val tracker: OfferTracker by inject()
     private val marketManager: MarketManager by inject()
 
     val handler = Handler(getMainLooper())
@@ -109,23 +108,7 @@ class OfferSignDialog : DialogFragment() {
                     }
                     SignState.COMPLETED -> {
                         binding.signStatus.setText(R.string.SIGN_SUCCESSFUL)
-                        tracker.userDidSign(
-                            model
-                                .data
-                                .value
-                                ?.lastQuoteOfMember
-                                ?.asCompleteQuote
-                                ?.insuranceCost
-                                ?.fragments
-                                ?.costFragment
-                                ?.monthlyNet
-                                ?.fragments
-                                ?.monetaryAmountFragment
-                                ?.amount
-                                ?.toBigDecimal()
-                                ?.toDouble()
-                                ?: 0.0
-                        )
+                        model.trackUserSign()
                         goToDirectDebit()
                     }
                     else -> {

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferViewModel.kt
@@ -1,22 +1,26 @@
 package com.hedvig.app.feature.offer
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.apollographql.apollo.api.Response
 import com.hedvig.android.owldroid.fragment.SignStatusFragment
 import com.hedvig.android.owldroid.graphql.OfferQuery
 import com.hedvig.android.owldroid.graphql.RedeemReferralCodeMutation
 import com.hedvig.android.owldroid.graphql.SignOfferMutation
+import com.hedvig.app.feature.offer.ui.OfferModel
 import e
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
 abstract class OfferViewModel : ViewModel() {
-    abstract val data: MutableLiveData<OfferQuery.Data>
+    abstract val viewState: LiveData<ViewState>
     abstract val autoStartToken: MutableLiveData<SignOfferMutation.Data>
     abstract val signStatus: MutableLiveData<SignStatusFragment>
     abstract val signError: MutableLiveData<Boolean>
@@ -28,12 +32,27 @@ abstract class OfferViewModel : ViewModel() {
     abstract fun manuallyRecheckSignStatus()
     abstract fun chooseStartDate(id: String, date: LocalDate)
     abstract fun removeStartDate(id: String)
+    abstract fun trackUserSign()
+
+    sealed class ViewState {
+        data class OfferItems(val items: List<OfferModel>) : ViewState()
+        sealed class Error : ViewState() {
+            data class GeneralError(val message: String?) : Error()
+            object EmptyResponse : Error()
+        }
+        object HasContracts : ViewState()
+    }
 }
 
 class OfferViewModelImpl(
-    private val offerRepository: OfferRepository
+    private val offerRepository: OfferRepository,
+    private val tracker: OfferTracker
 ) : OfferViewModel() {
-    override val data = MutableLiveData<OfferQuery.Data>()
+
+    private val _viewState = MutableLiveData<ViewState>()
+    override val viewState: LiveData<ViewState>
+        get() = _viewState
+
     override val autoStartToken = MutableLiveData<SignOfferMutation.Data>()
     override val signStatus = MutableLiveData<SignStatusFragment>()
     override val signError = MutableLiveData<Boolean>()
@@ -43,15 +62,24 @@ class OfferViewModelImpl(
     }
 
     fun load() {
-        viewModelScope.launch {
-            offerRepository
-                .offer()
-                .onEach { response ->
-                    response.data?.let { data.postValue(it) }
-                }
-                .catch { e(it) }
-                .collect()
-        }
+        offerRepository.offer()
+            .map(::toViewState)
+            .onEach(_viewState::postValue)
+            .catch { _viewState.postValue(ViewState.Error.GeneralError(it.message)) }
+            .launchIn(viewModelScope)
+    }
+
+    private fun toViewState(response: Response<OfferQuery.Data>): ViewState {
+        return response.errors?.let {
+            ViewState.Error.GeneralError(it.firstOrNull()?.message)
+        } ?: response.data?.let { data ->
+            if (data.contracts.isNotEmpty()) {
+                ViewState.HasContracts
+            } else {
+                val items = OfferItemsBuilder.createItems(data)
+                ViewState.OfferItems(items)
+            }
+        } ?: ViewState.Error.EmptyResponse
     }
 
     override fun removeDiscount() {
@@ -148,6 +176,13 @@ class OfferViewModelImpl(
                 return@launch
             }
             response.getOrNull()?.data?.let { offerRepository.removeStartDateFromCache(it) }
+        }
+    }
+
+    override fun trackUserSign() {
+        viewModelScope.launch {
+            val price = offerRepository.offer().firstOrNull()?.priceOrNull() ?: 0.0
+            tracker.userDidSign(price)
         }
     }
 }


### PR DESCRIPTION
Observe view state to decouple network model from view.

Upcoming PRs will remove `OfferQuery.Data` from `OfferModel` to further decrease coupling between view and network layer.

<!-- Add when these when applicable. -->
### Checklist

- [x] Functionality is covered by an integration test
- [x] Functionality is accessible in engineering mode
