### PR TITLE
APP-1661: Generic auth login

### DIFF
--- a/app/src/main/java/com/hedvig/app/authenticate/LoginDialog.kt
+++ b/app/src/main/java/com/hedvig/app/authenticate/LoginDialog.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import com.hedvig.android.owldroid.type.AuthState
 import com.hedvig.app.R
+import com.hedvig.app.feature.genericauth.GenericAuthActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.service.push.PushTokenManager
 import com.hedvig.app.util.extensions.viewLifecycleScope
@@ -30,6 +31,10 @@ class LoginDialog : AuthenticateDialog() {
         }
 
         model.fetchBankIdStartToken()
+
+        binding.login.setOnClickListener {
+            requireActivity().startActivity(GenericAuthActivity.newInstance(requireActivity()))
+        }
     }
 
     private fun bindNewStatus(state: AuthState): Any? = when (state) {

--- a/app/src/main/res/layout/dialog_authenticate.xml
+++ b/app/src/main/res/layout/dialog_authenticate.xml
@@ -50,6 +50,6 @@
         android:id="@+id/login"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Login with email" />
+        android:text="@string/bankid_missing_login.email_button" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_authenticate.xml
+++ b/app/src/main/res/layout/dialog_authenticate.xml
@@ -46,4 +46,10 @@
         android:contentDescription="@null"
         app:srcCompat="@drawable/ic_bank_id" />
 
+    <Button
+        android:id="@+id/login"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Login with email" />
+
 </LinearLayout>


### PR DESCRIPTION
Add button in QR code dialog which opens generic auth flow. This will only work for Qasa members, but we should be able to activate it for all members without doing any changes in the clients.