### PR TITLE
Fix/app 780 wrong theme on cross sell subheader

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/CrossSellingResultScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/CrossSellingResultScreen.kt
@@ -1,5 +1,6 @@
 package com.hedvig.app.feature.crossselling.ui
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.hedvig.app.R
 import com.hedvig.app.ui.compose.designsystem.LargeContainedButton
 import com.hedvig.app.ui.compose.designsystem.LargeOutlinedButton
@@ -152,7 +154,7 @@ private fun ButtonsSection(
                     onClick = openChat,
                 ) {
                     Image(
-                        painter = painterResource(R.drawable.ic_chat_white),
+                        painter = painterResource(R.drawable.ic_chat_on_primary),
                         contentDescription = null,
                     )
                     Spacer(Modifier.width(8.dp))
@@ -182,6 +184,28 @@ private fun ButtonsSection(
 )
 @Composable
 fun CrossSellingResultScreenPreview(
+    @PreviewParameter(ActivityResultProvider::class) crossSellingResult: CrossSellingResult,
+) {
+    HedvigTheme {
+        CrossSellingResultScreen(
+            crossSellingResult,
+            Clock.systemDefaultZone(),
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            {},
+            {}
+        )
+    }
+}
+
+@ShowkaseComposable(skip = true)
+@Preview(
+    showSystemUi = true,
+    name = "Accident Result • Dark",
+    group = "Cross Sell result",
+    uiMode = UI_MODE_NIGHT_YES,
+)
+@Composable
+fun CrossSellingResultScreenPreviewDark(
     @PreviewParameter(ActivityResultProvider::class) crossSellingResult: CrossSellingResult,
 ) {
     HedvigTheme {

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/result/ChangeAddressResultActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/result/ChangeAddressResultActivity.kt
@@ -16,7 +16,6 @@ import com.hedvig.app.util.extensions.viewBinding
 import e
 import kotlinx.parcelize.Parcelize
 import org.koin.android.ext.android.inject
-import org.koin.java.KoinJavaComponent.inject
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
@@ -1,5 +1,6 @@
 package com.hedvig.app.feature.insurance.ui
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -28,6 +29,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.commit451.coiltransformations.CropTransformation
 import com.hedvig.app.ui.compose.theme.HedvigTheme
 import com.hedvig.app.ui.compose.theme.hedvigBlack
@@ -79,7 +81,6 @@ fun CrossSell(
                             Color(0x00000000),
                             Color(0xFF000000),
                         ),
-
                     )
                 )
                 .padding(16.dp),
@@ -123,6 +124,15 @@ fun CrossSell(
     }
 }
 
+private val previewData = InsuranceModel.CrossSell(
+    title = "Accident Insurance",
+    description = "179 kr/mo.",
+    callToAction = "Calculate price",
+    action = InsuranceModel.CrossSell.Action.Chat,
+    backgroundUrl = "https://images.unsplash.com/photo-1628996796855-0b056a464e06",
+    backgroundBlurHash = "LJC6\$2-:DiWB~WxuRkayMwNGo~of",
+)
+
 @Preview(
     name = "Cross-Sell Card",
     group = "Insurance Tab",
@@ -132,14 +142,23 @@ fun CrossSell(
 fun CrossSellPreview() {
     HedvigTheme {
         CrossSell(
-            data = InsuranceModel.CrossSell(
-                title = "Accident Insurance",
-                description = "179 kr/mo.",
-                callToAction = "Calculate price",
-                action = InsuranceModel.CrossSell.Action.Chat,
-                backgroundUrl = "https://images.unsplash.com/photo-1628996796855-0b056a464e06",
-                backgroundBlurHash = "LJC6\$2-:DiWB~WxuRkayMwNGo~of",
-            ),
+            data = previewData,
+            onCtaClick = {}
+        )
+    }
+}
+
+@ShowkaseComposable(skip = true)
+@Preview(
+    name = "Cross-Sell Card • Dark",
+    group = "Insurance Tab",
+    uiMode = UI_MODE_NIGHT_YES,
+)
+@Composable
+fun CrossSellPreviewDark() {
+    HedvigTheme {
+        CrossSell(
+            data = previewData,
             onCtaClick = {}
         )
     }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceAdapter.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.feature.insurance.ui
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -36,8 +35,7 @@ class InsuranceAdapter(
     private val tracker: InsuranceTracker,
     private val marketManager: MarketManager,
     private val retry: () -> Unit
-) :
-    ListAdapter<InsuranceModel, InsuranceAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
+) : ListAdapter<InsuranceModel, InsuranceAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
         R.layout.insurance_contract_card -> ViewHolder.ContractViewHolder(parent)
@@ -200,8 +198,7 @@ class InsuranceAdapter(
             }
         }
 
-        class SubheadingViewHolder(val composeView: ComposeView) :
-            ViewHolder(composeView) {
+        class SubheadingViewHolder(val composeView: ComposeView) : ViewHolder(composeView) {
 
             init {
                 composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/Subheading.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/Subheading.kt
@@ -1,13 +1,16 @@
 package com.hedvig.app.feature.insurance.ui
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.hedvig.app.ui.compose.theme.HedvigTheme
 
 @Composable
@@ -35,5 +38,21 @@ fun Subheading(text: String) {
 fun SubheadingPreview() {
     HedvigTheme {
         Subheading("Add more coverage")
+    }
+}
+
+@ShowkaseComposable(skip = true)
+@Preview(
+    name = "Subheading • Dark",
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Composable
+fun SubheadingPreviewDark() {
+    HedvigTheme {
+        Surface(
+            color = MaterialTheme.colors.background,
+        ) {
+            Subheading("Add more coverage")
+        }
     }
 }

--- a/app/src/main/java/com/hedvig/app/ui/compose/designsystem/LargeContainedButton.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/designsystem/LargeContainedButton.kt
@@ -1,5 +1,6 @@
 package com.hedvig.app.ui.compose.designsystem
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.hedvig.app.R
 import com.hedvig.app.ui.compose.theme.HedvigTheme
 
@@ -36,6 +38,21 @@ fun LargeContainedButton(
 )
 @Composable
 fun LargeContainedButtonPreview() {
+    HedvigTheme {
+        LargeContainedButton({}) {
+            Text("Contained Button (Large)")
+        }
+    }
+}
+
+@ShowkaseComposable(skip = true)
+@Preview(
+    name = "LargeContainedButton • dark",
+    group = "Design System",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun LargeContainedButtonPreviewDark() {
     HedvigTheme {
         LargeContainedButton({}) {
             Text("Contained Button (Large)")

--- a/app/src/main/java/com/hedvig/app/ui/compose/theme/Theme.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/theme/Theme.kt
@@ -5,9 +5,5 @@ import com.google.android.material.composethemeadapter.MdcTheme
 
 @Composable
 fun HedvigTheme(content: @Composable () -> Unit) {
-    MdcTheme(
-        setTextColors = false,
-        setDefaultFontFamily = true,
-        content = content,
-    )
+    MdcTheme(content = content)
 }

--- a/app/src/main/java/com/hedvig/app/ui/compose/theme/Theme.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/theme/Theme.kt
@@ -5,5 +5,5 @@ import com.google.android.material.composethemeadapter.MdcTheme
 
 @Composable
 fun HedvigTheme(content: @Composable () -> Unit) {
-    MdcTheme(content = content)
+    MdcTheme(setDefaultFontFamily = true, content = content)
 }

--- a/app/src/main/res/drawable/ic_chat_on_primary.xml
+++ b/app/src/main/res/drawable/ic_chat_on_primary.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnPrimary"
+        android:fillType="evenOdd"
+        android:pathData="M19.5 3.25H4.562c-1.033 0-2.01 0.448-2.718 1.221C1.137 5.242 0.75 6.275 0.75 7.34v7.16c0.003 1.063 0.39 2.093 1.097 2.863 0.707 0.772 1.68 1.22 2.712 1.224h0.754v2.266c0.005 0.28 0.08 0.556 0.222 0.8 0.142 0.245 0.348 0.45 0.603 0.587 0.256 0.138 0.546 0.198 0.838 0.17 0.292-0.03 0.564-0.145 0.787-0.326l0.014-0.01 3.925-3.487h7.8c1.032-0.003 2.005-0.452 2.713-1.224 0.706-0.77 1.094-1.8 1.097-2.863V7.327c-0.003-1.062-0.392-2.092-1.098-2.86C21.505 3.697 20.53 3.25 19.5 3.25zM17 13.75H4v-1.5h13v1.5zM4 9.5h16V8H4v1.5z" />
+</vector>


### PR DESCRIPTION
<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode

Enabling the MdcTheme text colors just doesn't play well with what we're doing. It stops recognising what surface the composables are on top of and simply puts the values that are I guess specified in our theme. So all these may be true
* I understand something wrong about the MdcTheme implementation.
* Our theme doesn't contain the correct values for the text colors
* Some other changes are needed in our theme file?
* Some other weird bug?

For now it looks like this by simply not setting `setTextColors: Boolean` to true.

Light mode | Dark Mode
-|-
 ![Insurance_Cross_Sell](https://user-images.githubusercontent.com/44558292/134254870-34d2a403-6d5c-4b35-a5ae-64bae4a23f83.png)  |  ![Insurance_Cross_Sell_Dark](https://user-images.githubusercontent.com/44558292/134254860-130dbe50-4e4e-4e83-bf96-8508a140cedc.png)


