### PR TITLE
Delay starting transition to avoid glitchy input layouts

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.core.os.bundleOf
-import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
 import com.hedvig.app.databinding.EmbarkInputItemBinding
@@ -80,7 +79,10 @@ class TextActionFragment : Fragment(R.layout.fragment_text_action_set) {
                 .onEach { model.navigateToPassage(data.link) }
                 .launchIn(viewLifecycleScope)
 
-            messages.doOnNextLayout {
+            // We need to wait for all input views to be laid out before starting enter transition.
+            // This could perhaps be handled with a callback from the inputContainer.
+            viewLifecycleScope.launchWhenCreated {
+                delay(50)
                 startPostponedEnterTransition()
             }
         }


### PR DESCRIPTION
I looked around in the docs and there is a callback [onFinishInflate](https://developer.android.com/reference/android/view/View#onFinishInflate()), but could not get it to work properly. This works even though it is a bit hacky. Damn transitions... 

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
