### PR TITLE
Fix offer approve button text

### DIFF
--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferQueryExt.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferQueryExt.kt
@@ -7,11 +7,8 @@ import com.hedvig.app.feature.offer.model.CheckoutLabel
 
 fun QuoteBundleFragment.checkoutLabel(checkoutMethods: List<CheckoutMethod>) = when {
     checkoutMethods.contains(CheckoutMethod.SWEDISH_BANK_ID) -> CheckoutLabel.SIGN_UP
-    checkoutMethods.contains(CheckoutMethod.APPROVE_ONLY) -> CheckoutLabel.APPROVE
     checkoutMethods.contains(CheckoutMethod.SIMPLE_SIGN) -> CheckoutLabel.CONTINUE
-    checkoutMethods.contains(CheckoutMethod.APPROVE_ONLY) -> when (
-        appConfiguration.approveButtonTerminology
-    ) {
+    checkoutMethods.contains(CheckoutMethod.APPROVE_ONLY) -> when (appConfiguration.approveButtonTerminology) {
         QuoteBundleAppConfigurationApproveButtonTerminology.APPROVE_CHANGES -> CheckoutLabel.APPROVE
         QuoteBundleAppConfigurationApproveButtonTerminology.CONFIRM_PURCHASE -> CheckoutLabel.CONFIRM
         QuoteBundleAppConfigurationApproveButtonTerminology.UNKNOWN__ -> CheckoutLabel.UNKNOWN


### PR DESCRIPTION
Check app config when checkout method is approve only in order to show correct text in offer