### PR TITLE
APP-909: Sunsetting Error Middleware

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/MoreOptionsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/MoreOptionsTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.util.LazyIntentsActivityScenarioRule
 import com.hedvig.app.util.MarketRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -29,7 +30,7 @@ class MoreOptionsTest : TestCase() {
         MemberIdQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(MEMBER_ID_DATA)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/GraphQLErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlmutation/GraphQLErrorTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen
 import org.junit.Rule
@@ -23,7 +24,7 @@ class GraphQLErrorTest : TestCase() {
     val apolloMockServerRule = ApolloMockServerRule(
         EmbarkStoryQuery.QUERY_DOCUMENT to apolloResponse { success(STORY_WITH_GRAPHQL_MUTATION) },
         HELLO_MUTATION to apolloResponse {
-            graphQLError("some error")
+            graphQLError(jsonObjectOf("message" to "some error"))
         }
     )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/GraphQLErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/api/graphqlquery/GraphQLErrorTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
@@ -23,7 +24,7 @@ class GraphQLErrorTest : TestCase() {
     val apolloMockServerRule = ApolloMockServerRule(
         EmbarkStoryQuery.QUERY_DOCUMENT to apolloResponse { success(STORY_WITH_GRAPHQL_QUERY_API) },
         HELLO_QUERY to apolloResponse {
-            graphQLError("some error")
+            graphQLError(jsonObjectOf("message" to "some error"))
         }
     )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/home/GraphQLErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/home/GraphQLErrorTest.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
 import com.hedvig.app.util.hasText
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
@@ -35,7 +36,7 @@ class GraphQLErrorTest : TestCase() {
         HomeQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("example")
+                graphQLError(jsonObjectOf("message" to "example"))
             } else {
                 success(HOME_DATA_PENDING)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/ContractDetailErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/detail/ContractDetailErrorTest.kt
@@ -9,6 +9,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen
 import org.junit.Rule
@@ -25,7 +26,7 @@ class ContractDetailErrorTest : TestCase() {
         InsuranceQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(
                     INSURANCE_DATA_SWEDISH_HOUSE

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/ErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/tab/ErrorTest.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
@@ -34,7 +35,7 @@ class ErrorTest : TestCase() {
         InsuranceQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(INSURANCE_DATA)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/insurance/terminatedcontracts/ErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/insurance/terminatedcontracts/ErrorTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
@@ -27,7 +28,7 @@ class ErrorTest : TestCase() {
         InsuranceQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(INSURANCE_DATA_ONE_ACTIVE_ONE_TERMINATED)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/keygear/Error.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/keygear/Error.kt
@@ -13,6 +13,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -36,7 +37,7 @@ class Error : TestCase() {
         KeyGearItemsQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(KEY_GEAR_DATA)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/offer/ErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/offer/ErrorTest.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -25,7 +26,7 @@ class ErrorTest : TestCase() {
         OfferQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("Error")
+                graphQLError(jsonObjectOf("message" to "Error"))
             } else {
                 success(OFFER_DATA_SWEDISH_APARTMENT)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/onboarding/MoreOptionsTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/onboarding/MoreOptionsTest.kt
@@ -7,6 +7,7 @@ import com.hedvig.app.testdata.feature.onboarding.MEMBER_ID_DATA
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -23,7 +24,7 @@ class MoreOptionsTest : TestCase() {
         MemberIdQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(MEMBER_ID_DATA)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/profile/ErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/profile/ErrorTest.kt
@@ -13,6 +13,7 @@ import com.hedvig.app.util.ApolloCacheClearRule
 import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -36,7 +37,7 @@ class ErrorTest : TestCase() {
         ProfileQuery.QUERY_DOCUMENT to apolloResponse {
             if (shouldFail) {
                 shouldFail = false
-                graphQLError("error")
+                graphQLError(jsonObjectOf("message" to "error"))
             } else {
                 success(PROFILE_DATA)
             }

--- a/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/GenericErrorTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/referrals/editcode/GenericErrorTest.kt
@@ -8,6 +8,7 @@ import com.hedvig.app.util.ApolloMockServerRule
 import com.hedvig.app.util.LazyActivityScenarioRule
 import com.hedvig.app.util.apolloResponse
 import com.hedvig.app.util.context
+import com.hedvig.app.util.jsonObjectOf
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
@@ -21,7 +22,7 @@ class GenericErrorTest : TestCase() {
     @get:Rule
     val mockServerRule = ApolloMockServerRule(
         UpdateReferralCampaignCodeMutation.QUERY_DOCUMENT to apolloResponse {
-            graphQLError("example message")
+            graphQLError(jsonObjectOf("message" to "example message"))
         }
     )
 

--- a/app/src/androidTest/java/com/hedvig/app/feature/sunsetting/SunsettingTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/sunsetting/SunsettingTest.kt
@@ -1,0 +1,65 @@
+package com.hedvig.app.feature.sunsetting
+
+import com.hedvig.android.owldroid.graphql.HomeQuery
+import com.hedvig.android.owldroid.graphql.LoggedInQuery
+import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
+import com.hedvig.app.testdata.feature.home.HOME_DATA_PENDING
+import com.hedvig.app.util.ApolloCacheClearRule
+import com.hedvig.app.util.ApolloMockServerRule
+import com.hedvig.app.util.LazyIntentsActivityScenarioRule
+import com.hedvig.app.util.apolloResponse
+import com.hedvig.app.util.jsonObjectOf
+import com.hedvig.app.util.stub
+import com.kaspersky.kaspresso.screens.KScreen
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.kakao.intent.KIntent
+import org.junit.Rule
+import org.junit.Test
+
+class SunsettingTest : TestCase() {
+    @get:Rule
+    val activityRule = LazyIntentsActivityScenarioRule(LoggedInActivity::class.java)
+
+    @get:Rule
+    val mockServerRule = ApolloMockServerRule(
+        LoggedInQuery.QUERY_DOCUMENT to apolloResponse {
+            graphQLError(
+                jsonObjectOf(
+                    "message" to "Outdated app",
+                    "errorMessage" to "Buildversion -1 triggers test case for invalid versions",
+                    "errorCode" to "invalid_version",
+                    "supportPhoneNumber" to "+4670 123 45 67",
+                    "supportEmail" to "info@hedvig.com",
+                )
+            )
+        },
+        HomeQuery.QUERY_DOCUMENT to apolloResponse { success(HOME_DATA_PENDING) }
+    )
+
+    @get:Rule
+    val apolloCacheClearRule = ApolloCacheClearRule()
+
+    @Test
+    fun whenReceivingResponseWithSunsetErrorShouldOpenForceUpgrade() = run {
+        ForceUpgradeScreen {
+            step("Stub force upgrade") {
+                intent { stub() }
+            }
+            step("Launch activity which will receive sunsetting-error") {
+                activityRule.launch()
+            }
+            step("Verify that force upgrade was launched") {
+                intent { intended() }
+            }
+        }
+    }
+}
+
+object ForceUpgradeScreen : KScreen<ForceUpgradeScreen>() {
+    override val layoutId: Int? = null
+    override val viewClass = ForceUpgradeActivity::class.java
+
+    val intent = KIntent {
+        hasComponent(ForceUpgradeActivity::class.java.name)
+    }
+}

--- a/app/src/androidTest/java/com/hedvig/app/util/ApolloMockServer.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/ApolloMockServer.kt
@@ -44,11 +44,7 @@ fun apolloMockServer(vararg mocks: Pair<String, ApolloResultProvider>) =
                     ApolloMockServerResult.InternalServerError -> MockResponse().setResponseCode(500)
                     is ApolloMockServerResult.GraphQLError -> MockResponse().setBody(
                         jsonObjectOf(
-                            "errors" to result.errors.map {
-                                jsonObjectOf(
-                                    "message" to it
-                                )
-                            }.toJsonArray()
+                            "errors" to result.errors.toJsonArray()
                         ).toString()
                     )
                     is ApolloMockServerResult.GraphQLResponse -> MockResponse().setBody(result.body)
@@ -80,7 +76,7 @@ sealed class ApolloMockServerResult {
     object InternalServerError : ApolloMockServerResult()
 
     data class GraphQLError(
-        val errors: List<String>,
+        val errors: List<JSONObject>,
     ) : ApolloMockServerResult()
 
     data class GraphQLResponse(
@@ -92,7 +88,7 @@ class ApolloMockServerResponseBuilder(
     val variables: JSONObject,
 ) {
     fun internalServerError() = ApolloMockServerResult.InternalServerError
-    fun graphQLError(vararg errors: String) =
+    fun graphQLError(vararg errors: JSONObject) =
         ApolloMockServerResult.GraphQLError(errors.toList())
 
     fun success(data: Operation.Data) =

--- a/app/src/engineering/java/com/hedvig/app/DevelopmentActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/DevelopmentActivity.kt
@@ -21,6 +21,7 @@ import com.hedvig.app.feature.onboarding.OnboardingMockActivity
 import com.hedvig.app.feature.payment.PaymentMockActivity
 import com.hedvig.app.feature.profile.ProfileMockActivity
 import com.hedvig.app.feature.referrals.ReferralsMockActivity
+import com.hedvig.app.feature.sunsetting.ForceUpgradeActivity
 import com.hedvig.app.feature.tracking.TrackingLogActivity
 import com.hedvig.app.feature.trustly.TrustlyMockActivity
 import com.hedvig.app.util.extensions.viewBinding
@@ -43,6 +44,9 @@ class DevelopmentActivity : AppCompatActivity(R.layout.activity_development) {
                     },
                     DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Showkase") {
                         startActivity(Showkase.getBrowserIntent(this))
+                    },
+                    DevelopmentScreenAdapter.DevelopmentScreenItem.Row("App Sunsetting-Screen") {
+                        startActivity(ForceUpgradeActivity.newInstance(this))
                     },
                     DevelopmentScreenAdapter.DevelopmentScreenItem.Row("Change address intro") {
                         startActivity(Intent(this, ChangeAddressMockActivity::class.java))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -307,6 +307,7 @@
         <activity android:name=".feature.embark.passages.previousinsurer.askforprice.AskForPriceInfoActivity" />
         <activity android:name=".feature.crossselling.ui.detail.CrossSellDetailActivity" />
         <activity android:name=".feature.crossselling.ui.detail.CrossSellFaqActivity" />
+        <activity android:name=".feature.sunsetting.ForceUpgradeActivity" />
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -17,6 +17,7 @@ import com.apollographql.apollo.cache.normalized.NormalizedCacheFactory
 import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy
 import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCache
 import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory
+import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.subscription.SubscriptionConnectionParams
 import com.apollographql.apollo.subscription.WebSocketSubscriptionTransport
 import com.google.firebase.analytics.ktx.analytics
@@ -184,6 +185,7 @@ import com.hedvig.app.terminated.TerminatedTracker
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.ApolloTimberLogger
 import com.hedvig.app.util.apollo.CacheManager
+import com.hedvig.app.util.apollo.SunsettingInterceptor
 import com.hedvig.app.util.featureflags.FeatureManager
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import okhttp3.OkHttpClient
@@ -266,6 +268,7 @@ val applicationModule = module {
         }
         builder.build()
     }
+    single { SunsettingInterceptor(get()) } bind ApolloInterceptor::class
     single {
         val builder = ApolloClient
             .builder()
@@ -285,6 +288,10 @@ val applicationModule = module {
             .normalizedCache(get())
 
         CUSTOM_TYPE_ADAPTERS.customAdapters.forEach { (t, a) -> builder.addCustomTypeAdapter(t, a) }
+
+        getAll<ApolloInterceptor>().distinct().forEach {
+            builder.addApplicationInterceptor(it)
+        }
 
         if (isDebug()) {
             builder.logger(ApolloTimberLogger())

--- a/app/src/main/java/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
@@ -1,0 +1,85 @@
+package com.hedvig.app.feature.sunsetting
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hedvig.app.BaseActivity
+import com.hedvig.app.R
+import com.hedvig.app.feature.ratings.tryOpenPlayStore
+import com.hedvig.app.ui.compose.theme.HedvigTheme
+
+class ForceUpgradeActivity : BaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            HedvigTheme {
+                UpgradeApp(goToPlayStore = { tryOpenPlayStore() })
+            }
+        }
+    }
+
+    companion object {
+        fun newInstance(context: Context) = Intent(context, ForceUpgradeActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+    }
+}
+
+@Composable
+fun UpgradeApp(
+    goToPlayStore: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.EMBARK_UPDATE_APP_TITLE),
+            style = MaterialTheme.typography.h4,
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.EMBARK_UPDATE_APP_BODY),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body1,
+        )
+        Spacer(Modifier.height(16.dp))
+        Button(
+            onClick = goToPlayStore,
+        ) {
+            Text(
+                text = stringResource(R.string.EMBARK_UPDATE_APP_BUTTON),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun UpgradeAppPreview() {
+    HedvigTheme {
+        UpgradeApp(goToPlayStore = {})
+    }
+}

--- a/app/src/main/java/com/hedvig/app/util/apollo/SunsettingInterceptor.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/SunsettingInterceptor.kt
@@ -1,0 +1,86 @@
+package com.hedvig.app.util.apollo
+
+import android.content.Context
+import com.apollographql.apollo.api.Error
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.interceptor.ApolloInterceptor
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain
+import com.hedvig.app.feature.sunsetting.ForceUpgradeActivity
+import java.util.concurrent.Executor
+
+class SunsettingInterceptor(
+    private val context: Context,
+) : ApolloInterceptor {
+    @Volatile
+    var disposed: Boolean = false
+
+    override fun interceptAsync(
+        request: ApolloInterceptor.InterceptorRequest,
+        chain: ApolloInterceptorChain,
+        dispatcher: Executor,
+        callBack: ApolloInterceptor.CallBack,
+    ) {
+        chain.proceedAsync(
+            request, dispatcher,
+            object : ApolloInterceptor.CallBack {
+                override fun onResponse(response: ApolloInterceptor.InterceptorResponse) {
+                    if (disposed) {
+                        return
+                    }
+                    val parsedResponse = response.parsedResponse.orNull()
+
+                    if (parsedResponse == null) {
+                        callBack.onResponse(response)
+                        callBack.onCompleted()
+                        return
+                    }
+
+                    val errors = parsedResponse.errors
+
+                    if (errors == null) {
+                        callBack.onResponse(response)
+                        callBack.onCompleted()
+                        return
+                    }
+
+                    val hasBeenSunset = errors.any(::isSunsetError)
+
+                    if (hasBeenSunset) {
+                        context.startActivity(ForceUpgradeActivity.newInstance(context))
+                    }
+
+                    callBack.onResponse(response)
+                    callBack.onCompleted()
+                }
+
+                override fun onFetch(sourceType: ApolloInterceptor.FetchSourceType?) {
+                    callBack.onFetch(sourceType)
+                }
+
+                override fun onFailure(e: ApolloException) {
+                    if (disposed) {
+                        return
+                    }
+
+                    callBack.onFailure(e)
+                }
+
+                override fun onCompleted() {
+                }
+            }
+        )
+    }
+
+    override fun dispose() {
+        disposed = true
+    }
+}
+
+private fun isSunsetError(error: Any?): Boolean {
+    if (error !is Error) {
+        return false
+    }
+    val errorCode = error.customAttributes["errorCode"]
+
+    return errorCode == "invalid_version"
+}


### PR DESCRIPTION
- Preparative refactor: Allow errors to have more fields than simply 'message'
- Implement sunsetting-middleware

<!-- Add when these when applicable. -->
### Checklist

- [X] Functionality is covered by an integration test
- [X] Functionality is accessible in engineering mode
