### PR TITLE
Testing: Use fake feature manager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
     maybeCreate("staging")
     maybeCreate("pullrequest")
     named("release") {
-//      signingConfig = signingConfigs.getByName("debug") uncomment to run release build locally
+//      signingConfig = signingConfigs.getByName("debug") // uncomment to run release build locally
       applicationIdSuffix = ".app"
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = true
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
   implementation(projects.hedvigMarket)
 
   testImplementation(projects.hanalyticsTest)
+  androidTestImplementation(projects.hanalyticsTest)
 
   implementation(projects.hanalyticsEngineeringApi)
   releaseImplementation(projects.hanalyticsEngineeringNoop)

--- a/app/src/androidTest/java/com/hedvig/app/util/FeatureFlagRule.kt
+++ b/app/src/androidTest/java/com/hedvig/app/util/FeatureFlagRule.kt
@@ -3,25 +3,24 @@ package com.hedvig.app.util
 import com.hedvig.android.hanalytics.di.featureManagerModule
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.flags.Feature
+import com.hedvig.android.hanalytics.test.FakeFeatureManager
 import com.hedvig.hanalytics.PaymentType
-import io.mockk.coEvery
-import io.mockk.mockk
 import org.junit.rules.ExternalResource
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.unloadKoinModules
 import org.koin.dsl.module
 
+@Suppress("RemoveExplicitTypeArguments")
 class FeatureFlagRule(
   vararg flags: Pair<Feature, Boolean>,
-  private val paymentType: PaymentType? = PaymentType.TRUSTLY,
+  private val paymentType: PaymentType = PaymentType.TRUSTLY,
 ) : ExternalResource() {
-  @Suppress("RemoveExplicitTypeArguments")
   private val mockFeatureManagerModule = module {
     single<FeatureManager> {
-      val mock = mockk<FeatureManager>()
-      flags.forEach { coEvery { mock.isFeatureEnabled(it.first) } returns it.second }
-      paymentType?.let { coEvery { mock.getPaymentType() } returns it }
-      mock
+      FakeFeatureManager(
+        featureMap = { flags.toMap() },
+        paymentType = { paymentType },
+      )
     }
   }
 

--- a/app/src/test/java/com/hedvig/app/feature/embark/passages/ExternalInsurerViewModelTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/embark/passages/ExternalInsurerViewModelTest.kt
@@ -2,7 +2,7 @@ package com.hedvig.app.feature.embark.passages
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.hedvig.android.hanalytics.featureflags.FeatureManager
+import com.hedvig.android.hanalytics.test.FakeFeatureManager
 import com.hedvig.app.feature.embark.passages.externalinsurer.ExternalInsurerViewModel
 import com.hedvig.app.feature.embark.passages.externalinsurer.GetInsuranceProvidersUseCase
 import com.hedvig.app.feature.embark.passages.externalinsurer.InsuranceProvider
@@ -30,7 +30,6 @@ class ExternalInsurerViewModelTest {
   val mainCoroutineRule = MainCoroutineRule()
 
   private val getInsuranceProvidersUseCase = mockk<GetInsuranceProvidersUseCase>()
-  private val fakeFeatureManager = mockk<FeatureManager>(relaxed = true)
 
   @Test
   fun testLoadingInsurers() = runTest {
@@ -39,7 +38,7 @@ class ExternalInsurerViewModelTest {
       InsuranceProvidersResult.Success(insuranceProviders)
     }
 
-    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, fakeFeatureManager)
+    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, FakeFeatureManager())
     assertThat(viewModel.viewState.value.isLoading).isEqualTo(true)
     advanceUntilIdle()
     assertThat(viewModel.viewState.value.isLoading).isEqualTo(false)
@@ -52,7 +51,7 @@ class ExternalInsurerViewModelTest {
       InsuranceProvidersResult.Error.NetworkError
     }
 
-    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, fakeFeatureManager)
+    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, FakeFeatureManager())
 
     val events = mutableListOf<ExternalInsurerViewModel.Event>()
     val eventCollectingJob = launch {
@@ -75,7 +74,7 @@ class ExternalInsurerViewModelTest {
       InsuranceProvidersResult.Success(insuranceProviders)
     }
 
-    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, fakeFeatureManager)
+    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, FakeFeatureManager())
 
     val events = mutableListOf<ExternalInsurerViewModel.Event>()
     val eventCollectingJob = launch {
@@ -94,7 +93,7 @@ class ExternalInsurerViewModelTest {
     coEvery {
       getInsuranceProvidersUseCase.getInsuranceProviders()
     } returns InsuranceProvidersResult.Success(insuranceProviders)
-    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, fakeFeatureManager)
+    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, FakeFeatureManager())
 
     viewModel.selectInsuranceProvider(InsuranceProvider("1", "Test1"))
 
@@ -107,7 +106,7 @@ class ExternalInsurerViewModelTest {
       getInsuranceProvidersUseCase.getInsuranceProviders()
     } returns InsuranceProvidersResult.Success(insuranceProviders)
 
-    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, fakeFeatureManager)
+    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, FakeFeatureManager())
     advanceUntilIdle()
 
     assertThat(viewModel.viewState.value.isLoading).isEqualTo(false)
@@ -120,7 +119,7 @@ class ExternalInsurerViewModelTest {
       getInsuranceProvidersUseCase.getInsuranceProviders()
     } returns InsuranceProvidersResult.Success(insuranceProviders)
 
-    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, fakeFeatureManager)
+    val viewModel = ExternalInsurerViewModel(getInsuranceProvidersUseCase, FakeFeatureManager())
     advanceUntilIdle()
 
     viewModel.selectInsuranceProvider(InsuranceProvider("1", "Test1"))

--- a/app/src/test/java/com/hedvig/app/feature/home/model/HomeItemsBuilderTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/home/model/HomeItemsBuilderTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.util.containsOfType
 import com.hedvig.hanalytics.PaymentType
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import kotlin.random.Random.Default.nextBoolean
 
 class HomeItemsBuilderTest {
 
@@ -18,7 +19,12 @@ class HomeItemsBuilderTest {
   fun `when connect payin card-feature is disabled and payin is not connected, should not show connect payin`() =
     runTest {
       val featureManager: FeatureManager = FakeFeatureManager(
-        featureMap = { mapOf(Feature.CONNECT_PAYIN_REMINDER to false) },
+        featureMap = {
+          mapOf(
+            Feature.CONNECT_PAYIN_REMINDER to false,
+            Feature.COMMON_CLAIMS to nextBoolean(),
+          )
+        },
       )
       val builder = HomeItemsBuilder(featureManager)
 
@@ -31,7 +37,12 @@ class HomeItemsBuilderTest {
   fun `when connect payin card-feature is enabled and payin is not connected, should show connect payin`() =
     runTest {
       val featureManager: FeatureManager = FakeFeatureManager(
-        featureMap = { mapOf(Feature.CONNECT_PAYIN_REMINDER to true) },
+        featureMap = {
+          mapOf(
+            Feature.CONNECT_PAYIN_REMINDER to true,
+            Feature.COMMON_CLAIMS to nextBoolean(),
+          )
+        },
         paymentType = { enumValues<PaymentType>().random() },
       )
       val builder = HomeItemsBuilder(featureManager)

--- a/app/src/test/java/com/hedvig/app/feature/home/model/HomeItemsBuilderTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/home/model/HomeItemsBuilderTest.kt
@@ -3,28 +3,24 @@ package com.hedvig.app.feature.home.model
 import assertk.assertThat
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.flags.Feature
+import com.hedvig.android.hanalytics.test.FakeFeatureManager
 import com.hedvig.app.testdata.feature.home.HOME_DATA_ACTIVE
 import com.hedvig.app.testdata.feature.home.HOME_DATA_PAYIN_NEEDS_SETUP
 import com.hedvig.app.util.containsNoneOfType
 import com.hedvig.app.util.containsOfType
-import io.mockk.coEvery
-import io.mockk.mockk
+import com.hedvig.hanalytics.PaymentType
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class HomeItemsBuilderTest {
-  private fun sut(
-    featureManager: FeatureManager = mockk(relaxed = true),
-  ) = HomeItemsBuilder(
-    featureManager,
-  )
 
   @Test
   fun `when connect payin card-feature is disabled and payin is not connected, should not show connect payin`() =
     runTest {
-      val featureManager = mockk<FeatureManager>(relaxed = true)
-      coEvery { featureManager.isFeatureEnabled(Feature.CONNECT_PAYIN_REMINDER) } returns false
-      val builder = sut(featureManager)
+      val featureManager: FeatureManager = FakeFeatureManager(
+        featureMap = { mapOf(Feature.CONNECT_PAYIN_REMINDER to false) },
+      )
+      val builder = HomeItemsBuilder(featureManager)
 
       val result = builder.buildItems(HOME_DATA_PAYIN_NEEDS_SETUP)
 
@@ -34,9 +30,11 @@ class HomeItemsBuilderTest {
   @Test
   fun `when connect payin card-feature is enabled and payin is not connected, should show connect payin`() =
     runTest {
-      val featureManager = mockk<FeatureManager>(relaxed = true)
-      coEvery { featureManager.isFeatureEnabled(Feature.CONNECT_PAYIN_REMINDER) } returns true
-      val builder = sut(featureManager)
+      val featureManager: FeatureManager = FakeFeatureManager(
+        featureMap = { mapOf(Feature.CONNECT_PAYIN_REMINDER to true) },
+        paymentType = { enumValues<PaymentType>().random() },
+      )
+      val builder = HomeItemsBuilder(featureManager)
 
       val result = builder.buildItems(HOME_DATA_PAYIN_NEEDS_SETUP)
 
@@ -45,9 +43,10 @@ class HomeItemsBuilderTest {
 
   @Test
   fun `when common claims-feature is disabled, should not show common claims`() = runTest {
-    val featureManager = mockk<FeatureManager>(relaxed = true)
-    coEvery { featureManager.isFeatureEnabled(Feature.COMMON_CLAIMS) } returns false
-    val builder = sut(featureManager)
+    val featureManager: FeatureManager = FakeFeatureManager(
+      featureMap = { mapOf(Feature.COMMON_CLAIMS to false) },
+    )
+    val builder = HomeItemsBuilder(featureManager)
 
     val result = builder.buildItems(HOME_DATA_ACTIVE)
 
@@ -56,9 +55,10 @@ class HomeItemsBuilderTest {
 
   @Test
   fun `when common claims-feature is enabled, should show common claims`() = runTest {
-    val featureManager = mockk<FeatureManager>(relaxed = true)
-    coEvery { featureManager.isFeatureEnabled(Feature.COMMON_CLAIMS) } returns true
-    val builder = sut(featureManager)
+    val featureManager: FeatureManager = FakeFeatureManager(
+      featureMap = { mapOf(Feature.COMMON_CLAIMS to true) },
+    )
+    val builder = HomeItemsBuilder(featureManager)
 
     val result = builder.buildItems(HOME_DATA_ACTIVE)
 

--- a/app/src/test/java/com/hedvig/app/feature/home/model/HomeItemsBuilderTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/home/model/HomeItemsBuilderTest.kt
@@ -11,7 +11,7 @@ import com.hedvig.app.util.containsOfType
 import com.hedvig.hanalytics.PaymentType
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import kotlin.random.Random.Default.nextBoolean
+import kotlin.random.Random
 
 class HomeItemsBuilderTest {
 
@@ -22,7 +22,7 @@ class HomeItemsBuilderTest {
         featureMap = {
           mapOf(
             Feature.CONNECT_PAYIN_REMINDER to false,
-            Feature.COMMON_CLAIMS to nextBoolean(),
+            Feature.COMMON_CLAIMS to Random.nextBoolean(),
           )
         },
       )
@@ -40,7 +40,7 @@ class HomeItemsBuilderTest {
         featureMap = {
           mapOf(
             Feature.CONNECT_PAYIN_REMINDER to true,
-            Feature.COMMON_CLAIMS to nextBoolean(),
+            Feature.COMMON_CLAIMS to Random.nextBoolean(),
           )
         },
         paymentType = { enumValues<PaymentType>().random() },

--- a/app/src/test/java/com/hedvig/app/feature/profile/ui/tab/ProfileQueryDataToProfileUiStateMapperTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/profile/ui/tab/ProfileQueryDataToProfileUiStateMapperTest.kt
@@ -12,7 +12,7 @@ import com.hedvig.app.util.LocaleManager
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import kotlin.random.Random.Default.nextBoolean
+import kotlin.random.Random
 
 class ProfileQueryDataToProfileUiStateMapperTest {
   private fun sut(
@@ -31,7 +31,7 @@ class ProfileQueryDataToProfileUiStateMapperTest {
       featureMap = {
         mapOf(
           Feature.PAYMENT_SCREEN to false,
-          Feature.SHOW_CHARITY to nextBoolean(),
+          Feature.SHOW_CHARITY to Random.nextBoolean(),
         )
       },
     )
@@ -48,7 +48,7 @@ class ProfileQueryDataToProfileUiStateMapperTest {
       featureMap = {
         mapOf(
           Feature.PAYMENT_SCREEN to true,
-          Feature.SHOW_CHARITY to nextBoolean(),
+          Feature.SHOW_CHARITY to Random.nextBoolean(),
         )
       },
     )
@@ -65,7 +65,7 @@ class ProfileQueryDataToProfileUiStateMapperTest {
       featureMap = {
         mapOf(
           Feature.SHOW_CHARITY to false,
-          Feature.PAYMENT_SCREEN to nextBoolean(),
+          Feature.PAYMENT_SCREEN to Random.nextBoolean(),
         )
       },
     )
@@ -82,7 +82,7 @@ class ProfileQueryDataToProfileUiStateMapperTest {
       featureMap = {
         mapOf(
           Feature.SHOW_CHARITY to true,
-          Feature.PAYMENT_SCREEN to nextBoolean(),
+          Feature.PAYMENT_SCREEN to Random.nextBoolean(),
         )
       },
     )

--- a/app/src/test/java/com/hedvig/app/feature/profile/ui/tab/ProfileQueryDataToProfileUiStateMapperTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/profile/ui/tab/ProfileQueryDataToProfileUiStateMapperTest.kt
@@ -5,17 +5,17 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotInstanceOf
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.flags.Feature
+import com.hedvig.android.hanalytics.test.FakeFeatureManager
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.testdata.feature.profile.PROFILE_DATA
 import com.hedvig.app.util.LocaleManager
-import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class ProfileQueryDataToProfileUiStateMapperTest {
   private fun sut(
-    featureManager: FeatureManager = mockk(relaxed = true),
+    featureManager: FeatureManager = FakeFeatureManager(),
     marketManager: MarketManager = mockk(relaxed = true),
     localeManager: LocaleManager = mockk(relaxed = true),
   ) = ProfileQueryDataToProfileUiStateMapper(
@@ -26,11 +26,10 @@ class ProfileQueryDataToProfileUiStateMapperTest {
 
   @Test
   fun `when payment-feature is not activated, should not show payment-data`() = runTest {
-    val featureManager = mockk<FeatureManager>(relaxed = true)
-    coEvery { featureManager.isFeatureEnabled(Feature.PAYMENT_SCREEN) } returns false
-    val mapper = sut(
-      featureManager = featureManager,
+    val featureManager = FakeFeatureManager(
+      featureMap = { mapOf(Feature.PAYMENT_SCREEN to false) },
     )
+    val mapper = sut(featureManager = featureManager)
 
     val result = mapper.map(PROFILE_DATA)
 
@@ -39,11 +38,10 @@ class ProfileQueryDataToProfileUiStateMapperTest {
 
   @Test
   fun `when payment-feature is activated, should show payment-data`() = runTest {
-    val featureManager = mockk<FeatureManager>(relaxed = true)
-    coEvery { featureManager.isFeatureEnabled(Feature.PAYMENT_SCREEN) } returns true
-    val mapper = sut(
-      featureManager = featureManager,
+    val featureManager = FakeFeatureManager(
+      featureMap = { mapOf(Feature.PAYMENT_SCREEN to true) },
     )
+    val mapper = sut(featureManager = featureManager)
 
     val result = mapper.map(PROFILE_DATA)
 
@@ -52,11 +50,10 @@ class ProfileQueryDataToProfileUiStateMapperTest {
 
   @Test
   fun `when charity-feature is deactivated, should not show charity-data`() = runTest {
-    val featureManager = mockk<FeatureManager>(relaxed = true)
-    coEvery { featureManager.isFeatureEnabled(Feature.SHOW_CHARITY) } returns false
-    val mapper = sut(
-      featureManager = featureManager,
+    val featureManager = FakeFeatureManager(
+      featureMap = { mapOf(Feature.SHOW_CHARITY to false) },
     )
+    val mapper = sut(featureManager = featureManager)
 
     val result = mapper.map(PROFILE_DATA)
 
@@ -65,11 +62,8 @@ class ProfileQueryDataToProfileUiStateMapperTest {
 
   @Test
   fun `when charity-feature is activated, should show charity-data`() = runTest {
-    val featureManager = mockk<FeatureManager>(relaxed = true)
-    coEvery { featureManager.isFeatureEnabled(Feature.SHOW_CHARITY) } returns true
-    val mapper = sut(
-      featureManager = featureManager,
-    )
+    val featureManager = FakeFeatureManager(featureMap = { mapOf(Feature.SHOW_CHARITY to true) })
+    val mapper = sut(featureManager = featureManager)
 
     val result = mapper.map(PROFILE_DATA)
 

--- a/app/src/test/java/com/hedvig/app/feature/profile/ui/tab/ProfileQueryDataToProfileUiStateMapperTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/profile/ui/tab/ProfileQueryDataToProfileUiStateMapperTest.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.util.LocaleManager
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import kotlin.random.Random.Default.nextBoolean
 
 class ProfileQueryDataToProfileUiStateMapperTest {
   private fun sut(
@@ -27,7 +28,12 @@ class ProfileQueryDataToProfileUiStateMapperTest {
   @Test
   fun `when payment-feature is not activated, should not show payment-data`() = runTest {
     val featureManager = FakeFeatureManager(
-      featureMap = { mapOf(Feature.PAYMENT_SCREEN to false) },
+      featureMap = {
+        mapOf(
+          Feature.PAYMENT_SCREEN to false,
+          Feature.SHOW_CHARITY to nextBoolean(),
+        )
+      },
     )
     val mapper = sut(featureManager = featureManager)
 
@@ -39,7 +45,12 @@ class ProfileQueryDataToProfileUiStateMapperTest {
   @Test
   fun `when payment-feature is activated, should show payment-data`() = runTest {
     val featureManager = FakeFeatureManager(
-      featureMap = { mapOf(Feature.PAYMENT_SCREEN to true) },
+      featureMap = {
+        mapOf(
+          Feature.PAYMENT_SCREEN to true,
+          Feature.SHOW_CHARITY to nextBoolean(),
+        )
+      },
     )
     val mapper = sut(featureManager = featureManager)
 
@@ -51,7 +62,12 @@ class ProfileQueryDataToProfileUiStateMapperTest {
   @Test
   fun `when charity-feature is deactivated, should not show charity-data`() = runTest {
     val featureManager = FakeFeatureManager(
-      featureMap = { mapOf(Feature.SHOW_CHARITY to false) },
+      featureMap = {
+        mapOf(
+          Feature.SHOW_CHARITY to false,
+          Feature.PAYMENT_SCREEN to nextBoolean(),
+        )
+      },
     )
     val mapper = sut(featureManager = featureManager)
 
@@ -62,7 +78,14 @@ class ProfileQueryDataToProfileUiStateMapperTest {
 
   @Test
   fun `when charity-feature is activated, should show charity-data`() = runTest {
-    val featureManager = FakeFeatureManager(featureMap = { mapOf(Feature.SHOW_CHARITY to true) })
+    val featureManager = FakeFeatureManager(
+      featureMap = {
+        mapOf(
+          Feature.SHOW_CHARITY to true,
+          Feature.PAYMENT_SCREEN to nextBoolean(),
+        )
+      },
+    )
     val mapper = sut(featureManager = featureManager)
 
     val result = mapper.map(PROFILE_DATA)

--- a/app/src/test/java/com/hedvig/app/feature/swedishbankid/sign/SwedishBankIdSignViewModelTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/swedishbankid/sign/SwedishBankIdSignViewModelTest.kt
@@ -15,6 +15,7 @@ import com.hedvig.app.feature.offer.usecase.FakeCreateAccessTokenUseCase
 import com.hedvig.app.feature.offer.usecase.FakeObserveQuoteCartCheckoutUseCase
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.coroutines.MainCoroutineRule
+import com.hedvig.hanalytics.PaymentType
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
@@ -48,7 +49,7 @@ class SwedishBankIdSignViewModelTest {
         delay(10)
         CreateAccessTokenUseCase.Success.right()
       },
-      FakeFeatureManager(),
+      FakeFeatureManager(paymentType = { enumValues<PaymentType>().random() }),
     )
 
     var viewState: BankIdSignViewState = viewModel.viewState.value
@@ -105,7 +106,7 @@ class SwedishBankIdSignViewModelTest {
         delay(10)
         CreateAccessTokenUseCase.Success.right()
       },
-      FakeFeatureManager(),
+      FakeFeatureManager(paymentType = { enumValues<PaymentType>().random() }),
     )
 
     var viewState: BankIdSignViewState = viewModel.viewState.value
@@ -162,7 +163,7 @@ class SwedishBankIdSignViewModelTest {
         delay(10)
         CreateAccessTokenUseCase.Success.right()
       },
-      FakeFeatureManager(),
+      FakeFeatureManager(paymentType = { enumValues<PaymentType>().random() }),
     )
 
     var viewState: BankIdSignViewState = viewModel.viewState.value

--- a/hanalytics-test/src/main/java/com/hedvig/android/hanalytics/test/FakeFeatureManager.kt
+++ b/hanalytics-test/src/main/java/com/hedvig/android/hanalytics/test/FakeFeatureManager.kt
@@ -24,12 +24,4 @@ class FakeFeatureManager(
   override suspend fun getPaymentType(): PaymentType {
     return paymentType?.invoke() ?: error("Set the paymentType returned from FakeFeatureManager")
   }
-
-  companion object {
-    fun withSomePaymentType(): FakeFeatureManager {
-      return FakeFeatureManager(
-        paymentType = { PaymentType.ADYEN },
-      )
-    }
-  }
 }

--- a/hanalytics-test/src/main/java/com/hedvig/android/hanalytics/test/FakeFeatureManager.kt
+++ b/hanalytics-test/src/main/java/com/hedvig/android/hanalytics/test/FakeFeatureManager.kt
@@ -13,8 +13,8 @@ class FakeFeatureManager(
   override suspend fun invalidateExperiments() {}
 
   override suspend fun isFeatureEnabled(feature: Feature): Boolean {
-    return featureMap?.invoke()?.getOrDefault(feature, false)
-      ?: error("Set the featureMap returned from FakeFeatureManager")
+    val featureMap = featureMap?.invoke() ?: error("Set the featureMap returned from FakeFeatureManager")
+    return featureMap[feature] ?: error("Set a return value for feature:$feature on FakeFeatureManager")
   }
 
   override suspend fun getLoginMethod(): LoginMethod {

--- a/hanalytics-test/src/main/java/com/hedvig/android/hanalytics/test/FakeFeatureManager.kt
+++ b/hanalytics-test/src/main/java/com/hedvig/android/hanalytics/test/FakeFeatureManager.kt
@@ -6,21 +6,30 @@ import com.hedvig.hanalytics.LoginMethod
 import com.hedvig.hanalytics.PaymentType
 
 class FakeFeatureManager(
-  private val featureMap: Map<Feature, Boolean> = emptyMap(),
-  private val loginMethod: LoginMethod = LoginMethod.BANK_ID_SWEDEN,
-  private val paymentType: PaymentType = PaymentType.ADYEN,
+  private val featureMap: (() -> Map<Feature, Boolean>)? = null,
+  private val loginMethod: (() -> LoginMethod)? = null,
+  private val paymentType: (() -> PaymentType)? = null,
 ) : FeatureManager {
   override suspend fun invalidateExperiments() {}
 
   override suspend fun isFeatureEnabled(feature: Feature): Boolean {
-    return featureMap.getOrDefault(feature, false)
+    return featureMap?.invoke()?.getOrDefault(feature, false)
+      ?: error("Set the featureMap returned from FakeFeatureManager")
   }
 
   override suspend fun getLoginMethod(): LoginMethod {
-    return loginMethod
+    return loginMethod?.invoke() ?: error("Set the loginMethod returned from FakeFeatureManager")
   }
 
   override suspend fun getPaymentType(): PaymentType {
-    return paymentType
+    return paymentType?.invoke() ?: error("Set the paymentType returned from FakeFeatureManager")
+  }
+
+  companion object {
+    fun withSomePaymentType(): FakeFeatureManager {
+      return FakeFeatureManager(
+        paymentType = { PaymentType.ADYEN },
+      )
+    }
   }
 }


### PR DESCRIPTION
I want some feedback regarding the impl of FakeFeatureManager.

Using lambdas is I think a good improvement, so that if we want more control over what it will return depending on other local state we can simply do that inside the lambda. So I am confident about this decision.
However for the decision to error out if some feature is asked from the map but wasn't explicitly set I'd like your opinion.

If we let it default to `false` by doing `getOrDefault()` as we did before, that means that some tests may be using that return value in a way that is crucial for the test to pass. If we error out as I've done it, one *needs* to be explicit about what the return value would need to be for that particular test.
With that said, we do have tests where sometimes a value may be asked from the implementing code, but it may *actually* not be important for the test outcome. For such cases I opted for nextBoolean, or enumValues<T>().random() to indicate that we need a return value to be there, but we do not care about what it will be. With the mockk approach we had before, this was indicated by not declaring it at all, however then mockk was picking the same default all the time, which for some tests we may accidentally be depending on what that default value was.

I don't like implicitly depending on such defaults, whether that comes from mockk picking one, or having us default to `false` for each map entry that we're asking for but haven't previously declared. Because that means that for example for the test:
```kotlin
@Test
fun `when common claims-feature is disabled, should not show common claims`() = runTest {
  val featureManager = mockk<FeatureManager>(relaxed = true)
  coEvery { featureManager.isFeatureEnabled(Feature.COMMON_CLAIMS) } returns false  // <--- emphasis
  val builder = sut(featureManager)

  val result = builder.buildItems(HOME_DATA_ACTIVE)

  assertThat(result).containsNoneOfType<HomeModel.CommonClaim>()
}
```
Could be written as:
```kotlin
@Test
fun `when common claims-feature is disabled, should not show common claims`() = runTest {
  val featureManager = mockk<FeatureManager>(relaxed = true)
  // <---
  val builder = sut(featureManager)

  val result = builder.buildItems(HOME_DATA_ACTIVE)

  assertThat(result).containsNoneOfType<HomeModel.CommonClaim>()
}
```
And it'd still pass since we have the default.

But with the current impl, if we do
```kotlin
@Test
fun `when common claims-feature is disabled, should not show common claims`() = runTest {
  val featureManager: FeatureManager = FakeFeatureManager(
    featureMap = { mapOf(Feature.COMMON_CLAIMS to false) }, // <---
  )
  val builder = HomeItemsBuilder(featureManager)

  val result = builder.buildItems(HOME_DATA_ACTIVE)

  assertThat(result).containsNoneOfType<HomeModel.CommonClaim>()
}
```
It passes.

And if we do
```kotlin
@Test
fun `when common claims-feature is disabled, should not show common claims`() = runTest {
  val featureManager: FeatureManager = FakeFeatureManager(
    featureMap = { mapOf() }, // <---
  )
  val builder = HomeItemsBuilder(featureManager)

  val result = builder.buildItems(HOME_DATA_ACTIVE)

  assertThat(result).containsNoneOfType<HomeModel.CommonClaim>()
}
```
It will actually fail since we didn't specify that `COMMON_CLAIMS` `false`. And I like that it won't pass by using the implicit defaults.

So I see this entire thing as a compromise, and I myself lean more towards the "Be explicit and sometimes over-do stuff" over "Be implicit and sometimes pass tests even by chance".

We could event take it a step further and model the "It needs to be there but I don't care about what it returns" with a function inside the companion object of FakeFetureManager like
```kotlin
companion object {
  fun whateverLoginMethod(): LoginMethod = enumValues<LoginMethod>().random()
  fun whateverPaymentType(): PaymentType = enumValues<PaymentType>().random()
}
```
And then indicate this in tests like
`FakeFeatureManager(paymentType = { FakeFeatureManager.whateverPaymentType() }),`
instead of
`FakeFeatureManager(paymentType = { enumValues<PaymentType>().random() }),`
But I am not sure if this then is overkill :D 