### PR TITLE
APP-1882: accompanist to androidx insets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+# noinspection EditorConfigKeyCorrectness
 [*.{kt,kts}]
 indent_size = 2
 insert_final_newline = true
@@ -7,8 +8,7 @@ end_of_line = lf
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 
-# noinspection EditorConfigKeyCorrectness
-disabled_rules = experimental:enum-entry-name-case, filename
+disabled_rules = experimental:enum-entry-name-case, experimental:function-signature, filename, annotation
 
 [*.graphql]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ end_of_line = lf
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 
-disabled_rules = experimental:enum-entry-name-case, experimental:function-signature, filename, annotation
+disabled_rules = experimental:enum-entry-name-case, filename, annotation
 
 [*.graphql]
 indent_size = 2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,7 +196,6 @@ dependencies {
 
   implementation(libs.accompanist.pager)
   implementation(libs.accompanist.pagerIndicators)
-  implementation(libs.accompanist.insets)
   implementation(libs.accompanist.insetsUi)
   implementation(libs.accompanist.systemUiController)
 

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -92,7 +92,9 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".feature.embark.EmbarkStoryTesterActivity" />
+        <activity
+            android:name=".feature.embark.EmbarkStoryTesterActivity"
+            android:windowSoftInputMode="adjustResize" />
 
         <meta-data
             android:name="com.mixpanel.android.MPConfig.DisableEmulatorBindingUI"

--- a/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkStoryTesterActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkStoryTesterActivity.kt
@@ -11,8 +11,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -45,30 +48,32 @@ import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.feature.home.ui.changeaddress.appendQuoteCartId
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.dsl.viewModel
-import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.androidx.viewmodel.ext.android.getViewModel
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.unloadKoinModules
 import org.koin.dsl.module
 
 class EmbarkStoryTesterActivity : AppCompatActivity() {
 
-  val model: EmbarkStoryTesterViewModel by viewModel()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    window.compatSetDecorFitsSystemWindows(false)
     loadKoinModules(embarkStoryTesterModule)
 
+    val viewModel: EmbarkStoryTesterViewModel = getViewModel()
     setContent {
-      val viewState by model.viewState.collectAsState()
+      val viewState by viewModel.viewState.collectAsState()
 
       LaunchedEffect(viewState.selectedStoryName) {
         val selectedStoryName = viewState.selectedStoryName ?: return@LaunchedEffect
-        model.onStorySelected(null)
+        viewModel.onStorySelected(null)
         startActivity(
           EmbarkActivity.newInstance(
             this@EmbarkStoryTesterActivity,
@@ -80,7 +85,7 @@ class EmbarkStoryTesterActivity : AppCompatActivity() {
 
       HedvigTheme {
         Column(
-          modifier = Modifier.fillMaxSize(),
+          modifier = Modifier.fillMaxSize().safeDrawingPadding(),
         ) {
           TopAppBar(
             title = { Text(text = "Embark tester") },
@@ -94,85 +99,65 @@ class EmbarkStoryTesterActivity : AppCompatActivity() {
             },
             backgroundColor = MaterialTheme.colors.background,
             elevation = 0.dp,
-            modifier = Modifier.systemBarsPadding(top = true),
           )
-          Text(text = "Optional auth token or payments url")
-          TextField(
-            value = viewState.authTokenInput ?: "",
-            onValueChange = {
-              model.onAuthToken(it)
-            },
-          )
-          Button(
-            onClick = {
-              viewState.authTokenInput?.let {
-                model.setAuthToken(it)
-              }
-            },
+          Column(
+            Modifier.verticalScroll(rememberScrollState()),
           ) {
-            Text("Set token")
-          }
-          Button(
-            onClick = {
-              viewState.authTokenInput?.let {
-                model.generateAuthTokenFromPaymentsLink(it)
-              }
-            },
-          ) {
-            Text("Generate and set token from payments url")
-          }
-          Text(text = "Custom Story")
-          TextField(
-            value = viewState.storyNameInput ?: "",
-            onValueChange = {
-              model.onStoryName(it)
-            },
-          )
-          Button(
-            onClick = {
-              viewState.storyNameInput?.let {
-                model.onStorySelected(it)
-              }
-            },
-          ) {
-            Text("Start story")
-          }
-          Text(text = "Markets")
-          LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier
-              .padding(horizontal = 8.dp)
-              .fillMaxWidth(),
-          ) {
-            items(viewState.availableMarkets) { market ->
-              MarketItem(market) {
-                model.onMarketClick(market)
+            Text(text = "Optional auth token or payments url")
+            TextField(
+              value = viewState.authTokenInput ?: "",
+              onValueChange = {
+                viewModel.onAuthToken(it)
+              },
+            )
+            Button(
+              onClick = {
+                viewState.authTokenInput?.let {
+                  viewModel.setAuthToken(it)
+                }
+              },
+            ) {
+              Text("Set token")
+            }
+            Button(
+              onClick = {
+                viewState.authTokenInput?.let {
+                  viewModel.generateAuthTokenFromPaymentsLink(it)
+                }
+              },
+            ) {
+              Text("Generate and set token from payments url")
+            }
+            Text(text = "Custom Story")
+            TextField(
+              value = viewState.storyNameInput ?: "",
+              onValueChange = {
+                viewModel.onStoryName(it)
+              },
+            )
+            Button(
+              onClick = {
+                viewState.storyNameInput?.let {
+                  viewModel.onStorySelected(it)
+                }
+              },
+            ) {
+              Text("Start story")
+            }
+            Text(text = "Markets")
+            LazyRow(
+              horizontalArrangement = Arrangement.spacedBy(4.dp),
+              modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .fillMaxWidth(),
+            ) {
+              items(viewState.availableMarkets) { market ->
+                MarketItem(market) {
+                  viewModel.onMarketClick(market)
+                }
               }
             }
           }
-        }
-      }
-    }
-  }
-
-  @Composable
-  fun MarketItem(market: Market, onClick: () -> Unit) {
-    Surface(
-      shape = MaterialTheme.shapes.medium,
-      modifier = Modifier.clickable { onClick() },
-    ) {
-      Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
-        modifier = Modifier
-          .padding(12.dp),
-      ) {
-        Column {
-          Text(
-            text = market.name,
-            style = MaterialTheme.typography.body1,
-            modifier = Modifier
-              .padding(bottom = 8.dp),
-          )
         }
       }
     }
@@ -183,6 +168,29 @@ class EmbarkStoryTesterActivity : AppCompatActivity() {
     unloadKoinModules(embarkStoryTesterModule)
   }
 }
+
+@Composable
+private fun MarketItem(market: Market, onClick: () -> Unit) {
+  Surface(
+    shape = MaterialTheme.shapes.medium,
+    modifier = Modifier.clickable { onClick() },
+  ) {
+    Row(
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier
+        .padding(12.dp),
+    ) {
+      Column {
+        Text(
+          text = market.name,
+          style = MaterialTheme.typography.body1,
+          modifier = Modifier
+            .padding(bottom = 8.dp),
+        )
+      }
+      }
+    }
+  }
 
 val embarkStoryTesterModule = module {
   viewModel { EmbarkStoryTesterViewModel(get(), get(), get(), get(), get()) }

--- a/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkStoryTesterActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkStoryTesterActivity.kt
@@ -36,7 +36,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import arrow.core.Either
 import com.apollographql.apollo3.ApolloClient
-import com.google.accompanist.insets.systemBarsPadding
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
@@ -60,7 +59,6 @@ import org.koin.core.context.unloadKoinModules
 import org.koin.dsl.module
 
 class EmbarkStoryTesterActivity : AppCompatActivity() {
-
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -188,9 +186,9 @@ private fun MarketItem(market: Market, onClick: () -> Unit) {
             .padding(bottom = 8.dp),
         )
       }
-      }
     }
   }
+}
 
 val embarkStoryTesterModule = module {
   viewModel { EmbarkStoryTesterViewModel(get(), get(), get(), get(), get()) }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -296,7 +296,9 @@
             android:name=".feature.genericauth.otpinput.OtpInputActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize" />
-        <activity android:name=".feature.claimdetail.ClaimDetailActivity" />
+        <activity
+            android:name=".feature.claimdetail.ClaimDetailActivity"
+            android:windowSoftInputMode="adjustResize" />
         <activity android:name=".feature.tracking.NotificationOpenedTrackingActivity" />
         <activity
             android:name=".feature.marketing.MarketingActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -279,7 +279,9 @@
 
         <activity android:name=".feature.offer.quotedetail.QuoteDetailActivity" />
 
-        <activity android:name=".feature.crossselling.ui.detail.CrossSellDetailActivity" />
+        <activity
+            android:name=".feature.crossselling.ui.detail.CrossSellDetailActivity"
+            android:windowSoftInputMode="adjustResize" />
         <activity android:name=".feature.crossselling.ui.detail.CrossSellFaqActivity" />
         <activity android:name=".feature.sunsetting.ForceUpgradeActivity" />
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -300,7 +300,8 @@
         <activity android:name=".feature.tracking.NotificationOpenedTrackingActivity" />
         <activity
             android:name=".feature.marketing.MarketingActivity"
-            android:theme="@style/Hedvig.Theme.Marketing" />
+            android:theme="@style/Hedvig.Theme.Marketing"
+            android:windowSoftInputMode="adjustResize" />
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -382,7 +382,7 @@ val viewModelModule = module {
     CrossSellDetailViewModel(crossSell.action, get(), get())
   }
   viewModel { GenericAuthViewModel(get()) }
-  viewModel { (otpId: String, credential: String) ->
+  viewModel<OtpInputViewModel> { (otpId: String, credential: String) ->
     OtpInputViewModel(
       otpId,
       credential,

--- a/app/src/main/java/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/java/com/hedvig/app/ApplicationModule.kt
@@ -696,7 +696,7 @@ val sharedPreferencesModule = module {
 }
 
 val coilModule = module {
-  single {
+  single<ImageLoader> {
     ImageLoader.Builder(get())
       .components {
         add(SvgDecoder.Factory())

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -87,8 +86,8 @@ fun AddressAutoCompleteScreen(
         setNewTextInput = setNewTextInput,
         focusRequester = focusRequester,
         closeKeyboard = closeKeyboard,
-        contentPadding = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
-          .union(WindowInsets.safeDrawing.only(WindowInsetsSides.Top))
+        contentPadding = WindowInsets.safeDrawing
+          .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
           .asPaddingValues(),
       )
       SuggestionsList(
@@ -98,8 +97,8 @@ fun AddressAutoCompleteScreen(
           selectAddress(address)
         },
         cantFindAddress = cantFindAddress,
-        contentPadding = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
-          .union(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
+        contentPadding = WindowInsets.safeDrawing
+          .only(WindowInsetsSides.Horizontal.plus(WindowInsetsSides.Bottom))
           .asPaddingValues(),
         modifier = Modifier.weight(1f),
       )

--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ClaimDetailActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ClaimDetailActivity.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.BaseActivity
 import com.hedvig.app.feature.claimdetail.ui.ClaimDetailScreen
 import com.hedvig.app.feature.claimdetail.ui.ClaimDetailViewModel
 import com.hedvig.app.getLocale
+import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.showErrorDialog
 import com.hedvig.app.util.extensions.startChat
 import kotlinx.coroutines.flow.launchIn
@@ -27,6 +28,8 @@ class ClaimDetailActivity : BaseActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    window.compatSetDecorFitsSystemWindows(false)
 
     val claimId = intent.getStringExtra(CLAIM_ID)
       ?: throw IllegalArgumentException("Programmer error: Missing claimId in ${this.javaClass.name}")

--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimDetailScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/ClaimDetailScreen.kt
@@ -2,8 +2,14 @@ package com.hedvig.app.feature.claimdetail.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -11,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.insets.ui.Scaffold
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.android.core.ui.genericinfo.GenericErrorScreen
@@ -30,28 +35,31 @@ fun ClaimDetailScreen(
   onPlayClick: () -> Unit,
   locale: Locale,
 ) {
-  Scaffold(
-    topBar = {
-      TopAppBarWithBack(
-        onClick = onUpClick,
-        title = stringResource(hedvig.resources.R.string.claim_status_title),
-      )
-    },
-  ) { paddingValues ->
+  Column {
+    TopAppBarWithBack(
+      onClick = onUpClick,
+      title = stringResource(hedvig.resources.R.string.claim_status_title),
+      contentPadding = WindowInsets.safeDrawing
+        .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
+        .asPaddingValues(),
+    )
     when (viewState) {
       is ClaimDetailViewState.Content -> ClaimDetailScreen(
         uiState = viewState.uiState,
         locale = locale,
         onChatClick = onChatClick,
         onPlayClick = onPlayClick,
-        modifier = Modifier.padding(paddingValues),
       )
       ClaimDetailViewState.Error -> GenericErrorScreen(
         onRetryButtonClick = retry,
         modifier = Modifier
-          .padding(paddingValues)
           .padding(16.dp)
-          .padding(top = 40.dp),
+          .padding(top = 40.dp)
+          .padding(
+            WindowInsets.safeDrawing
+              .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
+              .asPaddingValues(),
+          ),
       )
       ClaimDetailViewState.Loading -> CenteredProgressIndicator()
     }
@@ -68,8 +76,9 @@ private fun ClaimDetailScreen(
 ) {
   Column(
     modifier = modifier
-      .padding(horizontal = 16.dp)
-      .verticalScroll(rememberScrollState()),
+      .verticalScroll(rememberScrollState())
+      .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+      .padding(horizontal = 16.dp),
   ) {
     Spacer(Modifier.height(24.dp))
     ClaimType(
@@ -89,15 +98,14 @@ private fun ClaimDetailScreen(
     SubmittedAndClosedColumns(uiState.submittedAt, uiState.closedAt, locale)
     Spacer(Modifier.height(24.dp))
     ClaimDetailCard(uiState.claimDetailCard, onChatClick)
-    Spacer(Modifier.height(56.dp))
     if (uiState.signedAudioURL != null) {
+      Spacer(Modifier.height(40.dp))
       AudioPlayBackItem(
         onPlayClick = onPlayClick,
         uiState.signedAudioURL,
       )
     }
-    // TODO claim detail screen v2.1, actually show files here
-    Spacer(Modifier.height(48.dp))
+    Spacer(Modifier.height(16.dp))
   }
 }
 

--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/FailedAudioPlayerCard.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/FailedAudioPlayerCard.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.ui.compose.theme.onWarning
+import com.hedvig.android.core.designsystem.theme.onWarning
 import com.hedvig.app.ui.compose.theme.warning
 
 @Composable

--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/FakeWaveAudioPlayerCard.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/ui/FakeWaveAudioPlayerCard.kt
@@ -37,10 +37,10 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.onWarning
 import com.hedvig.app.R
 import com.hedvig.app.service.audioplayer.AudioPlayerState
 import com.hedvig.app.service.audioplayer.AudioPlayerState.Ready.ReadyState
-import com.hedvig.app.ui.compose.theme.onWarning
 import com.hedvig.app.ui.compose.theme.warning
 import com.hedvig.app.util.ProgressPercentage
 

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailActivity.kt
@@ -7,13 +7,14 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import coil.ImageLoader
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.BaseActivity
-import com.hedvig.app.R
 import com.hedvig.app.feature.crossselling.ui.CrossSellData
 import com.hedvig.app.feature.offer.quotedetail.QuoteDetailActivity
 import com.hedvig.app.feature.perils.PerilItem
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
+import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.getViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -31,6 +32,7 @@ class CrossSellDetailActivity : BaseActivity() {
     val viewModel = getViewModel<CrossSellDetailViewModel> {
       parametersOf(crossSell)
     }
+    val imageLoader: ImageLoader = get()
 
     window.compatSetDecorFitsSystemWindows(false)
 
@@ -52,9 +54,10 @@ class CrossSellDetailActivity : BaseActivity() {
           onUpClick = { finish() },
           onCoverageClick = { openCoverage(crossSell) },
           onFaqClick = { openFaq(crossSell) },
-          onDismissError = { viewModel.dismissError() },
+          onDismissError = viewModel::dismissError,
           data = crossSell,
           errorMessage = viewState.errorMessage,
+          imageLoader = imageLoader,
         )
       }
     }

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
@@ -95,7 +95,7 @@ fun CrossSellDetailScreen(
   }
 
   if (errorMessage != null) {
-    ErrorDialog(onDismiss = onDismissError, message = errorMessage)
+    ErrorDialog(message = errorMessage, onDismiss = onDismissError)
   }
 }
 
@@ -108,11 +108,6 @@ private fun ScrollableContent(
   modifier: Modifier = Modifier,
   scrollState: ScrollState = rememberScrollState(),
 ) {
-  val placeholder by rememberBlurHash(
-    crossSellData.backgroundBlurHash,
-    64,
-    32,
-  )
   Column(
     modifier = modifier
       .fillMaxSize()
@@ -124,7 +119,7 @@ private fun ScrollableContent(
         builder = {
           scale(Scale.FILL)
           transformations(CropTransformation())
-          placeholder(placeholder)
+          placeholder(rememberBlurHash(crossSellData.backgroundBlurHash, 64, 32))
           crossfade(true)
         },
       ),

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
@@ -148,7 +148,9 @@ private fun ScrollableContent(
       imageLoader = imageLoader,
       placeholder = rememberBlurHashPainter(crossSellData.backgroundBlurHash, 64, 32),
       contentScale = ContentScale.Crop,
-      modifier = Modifier.height(imageHeight).fillMaxWidth(),
+      modifier = Modifier
+        .height(imageHeight)
+        .fillMaxWidth(),
     )
     Column(Modifier.padding(horizontal = 16.dp)) {
       Spacer(Modifier.height(24.dp))

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
@@ -1,14 +1,22 @@
 package com.hedvig.app.feature.crossselling.ui.detail
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumedWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
@@ -20,29 +28,30 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberImagePainter
-import coil.size.Scale
-import com.commit451.coiltransformations.CropTransformation
-import com.google.accompanist.insets.LocalWindowInsets
-import com.google.accompanist.insets.rememberInsetsPaddingValues
-import com.google.accompanist.insets.systemBarsPadding
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.list.SectionTitle
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
+import com.hedvig.android.core.ui.scaffold.Scaffold
 import com.hedvig.app.R
 import com.hedvig.app.feature.crossselling.ui.CrossSellData
 import com.hedvig.app.ui.compose.composables.ErrorDialog
 import com.hedvig.app.ui.compose.composables.appbar.FadingTopAppBar
-import com.hedvig.app.util.compose.rememberBlurHash
+import com.hedvig.app.util.compose.rememberBlurHashPainter
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CrossSellDetailScreen(
   onCtaClick: () -> Unit,
@@ -52,45 +61,58 @@ fun CrossSellDetailScreen(
   onDismissError: () -> Unit,
   data: CrossSellData,
   errorMessage: String?,
+  imageLoader: ImageLoader,
 ) {
   val scrollState = rememberScrollState()
-  val scrollFromTopInDp = with(LocalDensity.current) {
-    scrollState.value.toDp()
-  }
+  val localDensity = LocalDensity.current
   val imageHeight = 260.dp
-  val topAppBarBackgroundColorAlpha by derivedStateOf {
-    val percentageOfImageScrolledPast = scrollFromTopInDp.coerceAtMost(imageHeight) / imageHeight
-    percentageOfImageScrolledPast
+  val topAppBarBackgroundColorAlpha by remember {
+    derivedStateOf {
+      val scrollFromTopInDp = with(localDensity) { scrollState.value.toDp() }
+      val percentageOfImageScrolledPast = scrollFromTopInDp.coerceAtMost(imageHeight) / imageHeight
+      percentageOfImageScrolledPast
+    }
   }
-  Box(
-    modifier = Modifier.fillMaxSize(),
-  ) {
-    ScrollableContent(
-      crossSellData = data,
-      onCoverageClick = onCoverageClick,
-      onFaqClick = onFaqClick,
-      imageHeight = imageHeight,
-      scrollState = scrollState,
-    )
-    FadingTopAppBar(
-      backgroundAlpha = topAppBarBackgroundColorAlpha,
-      contentPadding = rememberInsetsPaddingValues(
-        insets = LocalWindowInsets.current.statusBars,
-      ),
-      navigationIcon = {
-        IconButton(onClick = onUpClick) {
-          Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = null)
-        }
-      },
-    )
-    LargeContainedButton(
-      onClick = onCtaClick,
-      modifier = Modifier
-        .align(Alignment.BottomCenter)
-        .systemBarsPadding(bottom = true)
-        .padding(16.dp),
+  Scaffold(
+    bottomBar = {
+      LargeContainedButton(
+        onClick = onCtaClick,
+        modifier = Modifier
+          .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal))
+          .padding(16.dp),
+      ) {
+        Text(text = data.callToAction)
+      }
+    },
+  ) { paddingValues ->
+    Box(
+      Modifier
+        .fillMaxSize()
+        // Since we've applied the insets on the bottomBar itself and that stays at the bottom of the screen, and the
+        // height that it takes is passed down inside [paddingValues], we need to inform children that the bottom
+        // insets are already consumed.
+        .consumedWindowInsets(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
     ) {
-      Text(text = data.callToAction)
+      ScrollableContent(
+        crossSellData = data,
+        onCoverageClick = onCoverageClick,
+        onFaqClick = onFaqClick,
+        imageHeight = imageHeight,
+        imageLoader = imageLoader,
+        contentPadding = paddingValues,
+        scrollState = scrollState,
+      )
+      FadingTopAppBar(
+        backgroundAlpha = topAppBarBackgroundColorAlpha,
+        contentPadding = WindowInsets.safeDrawing
+          .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
+          .asPaddingValues(),
+        navigationIcon = {
+          IconButton(onClick = onUpClick) {
+            Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = null)
+          }
+        },
+      )
     }
   }
 
@@ -105,29 +127,28 @@ private fun ScrollableContent(
   onCoverageClick: () -> Unit,
   onFaqClick: () -> Unit,
   imageHeight: Dp,
+  imageLoader: ImageLoader,
   modifier: Modifier = Modifier,
+  contentPadding: PaddingValues = PaddingValues(),
   scrollState: ScrollState = rememberScrollState(),
 ) {
   Column(
     modifier = modifier
       .fillMaxSize()
-      .verticalScroll(scrollState),
+      .verticalScroll(scrollState)
+      .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+      .padding(contentPadding),
   ) {
-    Image(
-      painter = rememberImagePainter(
-        data = crossSellData.backgroundUrl,
-        builder = {
-          scale(Scale.FILL)
-          transformations(CropTransformation())
-          placeholder(rememberBlurHash(crossSellData.backgroundBlurHash, 64, 32))
-          crossfade(true)
-        },
-      ),
+    AsyncImage(
+      model = ImageRequest.Builder(LocalContext.current)
+        .data(crossSellData.backgroundUrl)
+        .crossfade(true)
+        .build(),
       contentDescription = null,
-      modifier = Modifier
-        .height(imageHeight)
-        .fillMaxWidth(),
-      contentScale = ContentScale.FillBounds,
+      imageLoader = imageLoader,
+      placeholder = rememberBlurHashPainter(crossSellData.backgroundBlurHash, 64, 32),
+      contentScale = ContentScale.Crop,
+      modifier = Modifier.height(imageHeight).fillMaxWidth(),
     )
     Column(Modifier.padding(horizontal = 16.dp)) {
       Spacer(Modifier.height(24.dp))
@@ -166,10 +187,6 @@ private fun ScrollableContent(
       icon = R.drawable.ic_info_toolbar,
       text = stringResource(hedvig.resources.R.string.cross_sell_info_common_questions_row),
     )
-    val bottomSystemBarInset = with(LocalDensity.current) {
-      LocalWindowInsets.current.systemBars.bottom.toDp()
-    }
-    Spacer(Modifier.height(104.dp + bottomSystemBarInset))
   }
 }
 
@@ -218,6 +235,7 @@ fun CrossSellDetailScreenPreview() {
         insurableLimits = emptyList(),
       ),
       errorMessage = null,
+      imageLoader = rememberPreviewImageLoader(),
     )
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderScreen.kt
@@ -4,10 +4,15 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
@@ -18,12 +23,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.insets.LocalWindowInsets
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
@@ -46,17 +49,12 @@ fun AudioRecorderScreen(
   play: () -> Unit,
   pause: () -> Unit,
 ) {
-  val insets = LocalWindowInsets.current
-  val systemTop = with(LocalDensity.current) { insets.systemBars.top.toDp() }
-  val systemBottom = with(LocalDensity.current) { insets.systemBars.bottom.toDp() }
   Column(
     verticalArrangement = Arrangement.SpaceBetween,
     modifier = Modifier
-      .padding(
-        top = 24.dp + systemTop,
-        bottom = systemBottom,
-      )
-      .fillMaxSize(),
+      .fillMaxSize()
+      .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal))
+      .padding(top = 24.dp),
   ) {
     LazyColumn(
       verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/retrieveprice/RetrievePriceContent.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/retrieveprice/RetrievePriceContent.kt
@@ -83,6 +83,6 @@ fun RetrievePriceContent(
   }
 
   if (errorMessage != null) {
-    ErrorDialog(onDismiss = onDismissError, message = errorMessage)
+    ErrorDialog(message = errorMessage, onDismiss = onDismissError)
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
@@ -45,7 +45,7 @@ fun EmailInputScreen(
 ) {
   Column(
     modifier = Modifier
-      .safeContentPadding()
+      .safeDrawingPadding()
       .fillMaxSize(),
   ) {
     TopAppBarWithBack(

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputActivity.kt
@@ -4,90 +4,68 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
-import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import com.google.accompanist.insets.systemBarsPadding
+import androidx.compose.runtime.remember
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.app.BaseActivity
-import com.hedvig.app.R
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.openEmail
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.androidx.viewmodel.ext.android.getViewModel
 import org.koin.core.parameter.parametersOf
 import kotlin.time.Duration.Companion.seconds
 
 class OtpInputActivity : BaseActivity() {
-
-  val model: OtpInputViewModel by viewModel {
-    parametersOf(
-      intent.getStringExtra(OTP_ID_EXTRA) ?: throw IllegalArgumentException(
-        "Programmer error: Missing OTP_ID in ${this.javaClass.name}",
-      ),
-      intent.getStringExtra(CREDENTIAL_EXTRA) ?: throw IllegalArgumentException(
-        "Programmer error: Missing CREDENTIAL in ${this.javaClass.name}",
-      ),
-    )
-  }
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
     window.compatSetDecorFitsSystemWindows(false)
 
-    setContent {
-      val scaffoldState = rememberScaffoldState()
+    val viewModel: OtpInputViewModel = getViewModel {
+      parametersOf(
+        intent.getStringExtra(OTP_ID_EXTRA)
+          ?: error("Programmer error: Missing OTP_ID in ${this.javaClass.name}"),
+        intent.getStringExtra(CREDENTIAL_EXTRA)
+          ?: error("Programmer error: Missing CREDENTIAL in ${this.javaClass.name}"),
+      )
+    }
 
-      HedvigTheme {
-        LaunchedEffect(Unit) {
-          model.events.collectLatest { event ->
-            when (event) {
-              is OtpInputViewModel.Event.Success -> startLoggedIn()
-              OtpInputViewModel.Event.CodeResent -> {
-                delay(1.seconds)
-                val message = getString(hedvig.resources.R.string.login_snackbar_code_resent)
-                scaffoldState.snackbarHostState.showSnackbar(message)
-              }
+    setContent {
+      val snackbarHostState = remember { SnackbarHostState() }
+      LaunchedEffect(viewModel) {
+        viewModel.events.collectLatest { event ->
+          when (event) {
+            is OtpInputViewModel.Event.Success -> startLoggedIn()
+            OtpInputViewModel.Event.CodeResent -> {
+              delay(1.seconds)
+              val message = getString(hedvig.resources.R.string.login_snackbar_code_resent)
+              snackbarHostState.showSnackbar(message)
             }
           }
         }
-
-        Scaffold(
-          topBar = {
-            TopAppBarWithBack(
-              onClick = ::onBackPressed,
-              title = stringResource(hedvig.resources.R.string.login_navigation_bar_center_element_title),
-            )
-          },
-          scaffoldState = scaffoldState,
-          modifier = Modifier.systemBarsPadding(top = true),
-        ) { paddingValues ->
-          val viewState by model.viewState.collectAsState()
-
-          OtpInputScreen(
-            onInputChanged = model::setInput,
-            onOpenExternalApp = { openEmail(getString(hedvig.resources.R.string.login_bottom_sheet_view_code)) },
-            onSubmitCode = model::submitCode,
-            onResendCode = model::resendCode,
-            onDismissError = model::dismissError,
-            inputValue = viewState.input,
-            credential = viewState.credential,
-            otpErrorMessage = viewState.otpError?.toStringRes()?.let(::getString),
-            networkErrorMessage = viewState.networkErrorMessage,
-            loadingResend = viewState.loadingResend,
-            loadingCode = viewState.loadingCode,
-            modifier = Modifier.padding(paddingValues),
-          )
-        }
+      }
+      HedvigTheme {
+        val viewState by viewModel.viewState.collectAsState()
+        OtpInputScreen(
+          onInputChanged = viewModel::setInput,
+          onOpenExternalApp = { openEmail(getString(hedvig.resources.R.string.login_bottom_sheet_view_code)) },
+          onSubmitCode = viewModel::submitCode,
+          onResendCode = viewModel::resendCode,
+          onDismissError = viewModel::dismissError,
+          onBackPressed = ::onBackPressed,
+          inputValue = viewState.input,
+          credential = viewState.credential,
+          otpErrorMessage = viewState.otpError?.toStringRes()?.let(::getString),
+          networkErrorMessage = viewState.networkErrorMessage,
+          loadingResend = viewState.loadingResend,
+          loadingCode = viewState.loadingCode,
+          snackbarHostState = snackbarHostState,
+        )
       }
     }
   }

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
@@ -1,36 +1,44 @@
+@file:OptIn(ExperimentalComposeUiApi::class, ExperimentalUnitApi::class)
+
 package com.hedvig.app.feature.genericauth.otpinput
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.DrawerValue
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -42,14 +50,14 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
-import com.google.accompanist.insets.navigationBarsWithImePadding
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.app.R
 import com.hedvig.app.ui.compose.composables.ErrorDialog
 import com.hedvig.app.ui.compose.composables.FullScreenProgressOverlay
+import kotlinx.coroutines.isActive
 
-@OptIn(ExperimentalUnitApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun OtpInputScreen(
   onInputChanged: (String) -> Unit,
@@ -57,136 +65,190 @@ fun OtpInputScreen(
   onSubmitCode: (String) -> Unit,
   onResendCode: () -> Unit,
   onDismissError: () -> Unit,
+  onBackPressed: () -> Unit,
   inputValue: String,
   credential: String,
   otpErrorMessage: String?,
   networkErrorMessage: String?,
   loadingResend: Boolean,
   loadingCode: Boolean,
+  snackbarHostState: SnackbarHostState,
+  modifier: Modifier = Modifier,
+) {
+  Box(modifier) {
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    Scaffold(
+      scaffoldState = remember { ScaffoldState(drawerState, snackbarHostState) },
+      topBar = {
+        TopAppBarWithBack(
+          onClick = onBackPressed,
+          title = stringResource(hedvig.resources.R.string.login_navigation_bar_center_element_title),
+        )
+      },
+      modifier = modifier
+        .fillMaxSize()
+        .safeDrawingPadding(),
+    ) { paddingValues ->
+      OtpInputScreenContents(
+        credential,
+        inputValue,
+        onInputChanged,
+        onSubmitCode,
+        otpErrorMessage,
+        onResendCode,
+        loadingResend,
+        onOpenExternalApp,
+        Modifier.padding(paddingValues),
+      )
+    }
+    if (networkErrorMessage != null) {
+      ErrorDialog(message = networkErrorMessage, onDismiss = onDismissError)
+    }
+    FullScreenProgressOverlay(show = loadingCode)
+  }
+}
+
+@Composable
+private fun OtpInputScreenContents(
+  credential: String,
+  inputValue: String,
+  onInputChanged: (String) -> Unit,
+  onSubmitCode: (String) -> Unit,
+  otpErrorMessage: String?,
+  onResendCode: () -> Unit,
+  loadingResend: Boolean,
+  onOpenExternalApp: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val keyboardController = LocalSoftwareKeyboardController.current
-
-  Box(
-    modifier = modifier
+  Column(
+    modifier
+      .fillMaxSize()
       .padding(horizontal = 16.dp)
-      .fillMaxSize(),
+      .verticalScroll(rememberScrollState()),
   ) {
-    Column(
-      modifier = Modifier
-        .fillMaxSize()
-        .verticalScroll(rememberScrollState()),
-    ) {
-      Spacer(Modifier.height(60.dp))
-      Text(
-        text = stringResource(hedvig.resources.R.string.login_title_check_your_email),
-        style = MaterialTheme.typography.h4,
-      )
-      Spacer(Modifier.height(16.dp))
-      Text(
-        text = stringResource(hedvig.resources.R.string.login_subtitle_verification_code_email, credential),
-        style = MaterialTheme.typography.body1,
-      )
+    Spacer(Modifier.height(60.dp))
+    Text(
+      text = stringResource(hedvig.resources.R.string.login_title_check_your_email),
+      style = MaterialTheme.typography.h4,
+    )
+    Spacer(Modifier.height(16.dp))
+    Text(
+      text = stringResource(hedvig.resources.R.string.login_subtitle_verification_code_email, credential),
+      style = MaterialTheme.typography.body1,
+    )
+    Spacer(Modifier.height(40.dp))
+    SixDigitCodeInputField(inputValue, onInputChanged, keyboardController, onSubmitCode, otpErrorMessage)
+    Spacer(
+      Modifier.height((20 - 6).dp), // 20 from design, 6 to account for TextButton extra space taken
+    )
+    ResendCodeItem(onResendCode, keyboardController, loadingResend, Modifier.align(Alignment.CenterHorizontally))
+    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(16.dp))
+    LargeContainedButton(onOpenExternalApp) {
+      Text(stringResource(hedvig.resources.R.string.login_open_email_app_button))
+    }
+    Spacer(Modifier.height(16.dp))
+  }
+}
 
-      Spacer(Modifier.height(40.dp))
-      Box(Modifier.fillMaxSize()) {
-        OutlinedTextField(
-          modifier = Modifier.fillMaxSize(),
-          value = inputValue,
-          onValueChange = {
-            if (it.length <= 6 && it.isDigitsOnly()) {
-              onInputChanged(it)
-            }
+@Composable
+private fun ColumnScope.SixDigitCodeInputField(
+  inputValue: String,
+  onInputChanged: (String) -> Unit,
+  keyboardController: SoftwareKeyboardController?,
+  onSubmitCode: (String) -> Unit,
+  otpErrorMessage: String?,
+) {
+  OutlinedTextField(
+    modifier = Modifier.fillMaxSize(),
+    value = inputValue,
+    onValueChange = { newValue ->
+      if (newValue.length <= 6 && newValue.isDigitsOnly()) {
+        onInputChanged(newValue)
+      }
 
-            if (it.length == 6) {
-              keyboardController?.hide()
-              onSubmitCode(it)
-            }
-          },
-          isError = otpErrorMessage != null,
-          shape = MaterialTheme.shapes.medium,
-          textStyle = LocalTextStyle.current.copy(
-            letterSpacing = TextUnit(20f, TextUnitType.Sp),
-            fontWeight = FontWeight(400),
-            fontSize = TextUnit(28f, TextUnitType.Sp),
-            textAlign = TextAlign.Center,
-          ),
-          keyboardOptions = KeyboardOptions(
-            keyboardType = KeyboardType.Number,
-          ),
+      if (newValue.length == 6) {
+        keyboardController?.hide()
+        onSubmitCode(newValue)
+      }
+    },
+    isError = otpErrorMessage != null,
+    shape = MaterialTheme.shapes.medium,
+    textStyle = LocalTextStyle.current.copy(
+      letterSpacing = TextUnit(20f, TextUnitType.Sp),
+      fontWeight = FontWeight(400),
+      fontSize = TextUnit(28f, TextUnitType.Sp),
+      textAlign = TextAlign.Center,
+    ),
+    keyboardOptions = KeyboardOptions(
+      keyboardType = KeyboardType.Number,
+    ),
+  )
+  AnimatedVisibility(otpErrorMessage != null) {
+    Column {
+      Spacer(Modifier.height(8.dp))
+      Text(
+        text = otpErrorMessage ?: "",
+        style = MaterialTheme.typography.caption.copy(color = MaterialTheme.colors.error),
+        modifier = Modifier.fillMaxWidth(),
+        textAlign = TextAlign.Center,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ResendCodeItem(
+  onResendCode: () -> Unit,
+  keyboardController: SoftwareKeyboardController?,
+  loadingResend: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  TextButton(
+    onClick = {
+      onResendCode()
+      keyboardController?.hide()
+    },
+    enabled = !loadingResend,
+    modifier = modifier,
+  ) {
+    RotatingIcon(loadingResend)
+    Spacer(modifier = Modifier.width(8.dp))
+    Text(
+      modifier = Modifier.align(Alignment.CenterVertically),
+      text = stringResource(hedvig.resources.R.string.login_smedium_button_active_resend_code),
+      style = MaterialTheme.typography.caption,
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+@Composable
+private fun RotatingIcon(isLoading: Boolean) {
+  val angle = remember { Animatable(0f) }
+  LaunchedEffect(angle, isLoading) {
+    if (isLoading) {
+      while (isActive) {
+        angle.animateTo(
+          360f,
+          spring(stiffness = Spring.StiffnessVeryLow / 2, visibilityThreshold = 0.1f),
         )
+        angle.snapTo(0f)
       }
-
-      Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        Spacer(Modifier.height(8.dp))
-        AnimatedVisibility(visible = otpErrorMessage != null) {
-          Text(
-            text = otpErrorMessage ?: "",
-            style = MaterialTheme.typography.caption.copy(color = MaterialTheme.colors.error),
-            modifier = Modifier
-              .fillMaxSize()
-              .padding(horizontal = 16.dp),
-            textAlign = TextAlign.Center,
-          )
-        }
-
-        Spacer(Modifier.height(18.dp))
-        Row(
-          modifier = Modifier
-            .clickable(
-              onClick = {
-                onResendCode()
-                keyboardController?.hide()
-              },
-              enabled = !loadingResend,
-            )
-            .padding(8.dp),
-          horizontalArrangement = Arrangement.Center,
-        ) {
-          val infiniteTransition = rememberInfiniteTransition()
-          val angle by infiniteTransition.animateFloat(
-            initialValue = 0F,
-            targetValue = 360F,
-            animationSpec = infiniteRepeatable(
-              animation = tween(2000, easing = LinearEasing),
-            ),
-          )
-
-          Icon(
-            modifier = if (loadingResend) Modifier.rotate(angle) else Modifier,
-            painter = painterResource(id = R.drawable.ic_refresh),
-            contentDescription = stringResource(hedvig.resources.R.string.login_smedium_button_active_resend_code),
-          )
-          Spacer(modifier = Modifier.width(8.dp))
-          Text(
-            modifier = Modifier.align(Alignment.CenterVertically),
-            text = stringResource(hedvig.resources.R.string.login_smedium_button_active_resend_code),
-            style = MaterialTheme.typography.caption,
-            textAlign = TextAlign.Center,
-          )
-        }
-        Spacer(Modifier.height(144.dp))
+    } else {
+      if (angle.value != 0f) {
+        // Finish the rotation if it was already ongoing.
+        angle.animateTo(360f)
       }
-    }
-    LargeContainedButton(
-      onClick = onOpenExternalApp,
-      modifier = Modifier
-        .align(Alignment.BottomCenter)
-        .padding(bottom = 16.dp)
-        .navigationBarsWithImePadding(),
-    ) {
-      Text(text = stringResource(hedvig.resources.R.string.login_open_email_app_button))
+      angle.snapTo(0f)
     }
   }
-
-  if (networkErrorMessage != null) {
-    ErrorDialog(onDismiss = onDismissError, message = networkErrorMessage)
-  }
-
-  FullScreenProgressOverlay(show = loadingCode)
+  Icon(
+    modifier = Modifier.graphicsLayer { rotationZ = angle.value },
+    painter = painterResource(id = R.drawable.ic_refresh),
+    contentDescription = stringResource(hedvig.resources.R.string.login_smedium_button_active_resend_code),
+  )
 }
 
 @Preview(showBackground = true)
@@ -199,12 +261,14 @@ fun OtpInputScreenValidPreview() {
       onSubmitCode = {},
       onResendCode = {},
       onDismissError = {},
+      onBackPressed = {},
       inputValue = "0123456",
       credential = "john@doe.com",
       otpErrorMessage = null,
       networkErrorMessage = null,
       loadingResend = false,
       loadingCode = false,
+      snackbarHostState = SnackbarHostState(),
     )
   }
 }
@@ -219,12 +283,14 @@ fun OtpInputScreenInvalidPreview() {
       onSubmitCode = {},
       onResendCode = {},
       onDismissError = {},
+      onBackPressed = {},
       inputValue = "0123456",
       credential = "john@doe.com",
       otpErrorMessage = "Code has expired",
       networkErrorMessage = null,
       loadingResend = false,
       loadingCode = false,
+      snackbarHostState = SnackbarHostState(),
     )
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/otpinput/OtpInputViewModel.kt
@@ -39,7 +39,7 @@ class OtpInputViewModel(
 
   fun setInput(value: String) {
     _viewState.update {
-      it.copy(input = value)
+      it.copy(input = value, otpError = null)
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -51,7 +50,6 @@ fun CrossSell(
   onCardClick: () -> Unit,
   onCtaClick: (label: String) -> Unit,
 ) {
-  val placeholder by rememberBlurHash(data.backgroundBlurHash, 64, 32)
   Card(
     border = BorderStroke(1.dp, hedvigBlack12percent),
     modifier = Modifier
@@ -69,7 +67,7 @@ fun CrossSell(
         data = data.backgroundUrl,
         builder = {
           transformations(CropTransformation())
-          placeholder(placeholder)
+          placeholder(rememberBlurHash(data.backgroundBlurHash, 64, 32))
           crossfade(true)
         },
       ),

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/CrossSell.kt
@@ -31,10 +31,10 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 import com.commit451.coiltransformations.CropTransformation
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.hedvigBlack
+import com.hedvig.android.core.designsystem.theme.hedvigBlack12percent
+import com.hedvig.android.core.designsystem.theme.whiteHighEmphasis
 import com.hedvig.app.feature.crossselling.ui.CrossSellData
-import com.hedvig.app.ui.compose.theme.hedvigBlack
-import com.hedvig.app.ui.compose.theme.hedvigBlack12percent
-import com.hedvig.app.ui.compose.theme.whiteHighEmphasis
 import com.hedvig.app.util.compose.rememberBlurHash
 
 /*

--- a/app/src/main/java/com/hedvig/app/feature/marketing/MarketingActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/MarketingActivity.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -14,6 +14,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.hedvigBlack
+import com.hedvig.android.core.designsystem.theme.hedvigOffWhite
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
 import com.hedvig.android.market.createOnboardingUri
@@ -25,8 +27,6 @@ import com.hedvig.app.feature.marketing.marketpicked.MarketPickedScreen
 import com.hedvig.app.feature.marketing.pickmarket.PickMarketScreen
 import com.hedvig.app.feature.marketing.ui.BackgroundImage
 import com.hedvig.app.feature.zignsec.SimpleSignAuthenticationActivity
-import com.hedvig.app.ui.compose.theme.hedvigBlack
-import com.hedvig.app.ui.compose.theme.hedvigOffWhite
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.makeToast
 import com.hedvig.hanalytics.LoginMethod
@@ -80,13 +80,9 @@ class MarketingActivity : BaseActivity() {
   ) {
     Box(Modifier.fillMaxSize()) {
       BackgroundImage(marketingBackground)
-      Box(
-        Modifier
-          .fillMaxSize()
-          .safeDrawingPadding(),
-      ) {
-        val selectedMarket = state.selectedMarket
-        if (selectedMarket == null) {
+      val selectedMarket = state.selectedMarket
+      Crossfade(selectedMarket) { market ->
+        if (market == null) {
           PickMarketScreen(
             onSubmit = submitMarketAndLanguage,
             onSelectMarket = setMarket,
@@ -101,18 +97,18 @@ class MarketingActivity : BaseActivity() {
             onClickMarket = onFlagClick,
             onClickSignUp = {
               onClickSignUp()
-              openOnboarding(selectedMarket)
+              openOnboarding(market)
             },
             onClickLogIn = {
               onClickLogIn()
-              onClickLogin(state, selectedMarket)
+              onClickLogin(state, market)
             },
-            flagRes = selectedMarket.flag,
+            flagRes = market.flag,
           )
         }
-        if (state.isLoading) {
-          CircularProgressIndicator(Modifier.align(Alignment.Center))
-        }
+      }
+      if (state.isLoading) {
+        CircularProgressIndicator(Modifier.align(Alignment.Center))
       }
     }
   }

--- a/app/src/main/java/com/hedvig/app/feature/marketing/MarketingViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/MarketingViewModel.kt
@@ -32,8 +32,8 @@ class MarketingViewModel(
   private val _state = MutableStateFlow(MarketingViewState(selectedMarket = market))
   val state = _state.asStateFlow()
 
-  private val _background = MutableStateFlow(Background(data = null))
-  val background = _background.asStateFlow()
+  private val _marketingBackground = MutableStateFlow<MarketingBackground?>(null)
+  val marketingBackground = _marketingBackground.asStateFlow()
 
   init {
     viewModelScope.launch {
@@ -49,8 +49,8 @@ class MarketingViewModel(
       }
     }
     viewModelScope.launch {
-      getMarketingBackgroundUseCase.invoke().tap { bg ->
-        _background.value = Background(data = bg)
+      getMarketingBackgroundUseCase.invoke().tap { marketingBackground ->
+        _marketingBackground.value = marketingBackground
       }
     }
   }

--- a/app/src/main/java/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
@@ -2,12 +2,12 @@ package com.hedvig.app.feature.marketing.marketpicked
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -16,17 +16,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.insets.LocalWindowInsets
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.hedvigOffWhite
 import com.hedvig.app.R
-import com.hedvig.app.ui.compose.theme.hedvigOffWhite
 
 @Composable
 fun MarketPickedScreen(
@@ -35,17 +33,10 @@ fun MarketPickedScreen(
   onClickLogIn: () -> Unit,
   @DrawableRes flagRes: Int,
 ) {
-  val insets = LocalWindowInsets.current
-  val statusBarHeight = with(LocalDensity.current) { insets.statusBars.top.toDp() }
-  val navigationBarHeight = with(LocalDensity.current) { insets.navigationBars.bottom.toDp() }
-  Box(modifier = Modifier.fillMaxSize()) {
+  Box(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
     IconButton(
       onClick = onClickMarket,
-      modifier = Modifier
-        .padding(
-          start = 8.dp,
-          top = statusBarHeight,
-        ),
+      modifier = Modifier.padding(4.dp), // 4.dp from [androidx.compose.material.AppBar.AppBarHorizontalPadding].
     ) {
       Image(
         painter = painterResource(flagRes),
@@ -61,7 +52,8 @@ fun MarketPickedScreen(
     Column(
       modifier = Modifier
         .align(Alignment.BottomCenter)
-        .padding(horizontal = 16.dp),
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
       LargeContainedButton(
         onClick = onClickSignUp,
@@ -73,11 +65,9 @@ fun MarketPickedScreen(
           text = stringResource(hedvig.resources.R.string.MARKETING_GET_HEDVIG),
         )
       }
-      Spacer(Modifier.height(8.dp))
       LargeOutlinedButton(onClick = onClickLogIn) {
         Text(text = stringResource(hedvig.resources.R.string.MARKETING_SCREEN_LOGIN))
       }
-      Spacer(Modifier.height(8.dp + navigationBarHeight))
     }
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
@@ -2,26 +2,34 @@ package com.hedvig.app.feature.marketing.pickmarket
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LocalContentColor
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.RadioButton
+import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -32,20 +40,18 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter.Companion.tint
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.insets.LocalWindowInsets
+import com.hedvig.android.core.designsystem.component.BottomSheetHandle
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
 import com.hedvig.app.R
-import com.hedvig.app.ui.compose.theme.separator
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 enum class PickMarketSheet {
@@ -66,125 +72,169 @@ fun PickMarketScreen(
 ) {
   var sheet by rememberSaveable { mutableStateOf<PickMarketSheet?>(null) }
   val coroutineScope = rememberCoroutineScope()
-  val modalBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+  val modalBottomSheetState = rememberModalBottomSheetState(
+    initialValue = ModalBottomSheetValue.Hidden,
+    skipHalfExpanded = true,
+  )
 
-  val insets = LocalWindowInsets.current
-  val navigationBarHeight = with(LocalDensity.current) { insets.navigationBars.bottom.toDp() }
   ModalBottomSheetLayout(
     sheetState = modalBottomSheetState,
     sheetContent = {
-      HedvigTheme {
-        BackHandler(
-          enabled = modalBottomSheetState.isVisible,
-          onBack = {
-            coroutineScope.launch { modalBottomSheetState.hide() }
-          },
+      HedvigTheme { // Use standard theme again inside the sheet.
+        BottomSheetContent(
+          modalBottomSheetState = modalBottomSheetState,
+          coroutineScope = coroutineScope,
+          sheet = sheet,
+          onSelectMarket = onSelectMarket,
+          selectedMarket = selectedMarket,
+          markets = markets,
+          onSelectLanguage = onSelectLanguage,
+          selectedLanguage = selectedLanguage,
+          modifier = Modifier.windowInsetsPadding(
+            WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+          ),
         )
-        Spacer(Modifier.height(8.dp))
-        BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
-        when (sheet) {
-          PickMarketSheet.MARKET -> PickMarketSheetContent(
-            onSelectMarket = { market ->
-              coroutineScope.launch {
-                modalBottomSheetState.hide()
-                onSelectMarket(market)
-              }
-            },
-            selectedMarket = selectedMarket,
-            markets = markets,
-          )
-          PickMarketSheet.COUNTRY -> PickLanguageSheetContent(
-            onSelectLanguage = { language ->
-              coroutineScope.launch {
-                modalBottomSheetState.hide()
-                onSelectLanguage(language)
-              }
-            },
-            selectedLanguage = selectedLanguage,
-            selectedMarket = selectedMarket,
-          )
-          null -> {}
-        }
-        Spacer(Modifier.height(24.dp + navigationBarHeight))
       }
     },
   ) {
-    Box(modifier = Modifier.fillMaxSize()) {
-      Text(
-        text = stringResource(hedvig.resources.R.string.market_language_screen_title),
-        style = MaterialTheme.typography.h4,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.align(Alignment.Center),
+    ScreenContent(
+      setSheet = { sheet = it },
+      coroutineScope = coroutineScope,
+      modalBottomSheetState = modalBottomSheetState,
+      selectedMarket = selectedMarket,
+      selectedLanguage = selectedLanguage,
+      onSubmit = onSubmit,
+      enabled = enabled,
+      modifier = Modifier.safeDrawingPadding(),
+    )
+  }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun ScreenContent(
+  setSheet: (PickMarketSheet?) -> Unit,
+  coroutineScope: CoroutineScope,
+  modalBottomSheetState: ModalBottomSheetState,
+  selectedMarket: Market?,
+  selectedLanguage: Language?,
+  onSubmit: () -> Unit,
+  enabled: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  Box(modifier.fillMaxSize()) {
+    Text(
+      text = stringResource(hedvig.resources.R.string.market_language_screen_title),
+      style = MaterialTheme.typography.h4,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.align(Alignment.Center),
+    )
+    Column(
+      modifier = Modifier
+        .align(Alignment.BottomCenter)
+        .verticalScroll(rememberScrollState()),
+    ) {
+      PickerRow(
+        onClick = {
+          setSheet(PickMarketSheet.MARKET)
+          coroutineScope.launch { modalBottomSheetState.show() }
+        },
+        icon = selectedMarket?.flag?.let { flagId ->
+          {
+            Image(
+              painter = painterResource(flagId),
+              contentDescription = null,
+            )
+          }
+        },
+        header = stringResource(hedvig.resources.R.string.market_language_screen_market_label),
+        label = selectedMarket?.label?.let { stringResource(it) },
+        enabled = true,
       )
-      Column(
-        modifier = Modifier.align(Alignment.BottomCenter),
+      PickerRow(
+        onClick = {
+          setSheet(PickMarketSheet.COUNTRY)
+          coroutineScope.launch { modalBottomSheetState.show() }
+        },
+        icon = {
+          LanguageFlag()
+        },
+        header = stringResource(hedvig.resources.R.string.market_language_screen_language_label),
+        label = selectedLanguage?.getLabel()?.let { stringResource(it) },
+        enabled = selectedMarket?.let { Language.getAvailableLanguages(it).isNotEmpty() } ?: false,
+      )
+      Spacer(Modifier.height(32.dp))
+      LargeContainedButton(
+        onClick = onSubmit,
+        modifier = Modifier.padding(horizontal = 16.dp),
+        enabled = enabled,
       ) {
-        PickerRow(
-          onClick = {
-            sheet = PickMarketSheet.MARKET
-            coroutineScope.launch { modalBottomSheetState.show() }
-          },
-          icon = selectedMarket?.flag?.let { flagId ->
-            {
-              Image(
-                painter = painterResource(flagId),
-                contentDescription = null,
-              )
-            }
-          },
-          header = stringResource(hedvig.resources.R.string.market_language_screen_market_label),
-          label = selectedMarket?.label?.let { stringResource(it) },
-          enabled = true,
-        )
-        PickerRow(
-          onClick = {
-            sheet = PickMarketSheet.COUNTRY
-            coroutineScope.launch { modalBottomSheetState.show() }
-          },
-          icon = {
-            LanguageFlag()
-          },
-          header = stringResource(hedvig.resources.R.string.market_language_screen_language_label),
-          label = selectedLanguage?.getLabel()?.let { stringResource(it) },
-          enabled = selectedMarket?.let { Language.getAvailableLanguages(it).isNotEmpty() } ?: false,
-        )
-        Spacer(Modifier.height(32.dp))
-        LargeContainedButton(
-          onClick = onSubmit,
-          modifier = Modifier.padding(horizontal = 16.dp),
-          enabled = enabled,
-        ) {
-          Text(stringResource(hedvig.resources.R.string.market_language_screen_continue_button_text))
-        }
-        Spacer(Modifier.height(24.dp + navigationBarHeight))
+        Text(stringResource(hedvig.resources.R.string.market_language_screen_continue_button_text))
       }
+      Spacer(Modifier.height(16.dp))
     }
+  }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun BottomSheetContent(
+  modalBottomSheetState: ModalBottomSheetState,
+  coroutineScope: CoroutineScope,
+  sheet: PickMarketSheet?,
+  onSelectMarket: (Market) -> Unit,
+  selectedMarket: Market?,
+  markets: List<Market>,
+  onSelectLanguage: (Language) -> Unit,
+  selectedLanguage: Language?,
+  modifier: Modifier = Modifier,
+) {
+  BackHandler(
+    enabled = modalBottomSheetState.isVisible,
+    onBack = {
+      coroutineScope.launch { modalBottomSheetState.hide() }
+    },
+  )
+  Column(modifier.verticalScroll(rememberScrollState())) {
+    Spacer(Modifier.height(8.dp))
+    BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
+    when (sheet) {
+      PickMarketSheet.MARKET -> PickMarketSheetContent(
+        onSelectMarket = { market ->
+          coroutineScope.launch {
+            modalBottomSheetState.hide()
+            onSelectMarket(market)
+          }
+        },
+        selectedMarket = selectedMarket,
+        markets = markets,
+      )
+      PickMarketSheet.COUNTRY -> PickLanguageSheetContent(
+        onSelectLanguage = { language ->
+          coroutineScope.launch {
+            modalBottomSheetState.hide()
+            onSelectLanguage(language)
+          }
+        },
+        selectedLanguage = selectedLanguage,
+        selectedMarket = selectedMarket,
+      )
+      null -> {}
+    }
+    Spacer(Modifier.height(24.dp))
   }
 }
 
 @Composable
 private fun LanguageFlag() {
-  Image(
+  Icon(
     painter = painterResource(R.drawable.ic_language),
     contentDescription = null,
-    colorFilter = tint(LocalContentColor.current),
   )
 }
 
 @Composable
-fun BottomSheetHandle(modifier: Modifier = Modifier) {
-  Box(
-    modifier = modifier
-      .size(width = 32.dp, height = 4.dp)
-      .background(
-        color = MaterialTheme.colors.separator,
-        shape = RoundedCornerShape(20.dp),
-      ),
-  )
-}
-
-@Composable
-fun PickMarketSheetContent(
+private fun PickMarketSheetContent(
   onSelectMarket: (Market) -> Unit,
   selectedMarket: Market?,
   markets: List<Market>,
@@ -206,7 +256,7 @@ fun PickMarketSheetContent(
 }
 
 @Composable
-fun PickLanguageSheetContent(
+private fun PickLanguageSheetContent(
   onSelectLanguage: (Language) -> Unit,
   selectedLanguage: Language?,
   selectedMarket: Market?,
@@ -236,18 +286,66 @@ fun PickLanguageSheetContent(
 }
 
 @Composable
-fun RadioButtonRow(onClick: () -> Unit, selected: Boolean, text: String) {
+private fun RadioButtonRow(onClick: () -> Unit, selected: Boolean, text: String) {
   Row(
     modifier = Modifier
+      .fillMaxWidth()
       .clickable(onClick = onClick)
-      .fillMaxWidth(),
+      .height(48.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    RadioButton(selected = selected, onClick = onClick)
+    Spacer(Modifier.width(4.dp))
+    RadioButton(
+      selected = selected,
+      onClick = onClick,
+      colors = RadioButtonDefaults.colors(
+        selectedColor = MaterialTheme.colors.onSurface,
+      ),
+    )
     Spacer(Modifier.width(4.dp))
     Text(
       text = text,
       style = MaterialTheme.typography.body1,
+    )
+  }
+}
+
+@Composable
+private fun PickerRow(
+  onClick: () -> Unit,
+  icon: (@Composable () -> Unit)?,
+  header: String,
+  label: String?,
+  enabled: Boolean,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier
+      .height(56.dp)
+      .clickable(enabled = enabled, onClick = onClick)
+      .padding(horizontal = 16.dp),
+  ) {
+    Box(Modifier.size(24.dp)) {
+      if (icon != null) {
+        icon()
+      }
+    }
+    Spacer(Modifier.width(16.dp))
+    Column(
+      verticalArrangement = Arrangement.SpaceAround,
+    ) {
+      Text(header)
+      if (label != null) {
+        Text(
+          text = label,
+          style = MaterialTheme.typography.caption,
+        )
+      }
+    }
+    Spacer(Modifier.weight(1f))
+    Icon(
+      painter = painterResource(R.drawable.ic_arrow_forward),
+      contentDescription = null,
     )
   }
 }
@@ -260,49 +358,6 @@ fun RadioButtonRowPreview() {
       onClick = {},
       selected = false,
       text = "Sweden",
-    )
-  }
-}
-
-@Composable
-fun PickerRow(
-  onClick: () -> Unit,
-  icon: (@Composable () -> Unit)?,
-  header: String?,
-  label: String?,
-  enabled: Boolean,
-) {
-  Row(
-    modifier = Modifier
-      .clickable(enabled = enabled, onClick = onClick)
-      .padding(vertical = 8.dp),
-  ) {
-    Spacer(Modifier.width(16.dp))
-    if (icon != null) {
-      Box(modifier = Modifier.align(Alignment.CenterVertically)) {
-        icon()
-      }
-    } else {
-      Spacer(Modifier.width(24.dp))
-    }
-    Spacer(Modifier.width(16.dp))
-    Column(
-      modifier = Modifier.fillMaxWidth(),
-      verticalArrangement = Arrangement.SpaceAround,
-
-    ) {
-      Text(
-        text = header ?: "",
-      )
-      Text(
-        text = label ?: "",
-        style = MaterialTheme.typography.caption,
-      )
-    }
-    Spacer(Modifier.weight(1f))
-    Image(
-      painter = painterResource(R.drawable.ic_arrow_forward),
-      contentDescription = null,
     )
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
@@ -7,8 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
@@ -18,6 +16,7 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.hedvig.app.feature.marketing.data.MarketingBackground
 import com.hedvig.app.ui.compose.theme.hedvigBlack
 import com.hedvig.app.util.compose.blurHash
+import com.hedvig.app.util.compose.toPainter
 
 @Composable
 fun BackgroundImage(background: MarketingBackground?) {
@@ -65,11 +64,7 @@ private class BackgroundImageUiState private constructor(
       }
 
       val blurHashDrawable: BitmapDrawable? = blurHash(marketingBackground.blurHash, 32, 32, context)
-      val fallbackPainter = if (blurHashDrawable != null) {
-        BitmapPainter(blurHashDrawable.bitmap.asImageBitmap())
-      } else {
-        ColorPainter(hedvigBlack)
-      }
+      val fallbackPainter = blurHashDrawable?.toPainter() ?: ColorPainter(hedvigBlack)
       return BackgroundImageUiState(
         data = marketingBackground.url,
         fallbackPainter = fallbackPainter,

--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
@@ -27,12 +27,11 @@ fun BackgroundImage(background: Background, content: @Composable BoxScope.() -> 
           MarketingBackground.Theme.DARK -> true
         }
       }
-      val placeholder by rememberBlurHash(bg.blurHash, 32, 32)
       Image(
         painter = rememberImagePainter(
           data = bg.url,
           builder = {
-            placeholder(placeholder)
+            placeholder(rememberBlurHash(background.data.blurHash, 32, 32))
             crossfade(true)
             scale(Scale.FILL)
           },

--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
@@ -1,46 +1,80 @@
 package com.hedvig.app.feature.marketing.ui
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import coil.compose.rememberImagePainter
-import coil.size.Scale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.hedvig.app.feature.marketing.Background
 import com.hedvig.app.feature.marketing.data.MarketingBackground
-import com.hedvig.app.util.compose.rememberBlurHash
+import com.hedvig.app.ui.compose.theme.hedvigBlack
+import com.hedvig.app.util.compose.blurHash
 
 @Composable
-fun BackgroundImage(background: Background, content: @Composable BoxScope.() -> Unit) {
-  Box(modifier = Modifier.fillMaxSize()) {
-    background.data?.let { bg ->
-      val systemUiController = rememberSystemUiController()
-      SideEffect {
-        systemUiController.statusBarDarkContentEnabled = when (bg.theme) {
-          MarketingBackground.Theme.LIGHT -> false
-          MarketingBackground.Theme.DARK -> true
-        }
+fun BackgroundImage(background: MarketingBackground?) {
+  val backgroundImageState = rememberBackgroundImageState(background)
+  val systemUiController = rememberSystemUiController()
+  SideEffect {
+    if (backgroundImageState.theme != null) {
+      systemUiController.statusBarDarkContentEnabled = when (backgroundImageState.theme) {
+        MarketingBackground.Theme.LIGHT -> false
+        MarketingBackground.Theme.DARK -> true
       }
-      Image(
-        painter = rememberImagePainter(
-          data = bg.url,
-          builder = {
-            placeholder(rememberBlurHash(background.data.blurHash, 32, 32))
-            crossfade(true)
-            scale(Scale.FILL)
-          },
-        ),
-        contentDescription = null,
-        modifier = Modifier.fillMaxSize(),
-        contentScale = ContentScale.Crop,
+    } else {
+      // Black background as a fallback means we want the status bar items to be light
+      systemUiController.statusBarDarkContentEnabled = false
+    }
+  }
+  AsyncImage(
+    model = backgroundImageState.data,
+    contentDescription = null,
+    contentScale = ContentScale.Crop,
+    placeholder = backgroundImageState.fallbackPainter,
+    error = backgroundImageState.fallbackPainter,
+    fallback = backgroundImageState.fallbackPainter,
+    modifier = Modifier.fillMaxSize(),
+  )
+}
+
+@Composable
+private fun rememberBackgroundImageState(
+  background: MarketingBackground?,
+  context: Context = LocalContext.current,
+): BackgroundImageUiState {
+  return remember(background, context) { BackgroundImageUiState(background, context) }
+}
+
+private class BackgroundImageUiState private constructor(
+  val data: Any?,
+  val fallbackPainter: Painter?, // Painter for any case where the image can not be loaded.
+  val theme: MarketingBackground.Theme?,
+) {
+  companion object {
+    operator fun invoke(marketingBackground: MarketingBackground?, context: Context): BackgroundImageUiState {
+      if (marketingBackground == null) {
+        return BackgroundImageUiState(null, ColorPainter(hedvigBlack), null)
+      }
+
+      val blurHashDrawable: BitmapDrawable? = blurHash(marketingBackground.blurHash, 32, 32, context)
+      val fallbackPainter = if (blurHashDrawable != null) {
+        BitmapPainter(blurHashDrawable.bitmap.asImageBitmap())
+      } else {
+        ColorPainter(hedvigBlack)
+      }
+      return BackgroundImageUiState(
+        data = marketingBackground.url,
+        fallbackPainter = fallbackPainter,
+        theme = marketingBackground.theme,
       )
     }
-    content()
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/ui/BackgroundImage.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.hedvig.android.core.designsystem.theme.hedvigBlack
 import com.hedvig.app.feature.marketing.data.MarketingBackground
-import com.hedvig.app.ui.compose.theme.hedvigBlack
 import com.hedvig.app.util.compose.blurHash
 import com.hedvig.app.util.compose.toPainter
 

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/insurely/InsurelyCard.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/insurely/InsurelyCard.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.hedvigBlack12percent
 import com.hedvig.app.R
 import com.hedvig.app.feature.offer.ui.OfferItems
 import com.hedvig.app.feature.offer.ui.OfferItems.InsurelyCard.FailedToRetrieve
 import com.hedvig.app.feature.offer.ui.OfferItems.InsurelyCard.Loading
 import com.hedvig.app.feature.offer.ui.OfferItems.InsurelyCard.Retrieved
-import com.hedvig.app.ui.compose.theme.hedvigBlack12percent
 import com.hedvig.app.ui.compose.theme.hedvigContentColorFor
 import com.hedvig.app.util.compose.preview.previewData
 import java.util.Locale

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/variants/VariantButton.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/composable/variants/VariantButton.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.ui.compose.theme.hedvigBlack
-import com.hedvig.app.ui.compose.theme.hedvigBlack12percent
+import com.hedvig.android.core.designsystem.theme.hedvigBlack
+import com.hedvig.android.core.designsystem.theme.hedvigBlack12percent
 import com.hedvig.app.util.compose.HorizontalTextsWithMaximumSpaceTaken
 import com.hedvig.app.util.compose.RadioButton
 

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/BlurredFullScreenProgressOverlay.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/BlurredFullScreenProgressOverlay.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.progressBlue
+import com.hedvig.android.core.designsystem.theme.progressYellow
 import com.hedvig.app.ui.compose.theme.HedvigTypography
-import com.hedvig.app.ui.compose.theme.progressBlue
-import com.hedvig.app.ui.compose.theme.progressYellow
 import java.lang.Float.min
 
 @Composable

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/ErrorDialog.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/ErrorDialog.kt
@@ -9,9 +9,9 @@ import com.hedvig.app.R
 
 @Composable
 fun ErrorDialog(
+  message: String?,
   onDismiss: () -> Unit,
   title: String = stringResource(com.adyen.checkout.dropin.R.string.error_dialog_title),
-  message: String?,
 ) {
   AlertDialog(
     onDismissRequest = onDismiss,

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/FullScreenProgressOverlay.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/FullScreenProgressOverlay.kt
@@ -12,8 +12,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -21,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -56,13 +55,14 @@ fun FullScreenProgressOverlay(show: Boolean) {
         Icon(
           painter = painterResource(R.drawable.ic_hedvig_h_progress),
           modifier = Modifier
-            .rotate(angle)
+            .graphicsLayer {
+              rotationZ = angle
+            }
             .animateEnterExit(
               enter = fadeIn(animationSpec = tween(200, delayMillis = 700)),
               exit = fadeOut(animationSpec = tween(200)),
             )
-            .width(32.dp)
-            .height(32.dp),
+            .size(32.dp),
           contentDescription = null,
         )
       }

--- a/app/src/main/java/com/hedvig/app/ui/compose/composables/banner/InfoBanner.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/composables/banner/InfoBanner.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.hedvigBlack12percent
 import com.hedvig.app.R
-import com.hedvig.app.ui.compose.theme.hedvigBlack12percent
 
 @Composable
 fun InfoBanner(

--- a/app/src/main/java/com/hedvig/app/ui/compose/theme/Colors.kt
+++ b/app/src/main/java/com/hedvig/app/ui/compose/theme/Colors.kt
@@ -9,25 +9,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import com.hedvig.app.R
 
-val hedvigBlack = Color(0xff121212)
-val hedvigBlack12percent = hedvigBlack.copy(alpha = 0.12f)
-val hedvigOffWhite = Color(0xfffafafa)
-val hedvigDarkGray = Color(0xff505050)
-val background = Color(0xffF6F6F6)
-
-val whiteHighEmphasis = Color(0xFFFAFAFA)
-
-val errorLight = Color(0xffDD2727)
-val errorDark = Color(0xffE24646)
-
-val textColorPrimary = Color(0xAB121212)
-val textColorPrimaryDark = Color(0x8FFAFAFA)
-
-val surfaceDark = Color(0xffBE9BF3)
-
-val progressBlue = Color(0xffC3CBD6)
-val progressYellow = Color(0xffEDCDAB)
-
 @Composable
 fun hedvigContentColorFor(backgroundColor: Color): Color {
   return when (backgroundColor) {
@@ -45,16 +26,3 @@ val Colors.warning: Color
   @Composable
   @ReadOnlyComposable
   get() = colorResource(R.color.colorWarning)
-
-@Suppress("unused")
-val Colors.onWarning: Color
-  @Composable
-  @ReadOnlyComposable
-  get() = colorResource(R.color.hedvig_black)
-
-val Colors.separator: Color
-  get() = if (isLight) {
-    hedvigBlack.copy(alpha = 0.12f)
-  } else {
-    hedvigOffWhite.copy(alpha = 0.12f)
-  }

--- a/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
+++ b/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
@@ -14,7 +14,11 @@ fun rememberBlurHash(
   height: Int,
   context: Context = LocalContext.current,
 ): BitmapDrawable? = remember(blurHash, width, height, context) {
-  BlurHashDecoder.decode(blurHash, width, height)?.let { decodedBitmap ->
+  blurHash(blurHash, width, height, context)
+}
+
+fun blurHash(blurHash: String, width: Int, height: Int, context: Context): BitmapDrawable? {
+  return BlurHashDecoder.decode(blurHash, width, height)?.let { decodedBitmap ->
     BitmapDrawable(
       context.resources,
       decodedBitmap,

--- a/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
+++ b/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.util.compose
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.hedvig.app.util.BlurHashDecoder
@@ -14,13 +13,11 @@ fun rememberBlurHash(
   width: Int,
   height: Int,
   context: Context = LocalContext.current,
-) = remember(blurHash) {
-  mutableStateOf(
-    BlurHashDecoder.decode(blurHash, width, height)?.let {
-      BitmapDrawable(
-        context.resources,
-        it,
-      )
-    },
-  )
+): BitmapDrawable? = remember(blurHash, width, height, context) {
+  BlurHashDecoder.decode(blurHash, width, height)?.let { decodedBitmap ->
+    BitmapDrawable(
+      context.resources,
+      decodedBitmap,
+    )
+  }
 }

--- a/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
+++ b/app/src/main/java/com/hedvig/app/util/compose/RememberBlurHash.kt
@@ -4,8 +4,21 @@ import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import com.hedvig.app.util.BlurHashDecoder
+
+@Composable
+fun rememberBlurHashPainter(
+  blurHash: String,
+  width: Int,
+  height: Int,
+  context: Context = LocalContext.current,
+): Painter? = remember(blurHash, width, height, context) {
+  blurHash(blurHash, width, height, context)?.toPainter()
+}
 
 @Composable
 fun rememberBlurHash(
@@ -24,4 +37,8 @@ fun blurHash(blurHash: String, width: Int, height: Int, context: Context): Bitma
       decodedBitmap,
     )
   }
+}
+
+fun BitmapDrawable.toPainter(): Painter {
+  return BitmapPainter(bitmap.asImageBitmap())
 }

--- a/app/src/test/java/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
@@ -2,6 +2,8 @@ package com.hedvig.app.feature.genericauth
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.hedvig.app.authenticate.AuthenticationTokenService
 import com.hedvig.app.feature.genericauth.otpinput.OtpInputViewModel
 import com.hedvig.app.feature.genericauth.otpinput.OtpResult
@@ -156,5 +158,22 @@ class OtpInputViewModelTest {
 
     viewModel.setInput("123")
     assertThat(viewModel.viewState.value.input).isEqualTo("123")
+  }
+
+  @Test
+  fun `updating the input after getting an error should clear the error`() = runTest {
+    otpResult = OtpResult.Error.OtpError.WrongOtp
+    viewModel.setInput("111111")
+    viewModel.submitCode("111111")
+    assertThat(viewModel.viewState.value.loadingCode).isEqualTo(true)
+    assertThat(viewModel.viewState.value.loadingResend).isEqualTo(false)
+    assertThat(viewModel.viewState.value.otpError).isNull()
+
+    advanceUntilIdle()
+    assertThat(viewModel.viewState.value.loadingCode).isEqualTo(false)
+    assertThat(viewModel.viewState.value.otpError).isNotNull()
+
+    viewModel.setInput("1")
+    assertThat(viewModel.viewState.value.otpError).isNull()
   }
 }

--- a/core-design-system/build.gradle.kts
+++ b/core-design-system/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
   api(libs.androidx.compose.material)
   debugApi(libs.androidx.compose.uiTooling)
   api(libs.androidx.compose.uiToolingPreview)
-  api(libs.accompanist.insets)
   api(libs.accompanist.insetsUi)
   implementation(libs.androidx.compose.mdcAdapter)
 }

--- a/core-design-system/src/main/java/com/hedvig/android/core/designsystem/component/BottomSheetHandle.kt
+++ b/core-design-system/src/main/java/com/hedvig/android/core/designsystem/component/BottomSheetHandle.kt
@@ -1,0 +1,23 @@
+package com.hedvig.android.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.theme.separator
+
+@Composable
+fun BottomSheetHandle(modifier: Modifier = Modifier) {
+  Box(
+    modifier = modifier
+      .size(width = 32.dp, height = 4.dp)
+      .background(
+        color = MaterialTheme.colors.separator,
+        shape = RoundedCornerShape(20.dp),
+      ),
+  )
+}

--- a/core-design-system/src/main/java/com/hedvig/android/core/designsystem/theme/Colors.kt
+++ b/core-design-system/src/main/java/com/hedvig/android/core/designsystem/theme/Colors.kt
@@ -1,0 +1,29 @@
+package com.hedvig.android.core.designsystem.theme
+
+import androidx.compose.material.Colors
+import androidx.compose.ui.graphics.Color
+
+val hedvigBlack = Color(0xff121212)
+val hedvigBlack12percent = hedvigBlack.copy(alpha = 0.12f)
+val hedvigOffWhite = Color(0xfffafafa)
+val hedvigDarkGray = Color(0xff505050)
+val background = Color(0xffF6F6F6)
+val whiteHighEmphasis = Color(0xFFFAFAFA)
+val errorLight = Color(0xffDD2727)
+val errorDark = Color(0xffE24646)
+val textColorPrimary = Color(0xAB121212)
+val textColorPrimaryDark = Color(0x8FFAFAFA)
+val surfaceDark = Color(0xffBE9BF3)
+val progressBlue = Color(0xffC3CBD6)
+val progressYellow = Color(0xffEDCDAB)
+
+@Suppress("unused")
+val Colors.onWarning: Color
+  get() = hedvigBlack
+
+val Colors.separator: Color
+  get() = if (isLight) {
+    hedvigBlack.copy(alpha = 0.12f)
+  } else {
+    hedvigOffWhite.copy(alpha = 0.12f)
+  }

--- a/core-design-system/src/main/java/com/hedvig/android/core/designsystem/theme/Theme.kt
+++ b/core-design-system/src/main/java/com/hedvig/android/core/designsystem/theme/Theme.kt
@@ -9,9 +9,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
-import com.google.accompanist.insets.LocalWindowInsets
-import com.google.accompanist.insets.ProvideWindowInsets
-import com.google.accompanist.insets.WindowInsets
 import com.google.android.material.composethemeadapter.createMdcTheme
 import java.lang.reflect.Method
 
@@ -20,17 +17,6 @@ fun HedvigTheme(
   colorOverrides: ((Colors) -> Colors)? = null,
   content: @Composable () -> Unit,
 ) {
-  if (LocalWindowInsets.current == WindowInsets.Empty) {
-    ProvideWindowInsets {
-      InnerTheme(colorOverrides, content)
-    }
-  } else {
-    InnerTheme(colorOverrides, content)
-  }
-}
-
-@Composable
-private fun InnerTheme(colorOverrides: ((Colors) -> Colors)? = null, content: @Composable () -> Unit) {
   val context = LocalContext.current
   val key = context.theme.key ?: context.theme
   val layoutDirection = LocalLayoutDirection.current

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -8,11 +8,13 @@ dependencies {
   implementation(projects.coreResources)
   implementation(projects.coreDesignSystem)
 
-  api(libs.androidx.compose.foundation)
-  api(libs.androidx.compose.material)
-  debugApi(libs.androidx.compose.uiTooling)
-  api(libs.androidx.compose.uiToolingPreview)
   api(libs.accompanist.insets)
   api(libs.accompanist.insetsUi)
+  api(libs.androidx.compose.foundation)
+  api(libs.androidx.compose.material)
+  api(libs.androidx.compose.uiToolingPreview)
+  debugApi(libs.androidx.compose.uiTooling)
   implementation(libs.androidx.compose.mdcAdapter)
+  implementation(libs.androidx.compose.uiUtil)
+  implementation(libs.coil.coil)
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
   implementation(projects.coreResources)
   implementation(projects.coreDesignSystem)
 
-  api(libs.accompanist.insets)
   api(libs.accompanist.insetsUi)
   api(libs.androidx.compose.foundation)
   api(libs.androidx.compose.material)

--- a/core-ui/src/main/java/com/hedvig/android/core/ui/DebugBorder.kt
+++ b/core-ui/src/main/java/com/hedvig/android/core/ui/DebugBorder.kt
@@ -1,0 +1,9 @@
+package com.hedvig.android.core.ui
+
+import androidx.compose.foundation.border
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+fun Modifier.debugBorder(color: Color = Color.Red, dp: Dp = 1.dp): Modifier = border(dp, color)

--- a/core-ui/src/main/java/com/hedvig/android/core/ui/preview/PreviewImageLoader.kt
+++ b/core-ui/src/main/java/com/hedvig/android/core/ui/preview/PreviewImageLoader.kt
@@ -1,0 +1,58 @@
+package com.hedvig.android.core.ui.preview
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import coil.ComponentRegistry
+import coil.ImageLoader
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.DefaultRequestOptions
+import coil.request.Disposable
+import coil.request.ErrorResult
+import coil.request.ImageRequest
+import coil.request.ImageResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+
+/**
+ * A fake ImageLoader to be used inside compose @Previews to satisfy the demands of the composables that need it.
+ * Do *not* call from production code.
+ */
+class PreviewImageLoader(private val context: Context) : ImageLoader {
+  override val components: ComponentRegistry = ComponentRegistry()
+  override val defaults: DefaultRequestOptions = DefaultRequestOptions()
+  override val diskCache: DiskCache? = null
+  override val memoryCache: MemoryCache? = null
+  override fun enqueue(request: ImageRequest): Disposable {
+    return object : Disposable {
+      override val isDisposed: Boolean
+        get() = true
+      override val job: Deferred<ImageResult>
+        get() = CompletableDeferred()
+
+      override fun dispose() {}
+    }
+  }
+
+  override suspend fun execute(request: ImageRequest): ImageResult {
+    return ErrorResult(null, request, Throwable())
+  }
+
+  override fun newBuilder(): ImageLoader.Builder {
+    return ImageLoader.Builder(context)
+  }
+
+  override fun shutdown() {}
+}
+
+/**
+ * A fake ImageLoader to be used inside compose @Previews to satisfy the demands of the composables that need it.
+ * Do *not* call from production code.
+ */
+@Composable
+fun rememberPreviewImageLoader(): PreviewImageLoader {
+  val context = LocalContext.current
+  return remember { PreviewImageLoader(context) }
+}

--- a/core-ui/src/main/java/com/hedvig/android/core/ui/scaffold/Scaffold.kt
+++ b/core-ui/src/main/java/com/hedvig/android/core/ui/scaffold/Scaffold.kt
@@ -34,8 +34,14 @@ fun Scaffold(
 @Composable
 @UiComposable
 private fun ScaffoldLayout(
-  content: @Composable @UiComposable (PaddingValues) -> Unit,
-  bottomAnchoredContent: @Composable @UiComposable () -> Unit,
+  content:
+    @Composable
+    @UiComposable
+    (PaddingValues) -> Unit,
+  bottomAnchoredContent:
+    @Composable
+    @UiComposable
+    () -> Unit,
 ) {
   SubcomposeLayout { constraints ->
     val layoutWidth = constraints.maxWidth
@@ -58,7 +64,6 @@ private fun ScaffoldLayout(
       bodyContentPlaceables.forEach {
         it.place(0, 0)
       }
-      // The bottom bar is always at the bottom of the layout
       bottomAnchoredPlaceables.forEach {
         it.place(0, layoutHeight - bottomBarHeight)
       }

--- a/core-ui/src/main/java/com/hedvig/android/core/ui/scaffold/Scaffold.kt
+++ b/core-ui/src/main/java/com/hedvig/android/core/ui/scaffold/Scaffold.kt
@@ -1,0 +1,69 @@
+package com.hedvig.android.core.ui.scaffold
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.UiComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxBy
+
+/**
+ * Stripped version of [androidx.compose.material.Scaffold] which only contains the bottomBar slot.
+ */
+@Composable
+fun Scaffold(
+  bottomBar: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  backgroundColor: Color = MaterialTheme.colors.background,
+  contentColor: Color = contentColorFor(backgroundColor),
+  content: @Composable (PaddingValues) -> Unit,
+) {
+  Surface(modifier = modifier, color = backgroundColor, contentColor = contentColor) {
+    ScaffoldLayout(
+      content = content,
+      bottomAnchoredContent = bottomBar,
+    )
+  }
+}
+
+@Composable
+@UiComposable
+private fun ScaffoldLayout(
+  content: @Composable @UiComposable (PaddingValues) -> Unit,
+  bottomAnchoredContent: @Composable @UiComposable () -> Unit,
+) {
+  SubcomposeLayout { constraints ->
+    val layoutWidth = constraints.maxWidth
+    val layoutHeight = constraints.maxHeight
+
+    val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+
+    layout(layoutWidth, layoutHeight) {
+      val bottomAnchoredPlaceables = subcompose(ScaffoldLayoutContent.BottomBar, bottomAnchoredContent).fastMap {
+        it.measure(looseConstraints)
+      }
+
+      val bottomBarHeight = bottomAnchoredPlaceables.fastMaxBy { it.height }?.height ?: 0
+
+      val bodyContentPlaceables = subcompose(ScaffoldLayoutContent.MainContent) {
+        val innerPadding = PaddingValues(bottom = bottomBarHeight.toDp())
+        content(innerPadding)
+      }.map { it.measure(looseConstraints.copy(maxHeight = layoutHeight)) }
+
+      bodyContentPlaceables.forEach {
+        it.place(0, 0)
+      }
+      // The bottom bar is always at the bottom of the layout
+      bottomAnchoredPlaceables.forEach {
+        it.place(0, layoutHeight - bottomBarHeight)
+      }
+    }
+  }
+}
+
+private enum class ScaffoldLayoutContent { MainContent, BottomBar }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,7 +91,6 @@ kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 ktlint-gradlePlugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlintGradlePlugin" }
 
 # Libraries listed alphabetically
-accompanist-insets = { module = "com.google.accompanist:accompanist-insets", version.ref = "accompanist" }
 accompanist-insetsUi = { module = "com.google.accompanist:accompanist-insets-ui", version.ref = "accompanist" }
 accompanist-pager = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }
 accompanist-pagerIndicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,6 +108,7 @@ androidx-compose-uiTestJunit = { module = "androidx.compose.ui:ui-test-junit4", 
 androidx-compose-uiTestManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose" }
 androidx-compose-uiTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose" }
 androidx-compose-uiToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidx-compose" }
+androidx-compose-uiUtil = { module = "androidx.compose.ui:ui-util", version.ref = "androidx-compose" }
 androidx-compose-uiViewBinding = { module = "androidx.compose.ui:ui-viewbinding", version.ref = "androidx-compose" }
 androidx-datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "androidx-datastore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }


### PR DESCRIPTION
Umbrella PR to gather all the accompanist migrations here before they're merged to develop.

This is due to the changes done in MaterialTheme where the accompanist insets are no longer provided therefore all the screens don't inset properly so they all need to be fixed before merging.