### PR TITLE
Fix/flipped connect payment at sign flag

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/offer/model/QuoteCartFragmentToOfferModelMapper.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/model/QuoteCartFragmentToOfferModelMapper.kt
@@ -10,7 +10,7 @@ class QuoteCartFragmentToOfferModelMapper(
     private val featureManager: FeatureManager,
 ) : Mapper<QuoteCartFragment, OfferModel> {
     override suspend fun map(from: QuoteCartFragment): OfferModel {
-        val connectPaymentAtSign = featureManager.isFeatureEnabled(Feature.CONNECT_PAYMENT_AT_SIGN)
+        val connectPaymentPostOnboarding = featureManager.isFeatureEnabled(Feature.CONNECT_PAYMENT_POST_ONBOARDING)
         return with(from) {
             OfferModel(
                 id = QuoteCartId(id),
@@ -20,7 +20,7 @@ class QuoteCartFragmentToOfferModelMapper(
                 campaign = campaign?.toCampaign(),
                 checkout = checkout?.toCheckout(),
                 paymentMethodsApiResponse = run {
-                    if (connectPaymentAtSign.not()) return@run null
+                    if (connectPaymentPostOnboarding) return@run null
                     paymentConnection?.toPaymentConnection()?.toPaymentApiResponseOrNull()
                 },
             )

--- a/app/src/main/java/com/hedvig/app/util/featureflags/flags/DevFeatureFlagProvider.kt
+++ b/app/src/main/java/com/hedvig/app/util/featureflags/flags/DevFeatureFlagProvider.kt
@@ -10,7 +10,7 @@ class DevFeatureFlagProvider(
     override suspend fun isFeatureEnabled(feature: Feature): Boolean {
         val isQasaMember = true
         return when (feature) {
-            Feature.CONNECT_PAYMENT_AT_SIGN -> marketManager.market == Market.NO || marketManager.market == Market.DK
+            Feature.CONNECT_PAYMENT_POST_ONBOARDING -> marketManager.market == Market.SE
             Feature.COMMON_CLAIMS -> !isQasaMember
             Feature.CONNECT_PAYIN_REMINDER -> !isQasaMember
             Feature.EXTERNAL_DATA_COLLECTION -> marketManager.market == Market.SE

--- a/app/src/main/java/com/hedvig/app/util/featureflags/flags/Feature.kt
+++ b/app/src/main/java/com/hedvig/app/util/featureflags/flags/Feature.kt
@@ -3,8 +3,8 @@ package com.hedvig.app.util.featureflags.flags
 enum class Feature(
     @Suppress("unused") val explanation: String, // Used to easier get a context of what it's for.
 ) {
-    CONNECT_PAYMENT_AT_SIGN(
-        "Connecting payment at sign, to avoid missing payments. Show payment step in PostOnboarding"
+    CONNECT_PAYMENT_POST_ONBOARDING(
+        "Connecting payment post onboarding. Having this OFF means that it must happen in the offer page"
     ),
     EXTERNAL_DATA_COLLECTION("Enables external data collection for offers, from eg. Insurely"),
     FRANCE_MARKET("Used to select french market in app"),

--- a/app/src/main/java/com/hedvig/app/util/featureflags/flags/HAnalyticsFeatureFlagProvider.kt
+++ b/app/src/main/java/com/hedvig/app/util/featureflags/flags/HAnalyticsFeatureFlagProvider.kt
@@ -9,7 +9,7 @@ class HAnalyticsFeatureFlagProvider(
     //  Feature.MOVING_FLOW -> marketManager.market == Market.SE || marketManager.market == Market.NO
     //  Feature.CONNECT_PAYMENT_AT_SIGN -> marketManager.market == Market.NO || marketManager.market == Market.DK
     override suspend fun isFeatureEnabled(feature: Feature) = when (feature) {
-        Feature.CONNECT_PAYMENT_AT_SIGN -> hAnalytics.postOnboardingShowPaymentStep()
+        Feature.CONNECT_PAYMENT_POST_ONBOARDING -> hAnalytics.postOnboardingShowPaymentStep()
         Feature.EXTERNAL_DATA_COLLECTION -> hAnalytics.allowExternalDataCollection()
         Feature.FRANCE_MARKET -> hAnalytics.frenchMarket()
         Feature.KEY_GEAR -> hAnalytics.keyGear()


### PR DESCRIPTION
Context: https://hedviginsurance.slack.com/archives/C033ALASHL6/p1651843005804419?thread_ts=1651830564.242919&cid=C033ALASHL6

Apparently we understood this flag flipped. It was the opposite of what we had in mind on Android. This flips it basically and tries to help with understanding the context with the new flag description.