### PR TITLE
Remove double line breaks from schema.graphqls

### DIFF
--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -62,3 +62,12 @@ dependencies {
 
   implementation(libs.adyen)
 }
+
+tasks.withType<com.apollographql.apollo3.gradle.internal.ApolloDownloadSchemaTask> {
+  doLast {
+    val schemaPath = schema.get()
+    val schemaFile = file(schemaPath)
+    val textWithoutDoubleLineBreaks = schemaFile.readText().replace("\n\n", "\n")
+    schemaFile.writeText(textWithoutDoubleLineBreaks)
+  }
+}


### PR DESCRIPTION
This is a simple QoL change to make the schema a bit more readable.
This is similar to how the schema was generated for apollo v2.x.

No steps need to be different to get this result, this simply intercepts the existing `./gradlew :apollo:downloadGiraffeApolloSchemaFromIntrospection` command and edits the resulting file by removing the double line breaks. Simply run this command again to get it to show like that on your IDE as well

| before | after |
| --- | --- |
| <img width="2168" alt="image" src="https://user-images.githubusercontent.com/44558292/178441573-b25f621f-19e4-4ba8-a09e-ac922fdcaa8a.png"> | <img width="2168" alt="image" src="https://user-images.githubusercontent.com/44558292/178441787-14c72067-108e-4080-8ee7-02f3a09432b7.png"> |
