### PR TITLE
Feature/apollo graphqls schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,12 @@ sentry.properties
 *.li
 .classpath
 .project
-schema.json
 mapping.txt
 
 # graphql
 .graphqlconfig
+schema.json
+**/*.graphqls
 
 # adyen credentials
 adyen.xml

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.configureondemand=false
 systemProp.org.gradle.android.cache-fix.ignoreVersionCheck=true
 android.useAndroidX=true
 com.apollographql.apollo.endpoint=https://graphql.dev.hedvigit.com/graphql
-com.apollographql.apollo.schema=src/main/graphql/com/hedvig/android/owldroid/schema.json
+com.apollographql.apollo.schema=src/main/graphql/com/hedvig/android/owldroid/schema.graphqls


### PR DESCRIPTION
Checkout the branch, delete the schema.json file and download the schema again with the new gradle.properties changes.

graphqls format gives some very nice navigation inside the IDE along with autocompletion for types. It really helps me since I am unfamiliar with basically all the queries/types right now. Maybe it's something we want to merge into develop for everyone to use from now on?

I don't know if you've looked into it before and decided against it due to some limitation or whatever.