### PR TITLE
APP-1371: dk autocomplete cursor fix

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteActivity.kt
@@ -41,7 +41,7 @@ class AddressAutoCompleteActivity : AppCompatActivity() {
             HedvigTheme {
                 AddressAutoCompleteScreen(
                     viewState = viewState,
-                    setInput = viewModel::setNewInput,
+                    setNewTextInput = viewModel::setNewTextInput,
                     selectAddress = viewModel::selectAddress,
                     cancelAutoCompletion = { finishWithResult(FetchDanishAddressContractResult.Canceled) },
                     cantFindAddress = { finishWithResult(FetchDanishAddressContractResult.CantFind) },

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
@@ -88,7 +88,7 @@ class AddressAutoCompleteViewModel(
             replay = 1
         )
 
-    fun setNewInput(inputText: String) {
+    fun setNewTextInput(inputText: String) {
         addressSelectionChannel.trySend(null)
         currentInput.update { danishAddressInput ->
             danishAddressInput.withNewText(inputText)


### PR DESCRIPTION
Dealing with the cursor itself is a tiny bit weird. In my solution, I am somewhat breaking the "Single Source of Truth" pattern, but making the address internally hold the input data while also pushing it to the ViewModel on change.
This was the approach I took since whenever I was sending the data to the VM and it was coming back down to the composable, there was no way to know if that action was done by the user entering letters or clicking on an address suggestion. Since there was no distinction between the two, I couldn't find a way to know when to move the cursor at the end of the word or not. We wanted this behavior as when we click an address we want the cursor to go to the end of the word to allow for further modification. If we do this on *every* change, this then means that if the user edits the word at the middle of it, on pressing something the cursor would jump at the end of the word aka: super bad experience!