### PR TITLE
Cleanup build.gradle inside lokalise gradle plugin

### DIFF
--- a/lokalise-gradle-plugin/lokalise/build.gradle.kts
+++ b/lokalise-gradle-plugin/lokalise/build.gradle.kts
@@ -1,12 +1,9 @@
 plugins {
+  `embedded-kotlin`
   `java-gradle-plugin`
-  kotlin("jvm") version "1.7.10"
 }
 
 dependencies {
-  compileOnly("dev.gradleplugins:gradle-api:7.5")
-  compileOnly(libs.android.gradlePlugin)
-  compileOnly(libs.kotlin.gradlePlugin)
   implementation(libs.okio)
   implementation(libs.okhttp.core)
   implementation(libs.serialization)


### PR DESCRIPTION
Works the same, minus some extra config which turns out isn't needed.