### PR TITLE
APP-1422: Make offer query fetch the quoteIds from the most recent selection

### DIFF
--- a/app/src/androidTest/java/com/hedvig/app/util/ValueStoreRule.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/ValueStoreRule.kt
@@ -20,6 +20,9 @@ class ValueStoreRule(
         unloadKoinModules(valueStoreModule)
         loadKoinModules(module { single { valueStore } })
         every { valueStore.get(key) } returns value
+        every { valueStore.withCommittedVersion(any()) } coAnswers {
+            firstArg<ValueStore.() -> Unit>().invoke(valueStore)
+        }
     }
 
     override fun after() {

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -123,14 +123,6 @@ abstract class EmbarkViewModel(
 
     fun getPrefillFromStore(key: String) = valueStore.prefill.get(key)
 
-    private fun getFromStore(key: String) = valueStore.get(key)
-
-    private fun getListFromStore(keys: List<String>): List<String> {
-        return keys.map {
-            valueStore.getList(it) ?: listOfNotNull(valueStore.get(it))
-        }.flatten()
-    }
-
     fun submitAction(nextPassageName: String, submitIndex: Int = 0) {
         val apiFromAction = viewState.value?.passageState?.passage?.action?.api(submitIndex)
         if (apiFromAction != null) {
@@ -151,8 +143,12 @@ abstract class EmbarkViewModel(
             storyData.embarkStory == null || nextPassage == null -> _events.trySend(Event.Error())
             redirectPassage != null -> navigateToPassage(redirectPassage)
             keys != null && keys.isNotEmpty() -> {
-                val ids = getListFromStore(keys)
-                _events.trySend(Event.Offer(ids))
+                // For offers, there is a problem with the Offer screen not committing before this stage is reached,
+                //  meaning that the old values were returned from getList/get.
+                valueStore.withCommittedVersion {
+                    val ids = keys.flatMap { this.getList(it) ?: listOfNotNull(this.get(it)) }
+                    _events.trySend(Event.Offer(ids))
+                }
             }
             location != null -> handleRedirectLocation(location)
             api != null -> callApi(api)
@@ -206,7 +202,7 @@ abstract class EmbarkViewModel(
     }
 
     private fun sendOfferId() {
-        val id = getFromStore("quoteId")
+        val id = valueStore.get("quoteId")
         if (id == null) {
             _events.trySend(Event.Error())
         } else {

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferViewModel.kt
@@ -37,6 +37,7 @@ import com.hedvig.app.feature.settings.Market
 import com.hedvig.app.feature.settings.MarketManager
 import com.hedvig.hanalytics.HAnalytics
 import e
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -170,6 +171,7 @@ class OfferViewModelImpl(
     private val offerAndLoginStatus: MutableStateFlow<OfferAndLoginStatus> =
         MutableStateFlow(OfferAndLoginStatus.Loading)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override val viewState: StateFlow<ViewState> = offerAndLoginStatus.transformLatest { offerResponse ->
         when (offerResponse) {
             OfferAndLoginStatus.Error -> emit(ViewState.Error)
@@ -365,7 +367,7 @@ class OfferViewModelImpl(
 
     override fun onOpenQuoteDetails(id: String) {
         viewModelScope.launch {
-            when (val result = getQuoteUseCase(quoteIds, id)) {
+            when (val result = getQuoteUseCase.invoke(quoteIds, id)) {
                 GetQuoteUseCase.Result.Error -> {
                     offerAndLoginStatus.value = OfferAndLoginStatus.Error
                 }


### PR DESCRIPTION
The problem was as follows. The getList/get functions first look into
the stored values and if not existing then look into for example the
`stage` list. This means that if the key exists in both places, the
stored values are looked into first and the ones in staging are
disregarded.

This solves the bug where one may go through the entire flow, reach the
offer page. Then go back by pressing the back button to go and change
some input, and then continue the flow again. Then in the offer stage,
the old saved value is used instead of the latest one.

It was also considered to do a proper commit at this stage and a pop
after we're back into it, but was considered not a possible solution due
 to how some passages are skipped when coming back like OfferSuccess