### PR TITLE
APP-854: Use a single event name for tracking screen views

### DIFF
--- a/app/src/main/java/com/hedvig/app/ScreenTracker.kt
+++ b/app/src/main/java/com/hedvig/app/ScreenTracker.kt
@@ -1,6 +1,7 @@
 package com.hedvig.app
 
 import com.hedvig.app.feature.tracking.TrackingFacade
+import com.hedvig.app.util.jsonObjectOf
 
 class ScreenTracker(
     private val trackingFacade: TrackingFacade
@@ -13,6 +14,11 @@ class ScreenTracker(
         }
 
         previousScreen = name
-        trackingFacade.track("screen_view_$name")
+        trackingFacade.track(
+            "screen_view",
+            jsonObjectOf(
+                "name" to name
+            ),
+        )
     }
 }


### PR DESCRIPTION
We now track screen views on the event name `screen_view` with a property `name`.

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
