### PR TITLE
Add custom gradle.properties for CI

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx5120m
+org.gradle.workers.max=2
+
+kotlin.incremental=false
+kotlin.compiler.execution.strategy=in-process

--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx5120m
+org.gradle.jvmargs=-Xmx5120m -XX:+UseParallelGC
 org.gradle.workers.max=2
 
 kotlin.incremental=false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
         uses: actions/setup-java@v3.4.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
         uses: actions/setup-java@v3.4.0
         with:
@@ -38,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
         uses: actions/setup-java@v3.4.0
         with:
@@ -69,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
         uses: actions/setup-java@v3.4.0
         with:
@@ -98,6 +104,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
         uses: actions/setup-java@v3.4.0
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
         uses: actions/setup-java@v3.3.0
         with:

--- a/.github/workflows/unused-resources.yml
+++ b/.github/workflows/unused-resources.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Copy CI gradle.properties
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
     - name: Setup JDK 11
       uses: actions/setup-java@v3.4.0
       with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@
 plugins {
   alias(libs.plugins.buildTimeTracker)
   alias(libs.plugins.cacheFix) apply false
-//  alias(libs.plugins.doctor)
+  alias(libs.plugins.doctor)
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@
 plugins {
   alias(libs.plugins.buildTimeTracker)
   alias(libs.plugins.cacheFix) apply false
-  alias(libs.plugins.doctor)
+//  alias(libs.plugins.doctor)
 }
 
 subprojects {


### PR DESCRIPTION
According to the issue https://github.com/gradle/gradle/issues/19750
setting org.gradle.jvmargs in gradle.properties potentially breaks the
runner from Github Actions, something that has made all of our CI runs
fail lately.
Inspired from this PR https://github.com/android/nowinandroid/pull/191
this hopes to change that.
More context in both aforementioned links.