### PR TITLE
APP-1237: Alter safeQuery to handle error responses

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkRepository.kt
@@ -10,7 +10,7 @@ import com.hedvig.app.HedvigApplication
 import com.hedvig.app.service.FileService
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.QueryResult
-import com.hedvig.app.util.apollo.safeCall
+import com.hedvig.app.util.apollo.safeGraphqlCall
 import com.hedvig.app.util.jsonObjectOfNotNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
@@ -63,7 +63,7 @@ class EmbarkRepository(
                     .header("Content-Type", APPLICATION_JSON)
                     .post(requestBody)
                     .build()
-            ).safeCall()
+            ).safeGraphqlCall()
     }
 
     private fun createVariableRequestBody(

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -255,7 +255,6 @@ abstract class EmbarkViewModel(
     }
 
     private fun handleQueryResult(result: GraphQLQueryResult) {
-        // todo there was an empty Loading event here that was just to trigger the beginDelayedTransition or what?
         _loadingState.update { false }
 
         when (result) {


### PR DESCRIPTION
When graphQL returns an ok 200 result with partial data but an error in
the errors body, before it was considered a successful response,
breaking some embark flows. This change makes it so that such responses
are interpreted as a failed response, making the logic continue on the
unhappy path instead.

Should probably test as many other embark flows as possible before releasing with this change, I tried going through some of them to see that we were not relying on this behavior and it's looking okay so far, but I'm never sure with making embark changes. Let's see what the tests have to say too.