### PR TITLE
Reintroduce ConnectPaymentAtSign after merge deleting it

### DIFF
--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -466,7 +466,6 @@ val offerModule = module {
             loginStatusService = get(),
             signQuotesUseCase = get(),
             shouldShowOnNextAppStart = parametersHolder.get(),
-            adyenRepository = get(),
             chatRepository = get(),
             editCampaignUseCase = get(),
             featureManager = get(),
@@ -478,7 +477,7 @@ val offerModule = module {
     single { SubscribeToDataCollectionStatusUseCase(get()) }
     single { GetProviderDisplayNameUseCase(get()) }
     single { GetDataCollectionResultUseCase(get()) }
-    single { QuoteCartFragmentToOfferModelMapper() }
+    single { QuoteCartFragmentToOfferModelMapper(get()) }
 }
 
 val profileModule = module {

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferViewModel.kt
@@ -8,7 +8,6 @@ import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.hedvig.app.R
 import com.hedvig.app.authenticate.LoginStatus
 import com.hedvig.app.authenticate.LoginStatusService
-import com.hedvig.app.feature.adyen.AdyenRepository
 import com.hedvig.app.feature.adyen.PaymentTokenId
 import com.hedvig.app.feature.chat.data.ChatRepository
 import com.hedvig.app.feature.checkout.CheckoutParameter
@@ -17,7 +16,6 @@ import com.hedvig.app.feature.insurablelimits.InsurableLimitItem
 import com.hedvig.app.feature.offer.model.OfferModel
 import com.hedvig.app.feature.offer.model.QuoteBundleVariant
 import com.hedvig.app.feature.offer.model.QuoteCartId
-import com.hedvig.app.feature.offer.model.paymentApiResponseOrNull
 import com.hedvig.app.feature.offer.model.quotebundle.OfferStartDate
 import com.hedvig.app.feature.offer.model.quotebundle.PostSignScreen
 import com.hedvig.app.feature.offer.model.quotebundle.QuoteBundle
@@ -161,7 +159,6 @@ class OfferViewModelImpl(
     private val loginStatusService: LoginStatusService,
     private val signQuotesUseCase: SignQuotesUseCase,
     shouldShowOnNextAppStart: Boolean,
-    private val adyenRepository: AdyenRepository,
     private val chatRepository: ChatRepository,
     private val editCampaignUseCase: EditCampaignUseCase,
     private val featureManager: FeatureManager,
@@ -201,8 +198,7 @@ class OfferViewModelImpl(
                                 offerModel = offerModel,
                                 bundleVariant = bundle,
                                 loginStatus = loginStatusService.getLoginStatus(),
-                                paymentMethods = offerModel.paymentApiResponseOrNull()
-                                    ?: adyenRepository.paymentMethodsResponse(),
+                                paymentMethods = offerModel.paymentMethodsApiResponse,
                                 externalProvider = externalProvider,
                                 onVariantSelected = { variantId ->
                                     getBundleVariantUseCase.selectedVariant(variantId)
@@ -216,8 +212,7 @@ class OfferViewModelImpl(
                                 offerModel = offerModel,
                                 bundleVariant = bundle,
                                 loginStatus = loginStatusService.getLoginStatus(),
-                                paymentMethods = offerModel.paymentApiResponseOrNull()
-                                    ?: adyenRepository.paymentMethodsResponse(),
+                                paymentMethods = offerModel.paymentMethodsApiResponse,
                                 externalProvider = null,
                                 onVariantSelected = { variantId ->
                                     getBundleVariantUseCase.selectedVariant(variantId)

--- a/app/src/main/java/com/hedvig/app/feature/offer/model/OfferModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/model/OfferModel.kt
@@ -2,8 +2,6 @@ package com.hedvig.app.feature.offer.model
 
 import android.os.Parcelable
 import com.adyen.checkout.components.model.PaymentMethodsApiResponse
-import com.hedvig.android.owldroid.fragment.QuoteCartFragment
-import com.hedvig.android.owldroid.graphql.OfferQuery
 import kotlinx.parcelize.Parcelize
 
 @JvmInline
@@ -16,41 +14,5 @@ data class OfferModel(
     val checkoutMethod: CheckoutMethod,
     val campaign: Campaign?,
     val checkout: Checkout?,
-    val paymentConnection: PaymentConnection?,
-)
-
-fun OfferModel.paymentApiResponseOrNull(): PaymentMethodsApiResponse? {
-    return paymentConnection
-        ?.providers
-        ?.filterIsInstance(PaymentProvider.Adyen::class.java)
-        ?.firstOrNull()
-        ?.availablePaymentOptions
-}
-
-fun OfferQuery.Data.toOfferModel() = OfferModel(
-    id = null,
-    variants = emptyList(),
-    checkoutMethod = signMethodForQuotes.toCheckoutMethod(),
-    campaign = Campaign(
-        displayValue = redeemedCampaigns
-            .firstNotNullOfOrNull { it.fragments.incentiveFragment.displayValue },
-        incentive = redeemedCampaigns.firstOrNull()?.fragments?.incentiveFragment?.incentive?.toIncentive()
-            ?: Campaign.Incentive.NoDiscount
-    ),
-    checkout = Checkout(
-        status = Checkout.CheckoutStatus.FAILED,
-        statusText = null,
-        redirectUrl = null
-    ),
-    paymentConnection = null,
-)
-
-fun QuoteCartFragment.toOfferModel() = OfferModel(
-    id = QuoteCartId(id),
-    variants = bundle?.possibleVariations?.map { it.toQuoteBundleVariant(QuoteCartId(id), checkoutMethods) }
-        ?: emptyList(),
-    checkoutMethod = checkoutMethods.map { it.toCheckoutMethod() }.first(),
-    campaign = campaign?.toCampaign(),
-    checkout = checkout?.toCheckout(),
-    paymentConnection = paymentConnection?.toPaymentConnection(),
+    val paymentMethodsApiResponse: PaymentMethodsApiResponse?,
 )

--- a/app/src/main/java/com/hedvig/app/feature/offer/model/QuoteCartFragmentToOfferModelMapper.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/model/QuoteCartFragmentToOfferModelMapper.kt
@@ -1,10 +1,16 @@
 package com.hedvig.app.feature.offer.model
 
+import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.hedvig.android.owldroid.fragment.QuoteCartFragment
 import com.hedvig.app.common.Mapper
+import com.hedvig.app.util.featureflags.FeatureManager
+import com.hedvig.app.util.featureflags.flags.Feature
 
-class QuoteCartFragmentToOfferModelMapper : Mapper<QuoteCartFragment, OfferModel> {
+class QuoteCartFragmentToOfferModelMapper(
+    private val featureManager: FeatureManager,
+) : Mapper<QuoteCartFragment, OfferModel> {
     override suspend fun map(from: QuoteCartFragment): OfferModel {
+        val connectPaymentAtSign = featureManager.isFeatureEnabled(Feature.CONNECT_PAYMENT_AT_SIGN)
         return with(from) {
             OfferModel(
                 id = QuoteCartId(id),
@@ -13,8 +19,24 @@ class QuoteCartFragmentToOfferModelMapper : Mapper<QuoteCartFragment, OfferModel
                 checkoutMethod = checkoutMethods.map { it.toCheckoutMethod() }.first(),
                 campaign = campaign?.toCampaign(),
                 checkout = checkout?.toCheckout(),
-                paymentConnection?.toPaymentConnection(),
+                paymentMethodsApiResponse = run {
+                    if (connectPaymentAtSign.not()) return@run null
+                    paymentConnection?.toPaymentConnection()?.toPaymentApiResponseOrNull()
+                },
             )
         }
+    }
+
+    private fun PaymentConnection?.toPaymentApiResponseOrNull(): PaymentMethodsApiResponse? {
+        return this
+            ?.providers
+            ?.mapNotNull { paymentProvider ->
+                when (paymentProvider) {
+                    is PaymentProvider.Adyen -> paymentProvider
+                    PaymentProvider.Trustly -> null
+                }
+            }
+            ?.firstOrNull()
+            ?.availablePaymentOptions
     }
 }

--- a/app/src/test/java/com/hedvig/app/feature/offer/TestOfferModelBuilder.kt
+++ b/app/src/test/java/com/hedvig/app/feature/offer/TestOfferModelBuilder.kt
@@ -125,6 +125,6 @@ class TestOfferModelBuilder(
         checkoutMethod = checkoutMethod,
         campaign = campaign,
         checkout = null,
-        paymentConnection = null
+        paymentMethodsApiResponse = null
     )
 }


### PR DESCRIPTION
Not sure how exactly it happened, but during some merge this change was overwritten.

This PR reintroduces the changes done in this PR https://github.com/HedvigInsurance/android/pull/956/files

Tested manually for all markets

This makes APP-1497 ready to be QAd again