### PR TITLE
Variant cards UI tweaks

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/offer/model/quotebundle/ViewConfiguration.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/model/quotebundle/ViewConfiguration.kt
@@ -49,5 +49,6 @@ private fun TypeOfContractGradientOption.toGradient() = when (this) {
     TypeOfContractGradientOption.GRADIENT_ONE -> GradientType.FALL_SUNSET
     TypeOfContractGradientOption.GRADIENT_TWO -> GradientType.SPRING_FOG
     TypeOfContractGradientOption.GRADIENT_THREE -> GradientType.SUMMER_SKY
+    TypeOfContractGradientOption.GRADIENT_FOUR -> GradientType.SPRING_FOG
     TypeOfContractGradientOption.UNKNOWN__ -> GradientType.SPRING_FOG
 }

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/VariantButton.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/VariantButton.kt
@@ -4,9 +4,10 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentAlpha
@@ -17,12 +18,14 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.hedvig.app.ui.compose.theme.HedvigTheme
 import com.hedvig.app.ui.compose.theme.hedvigBlack
 import com.hedvig.app.ui.compose.theme.hedvigBlack12percent
+import com.hedvig.app.util.compose.HorizontalTextsWithMaximumSpaceTaken
 
 @Composable
 fun VariantButton(
@@ -31,7 +34,7 @@ fun VariantButton(
     subTitle: String?,
     cost: String,
     selected: Boolean,
-    onClick: (id: String) -> Unit
+    onClick: (id: String) -> Unit,
 ) {
     Card(
         border = if (selected) {
@@ -41,30 +44,38 @@ fun VariantButton(
         },
         modifier = Modifier
             .padding(top = 8.dp, start = 16.dp, end = 16.dp)
+            .heightIn(min = 110.dp)
             .clickable {
                 onClick(id)
-            }
+            },
     ) {
-        Row(
-            Modifier
-                .height(106.dp)
-        ) {
+        Row(modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 12.dp, bottom = 16.dp)) {
             RadioButton(selected = selected, onClick = { onClick(id) }, modifier = Modifier.padding(top = 4.dp))
-            Column(modifier = Modifier.padding(top = 16.dp).width(200.dp)) {
-                Text(text = title, style = MaterialTheme.typography.h6)
+            Column {
+                HorizontalTextsWithMaximumSpaceTaken(
+                    startText = {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.h6,
+                        )
+                    },
+                    endText = { textAlign ->
+                        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                            Text(
+                                text = cost,
+                                style = MaterialTheme.typography.h6,
+                                textAlign = textAlign,
+                            )
+                        }
+                    },
+                    spaceBetween = 10.dp,
+                )
                 if (subTitle != null) {
+                    Spacer(modifier = Modifier.height(10.dp))
                     CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                         Text(text = subTitle, style = MaterialTheme.typography.subtitle1)
                     }
                 }
-            }
-            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                Text(
-                    text = cost,
-                    style = MaterialTheme.typography.h6,
-                    modifier = Modifier.padding(top = 16.dp, end = 12.dp),
-                    textAlign = TextAlign.End
-                )
             }
         }
     }
@@ -72,19 +83,31 @@ fun VariantButton(
 
 @Preview
 @Composable
-fun VariantButtonPreview() {
+fun VariantButtonPreview(
+    @PreviewParameter(VariantButtonInputsProvider::class) inputs: Triple<String, String, Boolean>,
+) {
+    val (title, subtitle, selected) = inputs
     HedvigTheme {
         Surface(
             color = MaterialTheme.colors.background,
         ) {
             VariantButton(
                 id = "id",
-                title = "Hemförsäkring och Olyckssf",
-                subTitle = "Test subtitle",
+                title = title,
+                subTitle = subtitle,
                 cost = "12923 NOK",
-                selected = false,
+                selected = selected,
                 onClick = {}
             )
         }
     }
 }
+
+class VariantButtonInputsProvider : CollectionPreviewParameterProvider<Triple<String, String, Boolean>>(
+    listOf(
+        Triple("Hemförsäkring och Olyckssfall", "Test subtitle", true),
+        Triple("Title".repeat(5), "Subtitle", false),
+        Triple("Title", "Subtitle".repeat(5), false),
+        Triple("Title".repeat(10), "Subtitle".repeat(10), true),
+    )
+)

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/VariantButton.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/VariantButton.kt
@@ -1,18 +1,18 @@
 package com.hedvig.app.feature.offer.ui.composable
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.RadioButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -26,7 +26,9 @@ import com.hedvig.app.ui.compose.theme.HedvigTheme
 import com.hedvig.app.ui.compose.theme.hedvigBlack
 import com.hedvig.app.ui.compose.theme.hedvigBlack12percent
 import com.hedvig.app.util.compose.HorizontalTextsWithMaximumSpaceTaken
+import com.hedvig.app.util.compose.RadioButton
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun VariantButton(
     id: String,
@@ -37,6 +39,7 @@ fun VariantButton(
     onClick: (id: String) -> Unit,
 ) {
     Card(
+        onClick = { onClick(id) },
         border = if (selected) {
             BorderStroke(3.dp, hedvigBlack)
         } else {
@@ -44,13 +47,11 @@ fun VariantButton(
         },
         modifier = Modifier
             .padding(top = 8.dp, start = 16.dp, end = 16.dp)
-            .heightIn(min = 110.dp)
-            .clickable {
-                onClick(id)
-            },
+            .heightIn(min = 110.dp),
     ) {
         Row(modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 12.dp, bottom = 16.dp)) {
-            RadioButton(selected = selected, onClick = { onClick(id) }, modifier = Modifier.padding(top = 4.dp))
+            RadioButton(selected = selected, size = 24.dp)
+            Spacer(Modifier.width(12.dp))
             Column {
                 HorizontalTextsWithMaximumSpaceTaken(
                     startText = {

--- a/app/src/main/java/com/hedvig/app/util/compose/HorizontalTextsWithMaximumSpaceTaken.kt
+++ b/app/src/main/java/com/hedvig/app/util/compose/HorizontalTextsWithMaximumSpaceTaken.kt
@@ -1,0 +1,163 @@
+package com.hedvig.app.util.compose
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hedvig.app.ui.compose.theme.HedvigTheme
+import kotlin.math.max
+
+/**
+ * When two texts need to be laid out horizontally in a row, they can't know how much space they need to take out, which
+ * more often than not results in the starting text taking up all the width it needs, squeezing the end text. This
+ * layout makes sure to measure their max intrinsic width and give as much space as possible to each text, without
+ * squeezing the other one. If both of them were to need more than half of the space, or less than half of the space,
+ * they're simply given half of the width each.
+ */
+@Composable
+fun HorizontalTextsWithMaximumSpaceTaken(
+    startText: @Composable () -> Unit,
+    endText: @Composable (textAlign: TextAlign) -> Unit,
+    modifier: Modifier = Modifier,
+    spaceBetween: Dp = 0.dp,
+) {
+    Layout(
+        content = {
+            startText()
+            endText(textAlign = TextAlign.End)
+        },
+        modifier = modifier,
+    ) { measurables, constraints ->
+        val first = measurables[0]
+        val second = measurables[1]
+        val firstWidth = first.maxIntrinsicWidth(constraints.maxHeight)
+        val secondWidth = second.maxIntrinsicWidth(constraints.maxHeight)
+
+        val totalWidth = constraints.maxWidth
+        val halfWidth = totalWidth / 2
+
+        val centerSpace = spaceBetween.roundToPx()
+        val halfCenterSpace = centerSpace / 2
+
+        val halfWidthMinusSpace = halfWidth - halfCenterSpace
+
+        val bothTakeLessThanHalfSpace = firstWidth <= halfWidthMinusSpace && secondWidth <= halfWidthMinusSpace
+        val bothTakeMoreThanHalfSpace = firstWidth > halfWidthMinusSpace && secondWidth > halfWidthMinusSpace
+        val textsShouldShareEqualSpace = bothTakeLessThanHalfSpace || bothTakeMoreThanHalfSpace
+
+        val firstConstraints: Constraints
+        val secondConstraints: Constraints
+        if (textsShouldShareEqualSpace) {
+            val halfWidthMinusSpaceConstraints = constraints.copy(
+                minWidth = halfWidthMinusSpace,
+                maxWidth = halfWidthMinusSpace
+            )
+            firstConstraints = halfWidthMinusSpaceConstraints
+            secondConstraints = halfWidthMinusSpaceConstraints
+        } else if (firstWidth > halfWidthMinusSpace) {
+            firstConstraints = constraints.copy(
+                minWidth = totalWidth - secondWidth - halfCenterSpace,
+                maxWidth = totalWidth - secondWidth - halfCenterSpace,
+            )
+            secondConstraints = constraints.copy(
+                minWidth = secondWidth,
+                maxWidth = secondWidth,
+            )
+        } else {
+            firstConstraints = constraints.copy(
+                minWidth = firstWidth,
+                maxWidth = firstWidth,
+            )
+            secondConstraints = constraints.copy(
+                minWidth = totalWidth - firstWidth - halfCenterSpace,
+                maxWidth = totalWidth - firstWidth - halfCenterSpace,
+            )
+        }
+        val firstPlaceable = first.measure(firstConstraints)
+        val secondPlaceable = second.measure(secondConstraints)
+        layout(constraints.maxWidth, max(firstPlaceable.height, secondPlaceable.height)) {
+            firstPlaceable.placeRelative(0, 0)
+            secondPlaceable.placeRelative(constraints.maxWidth - secondPlaceable.width, 0)
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SmallTextsPreview() {
+    HedvigTheme {
+        HorizontalTextsWithMaximumSpaceTaken(
+            startText = { Text(text = "Start") },
+            endText = { Text(text = "End", textAlign = it) },
+            modifier = Modifier.size(width = 250.dp, height = 100.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BigTextsPreview() {
+    HedvigTheme {
+        HorizontalTextsWithMaximumSpaceTaken(
+            startText = { Text(text = "Start".repeat(10)) },
+            endText = { Text(text = "End".repeat(10), textAlign = it) },
+            modifier = Modifier.size(width = 250.dp, height = 100.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BigTextsWithSpaceTextPreview() {
+    HedvigTheme {
+        HorizontalTextsWithMaximumSpaceTaken(
+            startText = { Text(text = "Start".repeat(10)) },
+            endText = { Text(text = "End".repeat(10), textAlign = it) },
+            modifier = Modifier.size(width = 250.dp, height = 100.dp),
+            spaceBetween = 30.dp
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BigStartTextPreview() {
+    HedvigTheme {
+        HorizontalTextsWithMaximumSpaceTaken(
+            startText = { Text(text = "Start".repeat(10)) },
+            endText = { Text(text = "End", textAlign = it) },
+            modifier = Modifier.size(width = 250.dp, height = 100.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BigEndTextPreview() {
+    HedvigTheme {
+        HorizontalTextsWithMaximumSpaceTaken(
+            startText = { Text(text = "Start") },
+            endText = { Text(text = "End".repeat(10), textAlign = it) },
+            modifier = Modifier.size(width = 250.dp, height = 100.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BigEndTextWithSpacePreview() {
+    HedvigTheme {
+        HorizontalTextsWithMaximumSpaceTaken(
+            startText = { Text(text = "Start") },
+            endText = { Text(text = "End".repeat(10), textAlign = it) },
+            modifier = Modifier.size(width = 250.dp, height = 100.dp),
+            spaceBetween = 32.dp
+        )
+    }
+}

--- a/app/src/main/java/com/hedvig/app/util/compose/RadioButton.kt
+++ b/app/src/main/java/com/hedvig/app/util/compose/RadioButton.kt
@@ -1,0 +1,59 @@
+package com.hedvig.app.util.compose
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.RadioButtonColors
+import androidx.compose.material.RadioButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Stripped down version of [androidx.compose.material.RadioButton] which allows for a different size.
+ */
+@Composable
+fun RadioButton(
+    selected: Boolean,
+    size: Dp,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: RadioButtonColors = RadioButtonDefaults.colors(),
+) {
+    val radioRadius = remember(size) { size / 2 }
+    val radioButtonDotSize = remember(size) { size - 8.dp }
+    val dotRadius = animateDpAsState(
+        targetValue = if (selected) radioButtonDotSize / 2 else 0.dp,
+        animationSpec = tween(durationMillis = RadioAnimationDuration)
+    )
+    val radioColor = colors.radioColor(enabled, selected)
+    Canvas(
+        modifier
+            .wrapContentSize(Alignment.Center)
+            .padding(RadioButtonPadding)
+            .requiredSize(size)
+    ) {
+        val strokeWidth = RadioStrokeWidth.toPx()
+        drawCircle(
+            radioColor.value,
+            radioRadius.toPx() - strokeWidth / 2,
+            style = Stroke(strokeWidth)
+        )
+        if (dotRadius.value > 0.dp) {
+            drawCircle(radioColor.value, dotRadius.value.toPx() - strokeWidth / 2, style = Fill)
+        }
+    }
+}
+
+private const val RadioAnimationDuration = 100
+
+private val RadioButtonPadding = 2.dp
+private val RadioStrokeWidth = 2.dp


### PR DESCRIPTION
Some changes to do the following:

- Allow the card to expand vertically when it needs more space instead of hiding the text
- Make the radio button go away from the material fixed size specs and allow it to be bigger so that it matches the design
- Add a layout which allows two texts that are side to side to not squish each other or to have to use fixed widths to avoid this interaction. Instead this layout lets each text take the minimum space they need as possible, before expanding to take on the rest of the space if it's available.

Please if you can find a better name than `HorizontalTextsWithMaximumSpaceTaken` suggest it 😅

<img width="386" alt="image" src="https://user-images.githubusercontent.com/44558292/164428350-08497b5f-f13c-4e15-84b2-d5584fb07efc.png">
