### PR TITLE
APP-455: Redesign start date bottom sheet

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     implementation(Libs.AndroidX.browser)
     implementation(Libs.AndroidX.Lifecycle.common)
     implementation(Libs.AndroidX.Lifecycle.liveData)
+    implementation(Libs.AndroidX.Lifecycle.runtime)
     implementation(Libs.AndroidX.Lifecycle.viewModel)
     implementation(Libs.AndroidX.workManager)
     debugImplementation(Libs.AndroidX.startup)

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateExistingSwitchableInsuranceTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateExistingSwitchableInsuranceTest.kt
@@ -43,11 +43,8 @@ class ChooseStartDateExistingSwitchableInsuranceTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldUpdateStartDateWhenChoosingStartDate() = run {
+    fun shouldShowDatePickerDialogWhenPressingDate() = run {
         activityRule.launch()
-
-        val tomorrow = LocalDate.now().plusDays(1)
-
         onScreen<OfferScreen> {
             scroll {
                 childAt<OfferScreen.HeaderItem>(0) {
@@ -59,18 +56,9 @@ class ChooseStartDateExistingSwitchableInsuranceTest : TestCase() {
         }
         onScreen<ChangeDateSheet> {
             pickDate { click() }
-            datePicker {
-                datePicker { setDate(tomorrow) }
-                okButton { click() }
-            }
-            submit { click() }
-            confirm { positiveButton { click() } }
-        }
-        onScreen<OfferScreen> {
-            scroll {
-                childAt<OfferScreen.HeaderItem>(0) {
-                    startDate { containsText(tomorrow.toString()) }
-                }
+            materialDatePicker {
+                isVisible()
+                negativeButton { click() }
             }
         }
     }

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateExistingSwitchableInsuranceTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateExistingSwitchableInsuranceTest.kt
@@ -10,11 +10,10 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
-import com.hedvig.app.util.setDate
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import java.time.LocalDate
 import org.junit.Rule
 import org.junit.Test
-import java.time.LocalDate
 
 class ChooseStartDateExistingSwitchableInsuranceTest : TestCase() {
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateTest.kt
@@ -10,7 +10,6 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
-import com.hedvig.app.util.setDate
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import java.time.LocalDate
 import org.junit.Rule

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/ChooseStartDateTest.kt
@@ -12,9 +12,9 @@ import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.setDate
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import java.time.LocalDate
 import org.junit.Rule
 import org.junit.Test
-import java.time.LocalDate
 
 class ChooseStartDateTest : TestCase() {
 
@@ -39,11 +39,8 @@ class ChooseStartDateTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldUpdateStartDateWhenChoosingStartDate() = run {
+    fun shouldShowDatePickerDialogWhenPressingDate() = run {
         activityRule.launch()
-
-        val tomorrow = LocalDate.now().plusDays(1)
-
         onScreen<OfferScreen> {
             scroll {
                 childAt<OfferScreen.HeaderItem>(0) {
@@ -55,18 +52,9 @@ class ChooseStartDateTest : TestCase() {
         }
         onScreen<ChangeDateSheet> {
             pickDate { click() }
-            datePicker {
-                datePicker { setDate(tomorrow) }
-                okButton { click() }
-            }
-            submit { click() }
-            confirm { positiveButton { click() } }
-        }
-        onScreen<OfferScreen> {
-            scroll {
-                childAt<OfferScreen.HeaderItem>(0) {
-                    startDate { containsText(tomorrow.toString()) }
-                }
+            materialDatePicker {
+                isVisible()
+                negativeButton { click() }
             }
         }
     }

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/ExistingNonSwitchableInsuranceTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/ExistingNonSwitchableInsuranceTest.kt
@@ -36,7 +36,7 @@ class ExistingNonSwitchableInsuranceTest : TestCase() {
 
         onScreen<OfferScreen> {
             scroll {
-                hasSize(6)
+                hasSize(5)
                 childAt<OfferScreen.HeaderItem>(0) {
                     startDate {
                         hasText(R.string.START_DATE_TODAY)
@@ -47,7 +47,7 @@ class ExistingNonSwitchableInsuranceTest : TestCase() {
         }
 
         onScreen<ChangeDateSheet> {
-            autoSetDate { hasText(R.string.ACTIVATE_TODAY_BTN) }
+            autoSetDate { hasText(R.string.OFFER_PLAN_EXIRES_TEXT) }
         }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/NoExistingInsuranceTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/NoExistingInsuranceTest.kt
@@ -32,7 +32,7 @@ class NoExistingInsuranceTest : TestCase() {
 
         onScreen<OfferScreen> {
             scroll {
-                hasSize(6)
+                hasSize(5)
                 childAt<OfferScreen.HeaderItem>(0) {
                     startDate {
                         hasText(R.string.START_DATE_TODAY)
@@ -40,9 +40,6 @@ class NoExistingInsuranceTest : TestCase() {
                     }
                 }
             }
-        }
-        onScreen<ChangeDateSheet> {
-            autoSetDate { hasText(R.string.ACTIVATE_TODAY_BTN) }
         }
     }
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.feature.offer
 import android.view.View
 import com.agoda.kakao.common.views.KView
 import com.agoda.kakao.dialog.KAlertDialog
-import com.agoda.kakao.picker.date.KDatePickerDialog
 import com.agoda.kakao.recycler.KRecyclerItem
 import com.agoda.kakao.recycler.KRecyclerView
 import com.agoda.kakao.screen.Screen

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
@@ -10,6 +10,7 @@ import com.agoda.kakao.screen.Screen
 import com.agoda.kakao.text.KButton
 import com.agoda.kakao.text.KTextView
 import com.hedvig.app.R
+import com.hedvig.app.util.KMaterialDatePicker
 import org.hamcrest.Matcher
 
 class OfferScreen : Screen<OfferScreen>() {
@@ -40,7 +41,7 @@ class OfferScreen : Screen<OfferScreen>() {
 class ChangeDateSheet : Screen<ChangeDateSheet>() {
     val autoSetDate = KButton { withId(R.id.auto_set_date_switch) }
     val pickDate = KView { withId(R.id.date_pick_layout) }
-    val datePicker = KDatePickerDialog()
+    val materialDatePicker = KMaterialDatePicker()
     val submit = KButton { withId(R.id.chooseDateButton) }
     val confirm = KAlertDialog()
 }

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
@@ -38,8 +38,8 @@ class OfferScreen : Screen<OfferScreen>() {
 }
 
 class ChangeDateSheet : Screen<ChangeDateSheet>() {
-    val autoSetDate = KButton { withId(R.id.autoSetDateText) }
-    val pickDate = KView { withId(R.id.datePickButton) }
+    val autoSetDate = KButton { withId(R.id.`@+id/auto_set_date_switch`) }
+    val pickDate = KView { withId(R.id.`@+id/date_pick_layout`) }
     val datePicker = KDatePickerDialog()
     val submit = KButton { withId(R.id.chooseDateButton) }
     val confirm = KAlertDialog()

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/OfferScreen.kt
@@ -38,8 +38,8 @@ class OfferScreen : Screen<OfferScreen>() {
 }
 
 class ChangeDateSheet : Screen<ChangeDateSheet>() {
-    val autoSetDate = KButton { withId(R.id.`@+id/auto_set_date_switch`) }
-    val pickDate = KView { withId(R.id.`@+id/date_pick_layout`) }
+    val autoSetDate = KButton { withId(R.id.auto_set_date_switch) }
+    val pickDate = KView { withId(R.id.date_pick_layout) }
     val datePicker = KDatePickerDialog()
     val submit = KButton { withId(R.id.chooseDateButton) }
     val confirm = KAlertDialog()

--- a/app/src/androidTest/java/com/hedvig/app/util/KMaterialDatePicker.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/KMaterialDatePicker.kt
@@ -1,0 +1,17 @@
+package com.hedvig.app.util
+
+import com.agoda.kakao.common.views.KBaseView
+import com.agoda.kakao.text.KButton
+
+class KMaterialDatePicker : KBaseView<KMaterialDatePicker>({ isRoot() }) {
+
+    init {
+        inRoot { isDialog() }
+    }
+
+    val positiveButton = KButton { withId(com.google.android.material.R.id.confirm_button) }
+        .also { it.inRoot { isDialog() } }
+
+    val negativeButton = KButton { withId(com.google.android.material.R.id.cancel_button) }
+        .also { it.inRoot { isDialog() } }
+}

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -89,6 +89,8 @@ import com.hedvig.app.feature.offer.OfferRepository
 import com.hedvig.app.feature.offer.OfferTracker
 import com.hedvig.app.feature.offer.OfferViewModel
 import com.hedvig.app.feature.offer.OfferViewModelImpl
+import com.hedvig.app.feature.offer.ui.changestartdate.ChangeDateBottomSheetData
+import com.hedvig.app.feature.offer.ui.changestartdate.ChangeDateBottomSheetViewModel
 import com.hedvig.app.feature.onboarding.ChoosePlanRepository
 import com.hedvig.app.feature.onboarding.ChoosePlanViewModel
 import com.hedvig.app.feature.onboarding.ChoosePlanViewModelImpl
@@ -392,6 +394,10 @@ val trustlyModule = module {
 
 val changeAddressModule = module {
     viewModel<ChangeAddressViewModel> { ChangeAddressViewModelImpl(get(), get()) }
+}
+
+val changeDateBottomSheetModule = module {
+    viewModel { (data: ChangeDateBottomSheetData) -> ChangeDateBottomSheetViewModel(data) }
 }
 
 val serviceModule = module {

--- a/app/src/main/java/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/java/com/hedvig/app/HedvigApplication.kt
@@ -77,6 +77,7 @@ open class HedvigApplication : Application() {
                     embarkTrackerModule,
                     localeManagerModule,
                     changeAddressModule,
+                    changeDateBottomSheetModule,
                     useCaseModule,
                     valueStoreModule,
                     onboardingModule,

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/datepicker/DatePickerViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/datepicker/DatePickerViewModel.kt
@@ -2,9 +2,8 @@ package com.hedvig.app.feature.embark.passages.datepicker
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import java.time.Instant
+import com.hedvig.app.util.extensions.epochMillisToLocalDate
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 class DatePickerViewModel : ViewModel() {
 
@@ -21,6 +20,5 @@ class DatePickerViewModel : ViewModel() {
         showDatePicker.value = selectedEpochMillis
     }
 
-    private fun epochMillisToLocalDate(epochMillis: Long) =
-        LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault())
+    private fun epochMillisToLocalDate(epochMillis: Long) = epochMillis.epochMillisToLocalDate()
 }

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
@@ -62,20 +62,23 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
                 if (viewState.hasSwitchableInsurer) {
                     setupDateSwitch(viewState, dateText)
                 }
-
-                binding.chooseDateButton.setOnClickListener {
-                    val localDate = viewState.selectedDateTime.toLocalDate()
-                    if (viewState.selectedDateTime.isToday()) {
-                        setDateAndFinish(viewState.id, localDate)
-                    } else {
-                        showChooseOwnStartDateDialog(viewState.id, localDate)
-                    }
-                }
+                setupChooseDateButton(viewState)
             }
         }
 
         binding.datePickText.setHapticClickListener {
             showDatePickerDialog()
+        }
+    }
+
+    private fun setupChooseDateButton(viewState: ChangeDateBottomSheetViewModel.ViewState) {
+        binding.chooseDateButton.setOnClickListener {
+            val localDate = viewState.selectedDateTime.toLocalDate()
+            if (viewState.selectedDateTime.isToday()) {
+                setDateAndFinish(viewState.id, localDate)
+            } else {
+                showChooseOwnStartDateDialog(viewState.id, localDate)
+            }
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
@@ -13,7 +13,7 @@ import com.hedvig.app.databinding.DialogChangeStartDateBinding
 import com.hedvig.app.feature.offer.OfferTracker
 import com.hedvig.app.feature.offer.OfferViewModel
 import com.hedvig.app.util.extensions.isToday
-import com.hedvig.app.util.extensions.repeatOnLifeCycleLaunch
+import com.hedvig.app.util.extensions.repeatOnViewLifeCycleLaunch
 import com.hedvig.app.util.extensions.showAlert
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
@@ -50,7 +50,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        repeatOnLifeCycleLaunch {
+        repeatOnViewLifeCycleLaunch {
             changeDateBottomSheetViewModel.viewState.collect { viewState ->
                 val dateText = viewState.getFormattedDateText()
                 binding.datePickText.setText(dateText)

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
@@ -58,9 +58,9 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
                 binding.autoSetDateSwitch.isVisible = viewState.hasSwitchableInsurer
                 binding.autoSetDateTitle.isVisible = viewState.hasSwitchableInsurer
                 if (viewState.hasSwitchableInsurer) {
-                    setupDateSwitch(viewState, dateText)
+                    bindDateSwitch(viewState, dateText)
                 }
-                setupChooseDateButton(viewState)
+                bindChooseDateButton(viewState)
             }
         }
 
@@ -69,7 +69,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
         }
     }
 
-    private fun setupChooseDateButton(viewState: ChangeDateBottomSheetViewModel.ViewState) {
+    private fun bindChooseDateButton(viewState: ChangeDateBottomSheetViewModel.ViewState) {
         binding.chooseDateButton.setOnClickListener {
             val localDate = viewState.selectedDateTime.toLocalDate()
             if (viewState.selectedDateTime.isToday()) {
@@ -80,7 +80,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
         }
     }
 
-    private fun setupDateSwitch(
+    private fun bindDateSwitch(
         viewState: ChangeDateBottomSheetViewModel.ViewState,
         dateText: String?
     ) {

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
@@ -8,6 +8,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.hedvig.app.R
 import com.hedvig.app.databinding.DialogChangeStartDateBinding
@@ -31,6 +32,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
     private val offerViewModel: OfferViewModel by sharedViewModel()
     private val changeDateBottomSheetViewModel: ChangeDateBottomSheetViewModel by viewModel {
         val data = requireArguments().getParcelable<ChangeDateBottomSheetData>(DATA)
+            ?: throw IllegalArgumentException("No data provided to ChangeDateBottomSheet")
         parametersOf(data)
     }
     private val tracker: OfferTracker by inject()

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheet.kt
@@ -6,22 +6,20 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.hedvig.app.R
 import com.hedvig.app.databinding.DialogChangeStartDateBinding
 import com.hedvig.app.feature.offer.OfferTracker
 import com.hedvig.app.feature.offer.OfferViewModel
 import com.hedvig.app.util.extensions.isToday
+import com.hedvig.app.util.extensions.repeatOnLifeCycleLaunch
 import com.hedvig.app.util.extensions.showAlert
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -52,7 +50,7 @@ class ChangeDateBottomSheet : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        lifecycleScope.launch {
+        repeatOnLifeCycleLaunch {
             changeDateBottomSheetViewModel.viewState.collect { viewState ->
                 val dateText = viewState.getFormattedDateText()
                 binding.datePickText.setText(dateText)

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheetViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheetViewModel.kt
@@ -1,0 +1,30 @@
+package com.hedvig.app.feature.offer.ui.changestartdate
+
+import androidx.lifecycle.ViewModel
+import com.hedvig.app.util.extensions.epochMillisToLocalDate
+import java.time.LocalDateTime
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class ChangeDateBottomSheetViewModel(data: ChangeDateBottomSheetData) : ViewModel() {
+
+    private val _viewState = MutableStateFlow(ViewState(data))
+    val viewState: StateFlow<ViewState> = _viewState
+
+    fun onDateSelected(epochMillis: Long) {
+        val selectedDateTime = epochMillis.epochMillisToLocalDate()
+        _viewState.value = _viewState.value.copy(selectedDateTime = selectedDateTime)
+    }
+
+    data class ViewState(
+        val id: String,
+        val selectedDateTime: LocalDateTime = LocalDateTime.now(),
+        val hasSwitchableInsurer: Boolean
+    ) {
+        constructor(data: ChangeDateBottomSheetData) : this(
+            id = data.id,
+            selectedDateTime = LocalDateTime.now(),
+            hasSwitchableInsurer = data.hasSwitchableInsurer
+        )
+    }
+}

--- a/app/src/main/java/com/hedvig/app/util/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/FragmentExtensions.kt
@@ -13,7 +13,7 @@ val Fragment.screenWidth: Int
 val Fragment.viewLifecycleScope
     get() = viewLifecycleOwner.lifecycleScope
 
-fun Fragment.repeatOnLifeCycleLaunch(
+fun Fragment.repeatOnViewLifeCycleLaunch(
     repeatOnLifeCycleState: Lifecycle.State = Lifecycle.State.STARTED,
     block: suspend () -> Unit
 ) {

--- a/app/src/main/java/com/hedvig/app/util/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/FragmentExtensions.kt
@@ -2,12 +2,26 @@ package com.hedvig.app.util.extensions
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
 
 val Fragment.screenWidth: Int
     get() = requireActivity().screenWidth
 
 val Fragment.viewLifecycleScope
     get() = viewLifecycleOwner.lifecycleScope
+
+fun Fragment.repeatOnLifeCycleLaunch(
+    repeatOnLifeCycleState: Lifecycle.State = Lifecycle.State.STARTED,
+    block: suspend () -> Unit
+) {
+    viewLifecycleScope.launch {
+        viewLifecycleOwner.lifecycle.repeatOnLifecycle(repeatOnLifeCycleState) {
+            block()
+        }
+    }
+}
 
 fun FragmentTransaction.addToBackStack() = addToBackStack(null)

--- a/app/src/main/java/com/hedvig/app/util/extensions/LocalDateTimeExt.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/LocalDateTimeExt.kt
@@ -1,9 +1,12 @@
 package com.hedvig.app.util.extensions
 
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 fun Long.epochMillisToLocalDate(): LocalDateTime {
     return LocalDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneId.systemDefault())
 }
+
+fun LocalDateTime.isToday() = toLocalDate().isEqual(LocalDate.now())

--- a/app/src/main/java/com/hedvig/app/util/extensions/LocalDateTimeExt.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/LocalDateTimeExt.kt
@@ -1,0 +1,9 @@
+package com.hedvig.app.util.extensions
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+fun Long.epochMillisToLocalDate(): LocalDateTime {
+    return LocalDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneId.systemDefault())
+}

--- a/app/src/main/res/layout/dialog_change_start_date.xml
+++ b/app/src/main/res/layout/dialog_change_start_date.xml
@@ -6,10 +6,9 @@
     android:layout_height="match_parent"
     android:background="@drawable/bottom_sheet_dialog_no_title_fragment_background"
     android:orientation="vertical"
-    android:paddingStart="@dimen/base_margin_triple"
+    android:paddingHorizontal="@dimen/base_margin_double"
     android:paddingTop="@dimen/base_margin"
-    android:paddingEnd="@dimen/base_margin_triple"
-    android:paddingBottom="@dimen/peril_bottom_extra_spacing"
+    android:paddingBottom="@dimen/base_margin_triple"
     tools:context=".feature.offer.ui.changestartdate.ChangeDateBottomSheet">
 
     <ImageView
@@ -20,44 +19,60 @@
         app:srcCompat="@drawable/bottom_sheet_handle" />
 
     <TextView
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/base_margin_double"
-        android:text="@string/DRAGGABLE_STARTDATE_TITLE"
-        android:textAppearance="?textAppearanceHeadline4" />
+        android:gravity="center"
+        android:text="@string/OFFER_SET_START_DATE"
+        android:textAppearance="?textAppearanceHeadline5" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/date_pick_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:hint="@string/OFFER_START_DATE"
+        app:boxCornerRadiusBottomEnd="@dimen/base_margin"
+        app:boxCornerRadiusBottomStart="@dimen/base_margin"
+        app:boxCornerRadiusTopEnd="@dimen/base_margin"
+        app:boxCornerRadiusTopStart="@dimen/base_margin">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/datePickText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:editable="false"
+            android:focusable="false"
+            android:textAppearance="?textAppearanceBody1"
+            android:textColor="@color/textColorSecondary" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <TextView
-        android:id="@+id/info"
+        android:id="@+id/autoSetDateTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/base_margin_triple"
+        android:text="@string/OFFER_PLAN_EXPIRE_TITLE"
+        android:textAppearance="?textAppearanceSubtitle1" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/auto_set_date_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/base_margin"
-        android:text="@string/DRAGGABLE_STARTDATE_DESCRIPTION"
-        android:textAppearance="?textAppearanceBody1" />
-
-
-    <com.hedvig.app.ui.view.DateInputView
-        android:id="@+id/datePickButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/base_margin_sextuple"
-        app:dateHintBackground="?colorSurface" />
+        android:text="@string/OFFER_PLAN_EXIRES_TEXT"
+        app:switchPadding="@dimen/base_margin_triple"
+        app:switchTextAppearance="@style/SwitchTextAppearance" />
 
     <Button
         android:id="@+id/chooseDateButton"
-        android:layout_width="wrap_content"
+        style="@style/Hedvig.Button.Large"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="@dimen/base_margin_quintuple"
-        android:text="@string/CHOOSE_DATE_BTN" />
-
-    <Button
-        android:id="@+id/autoSetDateText"
-        style="?attr/materialButtonTextStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/auto_set_date_text_size"
-        android:textAlignment="center"
-        tools:text="@string/ACTIVATE_INSURANCE_END_BTN" />
+        android:text="@string/general_save_button" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_change_start_date.xml
+++ b/app/src/main/res/layout/dialog_change_start_date.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical"
     android:paddingHorizontal="@dimen/base_margin_double"
     android:paddingTop="@dimen/base_margin"
-    android:paddingBottom="@dimen/base_margin_triple"
+    android:paddingBottom="@dimen/base_margin"
     tools:context=".feature.offer.ui.changestartdate.ChangeDateBottomSheet">
 
     <ImageView
@@ -21,7 +21,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/base_margin_double"
+        android:layout_marginTop="@dimen/base_margin_triple"
         android:gravity="center"
         android:text="@string/OFFER_SET_START_DATE"
         android:textAppearance="?textAppearanceHeadline5" />
@@ -59,12 +59,13 @@
 
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/auto_set_date_switch"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/base_margin"
+        android:layout_marginTop="@dimen/base_margin_half"
         android:text="@string/OFFER_PLAN_EXIRES_TEXT"
+        android:textColor="@color/textColorSecondary"
         app:switchPadding="@dimen/base_margin_triple"
-        app:switchTextAppearance="@style/SwitchTextAppearance" />
+        app:switchTextAppearance="?textAppearanceBody2" />
 
     <Button
         android:id="@+id/chooseDateButton"
@@ -72,7 +73,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/base_margin_quintuple"
+        android:layout_marginTop="@dimen/base_margin_double"
         android:text="@string/general_save_button" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_change_start_date.xml
+++ b/app/src/main/res/layout/dialog_change_start_date.xml
@@ -57,13 +57,13 @@
         android:text="@string/OFFER_PLAN_EXPIRE_TITLE"
         android:textAppearance="?textAppearanceSubtitle1" />
 
-    <androidx.appcompat.widget.SwitchCompat
+    <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/auto_set_date_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/base_margin_half"
         android:text="@string/OFFER_PLAN_EXIRES_TEXT"
-        android:textColor="@color/textColorSecondary"
+        android:textColor="@color/textColorPrimary"
         app:switchPadding="@dimen/base_margin_triple"
         app:switchTextAppearance="?textAppearanceBody2" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -155,7 +155,4 @@
         <item name="android:paddingTop">12dp</item>
     </style>
 
-    <style name="SwitchTextAppearance" parent="Hedvig.TextAppearance.Body2">
-        <item name="android:textColor">@color/textColorThird</item>
-    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -154,4 +154,8 @@
         <item name="android:clipToPadding">false</item>
         <item name="android:paddingTop">12dp</item>
     </style>
+
+    <style name="SwitchTextAppearance" parent="Hedvig.TextAppearance.Body2">
+        <item name="android:textColor">@color/textColorThird</item>
+    </style>
 </resources>

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -25,8 +25,10 @@ object Libs {
 
         object Lifecycle {
             private const val version = "2.3.1"
+            private const val runtimeVersion = "2.4.0-alpha01"
             const val common = "androidx.lifecycle:lifecycle-common-java8:$version"
             const val liveData = "androidx.lifecycle:lifecycle-livedata-ktx:$version"
+            const val runtime = "androidx.lifecycle:lifecycle-runtime-ktx:$runtimeVersion"
             const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
         }
 


### PR DESCRIPTION
Redesigned start date bottom sheet in offer screen. Added a viewmodel to handle events from view and supply an observable viewstate. The viewmodel is using StateFlow instead of LiveData, I think we should move to StateFlow since it has better coroutines support. See this article: https://medium.com/androiddevelopers/migrating-from-livedata-to-kotlins-flow-379292f419fb

We will need to be able to support multiple start dates as well, but that is another PR :) 

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
