### PR TITLE
APP-1184: Disable moving flow

### DIFF
--- a/app/src/engineering/java/com/hedvig/app/MockContractDetailViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/MockContractDetailViewModel.kt
@@ -12,7 +12,7 @@ class MockContractDetailViewModel : ContractDetailViewModel() {
             _viewState.value = ViewState.Error
         } else {
             val contract = mockData.contracts.first { it.id == id }
-            val viewState = contract.toContractDetailViewState(true)
+            val viewState = contract.toContractDetailViewState()
             _viewState.value = ViewState.Success(viewState)
         }
     }

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -652,7 +652,7 @@ val localeManagerModule = module {
 
 val useCaseModule = module {
     single { GetUpcomingAgreementUseCase(get(), get()) }
-    single { GetAddressChangeStoryIdUseCase(get()) }
+    single { GetAddressChangeStoryIdUseCase(get(), get()) }
     single { StartDanishAuthUseCase(get()) }
     single { StartNorwegianAuthUseCase(get()) }
     single { SubscribeToAuthStatusUseCase(get()) }
@@ -670,7 +670,7 @@ val useCaseModule = module {
     single { GetDataCollectionUseCase(get(), get()) }
     single { GetClaimDetailUseCase(get(), get()) }
     single { GetClaimDetailUiStateFlowUseCase(get()) }
-    single { GetContractDetailsUseCase(get(), get(), get()) }
+    single { GetContractDetailsUseCase(get(), get()) }
     single<GetDanishAddressAutoCompletionUseCase> { GetDanishAddressAutoCompletionUseCase(get()) }
     single<GetFinalDanishAddressSelectionUseCase> { GetFinalDanishAddressSelectionUseCase(get()) }
     single { CreateQuoteCartUseCase(get(), get(), get()) }

--- a/app/src/main/java/com/hedvig/app/feature/home/model/HomeItemsBuilder.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/model/HomeItemsBuilder.kt
@@ -8,7 +8,6 @@ import com.hedvig.app.R
 import com.hedvig.app.feature.claims.ui.commonclaim.CommonClaimsData
 import com.hedvig.app.feature.claims.ui.commonclaim.EmergencyData
 import com.hedvig.app.feature.home.ui.claimstatus.data.ClaimStatusCardUiState
-import com.hedvig.app.util.featureflags.Feature
 import com.hedvig.app.util.featureflags.FeatureManager
 
 class HomeItemsBuilder(
@@ -50,10 +49,9 @@ class HomeItemsBuilder(
                 ).toTypedArray()
             )
         )
-        if (featureManager.isFeatureEnabled(Feature.MOVING_FLOW)) {
-            add(HomeModel.Header(R.string.home_tab_editing_section_title))
-            add(HomeModel.ChangeAddress)
-        }
+
+        add(HomeModel.Header(R.string.home_tab_editing_section_title))
+        add(HomeModel.ChangeAddress)
     }
 
     private fun buildActiveInFutureItems(homeData: HomeQuery.Data): List<HomeModel> = buildList {
@@ -84,10 +82,9 @@ class HomeItemsBuilder(
             add(HomeModel.StartClaimContained.FirstClaim)
         }
         add(HomeModel.HowClaimsWork(homeData.howClaimsWork))
-        if (featureManager.isFeatureEnabled(Feature.MOVING_FLOW)) {
-            add(HomeModel.Header(R.string.home_tab_editing_section_title))
-            add(HomeModel.ChangeAddress)
-        }
+
+        add(HomeModel.Header(R.string.home_tab_editing_section_title))
+        add(HomeModel.ChangeAddress)
     }
 
     private fun buildPendingItems(homeData: HomeQuery.Data): List<HomeModel> = buildList {

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
@@ -7,12 +7,19 @@ import com.hedvig.app.feature.home.ui.changeaddress.GetAddressChangeStoryIdUseCa
 import com.hedvig.app.feature.home.ui.changeaddress.GetAddressChangeStoryIdUseCase.SelfChangeEligibilityResult.Error
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.featureflags.Feature
+import com.hedvig.app.util.featureflags.FeatureManager
 
 class GetAddressChangeStoryIdUseCase(
     private val apolloClient: ApolloClient,
+    private val featureManager: FeatureManager,
 ) {
 
     suspend operator fun invoke(): SelfChangeEligibilityResult {
+        if (!featureManager.isFeatureEnabled(Feature.MOVING_FLOW)) {
+            return Blocked
+        }
+
         return when (val result = apolloClient.query(ActiveContractBundlesQuery()).safeQuery()) {
             is QueryResult.Success ->
                 result.data

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractExt.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractExt.kt
@@ -12,10 +12,10 @@ import com.hedvig.app.feature.perils.PerilItem
 import com.hedvig.app.feature.table.intoTable
 import com.hedvig.app.util.apollo.toUpcomingAgreementResult
 
-fun InsuranceQuery.Contract.toContractDetailViewState(isMovingFlowEnabled: Boolean): ContractDetailViewState {
+fun InsuranceQuery.Contract.toContractDetailViewState(): ContractDetailViewState {
     return ContractDetailViewState(
         contractCardViewState = toContractCardViewState(),
-        memberDetailsViewState = toMemberDetailsViewState(isMovingFlowEnabled),
+        memberDetailsViewState = toMemberDetailsViewState(),
         coverageViewState = toCoverageViewState(),
         documentsViewState = toDocumentsViewState()
     )
@@ -30,14 +30,14 @@ fun InsuranceQuery.Contract.toContractCardViewState() = ContractCardViewState(
     detailPills = detailPills,
 )
 
-fun InsuranceQuery.Contract.toMemberDetailsViewState(isMovingFlowEnabled: Boolean) =
+fun InsuranceQuery.Contract.toMemberDetailsViewState() =
     ContractDetailViewState.MemberDetailsViewState(
         pendingAddressChange = fragments
             .upcomingAgreementFragment
             .toUpcomingAgreementResult()
             ?.let { YourInfoModel.PendingAddressChange(it) },
         detailsTable = currentAgreementDetailsTable.fragments.tableFragment.intoTable(),
-        changeAddressButton = if (isMovingFlowEnabled && supportsAddressChange) {
+        changeAddressButton = if (supportsAddressChange) {
             YourInfoModel.ChangeAddressButton
         } else {
             null

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
@@ -7,16 +7,11 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
-import com.hedvig.app.util.featureflags.Feature
-import com.hedvig.app.util.featureflags.FeatureManager
 
 class GetContractDetailsUseCase(
     private val apolloClient: ApolloClient,
     private val localeManager: LocaleManager,
-    featureManager: FeatureManager,
 ) {
-
-    private val isMovingFlowEnabled = featureManager.isFeatureEnabled(Feature.MOVING_FLOW)
 
     suspend operator fun invoke(contractId: String): Either<ContractDetailError, ContractDetailViewState> {
         return apolloClient
@@ -27,7 +22,7 @@ class GetContractDetailsUseCase(
                 data.contracts
                     .firstOrNone { it.id == contractId }
                     .toEither { ContractDetailError.ContractNotFoundError }
-                    .map { it.toContractDetailViewState(isMovingFlowEnabled) }
+                    .map { it.toContractDetailViewState() }
             }
     }
 

--- a/app/src/test/java/com/hedvig/app/feature/insurance/ui/detail/YourInfoItemsTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/insurance/ui/detail/YourInfoItemsTest.kt
@@ -11,25 +11,13 @@ class YourInfoItemsTest {
 
     @Test
     fun `when there is no upcoming agreement, should show no upcoming agreement card`() {
-        val viewState = INSURANCE_DATA.contracts[0].toMemberDetailsViewState(false)
+        val viewState = INSURANCE_DATA.contracts[0].toMemberDetailsViewState()
         assertThat(viewState.pendingAddressChange).isNull()
     }
 
     @Test
     fun `when there is an upcoming agreement, should show an upcoming agreement card`() {
-        val viewState = INSURANCE_DATA_UPCOMING_AGREEMENT.contracts[0].toMemberDetailsViewState(false)
+        val viewState = INSURANCE_DATA_UPCOMING_AGREEMENT.contracts[0].toMemberDetailsViewState()
         assertThat(viewState.pendingAddressChange).isNotNull()
-    }
-
-    @Test
-    fun `when moving flow is not enabled, should not show move button`() {
-        val viewState = INSURANCE_DATA.contracts[0].toMemberDetailsViewState(false)
-        assertThat(viewState.changeAddressButton).isNull()
-    }
-
-    @Test
-    fun `when moving flow is enabled, should show move button`() {
-        val viewState = INSURANCE_DATA.contracts[0].toMemberDetailsViewState(true)
-        assertThat(viewState.changeAddressButton).isNotNull()
     }
 }


### PR DESCRIPTION
Related to [this](https://hedvig.atlassian.net/jira/software/c/projects/APP/boards/6?modal=detail&selectedIssue=APP-1613&quickFilter=51) ticket. We will use a new mutation for moving flow with quote cart. 

Moving flow can be disabled while that mutation is being implemented, in order to release faster.