### PR TITLE
Add version build number in the about app screen

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimDetailViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimDetailViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsAdapter.kt
@@ -8,6 +8,7 @@ import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import com.hedvig.app.databinding.MoreOptionsRowBinding
 import com.hedvig.app.feature.onboarding.MemberIdViewModel
+import com.hedvig.app.isDebug
 import com.hedvig.app.util.GenericDiffUtilItemCallback
 import com.hedvig.app.util.extensions.dp
 import com.hedvig.app.util.extensions.inflate
@@ -101,7 +102,14 @@ class MoreOptionsAdapter(private val viewModel: MemberIdViewModel) :
                         compoundDrawablePadding = 16.dp
                         putCompoundDrawablesRelativeWithIntrinsicBounds(start = R.drawable.ic_info_more_options)
                     }
-                    info.text = BuildConfig.VERSION_NAME
+                    info.text = buildString {
+                        append(BuildConfig.VERSION_NAME)
+                        if (isDebug()) {
+                            append(" (")
+                            append(BuildConfig.VERSION_CODE)
+                            append(")")
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/hedvig/app/feature/offer/model/quotebundle/ViewConfiguration.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/model/quotebundle/ViewConfiguration.kt
@@ -49,5 +49,6 @@ private fun TypeOfContractGradientOption.toGradient() = when (this) {
     TypeOfContractGradientOption.GRADIENT_ONE -> GradientType.FALL_SUNSET
     TypeOfContractGradientOption.GRADIENT_TWO -> GradientType.SPRING_FOG
     TypeOfContractGradientOption.GRADIENT_THREE -> GradientType.SUMMER_SKY
+    TypeOfContractGradientOption.GRADIENT_FOUR -> GradientType.SPRING_FOG // todo map the new gradient to another type?
     TypeOfContractGradientOption.UNKNOWN__ -> GradientType.SPRING_FOG
 }

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/aboutapp/AboutAppActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/aboutapp/AboutAppActivity.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.feature.dismissiblepager.DismissiblePagerModel
 import com.hedvig.app.feature.onboarding.MemberIdViewModel
 import com.hedvig.app.feature.whatsnew.WhatsNewDialog
 import com.hedvig.app.feature.whatsnew.WhatsNewViewModel
+import com.hedvig.app.isDebug
 import com.hedvig.app.util.apollo.ThemedIconUrls
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.setupToolbar
@@ -67,8 +68,14 @@ class AboutAppActivity : BaseActivity(R.layout.activity_about_app) {
                 }
             }
 
-            versionNumber.text =
-                resources.getString(R.string.PROFILE_ABOUT_APP_VERSION, BuildConfig.VERSION_NAME)
+            versionNumber.text = buildString {
+                append(resources.getString(R.string.PROFILE_ABOUT_APP_VERSION, BuildConfig.VERSION_NAME))
+                if (isDebug()) {
+                    append(" (")
+                    append(BuildConfig.VERSION_CODE)
+                    append(")")
+                }
+            }
 
             memberIdViewModel
                 .state

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ReferralsReceiverActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ReferralsReceiverActivity.kt
@@ -15,7 +15,6 @@ import com.hedvig.app.feature.referrals.ui.redeemcode.RedeemCodeViewModel
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.viewBinding
 import e
-import kotlinx.coroutines.flow.collect
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class ReferralsReceiverActivity : BaseActivity(R.layout.referrals_receiver_activity) {

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeBottomSheet.kt
@@ -20,7 +20,6 @@ import com.hedvig.app.util.extensions.hideKeyboard
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.hedvig.app.util.extensions.viewLifecycleScope
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
-import kotlinx.coroutines.flow.collect
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/CenteredContentWithTopBadge.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/CenteredContentWithTopBadge.kt
@@ -2,7 +2,6 @@ package com.hedvig.app.ui.compose.composables
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
 import androidx.compose.material.ContentAlpha

--- a/app/src/main/java/com/hedvig/app/util/apollo/DeviceIdInterceptor.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/DeviceIdInterceptor.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.util.apollo
 import com.hedvig.app.authenticate.DeviceIdStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.Request

--- a/app/src/main/java/com/hedvig/app/util/coroutines/HistoryOfLastValue.kt
+++ b/app/src/main/java/com/hedvig/app/util/coroutines/HistoryOfLastValue.kt
@@ -1,7 +1,6 @@
 package com.hedvig.app.util.coroutines
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 
 fun <T> Flow<T>.withHistoryOfLastValue(): Flow<ItemWithHistory<T>> = flow {

--- a/app/src/main/res/layout/promotion_code_dialog.xml
+++ b/app/src/main/res/layout/promotion_code_dialog.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/bottom_sheet_dialog_no_title_fragment_background"


### PR DESCRIPTION
Since we use this step https://github.com/bitrise-steplib/steps-change-android-versioncode-and-versionname it should work to simply add it on that screen. I didn't know we do that before, so I thought this wouldn't just work :D 

