### PR TITLE
Simplify GetAddressChangeStoryIdUseCase with `eager {}`

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/embark/quotecart/CreateQuoteCartUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/quotecart/CreateQuoteCartUseCase.kt
@@ -21,7 +21,7 @@ class CreateQuoteCartUseCase(
         marketManager.market?.toGraphQLMarket() ?: Market.SWEDEN
     )
 
-    suspend operator fun invoke(): Either<ErrorMessage, QuoteCartId> {
+    suspend fun invoke(): Either<ErrorMessage, QuoteCartId> {
         return apolloClient
             .mutate(mutation())
             .safeQuery()

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressViewModel.kt
@@ -65,7 +65,7 @@ class ChangeAddressViewModelImpl(
             is UpcomingAgreementResult.Error -> ViewState.UpcomingAgreementError(upcomingAgreement)
         }
 
-    private suspend fun getSelfChangeState() = when (val selfChangeEligibility = addressChangeStoryId()) {
+    private suspend fun getSelfChangeState() = when (val selfChangeEligibility = addressChangeStoryId.invoke()) {
         is SelfChangeEligibilityResult.Eligible -> ViewState.SelfChangeAddress(selfChangeEligibility.embarkStoryId)
         is SelfChangeEligibilityResult.Blocked -> ViewState.ManualChangeAddress
         is SelfChangeEligibilityResult.Error -> ViewState.SelfChangeError(selfChangeEligibility)

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
@@ -1,10 +1,7 @@
 package com.hedvig.app.feature.home.ui.changeaddress
 
 import arrow.core.Either
-import arrow.core.computations.either
-import arrow.core.computations.ensureNotNull
 import arrow.core.getOrHandle
-import arrow.core.identity
 import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.ActiveContractBundlesQuery
 import com.hedvig.app.feature.embark.QUOTE_CART_ID_KEY

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
@@ -3,11 +3,13 @@ package com.hedvig.app.feature.home.ui.changeaddress
 import arrow.core.Either
 import arrow.core.computations.either
 import arrow.core.computations.ensureNotNull
+import arrow.core.getOrHandle
 import arrow.core.identity
 import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.ActiveContractBundlesQuery
 import com.hedvig.app.feature.embark.QUOTE_CART_ID_KEY
 import com.hedvig.app.feature.embark.quotecart.CreateQuoteCartUseCase
+import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.apollo.safeQuery
 
 class GetAddressChangeStoryIdUseCase(
@@ -16,44 +18,29 @@ class GetAddressChangeStoryIdUseCase(
 ) {
 
     suspend fun invoke(): SelfChangeEligibilityResult {
-        return either<SelfChangeFailureType, SelfChangeEligibilityResult.Eligible> {
-            val activeContractBundlesQueryData = apolloClient.query(ActiveContractBundlesQuery())
-                .safeQuery()
-                .toEither(SelfChangeFailureType::Error)
-                .bind()
-            val storyId =
-                activeContractBundlesQueryData.activeContractBundles.firstOrNull()?.angelStories?.addressChangeV2
-            ensureNotNull(storyId) { SelfChangeFailureType.Blocked }
-            val storyIdWithQuoteCartId = addQuoteCartId(storyId).bind()
-            SelfChangeEligibilityResult.Eligible(storyIdWithQuoteCartId)
-        }.fold(SelfChangeFailureType::toSelfChangeEligibilityResult, ::identity)
+        val activeContractBundlesQueryData = apolloClient.query(ActiveContractBundlesQuery())
+            .safeQuery()
+            .toEither()
+            .getOrHandle { errorQueryResult ->
+                return SelfChangeEligibilityResult.Error(errorQueryResult.message)
+            }
+
+        val storyId = activeContractBundlesQueryData.activeContractBundles.firstOrNull()?.angelStories?.addressChangeV2
+            ?: return SelfChangeEligibilityResult.Blocked
+        val storyIdWithQuoteCartId = addQuoteCartId(storyId).getOrHandle { errorMessage ->
+            return SelfChangeEligibilityResult.Error(errorMessage.message)
+        }
+        return SelfChangeEligibilityResult.Eligible(storyIdWithQuoteCartId)
     }
 
-    private suspend fun addQuoteCartId(storyId: String): Either<SelfChangeFailureType.Error, String> {
-        return createQuoteCartUseCase.invoke()
-            .bimap(
-                { errorMessage -> SelfChangeFailureType.Error(errorMessage.message) },
-                { quoteCartId -> appendQuoteCartId(storyId, quoteCartId.id) }
-            )
+    private suspend fun addQuoteCartId(storyId: String): Either<ErrorMessage, String> {
+        return createQuoteCartUseCase.invoke().map { quoteCartId -> appendQuoteCartId(storyId, quoteCartId.id) }
     }
 
     sealed class SelfChangeEligibilityResult {
         data class Eligible(val embarkStoryId: String) : SelfChangeEligibilityResult()
         object Blocked : SelfChangeEligibilityResult()
         data class Error(val message: String?) : SelfChangeEligibilityResult()
-    }
-
-    private sealed interface SelfChangeFailureType {
-        fun toSelfChangeEligibilityResult(): SelfChangeEligibilityResult {
-            return when (this) {
-                Blocked -> SelfChangeEligibilityResult.Blocked
-                is Error -> SelfChangeEligibilityResult.Error(this.message)
-            }
-        }
-
-        object Blocked : SelfChangeFailureType
-
-        data class Error(val message: String?) : SelfChangeFailureType
     }
 }
 

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
@@ -1,13 +1,13 @@
 package com.hedvig.app.feature.home.ui.changeaddress
 
 import arrow.core.Either
-import arrow.core.flatMap
+import arrow.core.computations.either
+import arrow.core.computations.ensureNotNull
+import arrow.core.identity
 import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.ActiveContractBundlesQuery
 import com.hedvig.app.feature.embark.QUOTE_CART_ID_KEY
 import com.hedvig.app.feature.embark.quotecart.CreateQuoteCartUseCase
-import com.hedvig.app.util.ErrorMessage
-import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
 
 class GetAddressChangeStoryIdUseCase(
@@ -15,42 +15,45 @@ class GetAddressChangeStoryIdUseCase(
     private val apolloClient: ApolloClient,
 ) {
 
-    suspend operator fun invoke(): SelfChangeEligibilityResult {
-        return (
-            apolloClient.query(ActiveContractBundlesQuery()).safeQuery().toEither().flatMap { data ->
-                val storyId = data
-                    .activeContractBundles
-                    .firstOrNull()
-                    ?.angelStories
-                    ?.addressChangeV2
-                if (storyId != null) {
-                    addQuoteCartId(storyId).mapLeft { QueryResult.Error.GeneralError(it.message) }
-                } else {
-                    Either.Right(null)
-                }
-            }.fold(
-                ifLeft = { SelfChangeEligibilityResult.Error(it.message) },
-                ifRight = { maybeStoryId ->
-                    if (maybeStoryId != null) {
-                        SelfChangeEligibilityResult.Eligible(maybeStoryId)
-                    } else {
-                        SelfChangeEligibilityResult.Blocked
-                    }
-                }
-            )
-            )
+    suspend fun invoke(): SelfChangeEligibilityResult {
+        return either<SelfChangeFailureType, SelfChangeEligibilityResult.Eligible> {
+            val activeContractBundlesQueryData = apolloClient.query(ActiveContractBundlesQuery())
+                .safeQuery()
+                .toEither(SelfChangeFailureType::Error)
+                .bind()
+            val storyId =
+                activeContractBundlesQueryData.activeContractBundles.firstOrNull()?.angelStories?.addressChangeV2
+            ensureNotNull(storyId) { SelfChangeFailureType.Blocked }
+            val storyIdWithQuoteCartId = addQuoteCartId(storyId).bind()
+            SelfChangeEligibilityResult.Eligible(storyIdWithQuoteCartId)
+        }.fold(SelfChangeFailureType::toSelfChangeEligibilityResult, ::identity)
     }
 
-    private suspend fun addQuoteCartId(storyId: String): Either<ErrorMessage, String> {
-        return createQuoteCartUseCase.invoke().map { quoteCartId ->
-            appendQuoteCartId(storyId, quoteCartId.id)
-        }
+    private suspend fun addQuoteCartId(storyId: String): Either<SelfChangeFailureType.Error, String> {
+        return createQuoteCartUseCase.invoke()
+            .bimap(
+                { errorMessage -> SelfChangeFailureType.Error(errorMessage.message) },
+                { quoteCartId -> appendQuoteCartId(storyId, quoteCartId.id) }
+            )
     }
 
     sealed class SelfChangeEligibilityResult {
         data class Eligible(val embarkStoryId: String) : SelfChangeEligibilityResult()
         object Blocked : SelfChangeEligibilityResult()
         data class Error(val message: String?) : SelfChangeEligibilityResult()
+    }
+
+    private sealed interface SelfChangeFailureType {
+        fun toSelfChangeEligibilityResult(): SelfChangeEligibilityResult {
+            return when (this) {
+                Blocked -> SelfChangeEligibilityResult.Blocked
+                is Error -> SelfChangeEligibilityResult.Error(this.message)
+            }
+        }
+
+        object Blocked : SelfChangeFailureType
+
+        data class Error(val message: String?) : SelfChangeFailureType
     }
 }
 


### PR DESCRIPTION
Specifically changes it so that `arrow.core.Either.Right` isn't used for the unhappy path. Uses `either` to short-circuit in the case of reaching the unhappy path and have the logic happen sequentially from top to down.