### PR TITLE
APP-442: Fix update language never being called for default language

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/MarketingActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/MarketingActivity.kt
@@ -69,7 +69,11 @@ class MarketingActivity : BaseActivity(R.layout.activity_marketing) {
 
     private fun replaceFragment(fragment: Fragment, navigationState: NavigationState, tag: String) {
         supportFragmentManager.commit {
-            replace(R.id.container, fragment.also { it.sharedElementEnterTransition = MaterialContainerTransform() }, tag)
+            replace(
+                R.id.container,
+                fragment.also { it.sharedElementEnterTransition = MaterialContainerTransform() },
+                tag
+            )
 
             if (navigationState.addToBackStack) {
                 addToBackStack(null)
@@ -83,7 +87,6 @@ class MarketingActivity : BaseActivity(R.layout.activity_marketing) {
     }
 
     companion object {
-        const val HAS_SELECTED_MARKET = "SHOULD_MARKET_SELECTED"
         const val SHARED_ELEMENT_NAME = "marketButton"
 
         private const val MARKET_FRAGMENT_TAG = "market"

--- a/app/src/main/java/com/hedvig/app/feature/marketpicker/MarketPickerViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketpicker/MarketPickerViewModel.kt
@@ -42,6 +42,7 @@ class MarketPickerViewModelImpl(
 
     override fun submit() {
         marketManager.hasSelectedMarket = true
+        pickerState.value?.language?.let { languageRepository.uploadLanguage(it) }
     }
 
     private fun updateState(market: Market, language: Language) {


### PR DESCRIPTION
- Fix language never being sent to backend for default language selection
- Verify that it happens for unknown market as well

<!-- Add when these when applicable. -->
### Checklist

- [X] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
