### PR TITLE
Suppress false positive IDE hint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,8 @@
 import java.io.FileInputStream
 import java.util.Properties
 
+// TODO: Remove once https://youtrack.jetbrains.com/issue/KTIJ-19369 is fixed
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id("com.android.application")
     alias(libs.plugins.googleServices)


### PR DESCRIPTION
Just a small fix to hide the false positive

Context:
https://youtrack.jetbrains.com/issue/KTIJ-19369/False-positive-can-t-be-called-in-this-context-by-implicit-recei#focus=Comments-27-5181027.0-0

https://hedviginsurance.slack.com/archives/GKMA95VV1/p1652965054166069