### PR TITLE
APP-1296: Center the title text if subtitle is non existent

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimType.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimType.kt
@@ -44,11 +44,13 @@ fun ClaimType(
                 text = title,
                 style = MaterialTheme.typography.h6,
             )
-            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.subtitle2,
-                )
+            if (subtitle.isNotEmpty()) {
+                CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.subtitle2,
+                    )
+                }
             }
         }
     }
@@ -62,7 +64,10 @@ fun ClaimTypePreview() {
         Surface(
             color = MaterialTheme.colors.background,
         ) {
-            ClaimType(title = "title", subtitle = "subtitle")
+            Column {
+                ClaimType(title = "title", subtitle = "subtitle")
+                ClaimType(title = "title", subtitle = "")
+            }
         }
     }
 }


### PR DESCRIPTION
Sometimes the backend may return an empty subtitle. Best we can do
client side is to make the UI look a bit smoother.

https://hedvig.atlassian.net/jira/software/c/projects/APP/boards/6?modal=detail&selectedIssue=APP-1296&quickFilter=51