### PR TITLE
APP-1473: Fix bottom sheet not receiving any of the tooltips

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/Tooltip.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/Tooltip.kt
@@ -3,5 +3,9 @@ package com.hedvig.app.feature.embark.ui
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
+@JvmInline
+@Parcelize
+value class TooltipsParcel(val tooltips: List<Tooltip>) : Parcelable
+
 @Parcelize
 data class Tooltip(val title: String, val description: String) : Parcelable

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/TooltipBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/TooltipBottomSheet.kt
@@ -39,11 +39,12 @@ class TooltipBottomSheet : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         getViewModel<TooltipViewModel>()
-        val tooltips = requireArguments().getParcelableArrayList<Tooltip>(TOOLTIPS)
-        if (tooltips == null) {
+        val tooltipsParcel = requireArguments().getParcelable<TooltipsParcel>(TOOLTIPS)
+        if (tooltipsParcel == null) {
             e { "Programmer error: no tooltips passed to ${this::class.java.name}" }
             return
         }
+        val tooltips = tooltipsParcel.tooltips
         binding.apply {
             recycler.adapter = TooltipBottomSheetAdapter().also { adapter ->
                 adapter.submitList(
@@ -167,7 +168,7 @@ class TooltipBottomSheet : BottomSheetDialogFragment() {
                         )
                     }
                 }
-                arguments = bundleOf(TOOLTIPS to parcelableTooltips)
+                arguments = bundleOf(TOOLTIPS to TooltipsParcel(parcelableTooltips))
             }
 
         fun getTooltipsWithTitles(list: List<Tooltip>) =


### PR DESCRIPTION
Apparently `getParcelableArrayList` relies on the type of the list being a `ArrayList<T>` explicitly as when it unpacks the bundle it literally *casts* it to one, so passing it a `List` doesn't work... most of the time.

Passing this list to the bundle does *not* work
```kotlin
val listThatDoesNotWork = listOf(foo)
```
This also does *not* work
```kotlin
val listThatDoesNotWork = buildList { add(foo) }
```
But doing it this way (among other ways) it *does* work.
```kotlin
val list = buildList { add(foo) }
val listThatDoesWork = listOf(list).flatten()
```

That's because as an optimization, doing `listOf` with one element specifically creates a java.util.Collections.SingletonList which *can not* be cast to an ArrayList.
And `buildList{}` is a `List` but under the hood it's a `kotlin.collections.builders.ListBuilder` since the cast fails with:
`kotlin.collections.builders.ListBuilder cannot be cast to java.util.ArrayList`

And here's a picture of me finding out about how all this works 😭😂
![image](https://user-images.githubusercontent.com/44558292/157485674-5fd53511-8185-4619-9161-50eade69fe65.png)

Also the branch should've been called app-1473 instead, oops