### PR TITLE
Allow `TemplateExpressionCalculator` to see values from both `savedValues` and `stage`

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/ValueStore.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ValueStore.kt
@@ -52,7 +52,7 @@ class ValueStoreImpl : ValueStore {
 
     override fun get(key: String): String? {
         return computedValues?.get(key)?.let {
-            TemplateExpressionCalculator.evaluateTemplateExpression(it, storedValues.peek())
+            TemplateExpressionCalculator.evaluateTemplateExpression(it, storedValues.peek() + stage)
         } ?: storedValues.peek()[key] ?: stage[key]
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/computedvalues/TemplateExpressionCalculator.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/computedvalues/TemplateExpressionCalculator.kt
@@ -17,7 +17,7 @@ object TemplateExpressionCalculator {
         TokenType.STRING_CONSTANT to SINGLE_QUOTE_STRING_CONSTANT_EXPR,
     )
 
-    fun evaluateTemplateExpression(expression: String, store: HashMap<String, String>): String = try {
+    fun evaluateTemplateExpression(expression: String, store: Map<String, String>): String = try {
         val tokenStream = parseTokenStream(expression)
         val abstractExpression = parseAbstractExpression(tokenStream)
         evaluateAbstractExpression(abstractExpression, store)
@@ -123,7 +123,7 @@ object TemplateExpressionCalculator {
             ?: throw NoExpressionMatch("Could not create an abstract expression from $tokenStream")
     }
 
-    private fun evaluateAbstractExpression(expression: Expression, store: HashMap<String, String>): String =
+    private fun evaluateAbstractExpression(expression: Expression, store: Map<String, String>): String =
         when (expression) {
             is Expression.StoreKeyExpression -> store[expression.key] ?: ""
             is Expression.NumberConstantExpression -> expression.constant.toBigDecimal().stripTrailingZeros().toString()


### PR DESCRIPTION
<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
