### PR TITLE
Pass locale to upcoming agreement query. Remove include annotation.

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/upcomingAgreement.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/upcomingAgreement.graphql
@@ -1,4 +1,4 @@
-query UpcomingAgreement($showDetailsTable: Boolean! = false) {
+query UpcomingAgreement($locale: Locale!) {
   contracts {
     ... UpcomingAgreementFragment
   }
@@ -23,7 +23,7 @@ fragment UpcomingAgreementFragment on Contract {
     }
   }
 
-  upcomingAgreementDetailsTable @include(if: $showDetailsTable) {
+  upcomingAgreementDetailsTable(locale: $locale) {
     title
     sections {
       title

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -476,7 +476,7 @@ val localeManagerModule = module {
 }
 
 val useCaseModule = module {
-    single { GetUpcomingAgreementUseCase(get()) }
+    single { GetUpcomingAgreementUseCase(get(), get()) }
     single { GetAddressChangeStoryIdUseCase(get()) }
     single { StartDanishAuthUseCase(get()) }
     single { StartNorwegianAuthUseCase(get()) }

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetUpcomingAgreementUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetUpcomingAgreementUseCase.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.UpcomingAgreementQuery
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.NoUpcomingAgreementChange
+import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
 import com.hedvig.app.util.apollo.toUpcomingAgreementResult
@@ -13,10 +14,15 @@ import kotlinx.android.parcel.Parcelize
 
 class GetUpcomingAgreementUseCase(
     private val apolloClient: ApolloClient,
+    localeManager: LocaleManager
 ) {
 
+    private val upcomingAgreementQuery = UpcomingAgreementQuery(
+        locale = localeManager.defaultLocale()
+    )
+
     suspend operator fun invoke(): UpcomingAgreementResult {
-        return when (val response = apolloClient.query(UpcomingAgreementQuery(showDetailsTable = true)).safeQuery()) {
+        return when (val response = apolloClient.query(upcomingAgreementQuery).safeQuery()) {
             is QueryResult.Success -> {
                 val contracts = response.data?.contracts
                 if (contracts.isNullOrEmpty()) {

--- a/testdata/src/main/java/com/hedvig/app/testdata/dashboard/builders/InsuranceDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/dashboard/builders/InsuranceDataBuilder.kt
@@ -223,7 +223,10 @@ class InsuranceDataBuilder(
                             asTerminatedInFutureStatus = null,
                             asTerminatedTodayStatus = null
                         ),
-                        upcomingAgreementDetailsTable = null
+                        upcomingAgreementDetailsTable = UpcomingAgreementFragment.UpcomingAgreementDetailsTable(
+                            title = "",
+                            sections = emptyList()
+                        )
                     )
                 )
             )

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/UpcomingAgreementBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/changeaddress/builders/UpcomingAgreementBuilder.kt
@@ -27,7 +27,7 @@ class UpcomingAgreementBuilder(
         asNorwegianHomeContentAgreement = null,
         asSwedishHouseAgreement = null
     ),
-    private val table: UpcomingAgreementFragment.UpcomingAgreementDetailsTable? = UpcomingAgreementFragment.UpcomingAgreementDetailsTable(
+    private val table: UpcomingAgreementFragment.UpcomingAgreementDetailsTable = UpcomingAgreementFragment.UpcomingAgreementDetailsTable(
         title = "Upcoming Agreement",
         sections = listOf(
             UpcomingAgreementFragment.Section(

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/insurance/builders/InsuranceContractBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/insurance/builders/InsuranceContractBuilder.kt
@@ -180,7 +180,10 @@ class InsuranceContractBuilder(
                     asTerminatedTodayStatus = null,
                     asTerminatedInFutureStatus = null
                 ),
-                upcomingAgreementDetailsTable = null
+                upcomingAgreementDetailsTable = UpcomingAgreementFragment.UpcomingAgreementDetailsTable(
+                    title = "",
+                    sections = emptyList()
+                )
             )
         )
     )


### PR DESCRIPTION
Could not get the include annotation to work when the mutation also took an input parameter, so had to remove it. Always querying `upcomingAgreementDetailsTable` should be fine anyway.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
