### PR TITLE
APP-850: Fix opening chat from Moving Flow sometimes not allowing free text-chat

### DIFF
--- a/app/src/engineering/java/com/hedvig/app/feature/changeaddress/MockChangeAddressViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/changeaddress/MockChangeAddressViewModel.kt
@@ -22,6 +22,8 @@ class MockChangeAddressViewModel : ChangeAddressViewModel() {
         }
     }
 
+    override suspend fun triggerFreeTextChat() = Unit
+
     companion object {
         var mockedState: MutableLiveData<ViewState> = MutableLiveData()
     }

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -428,7 +428,7 @@ val trustlyModule = module {
 }
 
 val changeAddressModule = module {
-    viewModel<ChangeAddressViewModel> { ChangeAddressViewModelImpl(get(), get()) }
+    viewModel<ChangeAddressViewModel> { ChangeAddressViewModelImpl(get(), get(), get()) }
 }
 
 val changeDateBottomSheetModule = module {

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.transition.TransitionManager
 import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
 import com.hedvig.app.BaseActivity
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ChangeAddressActivityBinding
@@ -14,12 +15,7 @@ import com.hedvig.app.feature.chat.ui.ChatActivity
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.GeneralError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.NoContractsError
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ChangeAddressInProgress
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.Loading
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ManualChangeAddress
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeAddress
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeError
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.UpcomingAgreementError
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.*
 import com.hedvig.app.util.extensions.compatDrawable
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.view.applyNavigationBarInsetsMargin
@@ -28,6 +24,7 @@ import com.hedvig.app.util.extensions.view.remove
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.view.show
 import com.hedvig.app.util.extensions.viewBinding
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
@@ -91,7 +88,11 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
                 subtitleText = getString(R.string.moving_intro_existing_move_description),
                 buttonText = getString(R.string.moving_intro_manual_handling_button_text),
                 buttonIcon = R.drawable.ic_chat_white,
-                onContinue = { openChat() },
+                onContinue = {
+                    lifecycleScope.launch {
+                        openChat()
+                    }
+                },
                 viewState.upcomingAgreementResult
             )
             is UpcomingAgreementError -> setContent(

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -95,6 +95,7 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
                 buttonIcon = R.drawable.ic_chat_white,
                 onContinue = {
                     lifecycleScope.launch {
+                        model.triggerFreeTextChat()
                         openChat()
                     }
                 },

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -15,7 +15,12 @@ import com.hedvig.app.feature.chat.ui.ChatActivity
 import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.GeneralError
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult.Error.NoContractsError
-import com.hedvig.app.feature.home.ui.changeaddress.ViewState.*
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ChangeAddressInProgress
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.Loading
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.ManualChangeAddress
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeAddress
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.SelfChangeError
+import com.hedvig.app.feature.home.ui.changeaddress.ViewState.UpcomingAgreementError
 import com.hedvig.app.util.extensions.compatDrawable
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.view.applyNavigationBarInsetsMargin

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
@@ -4,19 +4,25 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hedvig.app.feature.chat.data.ChatRepository
 import com.hedvig.app.feature.home.ui.changeaddress.GetAddressChangeStoryIdUseCase.SelfChangeEligibilityResult
 import com.hedvig.app.feature.home.ui.changeaddress.GetUpcomingAgreementUseCase.UpcomingAgreementResult
+import com.hedvig.app.util.coroutines.runSuspendCatching
+import e
 import kotlinx.coroutines.launch
 
 abstract class ChangeAddressViewModel : ViewModel() {
     protected val _viewState = MutableLiveData<ViewState>()
     abstract val viewState: LiveData<ViewState>
     abstract fun reload()
+
+    abstract suspend fun triggerFreeTextChat()
 }
 
 class ChangeAddressViewModelImpl(
     private val getUpcomingAgreement: GetUpcomingAgreementUseCase,
     private val addressChangeStoryId: GetAddressChangeStoryIdUseCase,
+    private val chatRepository: ChatRepository,
 ) : ChangeAddressViewModel() {
 
     override val viewState: LiveData<ViewState>
@@ -54,6 +60,13 @@ class ChangeAddressViewModelImpl(
 
     override fun reload() {
         fetchDataAndCreateState()
+    }
+
+    override suspend fun triggerFreeTextChat() {
+        val result = runSuspendCatching {
+            chatRepository.triggerFreeTextChat()
+        }
+        result.exceptionOrNull()?.let { e(it) }
     }
 }
 

--- a/app/src/main/java/com/hedvig/app/util/coroutines/RunSuspendCatching.kt
+++ b/app/src/main/java/com/hedvig/app/util/coroutines/RunSuspendCatching.kt
@@ -1,0 +1,13 @@
+package com.hedvig.app.util.coroutines
+
+import kotlinx.coroutines.CancellationException
+
+inline fun <R> runSuspendCatching(block: () -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (cancellationException: CancellationException) {
+        throw cancellationException
+    } catch (throwable: Throwable) {
+        Result.failure(throwable)
+    }
+}

--- a/app/src/test/java/com/hedvig/app/util/coroutines/RunSuspendCatchingTest.kt
+++ b/app/src/test/java/com/hedvig/app/util/coroutines/RunSuspendCatchingTest.kt
@@ -1,0 +1,37 @@
+package com.hedvig.app.util.coroutines
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isSuccess
+import org.junit.Test
+import kotlin.coroutines.cancellation.CancellationException
+
+class RunSuspendCatchingTest {
+    @Test
+    fun `when CancellationException is thrown, should rethrow`() {
+        val ex = CancellationException()
+        assertThat {
+            runSuspendCatching {
+                throw ex
+            }
+        }.isFailure().isEqualTo(ex)
+    }
+
+    @Test
+    fun `when non-CancellationException is thrown, should return failure`() {
+        val error = Error()
+        assertThat {
+            runSuspendCatching {
+                throw error
+            }
+        }.isSuccess().isEqualTo(Result.failure(error))
+    }
+
+    @Test
+    fun `when no exception is thrown, should return success`() {
+        assertThat {
+            runSuspendCatching {}
+        }.isSuccess().isEqualTo(Result.success(Unit))
+    }
+}


### PR DESCRIPTION
Bonus: `suspend fun`-safe `runCatching`!

Draft for the time being, as this code is not testable due to a backend bug.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [ ] Functionality is accessible in engineering mode
