### PR TITLE
APP-1879: Migrate insets otp screen

### DIFF
--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -382,7 +382,7 @@ val viewModelModule = module {
     CrossSellDetailViewModel(crossSell.action, get(), get())
   }
   viewModel { GenericAuthViewModel(get()) }
-  viewModel { (otpId: String, credential: String) ->
+  viewModel<OtpInputViewModel> { (otpId: String, credential: String) ->
     OtpInputViewModel(
       otpId,
       credential,

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
@@ -108,11 +108,6 @@ private fun ScrollableContent(
   modifier: Modifier = Modifier,
   scrollState: ScrollState = rememberScrollState(),
 ) {
-  val placeholder by rememberBlurHash(
-    crossSellData.backgroundBlurHash,
-    64,
-    32,
-  )
   Column(
     modifier = modifier
       .fillMaxSize()
@@ -124,7 +119,7 @@ private fun ScrollableContent(
         builder = {
           scale(Scale.FILL)
           transformations(CropTransformation())
-          placeholder(placeholder)
+          placeholder(rememberBlurHash(crossSellData.backgroundBlurHash, 64, 32))
           crossfade(true)
         },
       ),

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
@@ -95,7 +95,7 @@ fun CrossSellDetailScreen(
   }
 
   if (errorMessage != null) {
-    ErrorDialog(onDismiss = onDismissError, message = errorMessage)
+    ErrorDialog(message = errorMessage, onDismiss = onDismissError)
   }
 }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/retrieveprice/RetrievePriceContent.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/retrieveprice/RetrievePriceContent.kt
@@ -83,6 +83,6 @@ fun RetrievePriceContent(
   }
 
   if (errorMessage != null) {
-    ErrorDialog(onDismiss = onDismissError, message = errorMessage)
+    ErrorDialog(message = errorMessage, onDismiss = onDismissError)
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
@@ -3,14 +3,12 @@ package com.hedvig.app.feature.genericauth
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -47,7 +45,7 @@ fun EmailInputScreen(
 ) {
   Column(
     modifier = Modifier
-      .windowInsetsPadding(WindowInsets.safeDrawing)
+      .safeDrawingPadding()
       .fillMaxSize(),
   ) {
     TopAppBarWithBack(

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
@@ -3,12 +3,14 @@ package com.hedvig.app.feature.genericauth
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -45,7 +47,7 @@ fun EmailInputScreen(
 ) {
   Column(
     modifier = Modifier
-      .safeContentPadding()
+      .windowInsetsPadding(WindowInsets.safeDrawing)
       .fillMaxSize(),
   ) {
     TopAppBarWithBack(

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputActivity.kt
@@ -4,90 +4,68 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
-import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import com.google.accompanist.insets.systemBarsPadding
+import androidx.compose.runtime.remember
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.app.BaseActivity
-import com.hedvig.app.R
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.openEmail
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.androidx.viewmodel.ext.android.getViewModel
 import org.koin.core.parameter.parametersOf
 import kotlin.time.Duration.Companion.seconds
 
 class OtpInputActivity : BaseActivity() {
-
-  val model: OtpInputViewModel by viewModel {
-    parametersOf(
-      intent.getStringExtra(OTP_ID_EXTRA) ?: throw IllegalArgumentException(
-        "Programmer error: Missing OTP_ID in ${this.javaClass.name}",
-      ),
-      intent.getStringExtra(CREDENTIAL_EXTRA) ?: throw IllegalArgumentException(
-        "Programmer error: Missing CREDENTIAL in ${this.javaClass.name}",
-      ),
-    )
-  }
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
     window.compatSetDecorFitsSystemWindows(false)
 
-    setContent {
-      val scaffoldState = rememberScaffoldState()
+    val viewModel: OtpInputViewModel = getViewModel {
+      parametersOf(
+        intent.getStringExtra(OTP_ID_EXTRA)
+          ?: error("Programmer error: Missing OTP_ID in ${this.javaClass.name}"),
+        intent.getStringExtra(CREDENTIAL_EXTRA)
+          ?: error("Programmer error: Missing CREDENTIAL in ${this.javaClass.name}"),
+      )
+    }
 
-      HedvigTheme {
-        LaunchedEffect(Unit) {
-          model.events.collectLatest { event ->
-            when (event) {
-              is OtpInputViewModel.Event.Success -> startLoggedIn()
-              OtpInputViewModel.Event.CodeResent -> {
-                delay(1.seconds)
-                val message = getString(hedvig.resources.R.string.login_snackbar_code_resent)
-                scaffoldState.snackbarHostState.showSnackbar(message)
-              }
+    setContent {
+      val snackbarHostState = remember { SnackbarHostState() }
+      LaunchedEffect(viewModel) {
+        viewModel.events.collectLatest { event ->
+          when (event) {
+            is OtpInputViewModel.Event.Success -> startLoggedIn()
+            OtpInputViewModel.Event.CodeResent -> {
+              delay(1.seconds)
+              val message = getString(hedvig.resources.R.string.login_snackbar_code_resent)
+              snackbarHostState.showSnackbar(message)
             }
           }
         }
-
-        Scaffold(
-          topBar = {
-            TopAppBarWithBack(
-              onClick = ::onBackPressed,
-              title = stringResource(hedvig.resources.R.string.login_navigation_bar_center_element_title),
-            )
-          },
-          scaffoldState = scaffoldState,
-          modifier = Modifier.systemBarsPadding(top = true),
-        ) { paddingValues ->
-          val viewState by model.viewState.collectAsState()
-
-          OtpInputScreen(
-            onInputChanged = model::setInput,
-            onOpenExternalApp = { openEmail(getString(hedvig.resources.R.string.login_bottom_sheet_view_code)) },
-            onSubmitCode = model::submitCode,
-            onResendCode = model::resendCode,
-            onDismissError = model::dismissError,
-            inputValue = viewState.input,
-            credential = viewState.credential,
-            otpErrorMessage = viewState.otpError?.toStringRes()?.let(::getString),
-            networkErrorMessage = viewState.networkErrorMessage,
-            loadingResend = viewState.loadingResend,
-            loadingCode = viewState.loadingCode,
-            modifier = Modifier.padding(paddingValues),
-          )
-        }
+      }
+      HedvigTheme {
+        val viewState by viewModel.viewState.collectAsState()
+        OtpInputScreen(
+          onInputChanged = viewModel::setInput,
+          onOpenExternalApp = { openEmail(getString(hedvig.resources.R.string.login_bottom_sheet_view_code)) },
+          onSubmitCode = viewModel::submitCode,
+          onResendCode = viewModel::resendCode,
+          onDismissError = viewModel::dismissError,
+          onBackPressed = ::onBackPressed,
+          inputValue = viewState.input,
+          credential = viewState.credential,
+          otpErrorMessage = viewState.otpError?.toStringRes()?.let(::getString),
+          networkErrorMessage = viewState.networkErrorMessage,
+          loadingResend = viewState.loadingResend,
+          loadingCode = viewState.loadingCode,
+          snackbarHostState = snackbarHostState,
+        )
       }
     }
   }

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContent
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -89,7 +89,7 @@ fun OtpInputScreen(
       },
       modifier = modifier
         .fillMaxSize()
-        .windowInsetsPadding(WindowInsets.safeContent),
+        .windowInsetsPadding(WindowInsets.safeDrawing),
     ) { paddingValues ->
       OtpInputScreenContents(
         credential,

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
@@ -10,14 +10,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -89,7 +87,7 @@ fun OtpInputScreen(
       },
       modifier = modifier
         .fillMaxSize()
-        .windowInsetsPadding(WindowInsets.safeDrawing),
+        .safeDrawingPadding(),
     ) { paddingValues ->
       OtpInputScreenContents(
         credential,

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputViewModel.kt
@@ -39,7 +39,7 @@ class OtpInputViewModel(
 
   fun setInput(value: String) {
     _viewState.update {
-      it.copy(input = value)
+      it.copy(input = value, otpError = null)
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -51,7 +50,6 @@ fun CrossSell(
   onCardClick: () -> Unit,
   onCtaClick: (label: String) -> Unit,
 ) {
-  val placeholder by rememberBlurHash(data.backgroundBlurHash, 64, 32)
   Card(
     border = BorderStroke(1.dp, hedvigBlack12percent),
     modifier = Modifier
@@ -69,7 +67,7 @@ fun CrossSell(
         data = data.backgroundUrl,
         builder = {
           transformations(CropTransformation())
-          placeholder(placeholder)
+          placeholder(rememberBlurHash(data.backgroundBlurHash, 64, 32))
           crossfade(true)
         },
       ),

--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
@@ -27,12 +27,11 @@ fun BackgroundImage(background: Background, content: @Composable BoxScope.() -> 
           MarketingBackground.Theme.DARK -> true
         }
       }
-      rememberSystemUiController()
       Image(
         painter = rememberImagePainter(
           data = bg.url,
           builder = {
-            placeholder(rememberBlurHash(marketingBackground.blurHash, 32, 32))
+            placeholder(rememberBlurHash(background.data.blurHash, 32, 32))
             crossfade(true)
             scale(Scale.FILL)
           },

--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
@@ -27,12 +27,12 @@ fun BackgroundImage(background: Background, content: @Composable BoxScope.() -> 
           MarketingBackground.Theme.DARK -> true
         }
       }
-      val placeholder by rememberBlurHash(bg.blurHash, 32, 32)
+      rememberSystemUiController()
       Image(
         painter = rememberImagePainter(
           data = bg.url,
           builder = {
-            placeholder(placeholder)
+            placeholder(rememberBlurHash(marketingBackground.blurHash, 32, 32))
             crossfade(true)
             scale(Scale.FILL)
           },

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/ErrorDialog.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/ErrorDialog.kt
@@ -9,9 +9,9 @@ import com.hedvig.app.R
 
 @Composable
 fun ErrorDialog(
+  message: String?,
   onDismiss: () -> Unit,
   title: String = stringResource(com.adyen.checkout.dropin.R.string.error_dialog_title),
-  message: String?,
 ) {
   AlertDialog(
     onDismissRequest = onDismiss,

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/FullScreenProgressOverlay.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/FullScreenProgressOverlay.kt
@@ -12,8 +12,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -21,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -56,13 +55,14 @@ fun FullScreenProgressOverlay(show: Boolean) {
         Icon(
           painter = painterResource(R.drawable.ic_hedvig_h_progress),
           modifier = Modifier
-            .rotate(angle)
+            .graphicsLayer {
+              rotationZ = angle
+            }
             .animateEnterExit(
               enter = fadeIn(animationSpec = tween(200, delayMillis = 700)),
               exit = fadeOut(animationSpec = tween(200)),
             )
-            .width(32.dp)
-            .height(32.dp),
+            .size(32.dp),
           contentDescription = null,
         )
       }

--- a/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
+++ b/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.util.compose
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.hedvig.app.util.BlurHashDecoder
@@ -14,13 +13,11 @@ fun rememberBlurHash(
   width: Int,
   height: Int,
   context: Context = LocalContext.current,
-) = remember(blurHash) {
-  mutableStateOf(
-    BlurHashDecoder.decode(blurHash, width, height)?.let {
-      BitmapDrawable(
-        context.resources,
-        it,
-      )
-    },
-  )
+): BitmapDrawable? = remember(blurHash, width, height, context) {
+  BlurHashDecoder.decode(blurHash, width, height)?.let { decodedBitmap ->
+    BitmapDrawable(
+      context.resources,
+      decodedBitmap,
+    )
+  }
 }

--- a/app/src/test/java/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
@@ -2,6 +2,8 @@ package com.hedvig.app.feature.genericauth
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.hedvig.app.authenticate.AuthenticationTokenService
 import com.hedvig.app.feature.genericauth.otpinput.OtpInputViewModel
 import com.hedvig.app.feature.genericauth.otpinput.OtpResult
@@ -156,5 +158,22 @@ class OtpInputViewModelTest {
 
     viewModel.setInput("123")
     assertThat(viewModel.viewState.value.input).isEqualTo("123")
+  }
+
+  @Test
+  fun `updating the input after getting an error should clear the error`() = runTest {
+    otpResult = OtpResult.Error.OtpError.WrongOtp
+    viewModel.setInput("111111")
+    viewModel.submitCode("111111")
+    assertThat(viewModel.viewState.value.loadingCode).isEqualTo(true)
+    assertThat(viewModel.viewState.value.loadingResend).isEqualTo(false)
+    assertThat(viewModel.viewState.value.otpError).isNull()
+
+    advanceUntilIdle()
+    assertThat(viewModel.viewState.value.loadingCode).isEqualTo(false)
+    assertThat(viewModel.viewState.value.otpError).isNotNull()
+
+    viewModel.setInput("1")
+    assertThat(viewModel.viewState.value.otpError).isNull()
   }
 }

--- a/core-design-system/src/main/java/com/hedvig/android/core/designsystem/theme/Theme.kt
+++ b/core-design-system/src/main/java/com/hedvig/android/core/designsystem/theme/Theme.kt
@@ -9,9 +9,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
-import com.google.accompanist.insets.LocalWindowInsets
-import com.google.accompanist.insets.ProvideWindowInsets
-import com.google.accompanist.insets.WindowInsets
 import com.google.android.material.composethemeadapter.createMdcTheme
 import java.lang.reflect.Method
 
@@ -20,17 +17,6 @@ fun HedvigTheme(
   colorOverrides: ((Colors) -> Colors)? = null,
   content: @Composable () -> Unit,
 ) {
-  if (LocalWindowInsets.current == WindowInsets.Empty) {
-    ProvideWindowInsets {
-      InnerTheme(colorOverrides, content)
-    }
-  } else {
-    InnerTheme(colorOverrides, content)
-  }
-}
-
-@Composable
-private fun InnerTheme(colorOverrides: ((Colors) -> Colors)? = null, content: @Composable () -> Unit) {
   val context = LocalContext.current
   val key = context.theme.key ?: context.theme
   val layoutDirection = LocalLayoutDirection.current


### PR DESCRIPTION
Get started with migrating to the new insets APIs.
tl;dr is that if you want to simply add the paddings to safely draw your items away from the system bars and the IME you can use the modifier `fun Modifier.windowInsetsPadding(insets: WindowInsets): Modifier` which takes in `WindowInsets` and you can decide which one you want from this list [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/foundation/foundation-layout/src/androidMain/kotlin/androidx/compose/foundation/layout/WindowInsets.android.kt;l=379-405) and then there's a list of convinience modifiers [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/foundation/foundation-layout/src/androidMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.android.kt) that do this for you under the hood.
In our use case we could do either:
`.windowInsetsPadding(WindowInsets.safeDrawing)`
OR:
`.safeDrawingPadding()`
And it's equivalent.

But one may want to do the more verbose solution when needing more control, like insetting for safeDrawing, but only horizontally and bottom. Sample here:
```
.windowInsetsPadding(
  WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
    .union(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
)
```


Refactored the OTP screen as it was all one big composable and made the migration quite hard

Used `.graphicsLayer { rotationZ = angle }` instead of `rotation(angle)` as that means we'll now be doing less recompositions in the way we're using it here.

While at it, also made sure that the error message goes away when editing the input field as the error persisted there forever. Look at the test `updating the input after getting an error should clear the error` for more details.