### PR TITLE
APP-1311: Add the PAID pill when the claim is paid out

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/model/ClaimDetailResult.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/model/ClaimDetailResult.kt
@@ -3,13 +3,12 @@ package com.hedvig.app.feature.claimdetail.model
 import com.hedvig.android.owldroid.graphql.ClaimDetailsQuery
 import com.hedvig.android.owldroid.type.ClaimOutcome
 import com.hedvig.android.owldroid.type.ClaimStatus
-import com.hedvig.app.util.apollo.toMonetaryAmount
 import javax.money.MonetaryAmount
 
 sealed class ClaimDetailResult {
     object Open : ClaimDetailResult()
     sealed class Closed : ClaimDetailResult() {
-        data class Paid(val monetaryAmount: MonetaryAmount) : Closed()
+        data class Paid(val monetaryAmount: MonetaryAmount?) : Closed()
         object NotCompensated : Closed()
         object NotCovered : Closed()
     }
@@ -21,19 +20,15 @@ sealed class ClaimDetailResult {
                 ClaimStatus.CLOSED -> {
                     when (claim.outcome) {
                         ClaimOutcome.PAID -> {
-                            val monetaryAmount = claim
-                                .payout
-                                ?.fragments
-                                ?.monetaryAmountFragment
-                                ?.toMonetaryAmount()
-                            if (monetaryAmount != null) {
-                                // todo Uncomment when the backend returns the proper payment amount
-                                // https://hedviginsurance.slack.com/archives/CN55X38T1/p1640192642025300?thread_ts=1639987758.015100&cid=CN55X38T1
-                                // Closed.Paid(monetaryAmount)
-                                Open
-                            } else {
-                                Open
-                            }
+                            // todo Uncomment when the backend returns the proper payment amount
+                            // https://hedviginsurance.slack.com/archives/CN55X38T1/p1640192642025300?thread_ts=1639987758.015100&cid=CN55X38T1
+//                            val monetaryAmount = claim
+//                                .payout
+//                                ?.fragments
+//                                ?.monetaryAmountFragment
+//                                ?.toMonetaryAmount()
+                            val monetaryAmount: MonetaryAmount? = null
+                            Closed.Paid(monetaryAmount)
                         }
                         ClaimOutcome.NOT_COMPENSATED -> Closed.NotCompensated
                         ClaimOutcome.NOT_COVERED -> Closed.NotCovered

--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimResultSection.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimResultSection.kt
@@ -52,19 +52,21 @@ fun ClaimResultSection(
                         stringResource(R.string.claim_decision_paid).uppercase(locale),
                         backgroundColor = ClaimStatusColors.Pill.paid
                     )
-                    Spacer(Modifier.width(12.dp))
-                    Text(
-                        claimDetailResult.monetaryAmount.formatOnlyNumber(locale),
-                        style = MaterialTheme.typography.h4,
-                        modifier = Modifier.alignByBaseline()
-                    )
-                    Spacer(Modifier.width(2.dp))
-                    CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                    if (claimDetailResult.monetaryAmount != null) {
+                        Spacer(Modifier.width(12.dp))
                         Text(
-                            claimDetailResult.monetaryAmount.currency.currencyCode,
-                            style = MaterialTheme.typography.subtitle2,
+                            claimDetailResult.monetaryAmount.formatOnlyNumber(locale),
+                            style = MaterialTheme.typography.h4,
                             modifier = Modifier.alignByBaseline()
                         )
+                        Spacer(Modifier.width(2.dp))
+                        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                            Text(
+                                claimDetailResult.monetaryAmount.currency.currencyCode,
+                                style = MaterialTheme.typography.subtitle2,
+                                modifier = Modifier.alignByBaseline()
+                            )
+                        }
                     }
                 }
             }
@@ -90,6 +92,7 @@ fun ClaimResultSectionPreview(
 class ClaimDetailResultProvider : CollectionPreviewParameterProvider<ClaimDetailResult.Closed>(
     listOf(
         ClaimDetailResult.Closed.Paid(PreviewData.monetaryAmount(2_500.00)),
+        ClaimDetailResult.Closed.Paid(null),
         ClaimDetailResult.Closed.NotCompensated,
         ClaimDetailResult.Closed.NotCovered,
     )


### PR DESCRIPTION
Before, since the monetaryAmount can't be shown yet due to backend
limitations, the pill was hidden altogether. This simply changes the
handling so that the pill does show only with no money amount shown.