### PR TITLE
APP-998: Ask for permissions when pressing start record button

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderFragment.kt
@@ -27,8 +27,8 @@ class AudioRecorderFragment : Fragment() {
 
     private val permission = Manifest.permission.RECORD_AUDIO
 
-    private val permissionResultLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) {
-        if (it) {
+    private val permissionResultLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { permissionGranted ->
+        if (permissionGranted) {
             model.startRecording()
         } else {
             requireActivity().showPermissionExplanationDialog(permission)

--- a/app/src/main/java/com/hedvig/app/util/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/com/hedvig/app/util/extensions/ActivityExtensions.kt
@@ -97,7 +97,7 @@ fun Activity.askForPermissions(
     }
 }
 
-private fun Activity.showPermissionExplanationDialog(permission: String) {
+fun Activity.showPermissionExplanationDialog(permission: String) {
     when (permission) {
         android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
         android.Manifest.permission.READ_EXTERNAL_STORAGE,


### PR DESCRIPTION
<!-- Add when these when applicable. -->
### Checklist

- [ ] Functionality is covered by an integration test
- [x] Functionality is accessible in engineering mode

Tried to implement compose-style permission handling (more info [here](https://github.com/google/accompanist/blob/main/sample/src/main/java/com/google/accompanist/sample/permissions/RequestPermissionSample.kt)), but didnt quite get it to work 100%. Used our already existing implementation since we are using a fragment here anyway. We can look at the compose implementation together later if you want. 