### PR TITLE
APP-644: Add some padding to the upcoming change bottom sheet

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/yourinfo/UpcomingChangeBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/yourinfo/UpcomingChangeBottomSheet.kt
@@ -3,9 +3,11 @@ package com.hedvig.app.feature.insurance.ui.detail.yourinfo
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.core.view.updatePadding
 import com.hedvig.app.feature.table.Table
 import com.hedvig.app.feature.table.TableAdapter
 import com.hedvig.app.ui.view.ExpandableBottomSheet
+import com.hedvig.app.util.extensions.dp
 
 class UpcomingChangeBottomSheet : ExpandableBottomSheet() {
 
@@ -17,6 +19,7 @@ class UpcomingChangeBottomSheet : ExpandableBottomSheet() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val adapter = TableAdapter()
+        binding.recycler.updatePadding(bottom = binding.recycler.paddingBottom + 56.dp)
         binding.recycler.adapter = adapter
         adapter.setTable(upcomingAgreement)
     }


### PR DESCRIPTION
Looks like it's never truly been fully expandable. This is the same solution as is in place on the peril bottom sheet.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
