### PR TITLE
APP-1455: Select dk address fluid selection

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/data/GetDanishAddressAutoCompletionUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/data/GetDanishAddressAutoCompletionUseCase.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.AddressAutocompleteQuery
 import com.hedvig.android.owldroid.type.AddressAutocompleteType
 import com.hedvig.app.feature.addressautocompletion.model.DanishAddress
+import com.hedvig.app.feature.addressautocompletion.model.DanishAddressInput
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
 
@@ -12,13 +13,13 @@ class GetDanishAddressAutoCompletionUseCase(
     private val apolloClient: ApolloClient,
 ) {
     suspend operator fun invoke(
-        addressText: String,
+        input: DanishAddressInput,
     ): Either<QueryResult.Error, AddressAutoCompleteResults> {
-        val query = AddressAutocompleteQuery(
-            addressText,
-            AddressAutocompleteType.STREET,
-        )
-        return runQuery(query)
+        return if (input.selectedAddress != null) {
+            invoke(input.selectedAddress)
+        } else {
+            invoke(input.rawText)
+        }
     }
 
     suspend operator fun invoke(
@@ -28,6 +29,16 @@ class GetDanishAddressAutoCompletionUseCase(
         val query = AddressAutocompleteQuery(
             address.toQueryString(),
             addressAutocompleteType ?: address.toAddressAutocompleteType(),
+        )
+        return runQuery(query)
+    }
+
+    private suspend operator fun invoke(
+        addressText: String,
+    ): Either<QueryResult.Error, AddressAutoCompleteResults> {
+        val query = AddressAutocompleteQuery(
+            addressText,
+            AddressAutocompleteType.STREET,
         )
         return runQuery(query)
     }

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/data/GetFinalDanishAddressSelectionUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/data/GetFinalDanishAddressSelectionUseCase.kt
@@ -28,9 +28,9 @@ class GetFinalDanishAddressSelectionUseCase(
         val newResults: List<DanishAddress> = fetchNewResults(selectedAddress).getOrElse {
             return FinalAddressResult.NetworkError
         }
-        if (newResults.size != 1) return FinalAddressResult.NotFinalAddress
-        val newResult = newResults.first()
-        if (newResult.isSameAddressAs(selectedAddress)) return FinalAddressResult.Found(selectedAddress)
+        if (newResults.size == 1) {
+            if (newResults.first().isSameAddressAs(selectedAddress)) return FinalAddressResult.Found(selectedAddress)
+        }
         return FinalAddressResult.NotFinalAddress
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/model/DanishAddressInput.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/model/DanishAddressInput.kt
@@ -2,10 +2,10 @@ package com.hedvig.app.feature.addressautocompletion.model
 
 class DanishAddressInput private constructor(
     val rawText: String,
-    val selectedDanishAddress: DanishAddress? = null,
+    val selectedAddress: DanishAddress? = null,
 ) {
     val isEmptyInput: Boolean
-        get() = selectedDanishAddress == null && rawText.isEmpty()
+        get() = selectedAddress == null && rawText.isEmpty()
 
     fun withNewText(newText: String): DanishAddressInput {
         return DanishAddressInput(newText)
@@ -14,15 +14,15 @@ class DanishAddressInput private constructor(
     fun withSelectedAddress(address: DanishAddress): DanishAddressInput {
         return DanishAddressInput(
             rawText = address.toPresentableTextPair().first,
-            selectedDanishAddress = address,
+            selectedAddress = address,
         )
     }
 
     companion object {
-        fun fromDanishAddress(danishAddress: DanishAddress?): DanishAddressInput {
+        fun fromDanishAddress(address: DanishAddress?): DanishAddressInput {
             return DanishAddressInput(
-                rawText = danishAddress?.toPresentableTextPair()?.first ?: "",
-                selectedDanishAddress = danishAddress,
+                rawText = address?.toPresentableTextPair()?.first ?: "",
+                selectedAddress = address,
             )
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteActivity.kt
@@ -5,9 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -36,19 +33,13 @@ class AddressAutoCompleteActivity : AppCompatActivity() {
                 finishWithResult(FetchDanishAddressContractResult.Selected(selectedFinalAddress))
             }
             HedvigTheme {
-                AnimatedVisibility(
-                    visible = viewState.selectedFinalAddress == null,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                ) {
-                    AddressAutoCompleteScreen(
-                        viewState = viewState,
-                        setNewTextInput = viewModel::setNewTextInput,
-                        selectAddress = viewModel::selectAddress,
-                        cancelAutoCompletion = { finishWithResult(FetchDanishAddressContractResult.Canceled) },
-                        cantFindAddress = { finishWithResult(FetchDanishAddressContractResult.CantFind) },
-                    )
-                }
+                AddressAutoCompleteScreen(
+                    viewState = viewState,
+                    setNewTextInput = viewModel::setNewTextInput,
+                    selectAddress = viewModel::selectAddress,
+                    cancelAutoCompletion = { finishWithResult(FetchDanishAddressContractResult.Canceled) },
+                    cantFindAddress = { finishWithResult(FetchDanishAddressContractResult.CantFind) },
+                )
             }
         }
     }

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
@@ -79,28 +79,7 @@ fun AddressAutoCompleteScreen(
     }
     Scaffold(
         topBar = {
-            Surface(
-                color = MaterialTheme.colors.background,
-            ) {
-                Column {
-                    CenterAlignedTopAppBar(
-                        title = stringResource(R.string.EMBARK_ADDRESS_AUTOCOMPLETE_ADDRESS),
-                        onClick = { cancelAutoCompletion() },
-                        backgroundColor = MaterialTheme.colors.background,
-                        contentPadding = rememberInsetsPaddingValues(
-                            insets = LocalWindowInsets.current.statusBars,
-                            applyBottom = false
-                        ),
-                    )
-                    AddressInput(
-                        viewState = viewState,
-                        setNewTextInput = setNewTextInput,
-                        focusRequester = focusRequester,
-                        closeKeyboard = closeKeyboard,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
-                }
-            }
+            TopAppBar(viewState, cancelAutoCompletion, setNewTextInput, focusRequester, closeKeyboard)
         },
         backgroundColor = MaterialTheme.colors.surface
     ) { paddingValues ->
@@ -122,6 +101,38 @@ fun AddressAutoCompleteScreen(
             ),
             modifier = Modifier.padding(paddingValues)
         )
+    }
+}
+
+@Composable
+private fun TopAppBar(
+    viewState: AddressAutoCompleteViewState,
+    cancelAutoCompletion: () -> Unit,
+    setNewTextInput: (String) -> Unit,
+    focusRequester: FocusRequester,
+    closeKeyboard: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colors.background,
+    ) {
+        Column {
+            CenterAlignedTopAppBar(
+                title = stringResource(R.string.EMBARK_ADDRESS_AUTOCOMPLETE_ADDRESS),
+                onClick = { cancelAutoCompletion() },
+                backgroundColor = MaterialTheme.colors.background,
+                contentPadding = rememberInsetsPaddingValues(
+                    insets = LocalWindowInsets.current.statusBars,
+                    applyBottom = false
+                ),
+            )
+            AddressInput(
+                viewState = viewState,
+                setNewTextInput = setNewTextInput,
+                focusRequester = focusRequester,
+                closeKeyboard = closeKeyboard,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
@@ -161,8 +161,8 @@ private fun AddressInput(
                     )
                 )
             }
-            LaunchedEffect(viewState.input.selectedDanishAddress) {
-                if (viewState.input.selectedDanishAddress == null) return@LaunchedEffect
+            LaunchedEffect(viewState.input.selectedAddress) {
+                if (viewState.input.selectedAddress == null) return@LaunchedEffect
                 textFieldValue = textFieldValue.copy(
                     text = viewState.input.rawText,
                     selection = TextRange(viewState.input.rawText.length),
@@ -191,7 +191,7 @@ private fun AddressInput(
                     .focusRequester(focusRequester)
                     .fillMaxWidth()
             )
-            val numberAndCity = viewState.input.selectedDanishAddress?.toPresentableTextPair()?.second
+            val numberAndCity = viewState.input.selectedAddress?.toPresentableTextPair()?.second
             AnimatedVisibility(numberAndCity != null) {
                 CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                     numberAndCity?.let {

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
@@ -265,7 +265,6 @@ fun AddressAutoCompleteScreenPreview() {
             AddressAutoCompleteScreen(
                 AddressAutoCompleteViewState(
                     input = DanishAddressInput.fromDanishAddress(previewDanishAddress),
-                    true,
                     results = DanishAddress.previewList(),
                 ),
                 {},

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
@@ -108,9 +108,11 @@ class AddressAutoCompleteViewModel(
 
 data class AddressAutoCompleteViewState(
     val input: DanishAddressInput,
-    val showCantFindAddressItem: Boolean = false,
     val results: List<DanishAddress> = emptyList(),
-)
+) {
+    val showCantFindAddressItem: Boolean
+        get() = input.isEmptyInput.not()
+}
 
 sealed interface AddressAutoCompleteEvent {
     data class Selection(val selectedAddress: DanishAddress) : AddressAutoCompleteEvent

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
@@ -39,8 +39,8 @@ class AddressAutoCompleteViewModel(
     )
     private val queryResults: Flow<List<DanishAddress>> = currentInput
         .mapLatest { input ->
-            if (input.selectedDanishAddress != null) {
-                getDanishAddressAutoCompletionUseCase.invoke(input.selectedDanishAddress)
+            if (input.selectedAddress != null) {
+                getDanishAddressAutoCompletionUseCase.invoke(input.selectedAddress)
             } else {
                 getDanishAddressAutoCompletionUseCase.invoke(input.rawText)
             }
@@ -57,7 +57,6 @@ class AddressAutoCompleteViewModel(
     ) { input, results ->
         AddressAutoCompleteViewState(
             input = input,
-            showCantFindAddressItem = input.isEmptyInput.not(),
             results = results,
         )
     }.stateIn(
@@ -98,10 +97,10 @@ class AddressAutoCompleteViewModel(
         }
     }
 
-    fun selectAddress(danishAddress: DanishAddress) {
-        addressSelectionChannel.trySend(danishAddress)
+    fun selectAddress(address: DanishAddress) {
+        addressSelectionChannel.trySend(address)
         currentInput.update { danishAddressInput ->
-            danishAddressInput.withSelectedAddress(danishAddress)
+            danishAddressInput.withSelectedAddress(address)
         }
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteViewModel.kt
@@ -72,7 +72,7 @@ class AddressAutoCompleteViewModel(
         .mapLatest { selectedAddressHistory ->
             val newSelection = selectedAddressHistory.current ?: return@mapLatest null
             val oldSelection = selectedAddressHistory.old
-            return@mapLatest getFinalDanishAddressSelectionUseCase.invoke(
+            getFinalDanishAddressSelectionUseCase.invoke(
                 selectedAddress = newSelection,
                 lastSelection = oldSelection,
             )

--- a/app/src/main/java/com/hedvig/app/util/featureflags/FeatureManager.kt
+++ b/app/src/main/java/com/hedvig/app/util/featureflags/FeatureManager.kt
@@ -22,7 +22,7 @@ data class FeatureManager(
             addProvider(DebugFeatureFlagProvider(dataStore))
         } else {
             addProvider(RemoteFeatureFlagProvider(marketManager, remoteConfig))
-            addProvider(ProductionFeatureFlagProvider(marketManager))
+            addProvider(ProductionFeatureFlagProvider())
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/util/featureflags/ProductionFeatureFlagProvider.kt
+++ b/app/src/main/java/com/hedvig/app/util/featureflags/ProductionFeatureFlagProvider.kt
@@ -1,16 +1,11 @@
 package com.hedvig.app.util.featureflags
 
-import com.hedvig.app.feature.settings.Market
-import com.hedvig.app.feature.settings.MarketManager
-
-class ProductionFeatureFlagProvider(
-    private val marketManager: MarketManager
-) : FeatureFlagProvider {
+class ProductionFeatureFlagProvider : FeatureFlagProvider {
 
     override val priority = PRODUCTION_PRIORITY
 
     override fun isFeatureEnabled(feature: Feature) = when (feature) {
-        Feature.MOVING_FLOW -> marketManager.market == Market.SE || marketManager.market == Market.NO
+        Feature.MOVING_FLOW -> true
         Feature.FRANCE_MARKET -> false
         Feature.ADDRESS_AUTO_COMPLETE -> true
         else -> false

--- a/app/src/main/java/com/hedvig/app/util/featureflags/ProductionFeatureFlagProvider.kt
+++ b/app/src/main/java/com/hedvig/app/util/featureflags/ProductionFeatureFlagProvider.kt
@@ -12,7 +12,7 @@ class ProductionFeatureFlagProvider(
     override fun isFeatureEnabled(feature: Feature) = when (feature) {
         Feature.MOVING_FLOW -> marketManager.market == Market.SE || marketManager.market == Market.NO
         Feature.FRANCE_MARKET -> false
-        Feature.ADDRESS_AUTO_COMPLETE -> false
+        Feature.ADDRESS_AUTO_COMPLETE -> true
         else -> false
     }
 


### PR DESCRIPTION
Before on every address selection, we did the same network request for 
the address autocomplete twice. Once for populating the list and once 
for getting the final address. These then individually reported to the 
viewState through a `combine` of their flows, meaning that the results 
came in an unexpected order. Specifically, almost all the time, they 
list result would come either first or so close to the final address 
result that the list was updating and then instantly after that the 
screen would dismiss the screen. This made the UI look jumpy when 
clicking on the final address as explained here 
https://hedvig.atlassian.net/browse/APP-1154?focusedCommentId=11349

This change makes it so that this process is all streamlined from the 
same source, `currentInput`. `withHistoryOfLastValue` is utilized to 
get access to the previous value to do the necessary logic. Now the two 
network requests happen in parallel again, but the final address result 
is taking precedence over the result of the normal list updating. This 
can work since if we get a final address result we can drop everything 
and simply finish the activity with that as the result. To make the UI 
not jump in that case, we simply retain the old list items and we 
populate the finalAddress field which the UI then uses to finish the 
activity.

AddressAutoCompleteViewModel.kt is where the core changes of this behavior lie. THe rest are mostly opportunistic refactoring.

Before: https://watch.screencastify.com/v/Zz2Bm84b0ye8MLbDOC6Y
After:https://user-images.githubusercontent.com/44558292/156319292-f60afeb8-35fb-401e-8f1e-5a99dd52c0f7.mp4

 