### PR TITLE
Remove tabs transition

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.bumptech.glide.RequestBuilder
-import com.google.android.material.transition.MaterialFadeThrough
 import com.hedvig.android.owldroid.graphql.HomeQuery
 import com.hedvig.android.owldroid.type.PayinMethodStatus
 import com.hedvig.app.R
@@ -36,13 +35,6 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
     private val requestBuilder: RequestBuilder<PictureDrawable> by inject()
     private val marketManager: MarketManager by inject()
     private val featureRuntimeBehavior: FeatureManager by inject()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        enterTransition = MaterialFadeThrough()
-        exitTransition = MaterialFadeThrough()
-    }
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceFragment.kt
@@ -29,13 +29,6 @@ class InsuranceFragment : Fragment(R.layout.fragment_insurance) {
     private val binding by viewBinding(FragmentInsuranceBinding::bind)
     private var scroll = 0
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        enterTransition = MaterialFadeThrough()
-        exitTransition = MaterialFadeThrough()
-    }
-
     override fun onResume() {
         super.onResume()
         loggedInViewModel.onScroll(scroll)

--- a/app/src/main/java/com/hedvig/app/feature/keygear/ui/tab/KeyGearFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/ui/tab/KeyGearFragment.kt
@@ -47,13 +47,6 @@ class KeyGearFragment : Fragment(R.layout.fragment_key_gear) {
 
     private var hasSentAutoAddedItems = false
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        enterTransition = MaterialFadeThrough()
-        exitTransition = MaterialFadeThrough()
-    }
-
     override fun onResume() {
         super.onResume()
         loggedInViewModel.onScroll(scroll)

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -7,8 +7,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.view.Menu
 import android.view.MenuItem
-import android.view.Window
-import androidx.core.view.WindowCompat
 import androidx.dynamicanimation.animation.FloatValueHolder
 import androidx.dynamicanimation.animation.SpringAnimation
 import androidx.dynamicanimation.animation.SpringForce
@@ -47,10 +45,10 @@ import com.hedvig.app.util.extensions.view.performOnTapHapticFeedback
 import com.hedvig.app.util.extensions.view.show
 import com.hedvig.app.util.extensions.viewBinding
 import e
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import java.time.LocalDate
 import javax.money.MonetaryAmount
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -74,8 +72,6 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
     private lateinit var referralsIncentive: MonetaryAmount
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        window.requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
-        window.allowReturnTransitionOverlap = true
         super.onCreate(savedInstanceState)
 
         savedTab = savedInstanceState?.getSerializable("tab") as? LoggedInTabs
@@ -117,7 +113,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 supportFragmentManager
                     .beginTransaction()
                     .replace(R.id.tabContent, id.fragment)
-                    .commitAllowingStateLoss()
+                    .commit()
 
                 setupToolBar()
                 animateGradient(id)

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -113,7 +113,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 supportFragmentManager
                     .beginTransaction()
                     .replace(R.id.tabContent, id.fragment)
-                    .commit()
+                    .commitNowAllowingStateLoss()
 
                 setupToolBar()
                 animateGradient(id)

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.transition.MaterialFadeThrough
 import com.hedvig.android.owldroid.fragment.CostFragment
 import com.hedvig.android.owldroid.graphql.ProfileQuery
 import com.hedvig.android.owldroid.type.DirectDebitStatus
@@ -43,13 +42,6 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
     private var scroll = 0
     private val tracker: ProfileTracker by inject()
     private val marketManager: MarketManager by inject()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        enterTransition = MaterialFadeThrough()
-        exitTransition = MaterialFadeThrough()
-    }
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.doOnLayout
+import androidx.core.view.doOnNextLayout
 import androidx.core.view.marginBottom
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.flowWithLifecycle
@@ -54,13 +55,6 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
     private var shareInitialBottomMargin = 0
     private var invitesInitialBottomPadding = 0
     private var scroll = 0
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        enterTransition = MaterialFadeThrough()
-        exitTransition = MaterialFadeThrough()
-    }
 
     override fun onResume() {
         super.onResume()


### PR DESCRIPTION
I noticed the transition between tabs were quite glitchy. This is because we need to postpone enter transitions, and wait until the recylerview in the enter fragment has been laid out. After trying different approaches for this and getting it to work quite well, I removed the transition just to compare the differences. Conclusion: the tabs feel more responsive and less glitchy when disabling the transitions altogether.

Please try it out and see what you think. I could spend some more time getting the original transitions to work if we really want to, but I think this is works well - especially when we have loading states for each tab. 

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
