### PR TITLE
Ignore some dependencies in our renovate configuration

### DIFF
--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -1,3 +1,4 @@
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id("com.android.library")
     id("kotlin-android")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("kotlin-kapt")
     alias(libs.plugins.lokalise)
     alias(libs.plugins.license)
-    kotlin("plugin.serialization") version "1.6.10"
+    alias(libs.plugins.serialization)
 }
 
 licenseReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.buildTimeTracker)
     alias(libs.plugins.unusedResourcesRemover)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -246,4 +246,6 @@ license = { id = "com.jaredsburrows.license", version.ref = "license" }
 
 lokalise = { id = "com.hedvig.android.lokalise", version.ref = "lokalise" }
 
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
 unusedResourcesRemover = { id = "com.github.konifar.gradle.unused-resources-remover", version.ref = "unusedResourcesRemover" }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignoreDeps": [
+    "org.jetbrains.kotlin:kotlin-serialization",
+    "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+    "org.jetbrains.kotlin:kotlin-gradle-plugin"
   ]
 }


### PR DESCRIPTION
Bonuses:

- Add annotations to remove false positive redlines
- Use Version Catalog to handle Kotlin Serialization-dependency
