### PR TITLE
APP-740: Do not use delegate when binding view

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
@@ -22,12 +22,10 @@ import com.hedvig.app.feature.connectpayin.ConnectPaymentViewModel
 import com.hedvig.app.feature.connectpayin.TransitionType
 import com.hedvig.app.feature.connectpayin.showConfirmCloseDialog
 import com.hedvig.app.util.onBackPressedCallback
-import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
-    private val binding by viewBinding(TrustlyConnectFragmentBinding::bind)
     private val trustlyViewModel: TrustlyViewModel by viewModel()
     private val connectPaymentViewModel: ConnectPaymentViewModel by sharedViewModel()
 
@@ -66,6 +64,8 @@ class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
                 })
             )
         }
+
+        val binding = TrustlyConnectFragmentBinding.bind(view)
 
         binding.apply {
             toolbar.apply {

--- a/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
@@ -11,6 +11,9 @@ import android.webkit.WebViewClient
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.withStateAtLeast
 import androidx.transition.TransitionManager
 import com.google.android.material.transition.MaterialFadeThrough
 import com.google.android.material.transition.MaterialSharedAxis
@@ -22,10 +25,13 @@ import com.hedvig.app.feature.connectpayin.ConnectPaymentViewModel
 import com.hedvig.app.feature.connectpayin.TransitionType
 import com.hedvig.app.feature.connectpayin.showConfirmCloseDialog
 import com.hedvig.app.util.onBackPressedCallback
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
+    private val binding by viewBinding(TrustlyConnectFragmentBinding::bind)
     private val trustlyViewModel: TrustlyViewModel by viewModel()
     private val connectPaymentViewModel: ConnectPaymentViewModel by sharedViewModel()
 
@@ -64,8 +70,6 @@ class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
                 })
             )
         }
-
-        val binding = TrustlyConnectFragmentBinding.bind(view)
 
         binding.apply {
             toolbar.apply {
@@ -107,14 +111,19 @@ class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
                 webViewClient = object : WebViewClient() {
                     override fun onPageFinished(view: WebView?, url: String?) {
                         super.onPageFinished(view, url)
-                        if (!hasLoadedWebView) {
-                            TransitionManager.beginDelayedTransition(
-                                binding.root,
-                                MaterialFadeThrough()
-                            )
-                            loadingContainer.isVisible = false
-                            trustly.isVisible = true
-                            hasLoadedWebView = true
+                        lifecycleScope.launch {
+                            // Need to check lifecycle here since we are starting other activities in onPageStarted
+                            viewLifecycleOwner.withStateAtLeast(Lifecycle.State.CREATED) {
+                                if (!hasLoadedWebView) {
+                                    TransitionManager.beginDelayedTransition(
+                                        binding.root,
+                                        MaterialFadeThrough()
+                                    )
+                                    loadingContainer.isVisible = false
+                                    trustly.isVisible = true
+                                    hasLoadedWebView = true
+                                }
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
@@ -12,8 +12,6 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.withStateAtLeast
 import androidx.transition.TransitionManager
 import com.google.android.material.transition.MaterialFadeThrough
 import com.google.android.material.transition.MaterialSharedAxis
@@ -26,7 +24,6 @@ import com.hedvig.app.feature.connectpayin.TransitionType
 import com.hedvig.app.feature.connectpayin.showConfirmCloseDialog
 import com.hedvig.app.util.onBackPressedCallback
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
-import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -111,18 +108,15 @@ class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
                 webViewClient = object : WebViewClient() {
                     override fun onPageFinished(view: WebView?, url: String?) {
                         super.onPageFinished(view, url)
-                        lifecycleScope.launch {
-                            // Need to check lifecycle here since we are starting other activities in onPageStarted
-                            viewLifecycleOwner.withStateAtLeast(Lifecycle.State.CREATED) {
-                                if (!hasLoadedWebView) {
-                                    TransitionManager.beginDelayedTransition(
-                                        binding.root,
-                                        MaterialFadeThrough()
-                                    )
-                                    loadingContainer.isVisible = false
-                                    trustly.isVisible = true
-                                    hasLoadedWebView = true
-                                }
+                        if (viewLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+                            if (!hasLoadedWebView) {
+                                TransitionManager.beginDelayedTransition(
+                                    binding.root,
+                                    MaterialFadeThrough()
+                                )
+                                loadingContainer.isVisible = false
+                                trustly.isVisible = true
+                                hasLoadedWebView = true
                             }
                         }
                     }


### PR DESCRIPTION
Trying to fix this: https://console.firebase.google.com/u/0/project/hedvig-app/crashlytics/app/android:com.hedvig.app/issues/dcb21560ba705b789ee6f32fffa67fdf?time=last-thirty-days&sessionEventKey=61093E3B024A00012F17C310AF9B5648_1570634230566486193

I think it may have something to do with starting bankId and then returning to this fragment and trying to access bindings which no longer exist (because view no longer exists?). Tried using "dont keep activities" with no success. Removing the binding delegate was the only thing I could think of worth trying.

Do you have any ideas what might cause this?

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
