### PR TITLE
Use committed valueStore inside `withCommittedVersion` block

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkViewModel.kt
@@ -158,7 +158,7 @@ abstract class EmbarkViewModel(
                 //  meaning that the old values were returned from getList/get.
                 valueStore.withCommittedVersion {
                     val quoteCartId = this.get(QUOTE_CART_ID_KEY)?.let { QuoteCartId(it) }
-                    val selectedContractTypes = nextPassage.getSelectedContractTypes(valueStore)
+                    val selectedContractTypes = nextPassage.getSelectedContractTypes(this)
                     _events.trySend(Event.Offer(quoteCartId, selectedContractTypes))
                 }
             }


### PR DESCRIPTION
We were using the wrong instance of `valueStore` for the function `getSelectedContractTypes`. Inside the `withCommittedVersion` scope we have access to `this` which is the "committed" version of the current `valueStore`.

Doesn't necessarily solve something in particular that I am aware of, but the way it was before was like that by accident as far as I can see.