### PR TITLE
APP-944: Cross Sell-tracks

### DIFF
--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -16,6 +16,11 @@ apollo {
             "JSONString" to "org.json.JSONObject"
         )
     )
+    sealedClassesForEnumsMatching.set(
+        listOf(
+            "TypeOfContract",
+        )
+    )
 }
 
 android {

--- a/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/owldroid/graphql/insurance.graphql
@@ -39,6 +39,7 @@ query InsuranceQuery($locale: Locale!) {
       title
       description
       callToAction
+      contractType
       action {
         ... on CrossSellEmbark {
           embarkStory(locale: $locale) {

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -42,6 +42,7 @@ import com.hedvig.app.feature.claims.data.ClaimsRepository
 import com.hedvig.app.feature.claims.service.ClaimsTracker
 import com.hedvig.app.feature.claims.ui.ClaimsViewModel
 import com.hedvig.app.feature.connectpayin.ConnectPaymentViewModel
+import com.hedvig.app.feature.crossselling.ui.CrossSellTracker
 import com.hedvig.app.feature.embark.EmbarkRepository
 import com.hedvig.app.feature.embark.EmbarkTracker
 import com.hedvig.app.feature.embark.EmbarkViewModel
@@ -494,6 +495,7 @@ val trackerModule = module {
     single { MarketingTracker(get()) }
     single { HomeTracker(get()) }
     single { ScreenTracker(get()) }
+    single { CrossSellTracker(get()) }
     single {
         // Workaround for https://github.com/InsertKoinIO/koin/issues/1146
         TrackingFacade(getAll<TrackerSink>().distinct())

--- a/app/src/main/java/com/hedvig/app/ScreenTracker.kt
+++ b/app/src/main/java/com/hedvig/app/ScreenTracker.kt
@@ -23,7 +23,7 @@ class ScreenTracker(
     }
 
     companion object {
-        const val SCREEN_VIEW = "screen_view"
+        const val SCREEN_VIEW = "screen_view_android"
         const val SCREEN_NAME = "name"
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/CrossSellTracker.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/CrossSellTracker.kt
@@ -1,0 +1,37 @@
+package com.hedvig.app.feature.crossselling.ui
+
+import com.hedvig.app.feature.tracking.TrackingFacade
+import com.hedvig.app.util.jsonObjectOf
+
+class CrossSellTracker(
+    private val trackingFacade: TrackingFacade,
+) {
+    private val viewedResults = mutableSetOf<CrossSellingResult>()
+
+    fun view(result: CrossSellingResult) {
+        if (viewedResults.contains(result)) {
+            return
+        }
+
+        viewedResults.add(result)
+        when (result) {
+            is CrossSellingResult.Success -> {
+                trackingFacade.track(
+                    "cross_sell_result_viewed",
+                    jsonObjectOf(
+                        "result" to "success",
+                        "bundle_display_name" to result.insuranceType,
+                    ),
+                )
+            }
+            CrossSellingResult.Error -> {
+                trackingFacade.track(
+                    "cross_sell_result_viewed",
+                    jsonObjectOf(
+                        "result" to "error"
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/CrossSellingResultActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/CrossSellingResultActivity.kt
@@ -13,8 +13,8 @@ import java.time.Clock
 import java.time.format.DateTimeFormatter
 
 class CrossSellingResultActivity : BaseActivity() {
-
     private val clock: Clock by inject()
+    private val tracker: CrossSellTracker by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +23,7 @@ class CrossSellingResultActivity : BaseActivity() {
                 "Programmer error: CROSS_SELLING_RESULT not provided to ${this.javaClass.name}"
             )
 
+        tracker.view(crossSellingResult)
         setContent {
             CrossSellingResultScreen(
                 crossSellingResult = crossSellingResult,

--- a/app/src/main/java/com/hedvig/app/feature/insurance/service/InsuranceTracker.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/service/InsuranceTracker.kt
@@ -1,9 +1,27 @@
 package com.hedvig.app.feature.insurance.service
 
 import com.hedvig.app.feature.tracking.TrackingFacade
+import com.hedvig.app.util.jsonObjectOf
 
 class InsuranceTracker(
     private val trackingFacade: TrackingFacade,
 ) {
     fun retry() = trackingFacade.track("home_tab.error_button_text")
+    fun crossSellCard(typeOfContract: String) = trackingFacade.track(
+        "card_clicked",
+        jsonObjectOf(
+            "type" to "cross_sell",
+            "type_of_contract" to typeOfContract,
+            "tab" to "insurance",
+        ),
+    )
+
+    fun crossSellCta(typeOfContract: String, label: String) = trackingFacade.track(
+        "button_click",
+        jsonObjectOf(
+            "text" to label.lowercase(),
+            "type_of_contract" to typeOfContract,
+            "tab" to "insurance",
+        )
+    )
 }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
@@ -50,7 +50,7 @@ import com.hedvig.app.util.compose.rememberBlurHash
 @Composable
 fun CrossSell(
     data: InsuranceModel.CrossSell,
-    onCtaClick: () -> Unit,
+    onClick: (label: String?) -> Unit,
 ) {
     val placeholder by rememberBlurHash(data.backgroundBlurHash, 64, 32)
     Card(
@@ -76,7 +76,7 @@ fun CrossSell(
             modifier = Modifier
                 .fillMaxSize()
                 .clickable(
-                    onClick = onCtaClick
+                    onClick = { onClick(null) }
                 ),
         )
         Box(
@@ -119,7 +119,7 @@ fun CrossSell(
                     LocalRippleTheme provides DarkRippleTheme,
                 ) {
                     Button(
-                        onClick = onCtaClick,
+                        onClick = { onClick(data.callToAction) },
                         colors = ButtonDefaults.buttonColors(
                             backgroundColor = whiteHighEmphasis,
                             contentColor = hedvigBlack,
@@ -152,6 +152,7 @@ private val previewData = InsuranceModel.CrossSell(
     title = "Accident Insurance",
     description = "179 kr/mo.",
     callToAction = "Calculate price",
+    typeOfContract = "SE_ACCIDENT",
     action = InsuranceModel.CrossSell.Action.Chat,
     backgroundUrl = "https://images.unsplash.com/photo-1628996796855-0b056a464e06",
     backgroundBlurHash = "LJC6\$2-:DiWB~WxuRkayMwNGo~of",
@@ -167,7 +168,7 @@ fun CrossSellPreview() {
     HedvigTheme {
         CrossSell(
             data = previewData,
-            onCtaClick = {}
+            onClick = {}
         )
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceModel.kt
@@ -17,6 +17,7 @@ sealed class InsuranceModel {
         val action: Action,
         val backgroundUrl: String,
         val backgroundBlurHash: String,
+        val typeOfContract: String
     ) : InsuranceModel() {
         sealed class Action {
             data class Embark(val embarkStoryId: String) : Action()

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/Items.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/Items.kt
@@ -48,6 +48,7 @@ private fun crossSell(potentialCrossSell: InsuranceQuery.PotentialCrossSell): In
         title = potentialCrossSell.title,
         description = potentialCrossSell.description,
         callToAction = potentialCrossSell.callToAction,
+        typeOfContract = potentialCrossSell.contractType.rawValue,
         action = action,
         backgroundUrl = potentialCrossSell.imageUrl,
         backgroundBlurHash = potentialCrossSell.blurHash,

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -137,6 +137,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 animateGradient(id)
                 lastSelectedTab = id
                 loggedInViewModel.onTabVisited(id)
+                loggedInTracker.tabVisited()
                 true
             }
 

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -137,7 +137,7 @@ class LoggedInActivity : BaseActivity(R.layout.activity_logged_in) {
                 animateGradient(id)
                 lastSelectedTab = id
                 loggedInViewModel.onTabVisited(id)
-                loggedInTracker.tabVisited()
+                loggedInTracker.tabVisited(id)
                 true
             }
 

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInTracker.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInTracker.kt
@@ -1,9 +1,22 @@
 package com.hedvig.app.feature.loggedin.ui
 
 import com.hedvig.app.feature.tracking.TrackingFacade
+import com.hedvig.app.util.jsonObjectOf
 
 class LoggedInTracker(
     private val trackingFacade: TrackingFacade,
 ) {
     fun setMemberId(memberId: String) = trackingFacade.identify(memberId)
+    fun tabVisited(tab: LoggedInTabs) = trackingFacade.track(
+        "tab_view",
+        jsonObjectOf(
+            "tab" to when (tab) {
+                LoggedInTabs.HOME -> "home"
+                LoggedInTabs.INSURANCE -> "insurance"
+                LoggedInTabs.KEY_GEAR -> "key_gear"
+                LoggedInTabs.REFERRALS -> "forever"
+                LoggedInTabs.PROFILE -> "profile"
+            }
+        )
+    )
 }

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferTracker.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferTracker.kt
@@ -25,4 +25,13 @@ class OfferTracker(
     fun activateOnInsuranceEnd() = trackingFacade.track("ACTIVATE_INSURANCE_END_BTN")
     fun changeDateContinue() = trackingFacade.track("ALERT_CONTINUE")
     fun settings() = trackingFacade.track("SETTINGS_ACCESSIBILITY_HINT")
+    fun checkoutHeader(method: String) = checkout(method, "header")
+    fun checkoutFloating(method: String) = checkout(method, "floating")
+    private fun checkout(method: String, location: String) = trackingFacade.track(
+        "button_click",
+        jsonObjectOf(
+            "localization_key" to method,
+            "location" to location,
+        )
+    )
 }

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/CheckoutLabel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/CheckoutLabel.kt
@@ -1,20 +1,17 @@
 package com.hedvig.app.feature.offer.ui
 
 import android.content.Context
+import androidx.annotation.StringRes
 import com.hedvig.app.R
 
-enum class CheckoutLabel {
-    SIGN_UP,
-    CONTINUE,
-    APPROVE,
-    CONFIRM,
-    UNKNOWN
-}
+enum class CheckoutLabel(@StringRes val resId: Int) {
+    SIGN_UP(R.string.OFFER_SIGN_BUTTON),
+    CONTINUE(R.string.OFFER_CHECKOUT_BUTTON),
+    APPROVE(R.string.OFFER_APPROVE_CHANGES),
+    CONFIRM(R.string.OFFER_CONFIRM_PURCHASE),
+    UNKNOWN(R.string.dummy_string);
 
-fun CheckoutLabel.toString(context: Context) = when (this) {
-    CheckoutLabel.SIGN_UP -> context.getString(R.string.OFFER_SIGN_BUTTON)
-    CheckoutLabel.CONTINUE -> context.getString(R.string.OFFER_CHECKOUT_BUTTON)
-    CheckoutLabel.APPROVE -> context.getString(R.string.OFFER_APPROVE_CHANGES)
-    CheckoutLabel.CONFIRM -> context.getString(R.string.OFFER_CONFIRM_PURCHASE)
-    CheckoutLabel.UNKNOWN -> ""
+    fun toString(context: Context) = context.getString(resId)
+
+    fun localizationKey(context: Context): String = context.resources.getResourceEntryName(resId)
 }

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferActivity.kt
@@ -316,6 +316,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
         binding.signButton.text = checkoutLabel.toString(this)
         binding.signButton.icon = signMethod.checkoutIconRes()?.let(::compatDrawable)
         binding.signButton.setHapticClickListener {
+            tracker.checkoutFloating(checkoutLabel.localizationKey(this))
             onSign(signMethod)
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferAdapter.kt
@@ -176,11 +176,12 @@ class OfferAdapter(
                     }
 
                     with(sign) {
-                        text = data.checkoutLabel.toString(this.context)
+                        text = data.checkoutLabel.toString(context)
                         icon = data.signMethod.checkoutIconRes()?.let {
                             context.compatDrawable(it)
                         }
                         setHapticClickListener {
+                            tracker.checkoutHeader(data.checkoutLabel.localizationKey(context))
                             onSign(data.signMethod)
                         }
                     }

--- a/testdata/src/main/java/com/hedvig/app/testdata/dashboard/Data.kt
+++ b/testdata/src/main/java/com/hedvig/app/testdata/dashboard/Data.kt
@@ -1,6 +1,7 @@
 package com.hedvig.app.testdata.dashboard
 
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
+import com.hedvig.android.owldroid.type.TypeOfContract
 import com.hedvig.app.testdata.common.ContractStatus
 import com.hedvig.app.testdata.dashboard.builders.InsuranceDataBuilder
 
@@ -39,6 +40,7 @@ val INSURANCE_DATA_WITH_CROSS_SELL = InsuranceDataBuilder(
             title = "Accident Insurance",
             description = "179 SEK/mo.",
             callToAction = "Calculate price",
+            contractType = TypeOfContract.SE_ACCIDENT,
             action = InsuranceQuery.Action(
                 __typename = "CrossSellEmbark",
                 asCrossSellEmbark = InsuranceQuery.AsCrossSellEmbark(


### PR DESCRIPTION
Draft because we're missing one track: `offer_viewed`.
Let's discuss how to best do this together.

Also, let's discuss how to practically track only once when the screen is
opened, and not for example when configuration changes (and the activity gets
recreated).

- Track checkout-button clicks
- Track tab views
- Rename event for screen view-tracks
- Fix the tab tracking
- Track clicks on cross-sell cards
- Track cross sell-result screen

<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
