### PR TITLE
Remove unused query parameter from insurance query

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
@@ -1,4 +1,4 @@
-query InsuranceQuery($locale: Locale!, $showDetailsTable: Boolean! = false) {
+query InsuranceQuery($locale: Locale!) {
   contracts {
     id
     status {

--- a/app/src/main/java/com/hedvig/app/feature/insurance/data/InsuranceRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/data/InsuranceRepository.kt
@@ -12,13 +12,13 @@ class InsuranceRepository(
     private val localeManager: LocaleManager
 ) {
     suspend fun insurance() = apolloClient
-        .query(InsuranceQuery(localeManager.defaultLocale(), showDetailsTable = false))
+        .query(InsuranceQuery(localeManager.defaultLocale()))
         .await()
 
     suspend operator fun invoke(): InsuranceResult {
         return when (
             val response =
-                apolloClient.query(InsuranceQuery(localeManager.defaultLocale(), showDetailsTable = false)).safeQuery()
+                apolloClient.query(InsuranceQuery(localeManager.defaultLocale())).safeQuery()
         ) {
             is QueryResult.Success -> InsuranceResult.Insurance(response.data)
             is QueryResult.Error -> InsuranceResult.Error(response.message)


### PR DESCRIPTION
Remove unused parameter from insurance query to avoid crash when fetching insurances

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
### 