### PR TITLE
APP-1359: Show error messages in embark

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/feature/embark/MissingActionTest.kt
+++ b/app/src/androidTest/java/com/hedvig/app/feature/embark/MissingActionTest.kt
@@ -28,7 +28,7 @@ class MissingActionTest : TestCase() {
     val apolloCacheClearRule = ApolloCacheClearRule()
 
     @Test
-    fun shouldDisplayInformationAboutAppNeedingUpdateWhenActionCannotBeRendered() = run {
+    fun shouldShowMessagesIfNoActionIsPresent() = run {
         activityRule.launch(
             EmbarkActivity.newInstance(
                 context(),
@@ -40,7 +40,7 @@ class MissingActionTest : TestCase() {
         stubExternalIntents()
 
         onScreen<EmbarkScreen> {
-            upgradeApp {
+            messages {
                 isVisible()
             }
         }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/noaction/NoActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/noaction/NoActionFragment.kt
@@ -1,0 +1,44 @@
+package com.hedvig.app.feature.embark.passages.noaction
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.os.bundleOf
+import androidx.core.view.doOnNextLayout
+import androidx.fragment.app.Fragment
+import com.hedvig.app.R
+import com.hedvig.app.databinding.FragmentEmbarkNoActionBinding
+import com.hedvig.app.feature.embark.passages.MessageAdapter
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
+import e
+
+class NoActionFragment : Fragment(R.layout.fragment_embark_no_action) {
+    private val binding by viewBinding(FragmentEmbarkNoActionBinding::bind)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        postponeEnterTransition()
+        val data = requireArguments().getParcelable<NoActionParameter>(DATA)
+
+        if (data == null) {
+            e { "Programmer error: No DATA provided to ${this.javaClass.name}" }
+            return
+        }
+
+        binding.apply {
+            messages.adapter = MessageAdapter(data.messages)
+            messages.doOnNextLayout {
+                startPostponedEnterTransition()
+            }
+        }
+    }
+
+    companion object {
+        private const val DATA = "DATA"
+        fun newInstance(data: NoActionParameter) =
+            NoActionFragment().apply {
+                arguments = bundleOf(
+                    DATA to data
+                )
+            }
+    }
+}

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/noaction/NoActionParameter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/noaction/NoActionParameter.kt
@@ -1,0 +1,9 @@
+package com.hedvig.app.feature.embark.passages.noaction
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class NoActionParameter(
+    val messages: List<String>,
+) : Parcelable

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
@@ -32,6 +32,8 @@ import com.hedvig.app.feature.embark.passages.externalinsurer.ExternalInsurerPar
 import com.hedvig.app.feature.embark.passages.multiaction.MultiActionComponent
 import com.hedvig.app.feature.embark.passages.multiaction.MultiActionFragment
 import com.hedvig.app.feature.embark.passages.multiaction.MultiActionParams
+import com.hedvig.app.feature.embark.passages.noaction.NoActionFragment
+import com.hedvig.app.feature.embark.passages.noaction.NoActionParameter
 import com.hedvig.app.feature.embark.passages.numberactionset.NumberActionFragment
 import com.hedvig.app.feature.embark.passages.numberactionset.NumberActionParams
 import com.hedvig.app.feature.embark.passages.previousinsurer.PreviousInsurerFragment
@@ -378,6 +380,11 @@ class EmbarkActivity : BaseActivity(R.layout.activity_embark) {
                 )
                 return AddressAutoCompleteFragment.newInstance(params)
             }
+        }
+
+        if (passage?.messages?.isNotEmpty() == true) {
+            val params = NoActionParameter(passage.messages.map { it.fragments.messageFragment.text })
+            return NoActionFragment.newInstance(params)
         }
 
         return UpgradeAppFragment.newInstance()

--- a/app/src/main/res/layout/fragment_embark_no_action.xml
+++ b/app/src/main/res/layout/fragment_embark_no_action.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/messages"
+        style="@style/Hedvig.Theme.EmbarkList"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:itemCount="3"
+        tools:listitem="@layout/embark_message_item" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
We can now show error messages like this: 

![image](https://user-images.githubusercontent.com/5929732/152801281-88abd59a-baab-4d70-8bf2-d08a1757aff6.png)

Before, since the passage did not have an action, we showed the "update app" passage.