### PR TITLE
Make offer page header and variants not flicker

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferAdapter.kt
@@ -539,6 +539,12 @@ class OfferAdapter(
                     // Should only display 1 PriceComparisonHeader ever
                     true
                 }
+                oldItem is OfferItems.Header && newItem is OfferItems.Header -> {
+                    true
+                }
+                oldItem is OfferItems.VariantButton && newItem is OfferItems.VariantButton -> {
+                    oldItem.id == newItem.id
+                }
                 else -> {
                     oldItem == newItem
                 }


### PR DESCRIPTION
Just let the reyclerView know they're the same item because on top of flickering, it was also scrolling down when selecting another variant, making the experience not ideal