### PR TITLE
APP-1575: Make embark continue when selecting "other" as insurer

### DIFF
--- a/app/src/main/java/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/java/com/hedvig/app/HedvigApplication.kt
@@ -18,7 +18,6 @@ import com.hedvig.app.util.FirebaseCrashlyticsLogExceptionTree
 import com.hedvig.app.util.extensions.SHARED_PREFERENCE_TRIED_MIGRATION_OF_TOKEN
 import com.hedvig.app.util.extensions.getStoredBoolean
 import com.hedvig.app.util.extensions.storeBoolean
-import com.hedvig.app.util.featureflags.FeatureManager
 import e
 import i
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/previousinsurer/PreviousInsurerFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/previousinsurer/PreviousInsurerFragment.kt
@@ -72,14 +72,18 @@ class PreviousInsurerFragment : Fragment(R.layout.previous_or_external_insurer_f
             MaterialAlertDialogBuilder(requireContext())
                 .setTitle(getString(R.string.EXTERNAL_INSURANCE_PROVIDER_ALERT_TITLE))
                 .setMessage(getString(R.string.EXTERNAL_INSURANCE_PROVIDER_ALERT_MESSAGE))
-                .setPositiveButton(getString(R.string.ALERT_OK)) { dialog, _ -> dialog.dismiss() }
+                .setPositiveButton(getString(R.string.ALERT_OK)) { dialog, _ -> continueEmbark() }
                 .show()
         } else {
             insurerId?.let {
                 model.putInStore(insurerData.storeKey, it)
-                model.submitAction(insurerData.next)
+                continueEmbark()
             } ?: d { "insurerId was null when continuing from PreviousInsurerFragment" }
         }
+    }
+
+    private fun continueEmbark() {
+        model.submitAction(insurerData.next)
     }
 
     private fun onShowInsurers() {


### PR DESCRIPTION
This screen has the same UI and works super similar with the `ExternalInsurerFragment`. Took inspiration from how that one handles this case here https://github.com/HedvigInsurance/android/blob/ee3d88a1ce79a4f39fdbd2320eec367b9b91461e/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/ExternalInsurerFragment.kt#L162 .

Now it continues without adding anything to the value store, as I assume is the correct approach to this problem.
I do however wonder if this ever worked in the first place, I did not find any code in the history that would indicate so to try and revert to that instead. I might've missed smth though.