### PR TITLE
APP-743: Show embark error messages

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -21,6 +21,8 @@ import com.hedvig.app.util.getWithDotNotation
 import com.hedvig.app.util.plus
 import com.hedvig.app.util.safeLet
 import com.hedvig.app.util.toStringArray
+import java.util.Stack
+import kotlin.math.max
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,8 +31,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
-import java.util.Stack
-import kotlin.math.max
 
 abstract class EmbarkViewModel(
     private val tracker: EmbarkTracker,
@@ -95,9 +95,9 @@ abstract class EmbarkViewModel(
 
     fun getPrefillFromStore(key: String) = valueStore.prefill.get(key)
 
-    fun getFromStore(key: String) = valueStore.get(key)
+    private fun getFromStore(key: String) = valueStore.get(key)
 
-    fun getListFromStore(keys: List<String>): List<String> {
+    private fun getListFromStore(keys: List<String>): List<String> {
         return keys.map {
             valueStore.getList(it) ?: listOfNotNull(valueStore.get(it))
         }.flatten()

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
@@ -36,6 +36,7 @@ import com.hedvig.app.feature.embark.passages.textaction.TextActionParameter
 import com.hedvig.app.feature.offer.ui.OfferActivity
 import com.hedvig.app.feature.settings.MarketManager
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
+import com.hedvig.app.util.extensions.showAlert
 import com.hedvig.app.util.extensions.view.applyStatusBarInsets
 import com.hedvig.app.util.extensions.view.remove
 import com.hedvig.app.util.extensions.viewBinding
@@ -81,7 +82,15 @@ class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
                 val passage = embarkData.passage
                 actionBar?.title = passage?.name
 
-                transitionToNextPassage(embarkData.navigationDirection, passage)
+                if (passage?.action == null && passage?.messages?.isNotEmpty() == true) {
+                    showAlert(
+                        title = getString(R.string.error_dialog_title),
+                        message = passage.messages.joinToString { it.fragments.messageFragment.text },
+                        positiveAction = {}
+                    )
+                } else {
+                    transitionToNextPassage(embarkData.navigationDirection, passage)
+                }
             }
 
             model


### PR DESCRIPTION
Not sure if checking action == null && messages.notEmpty is enough here. I want to not show the "update app" screen and instead show the error messages, for example if we input co-insured > 6. What do you think? 

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
