### PR TITLE
APP-838: Use `contractPerils` instead of the deprecated `perils`

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
@@ -19,7 +19,7 @@ query InsuranceQuery($locale: Locale!) {
     currentAgreementDetailsTable(locale: $locale) {
       ...TableFragment
     }
-    perils(locale: $locale) {
+    contractPerils(locale: $locale) {
       ...PerilFragment
     }
     insurableLimits(locale: $locale) {

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/offer.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/offer.graphql
@@ -19,7 +19,7 @@ query Offer($locale: Locale!, $ids: [ID!]!) {
         ...TableFragment
       }
 
-      perils(locale: $locale) {
+      contractPerils(locale: $locale) {
         ...PerilFragment
       }
       termsAndConditions(locale: $locale) {

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/CoverageTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/CoverageTest.kt
@@ -47,7 +47,7 @@ class CoverageTest : TestCase() {
                             2 +
                                 INSURANCE_DATA_NORWEGIAN_HOME_CONTENTS
                                     .contracts[0]
-                                    .let { it.perils.size + it.insurableLimits.size }
+                                    .let { it.contractPerils.size + it.insurableLimits.size }
                         )
                         childAt<PerilRecyclerItem>(3) {
                             click()

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/PerilBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/PerilBottomSheetTest.kt
@@ -43,7 +43,7 @@ class PerilBottomSheetTest : TestCase() {
                             2 +
                                 INSURANCE_DATA_SWEDISH_HOUSE
                                     .contracts[0]
-                                    .let { it.perils.size + it.insurableLimits.size }
+                                    .let { it.contractPerils.size + it.insurableLimits.size }
                         )
                         childAt<PerilRecyclerItem>(3) {
                             click()

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/MultipleQuotesTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/MultipleQuotesTest.kt
@@ -93,7 +93,7 @@ class MultipleQuotesTest : TestCase() {
     private val homeContentsFirstPerilTitle = OFFER_DATA_NORWAY_BUNDLE_HOME_CONTENTS_TRAVEL
         .quoteBundle
         .quotes[0]
-        .perils[0]
+        .contractPerils[0]
         .fragments
         .perilFragment
         .title

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewModel.kt
@@ -109,21 +109,19 @@ class ContractDetailViewModelImpl(
                         uri = Uri.parse(it),
                     )
                 },
-                contract.termsAndConditions?.url.let {
-                    DocumentItems.Document(
-                        titleRes = R.string.MY_DOCUMENTS_INSURANCE_TERMS,
-                        subTitleRes = R.string.insurance_details_view_documents_insurance_letter_subtitle,
-                        // TODO Quick fix for getting new terms and conditions
-                        uri = Uri.parse(
-                            if (marketManager.market == Market.SE) {
-                                "https://www.hedvig.com/se/villkor"
-                            } else {
-                                it
-                            }
-                        ),
-                        type = DocumentItems.Document.Type.TERMS_AND_CONDITIONS
-                    )
-                }
+                DocumentItems.Document(
+                    titleRes = R.string.MY_DOCUMENTS_INSURANCE_TERMS,
+                    subTitleRes = R.string.insurance_details_view_documents_insurance_letter_subtitle,
+                    // TODO Quick fix for getting new terms and conditions
+                    uri = Uri.parse(
+                        if (marketManager.market == Market.SE) {
+                            "https://www.hedvig.com/se/villkor"
+                        } else {
+                            contract.termsAndConditions.url
+                        }
+                    ),
+                    type = DocumentItems.Document.Type.TERMS_AND_CONDITIONS
+                )
             )
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageFragment.kt
@@ -24,7 +24,10 @@ class CoverageFragment : Fragment(R.layout.contract_detail_coverage_fragment) {
     private val imageLoader: ImageLoader by inject()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val perilsAdapter = PerilsAdapter(parentFragmentManager, imageLoader)
+        val perilsAdapter = PerilsAdapter(
+            fragmentManager = parentFragmentManager,
+            imageLoader = imageLoader,
+        )
         val insurableLimitsAdapter = InsurableLimitsAdapter(parentFragmentManager)
         val concatAdapter = ConcatAdapter(perilsAdapter, insurableLimitsAdapter)
         binding.root.apply {

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageItems.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageItems.kt
@@ -8,7 +8,7 @@ import com.hedvig.app.feature.perils.PerilItem
 fun createCoverageItems(contract: InsuranceQuery.Contract): List<PerilItem> {
     return listOf(
         PerilItem.Header(contract.typeOfContract)
-    ) + contract.perils.map {
+    ) + contract.contractPerils.map {
         PerilItem.Peril(Peril.from(it.fragments.perilFragment))
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/PerilAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/PerilAdapter.kt
@@ -20,7 +20,7 @@ import com.hedvig.app.util.extensions.isDarkThemeActive
 import com.hedvig.app.util.extensions.viewBinding
 
 class PerilAdapter(
-    private val imageLoader: ImageLoader
+    private val imageLoader: ImageLoader,
 ) : ListAdapter<PerilModel, PerilAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
@@ -117,20 +117,19 @@ class PerilAdapter(
         class Icon(parent: ViewGroup, private val imageLoader: ImageLoader) :
             ViewHolder(parent.inflate(R.layout.peril_icon)) {
             private val binding by viewBinding(PerilIconBinding::bind)
+
             override fun bind(item: PerilModel) {
                 if (item !is PerilModel.Icon) {
                     invalid(item)
                     return
                 }
                 binding.root.apply {
-                    val link = "${context.getString(R.string.BASE_URL)}${
-                    if (context.isDarkThemeActive) {
+                    val link = if (context.isDarkThemeActive) {
                         item.darkUrl
                     } else {
                         item.lightUrl
                     }
-                    }"
-                    this.load(link, imageLoader) {
+                    load(link, imageLoader) {
                         crossfade(true)
                     }
                 }

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferItemsBuilder.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferItemsBuilder.kt
@@ -153,7 +153,7 @@ object OfferItemsBuilder {
 
     fun createPerilItems(data: List<OfferQuery.Quote>) = if (data.size == 1) {
         data[0]
-            .perils
+            .contractPerils
             .map { peril ->
                 peril.fragments.perilFragment.let { perilFragment ->
                     PerilItem.Peril(Peril.from(perilFragment))

--- a/app/src/main/java/com/hedvig/app/feature/offer/quotedetail/ItemBuilders.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/quotedetail/ItemBuilders.kt
@@ -7,7 +7,7 @@ import com.hedvig.app.feature.perils.Peril
 import com.hedvig.app.feature.perils.PerilItem
 
 fun buildPerils(quote: OfferQuery.Quote) = quote
-    .perils
+    .contractPerils
     .map { PerilItem.Peril(Peril.from(it.fragments.perilFragment)) }
 
 fun buildInsurableLimits(quote: OfferQuery.Quote) = quote

--- a/app/src/main/java/com/hedvig/app/feature/perils/PerilsAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/perils/PerilsAdapter.kt
@@ -104,9 +104,13 @@ class PerilsAdapter(
             }
         }
 
-        class Peril(parent: ViewGroup, private val imageLoader: ImageLoader) :
+        class Peril(
+            parent: ViewGroup,
+            private val imageLoader: ImageLoader,
+        ) :
             ViewHolder(parent.inflate(R.layout.peril_detail)) {
             private val binding by viewBinding(PerilDetailBinding::bind)
+
             override fun bind(
                 data: PerilItem,
                 fragmentManager: FragmentManager,
@@ -116,13 +120,11 @@ class PerilsAdapter(
                 }
 
                 label.text = data.inner.title
-                val iconUrl = "${icon.context.getString(R.string.BASE_URL)}${
-                if (icon.context.isDarkThemeActive) {
+                val iconUrl = if (icon.context.isDarkThemeActive) {
                     data.inner.darkUrl
                 } else {
                     data.inner.lightUrl
                 }
-                }"
                 icon.load(iconUrl, imageLoader) {
                     crossfade(true)
                 }
@@ -132,7 +134,7 @@ class PerilsAdapter(
                         .newInstance(data.inner)
                         .show(
                             fragmentManager,
-                            PerilBottomSheet.TAG
+                            PerilBottomSheet.TAG,
                         )
                 }
             }

--- a/testdata/src/main/java/com/hedvig/app/testdata/dashboard/builders/InsuranceDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/dashboard/builders/InsuranceDataBuilder.kt
@@ -109,7 +109,7 @@ class InsuranceDataBuilder(
                 currentAgreementDetailsTable = InsuranceQuery.CurrentAgreementDetailsTable(
                     fragments = InsuranceQuery.CurrentAgreementDetailsTable.Fragments(detailsTable),
                 ),
-                perils = PerilBuilder().insuranceQueryBuild(5),
+                contractPerils = PerilBuilder().insuranceQueryBuild(5),
                 insurableLimits = listOf(
                     InsuranceQuery.InsurableLimit(
                         fragments = InsuranceQuery.InsurableLimit.Fragments(

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/insurance/builders/InsuranceContractBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/insurance/builders/InsuranceContractBuilder.kt
@@ -62,7 +62,7 @@ class InsuranceContractBuilder(
         currentAgreementDetailsTable = InsuranceQuery.CurrentAgreementDetailsTable(
             fragments = InsuranceQuery.CurrentAgreementDetailsTable.Fragments(detailsTable),
         ),
-        perils = PerilBuilder().insuranceQueryBuild(5),
+        contractPerils = PerilBuilder().insuranceQueryBuild(5),
         insurableLimits = listOf(
             InsuranceQuery.InsurableLimit(
                 fragments = InsuranceQuery.InsurableLimit.Fragments(

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/insurance/builders/PerilBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/insurance/builders/PerilBuilder.kt
@@ -12,24 +12,24 @@ class PerilBuilder {
     fun offerQueryBuild(noOfPerils: Int) = offerQueryPerils(noOfPerils)
 
     companion object {
-        private fun insuranceQueryPerils(noOfPerils: Int): MutableList<InsuranceQuery.Peril> {
-            val perilList: MutableList<InsuranceQuery.Peril> = mutableListOf()
+        private fun insuranceQueryPerils(noOfPerils: Int): MutableList<InsuranceQuery.ContractPeril> {
+            val perilList: MutableList<InsuranceQuery.ContractPeril> = mutableListOf()
             for (i in 0..noOfPerils) {
                 perilList.add(
-                    InsuranceQuery.Peril(
-                        fragments = InsuranceQuery.Peril.Fragments(PERIL_FRAGMENT)
+                    InsuranceQuery.ContractPeril(
+                        fragments = InsuranceQuery.ContractPeril.Fragments(PERIL_FRAGMENT)
                     )
                 )
             }
             return perilList
         }
 
-        private fun offerQueryPerils(noOfPerils: Int): MutableList<OfferQuery.Peril> {
-            val perilList: MutableList<OfferQuery.Peril> = mutableListOf()
+        private fun offerQueryPerils(noOfPerils: Int): MutableList<OfferQuery.ContractPeril> {
+            val perilList: MutableList<OfferQuery.ContractPeril> = mutableListOf()
             for (i in 0..noOfPerils) {
                 perilList.add(
-                    OfferQuery.Peril(
-                        fragments = OfferQuery.Peril.Fragments(PERIL_FRAGMENT)
+                    OfferQuery.ContractPeril(
+                        fragments = OfferQuery.ContractPeril.Fragments(PERIL_FRAGMENT)
                     )
                 )
             }

--- a/testdata/src/main/java/com/hedvig/app/testdata/feature/offer/builders/OfferDataBuilder.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/feature/offer/builders/OfferDataBuilder.kt
@@ -49,7 +49,7 @@ data class QuoteBuilder(
     private val id: String = "ea656f5f-40b2-4953-85d9-752b33e69e38",
     private val typeOfContract: TypeOfContract = TypeOfContract.SE_APARTMENT_RENT,
     private val currentInsurer: OfferQuery.CurrentInsurer? = null,
-    private val perils: List<OfferQuery.Peril> = PerilBuilder().offerQueryBuild(5),
+    private val perils: List<OfferQuery.ContractPeril> = PerilBuilder().offerQueryBuild(5),
     private val termsAndConditionsUrl: String = "https://www.example.com",
     private val insurableLimits: List<OfferQuery.InsurableLimit> = emptyList(),
     private val insuranceTerms: List<OfferQuery.InsuranceTerm> = emptyList(),
@@ -65,7 +65,7 @@ data class QuoteBuilder(
         detailsTable = OfferQuery.DetailsTable(
             fragments = OfferQuery.DetailsTable.Fragments(detailsTable),
         ),
-        perils = perils,
+        contractPerils = perils,
         termsAndConditions = OfferQuery.TermsAndConditions(
             displayName = "Villkor",
             url = termsAndConditionsUrl,


### PR DESCRIPTION
<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
