### PR TITLE
APP-1018: Remove termination info which was showing faulty information

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
@@ -101,9 +101,6 @@ class ContractDetailActivity : BaseActivity(R.layout.contract_detail_activity) {
                             error.root.isVisible = false
                             val contract = viewState.data
                             contract.bindTo(cardContainer, marketManager)
-                            terminationInfo.isVisible =
-                                contract.status.fragments.contractStatusFragment.asTerminatedStatus != null ||
-                                contract.status.fragments.contractStatusFragment.asTerminatedTodayStatus != null
                         }
                     }
                     startPostponedEnterTransition()

--- a/app/src/main/res/layout/contract_detail_activity.xml
+++ b/app/src/main/res/layout/contract_detail_activity.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -50,16 +49,6 @@
                     <include
                         android:id="@+id/cardContainer"
                         layout="@layout/insurance_contract_card" />
-
-                    <TextView
-                        android:id="@+id/termination_info"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:padding="@dimen/base_margin_double"
-                        android:text="@string/INSURANCE_DETAILS_TERMINATION_INFO"
-                        android:textAppearance="?textAppearanceCaption"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
 
                     <com.google.android.material.tabs.TabLayout
                         android:id="@+id/tabContainer"


### PR DESCRIPTION
Context:
https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1635932572116000
Optimally this should be shown in the case where specifically a previous
contract was over after the member went through the moving flow, but
there is no way to know that when we get a new clean contract, therefore
it was decided to show nothing instead.
The information about the old contract being active 30 days after the
moving is presented at the end of the moving flow.