### PR TITLE
APP-1651: Make insurance query not show stale data after approving a moving flow

### DIFF
--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -656,7 +656,7 @@ val useCaseModule = module {
     single { StartDanishAuthUseCase(get()) }
     single { StartNorwegianAuthUseCase(get()) }
     single { SubscribeToAuthStatusUseCase(get()) }
-    single { SignQuotesUseCase(get()) }
+    single { SignQuotesUseCase(get(), get()) }
     single { LogoutUseCase(get(), get(), get(), get(), get(), get(), get()) }
     single { GetContractsUseCase(get(), get()) }
     single { GetCrossSellsContractTypesUseCase(get(), get()) }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
@@ -1,24 +1,29 @@
 package com.hedvig.app.feature.insurance.data
 
+import arrow.core.Either
+import arrow.core.computations.either
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
+import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
-import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
 
 class GetContractsUseCase(
     private val apolloClient: ApolloClient,
-    private val localeManager: LocaleManager
+    private val localeManager: LocaleManager,
 ) {
-    suspend operator fun invoke(): InsuranceResult {
-        return when (val response = apolloClient.query(InsuranceQuery(localeManager.defaultLocale())).safeQuery()) {
-            is QueryResult.Error -> InsuranceResult.Error(response.message)
-            is QueryResult.Success -> InsuranceResult.Insurance(response.data)
+    suspend fun invoke(): Either<ErrorMessage, InsuranceQuery.Data> {
+        return either {
+            val insuranceQueryData = apolloClient
+                .query(InsuranceQuery(localeManager.defaultLocale()))
+                .toBuilder()
+                .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
+                .build()
+                .safeQuery()
+                .toEither(::ErrorMessage)
+                .bind()
+            insuranceQueryData
         }
-    }
-
-    sealed class InsuranceResult {
-        data class Insurance(val insurance: InsuranceQuery.Data) : InsuranceResult()
-        data class Error(val message: String?) : InsuranceResult()
     }
 }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
@@ -17,9 +17,6 @@ class GetContractsUseCase(
         return either {
             val insuranceQueryData = apolloClient
                 .query(InsuranceQuery(localeManager.defaultLocale()))
-                .toBuilder()
-                .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
-                .build()
                 .safeQuery()
                 .toEither(::ErrorMessage)
                 .bind()

--- a/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.feature.insurance.data
 import arrow.core.Either
 import arrow.core.computations.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.fetcher.ApolloResponseFetchers
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/InsuranceViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/InsuranceViewModel.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.feature.insurance.ui.tab
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import arrow.core.Either
 import com.hedvig.app.feature.insurance.data.GetContractsUseCase
 import com.hedvig.app.feature.insurance.ui.InsuranceModel
 import com.hedvig.app.service.badge.CrossSellNotificationBadgeService
@@ -33,17 +34,17 @@ class InsuranceViewModelImpl(
         viewModelScope.launch {
             _viewState.value = ViewState.Loading
             when (val result = getContractsUseCase.invoke()) {
-                is GetContractsUseCase.InsuranceResult.Error -> {
-                    result.message?.let { e { it } }
+                is Either.Left -> {
+                    result.value.message?.let { e { it } }
                     _viewState.value = ViewState.Error
                 }
-                is GetContractsUseCase.InsuranceResult.Insurance -> {
+                is Either.Right -> {
                     val showNotificationBadge = crossSellNotificationBadgeService
                         .getUnseenCrossSells(CrossSellNotificationBadgeService.CrossSellBadgeType.InsuranceFragmentCard)
                         .first()
                         .isNotEmpty()
                     val items = items(
-                        data = result.insurance,
+                        data = result.value,
                         showCrossSellNotificationBadge = showNotificationBadge
                     )
                     _viewState.value = ViewState.Success(items)

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
@@ -93,12 +93,11 @@ class TerminatedContractsViewModel(
 
     fun load() {
         viewModelScope.launch {
-            when (val result = getContractsUseCase.invoke()) {
-                is GetContractsUseCase.InsuranceResult.Error -> _viewState.value = ViewState.Error
-                is GetContractsUseCase.InsuranceResult.Insurance -> {
-                    _viewState.value = ViewState.Success(items(result.insurance))
-                }
-            }
+            _viewState.value = getContractsUseCase.invoke()
+                .fold(
+                    ifLeft = { ViewState.Error },
+                    ifRight = { insuranceQueryData -> ViewState.Success(items(insuranceQueryData)) }
+                )
         }
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/SignQuotesUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/SignQuotesUseCase.kt
@@ -7,12 +7,13 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.SignQuoteCartMutation
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
+import com.hedvig.app.util.apollo.CacheManager
 import com.hedvig.app.util.apollo.safeQuery
 
 class SignQuotesUseCase(
     private val apolloClient: ApolloClient,
+    private val cacheManager: CacheManager,
 ) {
-
     object Success
 
     suspend fun signQuotesAndClearCache(
@@ -25,7 +26,7 @@ class SignQuotesUseCase(
         val errorMessage = result.quoteCartStartCheckout.asBasicError?.message
 
         ensure(errorMessage == null) { ErrorMessage(errorMessage) }
-
+        cacheManager.clearCache()
         Success
     }
 


### PR DESCRIPTION
Judging from the logs:
`2022-05-05T08:12:41.157000+00:00 com.hedvig.test.app: 23377:23474 D/a: Cache HIT for operation InsuranceQuery`

The cache is hit when it should actually try to fetch from the network.

Tested this change by using the original code:
- signing a new member
- approved the accident cross sell
- refreshing the page and seeing the cache being hit despite the giraffe query returning both contracts at this point

After this commit, did this:
- unsigned old member and started fresh
- signed a new member
- approved the accident cross sell
- now the page even before refreshing properly fetches the new data that the screens should be showing.