### PR TITLE
Allow finding the jira ticket to fail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -137,6 +137,7 @@ jobs:
         id: find_issue
         with:
           string: ${{ github.event.pull_request.title }}
+        continue-on-error: true
       - name: Update Jira issue with artifact URL
         if: ${{ steps.find_issue.outputs.issue != null }}
         env:


### PR DESCRIPTION
Sometimes some PRs might not have an associated Jira ticket. Let the
build still show as successful when this happens