### PR TITLE
Change model to viewmodel

### DIFF
--- a/app/src/main/java/com/hedvig/app/SplashActivity.kt
+++ b/app/src/main/java/com/hedvig/app/SplashActivity.kt
@@ -31,7 +31,7 @@ class SplashActivity : BaseActivity(R.layout.activity_splash) {
   private val marketManager: MarketManager by inject()
   private val featureManager: FeatureManager by inject()
   private val binding by viewBinding(ActivitySplashBinding::bind)
-  private val model: SplashViewModel by viewModel()
+  private val viewModel: SplashViewModel by viewModel()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -61,7 +61,7 @@ class SplashActivity : BaseActivity(R.layout.activity_splash) {
         LoginStatus.LoggedIn,
         -> {
           val dynamicLink = getDynamicLinkFromFirebase(intent)
-          model.onDynamicLinkOpened(dynamicLink)
+          viewModel.onDynamicLinkOpened(dynamicLink)
           dynamicLink.startActivity(
             context = this@SplashActivity,
             marketManager = marketManager,

--- a/app/src/main/java/com/hedvig/app/authenticate/LoginDialog.kt
+++ b/app/src/main/java/com/hedvig/app/authenticate/LoginDialog.kt
@@ -3,26 +3,25 @@ package com.hedvig.app.authenticate
 import android.os.Bundle
 import android.view.View
 import com.hedvig.android.owldroid.graphql.type.AuthState
-import com.hedvig.app.R
 import com.hedvig.app.feature.genericauth.GenericAuthActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class LoginDialog : AuthenticateDialog() {
-  private val model: UserViewModel by viewModel()
+  private val viewModel: UserViewModel by viewModel()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    model.authStatus.observe(viewLifecycleOwner) { data ->
+    viewModel.authStatus.observe(viewLifecycleOwner) { data ->
       data.authStatus?.status?.let(::bindNewStatus)
     }
 
-    model.autoStartToken.observe(viewLifecycleOwner) { data ->
+    viewModel.autoStartToken.observe(viewLifecycleOwner) { data ->
       handleAutoStartToken(data.swedishBankIdAuth.autoStartToken)
     }
 
-    model.fetchBankIdStartToken()
+    viewModel.fetchBankIdStartToken()
 
     binding.login.setOnClickListener {
       requireActivity().startActivity(GenericAuthActivity.newInstance(requireActivity()))

--- a/app/src/main/java/com/hedvig/app/feature/adyen/payout/AdyenConnectPayoutActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/adyen/payout/AdyenConnectPayoutActivity.kt
@@ -22,7 +22,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
  * Hedvig paying to member
  */
 class AdyenConnectPayoutActivity : BaseActivity(R.layout.fragment_container_activity) {
-  private val model: AdyenConnectPayoutViewModel by viewModel()
+  private val viewModel: AdyenConnectPayoutViewModel by viewModel()
   private val marketManager: MarketManager by inject()
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,7 +36,7 @@ class AdyenConnectPayoutActivity : BaseActivity(R.layout.fragment_container_acti
       return
     }
 
-    model.payoutMethods.observe(this) { response ->
+    viewModel.payoutMethods.observe(this) { response ->
       val dropInConfiguration = DropInConfiguration
         .Builder(
           this,
@@ -62,7 +62,7 @@ class AdyenConnectPayoutActivity : BaseActivity(R.layout.fragment_container_acti
       DropIn.startPayment(this, response, dropInConfiguration)
     }
 
-    model.shouldClose.observe(this) { shouldClose ->
+    viewModel.shouldClose.observe(this) { shouldClose ->
       if (shouldClose) {
         finish()
       }

--- a/app/src/main/java/com/hedvig/app/feature/adyen/payout/ConnectPayoutResultFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/adyen/payout/ConnectPayoutResultFragment.kt
@@ -11,7 +11,7 @@ import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class ConnectPayoutResultFragment : Fragment(R.layout.connect_payout_result_fragment) {
-  private val model: AdyenConnectPayoutViewModel by sharedViewModel()
+  private val viewModel: AdyenConnectPayoutViewModel by sharedViewModel()
   private val binding by viewBinding(ConnectPayoutResultFragmentBinding::bind)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -20,7 +20,7 @@ class ConnectPayoutResultFragment : Fragment(R.layout.connect_payout_result_frag
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     binding.close.setHapticClickListener {
-      model.close()
+      viewModel.close()
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/chat/ui/GifPickerBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/chat/ui/GifPickerBottomSheet.kt
@@ -24,7 +24,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import java.util.concurrent.TimeUnit
 
 class GifPickerBottomSheet : BottomSheetDialogFragment() {
-  private val model: ChatViewModel by sharedViewModel()
+  private val viewModel: ChatViewModel by sharedViewModel()
   private val binding by viewBinding(SendGifDialogBinding::bind)
   private val imageLoader: ImageLoader by inject()
 
@@ -52,17 +52,17 @@ class GifPickerBottomSheet : BottomSheetDialogFragment() {
             if (query.isBlank()) {
               return@subscribe
             }
-            model.searchGifs(query)
+            viewModel.searchGifs(query)
           },
           { e(it) },
         )
       val adapter = GifAdapter(imageLoader) { url ->
-        model.respondWithGif(url)
+        viewModel.respondWithGif(url)
         dismiss()
       }
       gifRecyclerView.adapter = adapter
 
-      model.gifs.observe(viewLifecycleOwner) { data ->
+      viewModel.gifs.observe(viewLifecycleOwner) { data ->
         data?.gifs?.let { gifs ->
           (gifRecyclerView.adapter as? GifAdapter)?.submitList(gifs.filterNotNull())
           if (gifs.isEmpty()) {

--- a/app/src/main/java/com/hedvig/app/feature/connectpayin/PostSignExplainerFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/connectpayin/PostSignExplainerFragment.kt
@@ -33,9 +33,9 @@ class PostSignExplainerFragment : Fragment(R.layout.connect_payment_explainer_fr
 
     requireActivity().onBackPressedDispatcher.addCallback(
       viewLifecycleOwner,
-      onBackPressedCallback({
+      onBackPressedCallback {
         showConfirmCloseDialog(requireContext(), paymentType, viewModel::close)
-      },),
+      },
     )
 
     binding.apply {

--- a/app/src/main/java/com/hedvig/app/feature/connectpayin/PostSignExplainerFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/connectpayin/PostSignExplainerFragment.kt
@@ -14,7 +14,7 @@ import e
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class PostSignExplainerFragment : Fragment(R.layout.connect_payment_explainer_fragment) {
-  private val model: ConnectPaymentViewModel by sharedViewModel()
+  private val viewModel: ConnectPaymentViewModel by sharedViewModel()
   private val binding by viewBinding(ConnectPaymentExplainerFragmentBinding::bind)
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -34,7 +34,7 @@ class PostSignExplainerFragment : Fragment(R.layout.connect_payment_explainer_fr
     requireActivity().onBackPressedDispatcher.addCallback(
       viewLifecycleOwner,
       onBackPressedCallback({
-        showConfirmCloseDialog(requireContext(), paymentType, model::close)
+        showConfirmCloseDialog(requireContext(), paymentType, viewModel::close)
       },),
     )
 
@@ -50,11 +50,11 @@ class PostSignExplainerFragment : Fragment(R.layout.connect_payment_explainer_fr
         }
       }
       explainerButton.setHapticClickListener {
-        model.navigateTo(ConnectPaymentScreenState.Connect(TransitionType.ENTER_LEFT_EXIT_RIGHT))
+        viewModel.navigateTo(ConnectPaymentScreenState.Connect(TransitionType.ENTER_LEFT_EXIT_RIGHT))
       }
     }
 
-    model.readyToStart.observe(viewLifecycleOwner) { binding.explainerButton.isEnabled = it }
+    viewModel.readyToStart.observe(viewLifecycleOwner) { binding.explainerButton.isEnabled = it }
   }
 
   companion object {

--- a/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellFaqActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/crossselling/ui/detail/CrossSellFaqActivity.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.viewModelScope
 import arrow.core.Either
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.BaseActivity
-import com.hedvig.app.R
 import com.hedvig.app.feature.chat.data.ChatRepository
 import com.hedvig.app.feature.crossselling.model.NavigateChat
 import com.hedvig.app.feature.crossselling.model.NavigateEmbark
@@ -36,12 +35,12 @@ class CrossSellFaqActivity : BaseActivity() {
       ?: throw IllegalArgumentException("Programmer error: CROSS_SELL not passed to ${this.javaClass.name}")
   }
 
-  private val model: CrossSellFaqViewModel by viewModel { parametersOf(crossSell) }
+  private val viewModel: CrossSellFaqViewModel by viewModel { parametersOf(crossSell) }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    model.viewState
+    viewModel.viewState
       .flowWithLifecycle(lifecycle)
       .onEach(::handleViewState)
       .launchIn(lifecycleScope)
@@ -57,7 +56,7 @@ class CrossSellFaqActivity : BaseActivity() {
               .show(supportFragmentManager, FAQBottomSheet.TAG)
           },
           openChat = ::openChat,
-          onCtaClick = { model.onCtaClick() },
+          onCtaClick = { viewModel.onCtaClick() },
           items = crossSell.faq,
         )
       }
@@ -67,22 +66,22 @@ class CrossSellFaqActivity : BaseActivity() {
   private fun handleViewState(viewState: CrossSellFaqViewModel.ViewState) = with(viewState) {
     errorMessage?.let {
       showErrorDialog(getString(com.adyen.checkout.dropin.R.string.component_error)) {
-        model.dismissError()
+        viewModel.dismissError()
       }
     }
 
     navigateChat
       ?.navigate(this@CrossSellFaqActivity)
-      ?.also { model.actionOpened() }
+      ?.also { viewModel.actionOpened() }
 
     navigateEmbark
       ?.navigate(this@CrossSellFaqActivity)
-      ?.also { model.actionOpened() }
+      ?.also { viewModel.actionOpened() }
   }
 
   private fun openChat() {
     lifecycleScope.launch {
-      model.triggerOpenChat()
+      viewModel.triggerOpenChat()
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderFragment.kt
@@ -23,7 +23,7 @@ import java.time.Clock
 
 class AudioRecorderFragment : Fragment() {
   private val embarkViewModel: EmbarkViewModel by sharedViewModel()
-  private val model: AudioRecorderViewModel by viewModel()
+  private val viewModel: AudioRecorderViewModel by viewModel()
   private val clock: Clock by inject()
   private val hAnalytics: HAnalytics by inject()
 
@@ -33,7 +33,7 @@ class AudioRecorderFragment : Fragment() {
     ActivityResultContracts.RequestPermission(),
   ) { permissionGranted ->
     if (permissionGranted) {
-      model.startRecording()
+      viewModel.startRecording()
     } else {
       requireActivity().showPermissionExplanationDialog(permission)
     }
@@ -51,14 +51,14 @@ class AudioRecorderFragment : Fragment() {
 
     setContent {
       HedvigTheme {
-        val state by model.viewState.collectAsState()
+        val state by viewModel.viewState.collectAsState()
         AudioRecorderScreen(
           parameters = parameters,
           viewState = state,
           startRecording = ::askForPermission,
           clock = clock,
           stopRecording = {
-            model.stopRecording()
+            viewModel.stopRecording()
             logWithStoryAndStore(hAnalytics::embarkAudioRecordingStopped)
           },
           submit = {
@@ -66,15 +66,15 @@ class AudioRecorderFragment : Fragment() {
             logWithStoryAndStore(hAnalytics::embarkAudioRecordingSubmitted)
           },
           redo = {
-            model.redo()
+            viewModel.redo()
             logWithStoryAndStore(hAnalytics::embarkAudioRecordingRetry)
           },
           play = {
-            model.play()
+            viewModel.play()
             logWithStoryAndStore(hAnalytics::embarkAudioRecordingPlayback)
           },
           pause = {
-            model.pause()
+            viewModel.pause()
             logWithStoryAndStore(hAnalytics::embarkAudioRecordingStopped)
           },
         )
@@ -100,7 +100,7 @@ class AudioRecorderFragment : Fragment() {
 
   private fun askForPermission() {
     if (requireActivity().hasPermissions(permission)) {
-      model.startRecording()
+      viewModel.startRecording()
       logWithStoryAndStore(hAnalytics::embarkAudioRecordingBegin)
     } else {
       permissionResultLauncher.launch(permission)

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/datepicker/DatePickerFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/datepicker/DatePickerFragment.kt
@@ -26,7 +26,7 @@ import java.lang.IllegalArgumentException
 import java.time.format.DateTimeFormatter
 
 class DatePickerFragment : Fragment(R.layout.fragment_embark_date_picker) {
-  private val model: EmbarkViewModel by sharedViewModel()
+  private val viewModel: EmbarkViewModel by sharedViewModel()
   private val datePickerViewModel: DatePickerViewModel by viewModel()
   private val binding by viewBinding(FragmentEmbarkDatePickerBinding::bind)
   private val data: DatePickerParams
@@ -48,7 +48,7 @@ class DatePickerFragment : Fragment(R.layout.fragment_embark_date_picker) {
       continueButton
         .hapticClicks()
         .mapLatest { saveAndAnimate() }
-        .onEach { model.submitAction(data.link) }
+        .onEach { viewModel.submitAction(data.link) }
         .launchIn(viewLifecycleScope)
     }
 
@@ -85,9 +85,9 @@ class DatePickerFragment : Fragment(R.layout.fragment_embark_date_picker) {
     val date = datePickerViewModel.selectedDate.value?.format(DateTimeFormatter.ISO_DATE)
       ?: throw IllegalArgumentException("No date selected when trying to continue")
     val inputText = binding.dateLabel.text.toString()
-    model.putInStore("${data.passageName}Result", inputText)
-    model.putInStore(data.storeKey, date)
-    val response = model.preProcessResponse(data.passageName) ?: Response.SingleResponse(inputText)
+    viewModel.putInStore("${data.passageName}Result", inputText)
+    viewModel.putInStore(data.storeKey, date)
+    val response = viewModel.preProcessResponse(data.passageName) ?: Response.SingleResponse(inputText)
     animateResponse(binding.responseContainer, response)
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/askforprice/AskForPriceInfoActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/externalinsurer/askforprice/AskForPriceInfoActivity.kt
@@ -27,7 +27,7 @@ class AskForPriceInfoActivity : BaseActivity() {
       ?: throw Error("Programmer error: DATA is null in ${this.javaClass.name}")
   }
 
-  private val model: AskForPriceInfoViewModel by viewModel {
+  private val viewModel: AskForPriceInfoViewModel by viewModel {
     parametersOf(parameter.selectedInsuranceProviderCollectionId)
   }
 
@@ -56,7 +56,7 @@ class AskForPriceInfoActivity : BaseActivity() {
           AskForPriceScreen(
             parameter.selectedInsuranceProviderName,
             onSkipRetrievePriceInfo = {
-              model.onSkipRetrievePriceInfo()
+              viewModel.onSkipRetrievePriceInfo()
               finishWithResult(null, null)
             },
             onNavigateToRetrievePrice = ::startRetrievePriceActivity,

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/multiaction/MultiActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/multiaction/MultiActionFragment.kt
@@ -28,7 +28,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.core.parameter.parametersOf
 
 class MultiActionFragment : Fragment(R.layout.fragment_embark_multi_action) {
-  private val model: EmbarkViewModel by sharedViewModel()
+  private val viewModel: EmbarkViewModel by sharedViewModel()
 
   private val multiActionParams: MultiActionParams by lazy {
     requireArguments().getParcelable<MultiActionParams>(DATA)
@@ -83,15 +83,15 @@ class MultiActionFragment : Fragment(R.layout.fragment_embark_multi_action) {
       .hapticClicks()
       .mapLatest { saveAndAnimate() }
       .onEach {
-        model.submitAction(multiActionParams.link)
+        viewModel.submitAction(multiActionParams.link)
       }
       .launchIn(viewLifecycleScope)
   }
 
   private suspend fun saveAndAnimate() {
-    multiActionViewModel.onContinue(model::putInStore)
+    multiActionViewModel.onContinue(viewModel::putInStore)
     val response =
-      model.preProcessResponse(multiActionParams.passageName) ?: Response.SingleResponse("")
+      viewModel.preProcessResponse(multiActionParams.passageName) ?: Response.SingleResponse("")
     animateResponse(binding.responseContainer, response)
     delay(PASSAGE_ANIMATION_DELAY_DURATION)
   }

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/numberactionset/NumberActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/numberactionset/NumberActionFragment.kt
@@ -42,7 +42,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * Used for Embark actions NumberAction and NumberActionSet
  */
 class NumberActionFragment : Fragment(R.layout.number_action_set_fragment) {
-  private val model: EmbarkViewModel by sharedViewModel()
+  private val viewModel: EmbarkViewModel by sharedViewModel()
   private val binding by viewBinding(NumberActionSetFragmentBinding::bind)
   private val data: NumberActionParams
     get() = requireArguments().getParcelable(PARAMS)
@@ -76,7 +76,7 @@ class NumberActionFragment : Fragment(R.layout.number_action_set_fragment) {
       submit
         .hapticClicks()
         .mapLatest { saveAndAnimate() }
-        .onEach { model.submitAction(data.link) }
+        .onEach { viewModel.submitAction(data.link) }
         .launchIn(viewLifecycleScope)
 
       messages.doOnNextLayout {
@@ -114,13 +114,13 @@ class NumberActionFragment : Fragment(R.layout.number_action_set_fragment) {
           if (numberActionViewModel.valid.value == true) {
             viewLifecycleScope.launch {
               saveAndAnimate()
-              model.submitAction(data.link)
+              viewModel.submitAction(data.link)
             }
           }
         }
       }
 
-      model.getPrefillFromStore(numberAction.key)?.let { binding.input.setText(it) }
+      viewModel.getPrefillFromStore(numberAction.key)?.let { binding.input.setText(it) }
       binding.root
     }
   }
@@ -130,10 +130,10 @@ class NumberActionFragment : Fragment(R.layout.number_action_set_fragment) {
       inputView = binding.inputLayout,
       delayDuration = KEYBOARD_HIDE_DELAY_DURATION,
     )
-    numberActionViewModel.onContinue(model::putInStore)
+    numberActionViewModel.onContinue(viewModel::putInStore)
     val allInput = numberActionViewModel.getAllInput()
     val response =
-      model.preProcessResponse(data.passageName)
+      viewModel.preProcessResponse(data.passageName)
         ?: Response.SingleResponse(allInput ?: "")
     animateResponse(binding.responseContainer, response)
     delay(PASSAGE_ANIMATION_DELAY_DURATION)

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/previousinsurer/PreviousInsurerFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/previousinsurer/PreviousInsurerFragment.kt
@@ -21,7 +21,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 class PreviousInsurerFragment : Fragment(R.layout.previous_or_external_insurer_fragment) {
 
   private val binding by viewBinding(PreviousOrExternalInsurerFragmentBinding::bind)
-  private val model: EmbarkViewModel by sharedViewModel()
+  private val viewModel: EmbarkViewModel by sharedViewModel()
   private var insurerId: String? = null
 
   private val insurerData by lazy {
@@ -76,14 +76,14 @@ class PreviousInsurerFragment : Fragment(R.layout.previous_or_external_insurer_f
         .show()
     } else {
       insurerId?.let {
-        model.putInStore(insurerData.storeKey, it)
+        viewModel.putInStore(insurerData.storeKey, it)
         continueEmbark()
       } ?: d { "insurerId was null when continuing from PreviousInsurerFragment" }
     }
   }
 
   private fun continueEmbark() {
-    model.submitAction(insurerData.next)
+    viewModel.submitAction(insurerData.next)
   }
 
   private fun onShowInsurers() {

--- a/app/src/main/java/com/hedvig/app/feature/embark/passages/selectaction/SelectActionFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/passages/selectaction/SelectActionFragment.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.yield
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
-  private val model: EmbarkViewModel by sharedViewModel()
+  private val viewModel: EmbarkViewModel by sharedViewModel()
   private val binding by viewBinding(FragmentEmbarkSelectActionBinding::bind)
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -73,7 +73,7 @@ class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
       isVisible = true
       hapticClicks()
         .mapLatest { onActionSelected(action, data, responseContainer) }
-        .onEach { model.submitAction(action.link, 0) }
+        .onEach { viewModel.submitAction(action.link, 0) }
         .launchIn(viewLifecycleScope)
       text = action.label
     }
@@ -94,7 +94,7 @@ class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
               actionJob = viewLifecycleScope.launch {
                 onActionSelected(selectAction, data, responseContainer)
                 yield()
-                model.submitAction(selectAction.link, position)
+                viewModel.submitAction(selectAction.link, position)
               }
             },
           )
@@ -109,10 +109,10 @@ class SelectActionFragment : Fragment(R.layout.fragment_embark_select_action) {
     responseBinding: EmbarkResponseBinding,
   ) {
     (selectAction.keys zip selectAction.values).forEach { (key, value) ->
-      model.putInStore(key, value)
+      viewModel.putInStore(key, value)
     }
-    model.putInStore("${data.passageName}Result", selectAction.label)
-    val response = model.preProcessResponse(data.passageName)
+    viewModel.putInStore("${data.passageName}Result", selectAction.label)
+    val response = viewModel.preProcessResponse(data.passageName)
       ?: Response.SingleResponse(selectAction.label)
     animateResponse(responseBinding, response)
     delay(PASSAGE_ANIMATION_DELAY_DURATION)

--- a/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
@@ -17,7 +17,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MoreOptionsActivity : BaseActivity(R.layout.activity_more_options) {
   private val binding by viewBinding(ActivityMoreOptionsBinding::bind)
-  private val model: MemberIdViewModel by viewModel()
+  private val viewModel: MemberIdViewModel by viewModel()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -31,10 +31,10 @@ class MoreOptionsActivity : BaseActivity(R.layout.activity_more_options) {
         onBackPressed()
       }
 
-      val adapter = MoreOptionsAdapter(model)
+      val adapter = MoreOptionsAdapter(viewModel)
       recycler.adapter = adapter
 
-      model
+      viewModel
         .state
         .flowWithLifecycle(lifecycle)
         .onEach { state ->

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/HomeFragment.kt
@@ -29,7 +29,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class HomeFragment : Fragment(R.layout.home_fragment) {
-  private val model: HomeViewModel by viewModel()
+  private val viewModel: HomeViewModel by viewModel()
   private val loggedInViewModel: LoggedInViewModel by sharedViewModel()
   private val binding by viewBinding(HomeFragmentBinding::bind)
   private var scroll = 0
@@ -38,7 +38,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
 
   private val registerForActivityResult: ActivityResultLauncher<Intent> =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-      model.reload()
+      viewModel.reload()
     }
 
   override fun onResume() {
@@ -51,18 +51,18 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
 
     val homeAdapter = HomeAdapter(
       fragmentManager = parentFragmentManager,
-      retry = model::reload,
+      retry = viewModel::reload,
       startIntentForResult = ::startEmbarkForResult,
       imageLoader = imageLoader,
       marketManager = marketManager,
-      onClaimDetailCardClicked = model::onClaimDetailCardClicked,
-      onClaimDetailCardShown = model::onClaimDetailCardShown,
-      onPaymentCardShown = model::onPaymentCardShown,
+      onClaimDetailCardClicked = viewModel::onClaimDetailCardClicked,
+      onClaimDetailCardShown = viewModel::onClaimDetailCardShown,
+      onPaymentCardShown = viewModel::onPaymentCardShown,
       onPaymentCardClicked = ::onPaymentCardClicked,
     )
 
     binding.swipeToRefresh.setOnRefreshListener {
-      model.reload()
+      viewModel.reload()
     }
 
     binding.recycler.apply {
@@ -96,7 +96,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
       )
     }
 
-    model.viewState
+    viewModel.viewState
       .flowWithLifecycle(lifecycle)
       .onEach { viewState ->
         binding.swipeToRefresh.isRefreshing = viewState is HomeViewModel.ViewState.Loading
@@ -111,7 +111,7 @@ class HomeFragment : Fragment(R.layout.home_fragment) {
   }
 
   private fun onPaymentCardClicked(paymentType: PaymentType) {
-    model.onPaymentCardClicked()
+    viewModel.onPaymentCardClicked()
     val market = marketManager.market ?: return
     startActivity(
       connectPayinIntent(

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -39,12 +39,12 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
 
   private val binding by viewBinding(ChangeAddressActivityBinding::bind)
-  private val model: ChangeAddressViewModel by viewModel()
+  private val viewModel: ChangeAddressViewModel by viewModel()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    model.events
+    viewModel.events
       .flowWithLifecycle(lifecycle)
       .onEach { event ->
         when (event) {
@@ -68,7 +68,7 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
   }
 
   private fun observeViewModel() {
-    model.viewState.observe(this) { viewState ->
+    viewModel.viewState.observe(this) { viewState ->
       TransitionManager.beginDelayedTransition(binding.root)
       setViewState(viewState)
     }
@@ -109,7 +109,7 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         buttonIcon = R.drawable.ic_chat_white,
         onContinue = {
           lifecycleScope.launch {
-            model.triggerFreeTextChat()
+            viewModel.triggerFreeTextChat()
           }
         },
         viewState.upcomingAgreementResult,
@@ -122,14 +122,14 @@ class ChangeAddressActivity : BaseActivity(R.layout.change_address_activity) {
         },
         buttonText = "Try again",
         buttonIcon = null,
-        onContinue = { model.reload() },
+        onContinue = { viewModel.reload() },
       )
       is SelfChangeError -> setContent(
         titleText = getString(com.adyen.checkout.dropin.R.string.error_dialog_title),
         subtitleText = viewState.error.message ?: "Could not continue, please try again later",
         buttonText = "Try again",
         buttonIcon = null,
-        onContinue = { model.reload() },
+        onContinue = { viewModel.reload() },
       )
     }
   }

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
@@ -42,7 +42,7 @@ class ContractDetailActivity : BaseActivity(R.layout.contract_detail_activity) {
   private val contractId: String
     get() = intent.getStringExtra(ID)
       ?: throw IllegalArgumentException("Programmer error: ID not provided to ${this.javaClass.name}")
-  private val model: ContractDetailViewModel by viewModel { parametersOf(contractId) }
+  private val viewModel: ContractDetailViewModel by viewModel { parametersOf(contractId) }
   private val marketManager: MarketManager by inject()
   private val imageLoader: ImageLoader by inject()
 
@@ -79,9 +79,9 @@ class ContractDetailActivity : BaseActivity(R.layout.contract_detail_activity) {
       }.attach()
       cardContainer.arrow.isInvisible = true
       cardContainer.card.transitionName = "contract_card"
-      error.onClick = { model.loadContract(contractId) }
+      error.onClick = { viewModel.loadContract(contractId) }
 
-      model
+      viewModel
         .viewState
         .flowWithLifecycle(lifecycle)
         .onEach { viewState ->

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageFragment.kt
@@ -24,7 +24,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class CoverageFragment : Fragment(R.layout.contract_detail_coverage_fragment) {
   private val binding by viewBinding(ContractDetailCoverageFragmentBinding::bind)
-  private val model: ContractDetailViewModel by sharedViewModel()
+  private val viewModel: ContractDetailViewModel by sharedViewModel()
   private val imageLoader: ImageLoader by inject()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -41,7 +41,7 @@ class CoverageFragment : Fragment(R.layout.contract_detail_coverage_fragment) {
         lm.spanSizeLookup = ConcatSpanSizeLookup(lm.spanCount) { concatAdapter.adapters }
       }
       addItemDecoration(ConcatItemDecoration { concatAdapter.adapters })
-      model.viewState
+      viewModel.viewState
         .flowWithLifecycle(lifecycle)
         .onEach { viewState ->
           when (viewState) {

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/documents/DocumentsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/documents/DocumentsFragment.kt
@@ -17,14 +17,14 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class DocumentsFragment : Fragment(R.layout.contract_detail_documents_fragment) {
   private val binding by viewBinding(ContractDetailDocumentsFragmentBinding::bind)
-  private val model: ContractDetailViewModel by sharedViewModel()
+  private val viewModel: ContractDetailViewModel by sharedViewModel()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     binding.root.apply {
       applyNavigationBarInsets()
       val documentsAdapter = DocumentAdapter()
       adapter = documentsAdapter
-      model.viewState
+      viewModel.viewState
         .flowWithLifecycle(lifecycle)
         .onEach { viewState ->
           val listItems = when (viewState) {

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoFragment.kt
@@ -19,7 +19,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
 
   private val binding by viewBinding(ContractDetailYourInfoFragmentBinding::bind)
-  private val model: ContractDetailViewModel by sharedViewModel()
+  private val viewModel: ContractDetailViewModel by sharedViewModel()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     binding.root.applyNavigationBarInsets()
@@ -33,7 +33,7 @@ class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
       bottomYourInfoAdapter,
     )
 
-    model.viewState
+    viewModel.viewState
       .flowWithLifecycle(lifecycle)
       .onEach { viewState ->
         when (viewState) {

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
@@ -33,7 +33,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class TerminatedContractsActivity : BaseActivity(R.layout.terminated_contracts_activity) {
   private val binding by viewBinding(TerminatedContractsActivityBinding::bind)
-  private val model: TerminatedContractsViewModel by viewModel()
+  private val viewModel: TerminatedContractsViewModel by viewModel()
   private val marketManager: MarketManager by inject()
   private val imageLoader: ImageLoader by inject()
 
@@ -50,9 +50,9 @@ class TerminatedContractsActivity : BaseActivity(R.layout.terminated_contracts_a
       toolbar.applyStatusBarInsets()
       recycler.applyNavigationBarInsets()
       toolbar.setNavigationOnClickListener { onBackPressed() }
-      val adapter = InsuranceAdapter(marketManager, model::load, {}, imageLoader, {})
+      val adapter = InsuranceAdapter(marketManager, viewModel::load, {}, imageLoader, {})
       recycler.adapter = adapter
-      model
+      viewModel
         .viewState
         .flowWithLifecycle(lifecycle)
         .onEach { viewState ->

--- a/app/src/main/java/com/hedvig/app/feature/keygear/KeyGearValuationActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/KeyGearValuationActivity.kt
@@ -40,7 +40,7 @@ import java.time.LocalDate
 import java.util.Calendar
 
 class KeyGearValuationActivity : BaseActivity(R.layout.activity_key_gear_valuation) {
-  private val model: KeyGearValuationViewModel by viewModel()
+  private val viewModel: KeyGearValuationViewModel by viewModel()
   private val binding by viewBinding(ActivityKeyGearValuationBinding::bind)
 
   private var isUploading = false
@@ -74,7 +74,7 @@ class KeyGearValuationActivity : BaseActivity(R.layout.activity_key_gear_valuati
         bottom = scrollView.paddingBottom + saveContainer.measuredHeight,
       )
 
-      model.data.observe(this@KeyGearValuationActivity) { data ->
+      viewModel.data.observe(this@KeyGearValuationActivity) { data ->
         safeLet(
           data,
           data?.fragments?.keyGearItemFragment?.maxInsurableAmount?.amount,
@@ -87,7 +87,7 @@ class KeyGearValuationActivity : BaseActivity(R.layout.activity_key_gear_valuati
             getString(hedvig.resources.R.string.KEY_GEAR_ITEM_VIEW_ADD_PURCHASE_DATE_BODY, category)
         }
       }
-      model.loadItem(id)
+      viewModel.loadItem(id)
 
       dateInput.setHapticClickListener {
         val calendar = Calendar.getInstance()
@@ -126,7 +126,7 @@ class KeyGearValuationActivity : BaseActivity(R.layout.activity_key_gear_valuati
           val monetaryValue =
             MonetaryAmountV2Input(amount = price, currency = "SEK")
 
-          model.updatePurchaseDateAndPrice(id, date, monetaryValue)
+          viewModel.updatePurchaseDateAndPrice(id, date, monetaryValue)
         }
       }
 
@@ -149,7 +149,7 @@ class KeyGearValuationActivity : BaseActivity(R.layout.activity_key_gear_valuati
       }
     }
 
-    model.uploadResult.observe(this) { uploadResult ->
+    viewModel.uploadResult.observe(this) { uploadResult ->
       safeLet(
         uploadResult?.keyGearItem,
         uploadResult?.keyGearItem?.fragments?.keyGearItemFragment?.purchasePrice?.amount,

--- a/app/src/main/java/com/hedvig/app/feature/keygear/ui/createitem/CreateKeyGearItemActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/ui/createitem/CreateKeyGearItemActivity.kt
@@ -51,7 +51,7 @@ import java.io.IOException
 import kotlin.math.max
 
 class CreateKeyGearItemActivity : BaseActivity(R.layout.activity_create_key_gear_item) {
-  private val model: CreateKeyGearItemViewModel by viewModel()
+  private val viewModel: CreateKeyGearItemViewModel by viewModel()
   private val binding by viewBinding(ActivityCreateKeyGearItemBinding::bind)
 
   private lateinit var tempPhotoPath: String
@@ -83,7 +83,7 @@ class CreateKeyGearItemActivity : BaseActivity(R.layout.activity_create_key_gear
               PHOTO_PERMISSION_REQUEST_CODE,
             )
           },
-          model::deletePhoto,
+          viewModel::deletePhoto,
         )
       photos.addItemDecoration(CenterItemDecoration())
       photos.itemAnimator = SlideInItemAnimator(Gravity.START)
@@ -93,7 +93,7 @@ class CreateKeyGearItemActivity : BaseActivity(R.layout.activity_create_key_gear
       }
 
       categories.adapter = CategoryAdapter(
-        model::setActiveCategory,
+        viewModel::setActiveCategory,
       )
       categories.addItemDecoration(GridSpacingItemDecoration(BASE_MARGIN_HALF))
 
@@ -107,23 +107,23 @@ class CreateKeyGearItemActivity : BaseActivity(R.layout.activity_create_key_gear
         }
         isUploading = true
         transitionToUploading()
-        model.createItem()
+        viewModel.createItem()
       }
     }
 
-    model.photos.observe(this) { photos ->
+    viewModel.photos.observe(this) { photos ->
       photos?.let { bind(it) }
     }
 
-    model.categories.observe(this) { categories ->
+    viewModel.categories.observe(this) { categories ->
       categories?.let { bindCategories(it) }
     }
 
-    model.dirty.observe(this) { d ->
+    viewModel.dirty.observe(this) { d ->
       d?.let { dirty = it }
     }
 
-    model.createResult.observe(this) { cr ->
+    viewModel.createResult.observe(this) { cr ->
       cr?.let { showCreatedAnimation(it) }
     }
   }
@@ -270,7 +270,7 @@ class CreateKeyGearItemActivity : BaseActivity(R.layout.activity_create_key_gear
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     if (requestCode == PHOTO_REQUEST_CODE && resultCode == RESULT_OK) {
-      model.addPhotoUri(
+      viewModel.addPhotoUri(
         FileProvider.getUriForFile(
           this,
           getString(R.string.file_provider_authority),

--- a/app/src/main/java/com/hedvig/app/feature/keygear/ui/itemdetail/KeyGearItemDetailActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/ui/itemdetail/KeyGearItemDetailActivity.kt
@@ -31,7 +31,7 @@ import com.hedvig.app.util.spring
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class KeyGearItemDetailActivity : BaseActivity(R.layout.activity_key_gear_item_detail) {
-  private val model: KeyGearItemDetailViewModel by viewModel()
+  private val viewModel: KeyGearItemDetailViewModel by viewModel()
   private val binding by viewBinding(ActivityKeyGearItemDetailBinding::bind)
 
   private lateinit var photosBinder: PhotosBinder
@@ -58,16 +58,16 @@ class KeyGearItemDetailActivity : BaseActivity(R.layout.activity_key_gear_item_d
         intent.getSerializableExtra(CATEGORY) as KeyGearItemCategory,
       ) { supportStartPostponedEnterTransition() }
       valuationBinder = ValuationBinder(valuationSection)
-      nameBinder = NameBinder(nameSection, model)
+      nameBinder = NameBinder(nameSection, viewModel)
       receiptBinder =
         ReceiptBinder(receiptSection, supportFragmentManager)
     }
 
-    model.data.observe(this) { data ->
+    viewModel.data.observe(this) { data ->
       data?.let { bind(it) }
     }
 
-    model.isDeleted.observe(this) { isDeleted ->
+    viewModel.isDeleted.observe(this) { isDeleted ->
       isDeleted?.let { isd ->
         if (isd) {
           onBackPressed()
@@ -75,7 +75,7 @@ class KeyGearItemDetailActivity : BaseActivity(R.layout.activity_key_gear_item_d
       }
     }
     intent.getStringExtra(ID)?.let { id ->
-      model.loadItem(id)
+      viewModel.loadItem(id)
     }
   }
 
@@ -86,7 +86,7 @@ class KeyGearItemDetailActivity : BaseActivity(R.layout.activity_key_gear_item_d
 
   override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
     R.id.deleteItem -> {
-      model.deleteItem()
+      viewModel.deleteItem()
       true
     }
     else -> super.onOptionsItemSelected(item)

--- a/app/src/main/java/com/hedvig/app/feature/keygear/ui/itemdetail/ReceiptFileUploadBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/ui/itemdetail/ReceiptFileUploadBottomSheet.kt
@@ -3,19 +3,18 @@ package com.hedvig.app.feature.keygear.ui.itemdetail
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
-import com.hedvig.app.R
 import com.hedvig.app.ui.fragment.FileUploadBottomSheet
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class ReceiptFileUploadBottomSheet : FileUploadBottomSheet() {
-  private val model: KeyGearItemDetailViewModel by sharedViewModel()
+  private val viewModel: KeyGearItemDetailViewModel by sharedViewModel()
 
   override val title = hedvig.resources.R.string.KEY_GEAR_RECEIPT_UPLOAD_SHEET_TITLE
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    model.isUploading.observe(viewLifecycleOwner) { isUploading ->
+    viewModel.isUploading.observe(viewLifecycleOwner) { isUploading ->
       if (isUploading) {
         uploadStarted()
       } else {
@@ -25,7 +24,7 @@ class ReceiptFileUploadBottomSheet : FileUploadBottomSheet() {
   }
 
   override fun onFileChosen(uri: Uri) {
-    model.uploadReceipt(uri)
+    viewModel.uploadReceipt(uri)
   }
 
   companion object {

--- a/app/src/main/java/com/hedvig/app/feature/keygear/ui/itemdetail/viewbinders/NameBinder.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/ui/itemdetail/viewbinders/NameBinder.kt
@@ -1,7 +1,6 @@
 package com.hedvig.app.feature.keygear.ui.itemdetail.viewbinders
 
 import com.hedvig.android.owldroid.graphql.KeyGearItemQuery
-import com.hedvig.app.R
 import com.hedvig.app.databinding.KeyGearItemDetailNameSectionBinding
 import com.hedvig.app.feature.keygear.ui.createitem.label
 import com.hedvig.app.feature.keygear.ui.itemdetail.KeyGearItemDetailViewModel
@@ -13,7 +12,7 @@ import com.hedvig.app.util.extensions.view.show
 
 class NameBinder(
   private val binding: KeyGearItemDetailNameSectionBinding,
-  private val model: KeyGearItemDetailViewModel,
+  private val viewModel: KeyGearItemDetailViewModel,
 ) {
   init {
     var isEditState = false
@@ -56,7 +55,7 @@ class NameBinder(
 
   private fun updateName() {
     val name = binding.nameEditText.text.toString()
-    model.updateItemName(name)
+    viewModel.updateItemName(name)
   }
 
   private fun focusEditName() {

--- a/app/src/main/java/com/hedvig/app/feature/keygear/ui/tab/KeyGearFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/keygear/ui/tab/KeyGearFragment.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.flow.onEach
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class KeyGearFragment : Fragment(R.layout.fragment_key_gear) {
-  private val model: KeyGearViewModel by sharedViewModel()
+  private val viewModel: KeyGearViewModel by sharedViewModel()
   private val loggedInViewModel: LoggedInViewModel by sharedViewModel()
   private val binding by viewBinding(FragmentKeyGearBinding::bind)
   private var scroll = 0
@@ -55,7 +55,7 @@ class KeyGearFragment : Fragment(R.layout.fragment_key_gear) {
         }
       }
 
-      error.onClick = { model.load() }
+      error.onClick = { viewModel.load() }
 
       items.adapter =
         KeyGearItemsAdapter(
@@ -84,7 +84,7 @@ class KeyGearFragment : Fragment(R.layout.fragment_key_gear) {
       items.addItemDecoration(GridSpacingItemDecoration(BASE_MARGIN))
       items.itemAnimator = SlideInItemAnimator()
 
-      model
+      viewModel
         .data
         .flowWithLifecycle(viewLifecycle)
         .onEach { viewState ->
@@ -103,7 +103,7 @@ class KeyGearFragment : Fragment(R.layout.fragment_key_gear) {
           }
           if (!hasSentAutoAddedItems) {
             hasSentAutoAddedItems = true
-            model.sendAutoAddedItems(requireContext())
+            viewModel.sendAutoAddedItems(requireContext())
           }
         }
         .launchIn(viewLifecycleScope)

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/OfferActivity.kt
@@ -83,7 +83,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
   private val shouldShowOnNextAppStart: Boolean
     get() = intent.getBooleanExtra(SHOULD_SHOW_ON_NEXT_APP_START, false)
 
-  private val model: OfferViewModel by viewModel {
+  private val viewModel: OfferViewModel by viewModel {
     parametersOf(quoteCartId, selectedContractTypes, shouldShowOnNextAppStart)
   }
   private val binding by viewBinding(ActivityOfferBinding::bind)
@@ -131,10 +131,10 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
     val topOfferAdapter = OfferAdapter(
       fragmentManager = supportFragmentManager,
       locale = locale,
-      openQuoteDetails = model::onOpenQuoteDetails,
-      onRemoveDiscount = model::removeDiscount,
+      openQuoteDetails = viewModel::onOpenQuoteDetails,
+      onRemoveDiscount = viewModel::removeDiscount,
       onSign = ::onSign,
-      reload = model::reload,
+      reload = viewModel::reload,
       openChat = ::openChat,
     )
     val perilsAdapter = PerilsAdapter(
@@ -148,10 +148,10 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
     val bottomOfferAdapter = OfferAdapter(
       fragmentManager = supportFragmentManager,
       locale = locale,
-      openQuoteDetails = model::onOpenQuoteDetails,
-      onRemoveDiscount = model::removeDiscount,
+      openQuoteDetails = viewModel::onOpenQuoteDetails,
+      onRemoveDiscount = viewModel::removeDiscount,
       onSign = ::onSign,
-      reload = model::reload,
+      reload = viewModel::reload,
       openChat = ::openChat,
     )
 
@@ -171,7 +171,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
         ConcatSpanSizeLookup(gridLayoutManager.spanCount) { concatAdapter.adapters }
     }
 
-    model
+    viewModel
       .viewState
       .flowWithLifecycle(lifecycle)
       .onEach { viewState ->
@@ -206,7 +206,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
       }
       .launchIn(lifecycleScope)
 
-    model
+    viewModel
       .events
       .flowWithLifecycle(lifecycle)
       .onEach { event ->
@@ -333,7 +333,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
 
   private fun openChat() {
     lifecycleScope.launch {
-      model.triggerOpenChat()
+      viewModel.triggerOpenChat()
     }
   }
 
@@ -362,15 +362,15 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
 
   private fun onSign(checkoutMethod: CheckoutMethod, paymentMethods: PaymentMethodsApiResponse?) {
     when (checkoutMethod) {
-      CheckoutMethod.SWEDISH_BANK_ID -> model.onSwedishBankIdSign()
+      CheckoutMethod.SWEDISH_BANK_ID -> viewModel.onSwedishBankIdSign()
       CheckoutMethod.SIMPLE_SIGN -> {
         if (paymentMethods != null) {
           startAdyenPayment(marketManager.market, paymentMethods)
         } else {
-          model.onOpenCheckout()
+          viewModel.onOpenCheckout()
         }
       }
-      CheckoutMethod.APPROVE_ONLY -> model.approveOffer()
+      CheckoutMethod.APPROVE_ONLY -> viewModel.approveOffer()
       CheckoutMethod.NORWEGIAN_BANK_ID,
       CheckoutMethod.DANISH_BANK_ID,
       CheckoutMethod.UNKNOWN,
@@ -386,7 +386,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
       is DropInResult.CancelledByUser -> {}
       is DropInResult.Error -> showErrorDialog("Could not connect payment") {}
       is DropInResult.Finished -> {
-        model.onPaymentTokenIdReceived(PaymentTokenId(result.result))
+        viewModel.onPaymentTokenIdReceived(PaymentTokenId(result.result))
       }
       else -> {}
     }
@@ -416,7 +416,7 @@ class OfferActivity : BaseActivity(R.layout.activity_offer) {
         positiveLabel = hedvig.resources.R.string.general_back_button,
         negativeLabel = hedvig.resources.R.string.general_discard_button,
         positiveAction = {},
-        negativeAction = { model.onDiscardOffer() },
+        negativeAction = { viewModel.onDiscardOffer() },
       )
       true
     }

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/payment/PaymentActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/payment/PaymentActivity.kt
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter
 
 class PaymentActivity : BaseActivity(R.layout.activity_payment) {
   private val binding by viewBinding(ActivityPaymentBinding::bind)
-  private val model: PaymentViewModel by viewModel()
+  private val viewModel: PaymentViewModel by viewModel()
 
   private val marketManager: MarketManager by inject()
 
@@ -43,7 +43,7 @@ class PaymentActivity : BaseActivity(R.layout.activity_payment) {
       recycler.applyNavigationBarInsets()
       recycler.adapter = PaymentAdapter(marketManager, supportFragmentManager)
 
-      model
+      viewModel
         .data
         .flowWithLifecycle(lifecycle)
         .onEach { data ->

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/payment/PaymentHistoryActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/payment/PaymentHistoryActivity.kt
@@ -22,7 +22,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PaymentHistoryActivity : BaseActivity(R.layout.activity_payment_history) {
   private val binding by viewBinding(ActivityPaymentHistoryBinding::bind)
-  private val model: PaymentViewModel by viewModel()
+  private val viewModel: PaymentViewModel by viewModel()
   private val marketManager: MarketManager by inject()
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,7 +39,7 @@ class PaymentHistoryActivity : BaseActivity(R.layout.activity_payment_history) {
 
       paymentHistory.adapter = PaymentHistoryAdapter(marketManager)
 
-      model
+      viewModel
         .data
         .flowWithLifecycle(lifecycle)
         .onEach { (data, _) ->

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileFragment.kt
@@ -27,7 +27,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class ProfileFragment : Fragment(R.layout.profile_fragment) {
   private val binding by viewBinding(ProfileFragmentBinding::bind)
-  private val model: ProfileViewModel by sharedViewModel()
+  private val viewModel: ProfileViewModel by sharedViewModel()
   private val loggedInViewModel: LoggedInViewModel by sharedViewModel()
   private var scroll = 0
 
@@ -41,7 +41,7 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
 
     scroll = 0
 
-    val adapter = ProfileAdapter(viewLifecycleOwner, model::reload, model::onLogout)
+    val adapter = ProfileAdapter(viewLifecycleOwner, viewModel::reload, viewModel::onLogout)
     binding.recycler.apply {
       scroll = 0
       addOnScrollListener(
@@ -56,7 +56,7 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
       this.adapter = adapter
     }
 
-    model
+    viewModel
       .data
       .flowWithLifecycle(viewLifecycle)
       .onEach { viewState ->
@@ -70,7 +70,7 @@ class ProfileFragment : Fragment(R.layout.profile_fragment) {
       }
       .launchIn(viewLifecycleScope)
 
-    model.events
+    viewModel.events
       .flowWithLifecycle(lifecycle)
       .onEach { event ->
         when (event) {

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/activated/ReferralsActivatedActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/activated/ReferralsActivatedActivity.kt
@@ -23,7 +23,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class ReferralsActivatedActivity : BaseActivity(R.layout.activity_referrals_activated) {
   private val binding by viewBinding(ActivityReferralsActivatedBinding::bind)
-  private val model: ReferralsActivatedViewModel by viewModel()
+  private val viewModel: ReferralsActivatedViewModel by viewModel()
   private val marketManager: MarketManager by inject()
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,7 +45,7 @@ class ReferralsActivatedActivity : BaseActivity(R.layout.activity_referrals_acti
         finish()
       }
 
-      model.data.observe(this@ReferralsActivatedActivity) { data ->
+      viewModel.data.observe(this@ReferralsActivatedActivity) { data ->
         data
           .referralInformation
           .campaign

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/editcode/ReferralsEditCodeActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/editcode/ReferralsEditCodeActivity.kt
@@ -26,7 +26,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class ReferralsEditCodeActivity : BaseActivity(R.layout.activity_referrals_edit_code) {
   private val binding by viewBinding(ActivityReferralsEditCodeBinding::bind)
-  private val model: ReferralsEditCodeViewModel by viewModel()
+  private val viewModel: ReferralsEditCodeViewModel by viewModel()
 
   private var isSubmitting = false
   private var dirty = false
@@ -65,7 +65,7 @@ class ReferralsEditCodeActivity : BaseActivity(R.layout.activity_referrals_edit_
 
       code.setText(currentCode)
       code.onChange { newValue ->
-        model.setIsDirty()
+        viewModel.setIsDirty()
         when (validate(newValue)) {
           ValidationResult.VALID -> {
             toolbar.menu.findItem(R.id.save).isEnabled = true
@@ -91,7 +91,7 @@ class ReferralsEditCodeActivity : BaseActivity(R.layout.activity_referrals_edit_
         false
       }
 
-      model.isSubmitting.observe(this@ReferralsEditCodeActivity) { iss ->
+      viewModel.isSubmitting.observe(this@ReferralsEditCodeActivity) { iss ->
         isSubmitting = iss
 
         toolbar.menu.findItem(R.id.save).let { save ->
@@ -107,9 +107,9 @@ class ReferralsEditCodeActivity : BaseActivity(R.layout.activity_referrals_edit_
           }
         }
       }
-      model.dirty.observe(this@ReferralsEditCodeActivity) { dirty = it }
+      viewModel.dirty.observe(this@ReferralsEditCodeActivity) { dirty = it }
 
-      model
+      viewModel
         .data
         .flowWithLifecycle(lifecycle)
         .onEach { viewState ->
@@ -189,7 +189,7 @@ class ReferralsEditCodeActivity : BaseActivity(R.layout.activity_referrals_edit_
     }
     val enteredCode = binding.code.text.toString()
     if (validate(enteredCode) == ValidationResult.VALID) {
-      model.changeCode(enteredCode)
+      viewModel.changeCode(enteredCode)
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeBottomSheet.kt
@@ -27,7 +27,7 @@ abstract class RedeemCodeBottomSheet : BottomSheetDialogFragment() {
 
   abstract val quoteCartId: QuoteCartId?
 
-  private val model: RedeemCodeViewModel by viewModel {
+  private val viewModel: RedeemCodeViewModel by viewModel {
     parametersOf(quoteCartId)
   }
 
@@ -63,7 +63,7 @@ abstract class RedeemCodeBottomSheet : BottomSheetDialogFragment() {
 
       viewLifecycleScope.launchWhenStarted {
         viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-          model.viewState.collect { state ->
+          viewModel.viewState.collect { state ->
             state.errorMessage?.let {
               wrongPromotionCode(it)
             }
@@ -80,7 +80,7 @@ abstract class RedeemCodeBottomSheet : BottomSheetDialogFragment() {
   }
 
   private fun redeemPromotionCode(code: CampaignCode) {
-    model.redeemReferralCode(code)
+    viewModel.redeemReferralCode(code)
   }
 
   private fun wrongPromotionCode(errorMessage: String) {

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/redeemcode/RefetchingRedeemCodeBottomSheet.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/redeemcode/RefetchingRedeemCodeBottomSheet.kt
@@ -9,10 +9,10 @@ class RefetchingRedeemCodeBottomSheet : RedeemCodeBottomSheet() {
   override val quoteCartId: QuoteCartId?
     get() = null
 
-  private val model: PaymentViewModel by sharedViewModel()
+  private val viewModel: PaymentViewModel by sharedViewModel()
 
   override fun onRedeemSuccess(data: RedeemReferralCodeMutation.Data) {
-    model.load()
+    viewModel.load()
     dismiss()
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/settings/SettingsActivity.kt
@@ -52,7 +52,7 @@ class SettingsActivity : BaseActivity(R.layout.activity_settings) {
   class PreferenceFragment : PreferenceFragmentCompat() {
     private val marketManager: MarketManager by inject()
     private val userViewModel: UserViewModel by sharedViewModel()
-    private val model: SettingsViewModel by sharedViewModel()
+    private val viewModel: SettingsViewModel by sharedViewModel()
     private val localeManager: LocaleManager by inject()
 
     @SuppressLint("ApplySharedPref")
@@ -138,7 +138,7 @@ class SettingsActivity : BaseActivity(R.layout.activity_settings) {
             Language
               .from(v)
               .apply(requireContext()).let { ctx ->
-                model.save(makeLocaleString(ctx, marketManager.market), localeManager.defaultLocale())
+                viewModel.save(makeLocaleString(ctx, marketManager.market), localeManager.defaultLocale())
               }
           }
           true

--- a/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/trustly/TrustlyConnectFragment.kt
@@ -57,13 +57,13 @@ class TrustlyConnectFragment : Fragment(R.layout.trustly_connect_fragment) {
     if (isPostSign) {
       requireActivity().onBackPressedDispatcher.addCallback(
         viewLifecycleOwner,
-        onBackPressedCallback({
+        onBackPressedCallback {
           showConfirmCloseDialog(
             requireContext(),
             ConnectPayinType.TRUSTLY,
             connectPaymentViewModel::close,
           )
-        },),
+        },
       )
     }
 

--- a/app/src/main/java/com/hedvig/app/feature/zignsec/ui/ErrorFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/zignsec/ui/ErrorFragment.kt
@@ -15,7 +15,7 @@ import com.hedvig.app.feature.zignsec.SimpleSignAuthenticationViewModel
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class ErrorFragment : Fragment() {
-  private val model: SimpleSignAuthenticationViewModel by sharedViewModel()
+  private val viewModel: SimpleSignAuthenticationViewModel by sharedViewModel()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -29,7 +29,7 @@ class ErrorFragment : Fragment() {
       setContent {
         HedvigTheme {
           GenericErrorScreen(
-            onRetryButtonClick = { model.cancelSignIn() },
+            onRetryButtonClick = { viewModel.cancelSignIn() },
             modifier = Modifier
               .padding(16.dp)
               .padding(top = (80 - 16).dp),

--- a/app/src/main/java/com/hedvig/app/feature/zignsec/ui/IdentityInputFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/zignsec/ui/IdentityInputFragment.kt
@@ -21,7 +21,7 @@ import org.koin.core.parameter.parametersOf
 
 class IdentityInputFragment : Fragment(R.layout.identity_input_fragment) {
   private val binding by viewBinding(IdentityInputFragmentBinding::bind)
-  private val model: SimpleSignAuthenticationViewModel by sharedViewModel { parametersOf(data) }
+  private val viewModel: SimpleSignAuthenticationViewModel by sharedViewModel { parametersOf(data) }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -50,22 +50,22 @@ class IdentityInputFragment : Fragment(R.layout.identity_input_fragment) {
           signIn.setText(hedvig.resources.R.string.simple_sign_sign_in_dk)
         }
         else -> {
-          model.invalidMarket()
+          viewModel.invalidMarket()
           return
         }
       }
 
       inputText.apply {
         requestFocus()
-        doOnTextChanged { text, _, _, _ -> model.setInput(text) }
+        doOnTextChanged { text, _, _, _ -> viewModel.setInput(text) }
         onImeAction { startZignSecIfValid() }
       }
-      model.isValid.observe(viewLifecycleOwner) { isValid ->
-        if (model.isSubmitting.value != true) {
+      viewModel.isValid.observe(viewLifecycleOwner) { isValid ->
+        if (viewModel.isSubmitting.value != true) {
           signIn.isEnabled = isValid
         }
       }
-      model.isSubmitting.observe(viewLifecycleOwner) { isSubmitting ->
+      viewModel.isSubmitting.observe(viewLifecycleOwner) { isSubmitting ->
         if (isSubmitting) {
           signIn.isEnabled = false
         }
@@ -78,8 +78,8 @@ class IdentityInputFragment : Fragment(R.layout.identity_input_fragment) {
   }
 
   private fun startZignSecIfValid() {
-    if (model.isValid.value == true) {
-      model.startZignSec()
+    if (viewModel.isValid.value == true) {
+      viewModel.startZignSec()
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/feature/zignsec/ui/ZignSecWebViewFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/zignsec/ui/ZignSecWebViewFragment.kt
@@ -17,7 +17,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class ZignSecWebViewFragment : Fragment(R.layout.activity_zign_sec_authentication) {
   private val binding by viewBinding(ActivityZignSecAuthenticationBinding::bind)
-  private val model: SimpleSignAuthenticationViewModel by sharedViewModel()
+  private val viewModel: SimpleSignAuthenticationViewModel by sharedViewModel()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -45,7 +45,7 @@ class ZignSecWebViewFragment : Fragment(R.layout.activity_zign_sec_authenticatio
               return true
             }
             if (request?.url?.toString()?.contains("fail") == true) {
-              model.authFailed()
+              viewModel.authFailed()
               return true
             }
             request?.url?.toString()?.let { view?.loadUrl(it) }
@@ -62,7 +62,7 @@ class ZignSecWebViewFragment : Fragment(R.layout.activity_zign_sec_authenticatio
           }
         }
       }
-      model.zignSecUrl.observe(viewLifecycleOwner) { danishBankIdContainer.loadUrl(it) }
+      viewModel.zignSecUrl.observe(viewLifecycleOwner) { danishBankIdContainer.loadUrl(it) }
     }
   }
 

--- a/app/src/main/java/com/hedvig/app/util/OnBackPressedCallback.kt
+++ b/app/src/main/java/com/hedvig/app/util/OnBackPressedCallback.kt
@@ -2,7 +2,7 @@ package com.hedvig.app.util
 
 import androidx.activity.OnBackPressedCallback
 
-inline fun onBackPressedCallback(crossinline callback: () -> Unit, enabled: Boolean = true) =
+inline fun onBackPressedCallback(enabled: Boolean = true, crossinline callback: () -> Unit) =
   object : OnBackPressedCallback(enabled) {
     override fun handleOnBackPressed() {
       callback()

--- a/app/src/test/java/com/hedvig/app/feature/marketing/ui/MarketingViewModelTest.kt
+++ b/app/src/test/java/com/hedvig/app/feature/marketing/ui/MarketingViewModelTest.kt
@@ -50,10 +50,10 @@ class MarketingViewModelTest {
 
   @Test
   fun `when no market is selected, should display the market picker`() = runTest {
-    val model = createMarketingViewModel()
+    val viewModel = createMarketingViewModel()
 
-    assertThat(model.state.value.selectedMarket).isEqualTo(null)
-    assertThat(model.state.value).prop(com.hedvig.app.feature.marketing.MarketingViewState::isLoading).isTrue()
+    assertThat(viewModel.state.value.selectedMarket).isEqualTo(null)
+    assertThat(viewModel.state.value).prop(com.hedvig.app.feature.marketing.MarketingViewState::isLoading).isTrue()
   }
 
   @Test
@@ -61,71 +61,71 @@ class MarketingViewModelTest {
     val initialValues = mockk<GetInitialMarketPickerValuesUseCase>()
     coEvery { initialValues.invoke() } returns Pair(Market.SE, Language.EN_SE)
 
-    val model = createMarketingViewModel(getInitialMarketPickerValuesUseCase = initialValues)
+    val viewModel = createMarketingViewModel(getInitialMarketPickerValuesUseCase = initialValues)
     advanceUntilIdle()
 
-    assertThat(model.state.value.isLoading).isFalse()
-    assertThat(model.state.value.market).isEqualTo(Market.SE)
+    assertThat(viewModel.state.value.isLoading).isFalse()
+    assertThat(viewModel.state.value.market).isEqualTo(Market.SE)
   }
 
   @Test
   fun `when selecting a market, should update with that market showing`() = runTest {
-    val model = createMarketingViewModel()
+    val viewModel = createMarketingViewModel()
     advanceUntilIdle()
-    model.setMarket(Market.SE)
+    viewModel.setMarket(Market.SE)
 
-    assertThat(model.state.value.market).isEqualTo(Market.SE)
+    assertThat(viewModel.state.value.market).isEqualTo(Market.SE)
   }
 
   @Test
   fun `when selecting a language, should update with that language showing`() = runTest {
-    val model = createMarketingViewModel()
+    val viewModel = createMarketingViewModel()
     advanceUntilIdle()
-    model.setLanguage(Language.EN_SE)
+    viewModel.setLanguage(Language.EN_SE)
 
-    assertThat(model.state.value.language).isEqualTo(Language.EN_SE)
+    assertThat(viewModel.state.value.language).isEqualTo(Language.EN_SE)
   }
 
   @Test
   fun `after setting both market and language, should be able to set`() = runTest {
-    val model = createMarketingViewModel()
+    val viewModel = createMarketingViewModel()
 
     advanceUntilIdle()
-    model.setMarket(Market.SE)
-    model.setLanguage(Language.EN_SE)
+    viewModel.setMarket(Market.SE)
+    viewModel.setLanguage(Language.EN_SE)
 
-    assertThat(model.state.value.canSetMarketAndLanguage()).isTrue()
+    assertThat(viewModel.state.value.canSetMarketAndLanguage()).isTrue()
   }
 
   @Test
   fun `when setting market but not language, should set a default language for that market`() = runTest {
-    val model = createMarketingViewModel()
+    val viewModel = createMarketingViewModel()
 
     advanceUntilIdle()
-    model.setMarket(Market.SE)
+    viewModel.setMarket(Market.SE)
 
-    assertThat(model.state.value.language).isNotNull()
+    assertThat(viewModel.state.value.language).isNotNull()
   }
 
   @Test
   fun `when switching market and old language is incompatible, should set default language for that market`() =
     runTest {
-      val model = createMarketingViewModel()
+      val viewModel = createMarketingViewModel()
 
       advanceUntilIdle()
-      model.setMarket(Market.SE)
-      model.setMarket(Market.NO)
+      viewModel.setMarket(Market.SE)
+      viewModel.setMarket(Market.NO)
 
-      assertThat(model.state.value.language).all {
+      assertThat(viewModel.state.value.language).all {
         isNotNull()
         isNotEqualTo(Language.EN_SE)
       }
     }
 
   @Test
-  fun `when a market is provided to view model, should have a selected market`() = runTest {
-    val model = createMarketingViewModel(market = Market.SE)
-    assertThat(model.state.value.selectedMarket).isEqualTo(Market.SE)
+  fun `when a market is provided to viewModel, should have a selected market`() = runTest {
+    val viewModel = createMarketingViewModel(market = Market.SE)
+    assertThat(viewModel.state.value.selectedMarket).isEqualTo(Market.SE)
   }
 
   @Test
@@ -133,15 +133,15 @@ class MarketingViewModelTest {
     val submitMarketAndLanguagePreferencesUseCase = mockk<SubmitMarketAndLanguagePreferencesUseCase>()
     coEvery { submitMarketAndLanguagePreferencesUseCase.invoke(any(), any()) } returns Either.Right(Unit)
 
-    val model = createMarketingViewModel(
+    val viewModel = createMarketingViewModel(
       market = null,
       submitMarketAndLanguagePreferencesUseCase = submitMarketAndLanguagePreferencesUseCase,
     )
     advanceUntilIdle()
-    model.setMarket(Market.SE)
-    model.submitMarketAndLanguage()
+    viewModel.setMarket(Market.SE)
+    viewModel.submitMarketAndLanguage()
     advanceUntilIdle()
 
-    assertThat(model.state.value.selectedMarket).isNotNull()
+    assertThat(viewModel.state.value.selectedMarket).isNotNull()
   }
 }


### PR DESCRIPTION
Just a consistency PR, since when we're talking about them we always refer to viewmodels as "viewModel(s)" I think it makes it easier on your brain to see `viewModel` and know what it means.
We do use the term `model` some times in the code base also for a simple class which holds the "model" of an UI, like [here](https://github.com/HedvigInsurance/android/blob/f689a0e2e0122c53bda476a81cdb2d7ef6ec6565/app/src/main/java/com/hedvig/app/feature/checkout/CheckoutViewModel.kt#L85) so figured this change makes sense to differentiate from such usages.