### PR TITLE
Error handling/no internet

### DIFF
--- a/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkStoryTesterActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/embark/EmbarkStoryTesterActivity.kt
@@ -47,6 +47,7 @@ import com.hedvig.app.feature.embark.ui.EmbarkActivity
 import com.hedvig.app.feature.home.ui.changeaddress.appendQuoteCartId
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/engineering/java/com/hedvig/app/feature/impersonation/ImpersonationReceiverActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/impersonation/ImpersonationReceiverActivity.kt
@@ -25,6 +25,7 @@ import com.hedvig.app.authenticate.AuthenticationTokenService
 import com.hedvig.app.authenticate.LoginStatusService
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/engineering/java/com/hedvig/app/feature/referrals/MockReferralsViewModel.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/referrals/MockReferralsViewModel.kt
@@ -2,36 +2,45 @@ package com.hedvig.app.feature.referrals
 
 import android.os.Handler
 import android.os.Looper.getMainLooper
+import com.hedvig.app.feature.referrals.ui.tab.ReferralsUiState
 import com.hedvig.app.feature.referrals.ui.tab.ReferralsViewModel
 import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNTS
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class MockReferralsViewModel : ReferralsViewModel() {
+
+  private val _data = MutableStateFlow<ReferralsUiState>(ReferralsUiState.Loading)
+  override val data: StateFlow<ReferralsUiState> = _data.asStateFlow()
+
   init {
     if (loadInitially) {
-      load()
+      reload()
     }
   }
 
-  override fun load() {
+  override fun reload() {
+    _data.value = ReferralsUiState.Loading
     if (shouldSucceed) {
       Handler(getMainLooper()).postDelayed(
         {
           if (!hasLoadedOnce) {
             hasLoadedOnce = true
-            _data.value = ViewState.Success(
+            _data.value = ReferralsUiState.Success(
               data = referralsData,
+              isLoading = false,
             )
           } else {
-            _data.value = ViewState.Error
+            _data.value = ReferralsUiState.Error(false)
           }
         },
         1000,
       )
     } else {
       shouldSucceed = true
-      _data.value = ViewState.Error
+      _data.value = ReferralsUiState.Error(false)
     }
-    _isRefreshing.postValue(false)
   }
 
   companion object {
@@ -39,6 +48,5 @@ class MockReferralsViewModel : ReferralsViewModel() {
     var shouldSucceed = false
     var referralsData = REFERRALS_DATA_WITH_NO_DISCOUNTS
     var hasLoadedOnce = false
-    var afterRefreshData = referralsData
   }
 }

--- a/app/src/engineering/java/com/hedvig/app/feature/referrals/ReferralsMockActivity.kt
+++ b/app/src/engineering/java/com/hedvig/app/feature/referrals/ReferralsMockActivity.kt
@@ -20,7 +20,6 @@ import com.hedvig.app.referralsModule
 import com.hedvig.app.service.push.senders.ReferralsNotificationSender
 import com.hedvig.app.service.push.senders.ReferralsNotificationSender.Companion.DATA_MESSAGE_REFERRED_SUCCESS_NAME
 import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_MULTIPLE_REFERRALS_IN_DIFFERENT_STATES
-import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_NO_DISCOUNTS
 import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_ONE_REFEREE
 import com.hedvig.app.testdata.feature.referrals.REFERRALS_DATA_WITH_ONE_REFEREE_AND_OTHER_DISCOUNT
 import com.hedvig.app.testdata.feature.referrals.builders.EditCodeDataBuilder
@@ -59,7 +58,6 @@ class ReferralsMockActivity : MockActivity() {
         loadInitially = true
         shouldSucceed = true
         hasLoadedOnce = false
-        afterRefreshData = REFERRALS_DATA_WITH_NO_DISCOUNTS
       }
       startReferralsTab()
     }
@@ -69,7 +67,6 @@ class ReferralsMockActivity : MockActivity() {
         shouldSucceed = true
         hasLoadedOnce = false
         referralsData = REFERRALS_DATA_WITH_ONE_REFEREE
-        afterRefreshData = REFERRALS_DATA_WITH_ONE_REFEREE
       }
       startReferralsTab()
     }
@@ -79,8 +76,6 @@ class ReferralsMockActivity : MockActivity() {
         shouldSucceed = true
         hasLoadedOnce = false
         referralsData = REFERRALS_DATA_WITH_MULTIPLE_REFERRALS_IN_DIFFERENT_STATES
-        afterRefreshData =
-          REFERRALS_DATA_WITH_MULTIPLE_REFERRALS_IN_DIFFERENT_STATES
       }
       startReferralsTab()
     }
@@ -90,17 +85,6 @@ class ReferralsMockActivity : MockActivity() {
         shouldSucceed = true
         hasLoadedOnce = false
         referralsData = REFERRALS_DATA_WITH_ONE_REFEREE_AND_OTHER_DISCOUNT
-        afterRefreshData = REFERRALS_DATA_WITH_ONE_REFEREE_AND_OTHER_DISCOUNT
-      }
-      startReferralsTab()
-    }
-    clickableItem("Pull to Refresh, Empty then One Referee") {
-      MockReferralsViewModel.apply {
-        loadInitially = true
-        shouldSucceed = true
-        referralsData = REFERRALS_DATA_WITH_NO_DISCOUNTS
-        hasLoadedOnce = false
-        afterRefreshData = REFERRALS_DATA_WITH_ONE_REFEREE
       }
       startReferralsTab()
     }

--- a/app/src/main/java/com/hedvig/app/authenticate/LoginStatusService.kt
+++ b/app/src/main/java/com/hedvig/app/authenticate/LoginStatusService.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.owldroid.graphql.ContractStatusQuery
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toOption
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/hedvig/app/authenticate/LogoutUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/authenticate/LogoutUseCase.kt
@@ -23,7 +23,7 @@ class LogoutUseCase(
     data class Error(val message: String?) : LogoutResult()
   }
 
-  suspend fun logout() = when (val result = userRepository.logout()) {
+  suspend fun invoke(): LogoutResult = when (val result = userRepository.logout()) {
     is QueryResult.Error -> LogoutResult.Error(result.message)
     is QueryResult.Success -> {
       clearLoginStatus()

--- a/app/src/main/java/com/hedvig/app/authenticate/UserViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/authenticate/UserViewModel.kt
@@ -67,7 +67,7 @@ class UserViewModel(
 
   fun logout() {
     viewModelScope.launch {
-      when (val result = logoutUserCase.logout()) {
+      when (val result = logoutUserCase.invoke()) {
         is LogoutUseCase.LogoutResult.Error -> {
           _events.trySend(Event.Error(result.message))
         }

--- a/app/src/main/java/com/hedvig/app/feature/addressautocompletion/data/GetDanishAddressAutoCompletionUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/addressautocompletion/data/GetDanishAddressAutoCompletionUseCase.kt
@@ -8,6 +8,7 @@ import com.hedvig.app.feature.addressautocompletion.model.DanishAddress
 import com.hedvig.app.feature.addressautocompletion.model.DanishAddressInput
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetDanishAddressAutoCompletionUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/adyen/ConnectPaymentUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/adyen/ConnectPaymentUseCase.kt
@@ -9,6 +9,7 @@ import com.hedvig.android.market.Market
 import com.hedvig.android.market.MarketManager
 import com.hedvig.android.owldroid.graphql.ConnectPaymentMutation
 import com.hedvig.app.util.apollo.GraphQLQueryHandler
+import com.hedvig.app.util.apollo.toEither
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.json.JSONObject

--- a/app/src/main/java/com/hedvig/app/feature/adyen/ConnectPayoutUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/adyen/ConnectPayoutUseCase.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.owldroid.graphql.TokenizePayoutDetailsMutation
 import com.hedvig.android.owldroid.graphql.type.TokenizationResultType
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import org.json.JSONObject
 
 class ConnectPayoutUseCase(

--- a/app/src/main/java/com/hedvig/app/feature/adyen/SubmitAdditionalPaymentDetailsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/adyen/SubmitAdditionalPaymentDetailsUseCase.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.owldroid.graphql.SubmitAdditionalPaymentDetailsMutation
 import com.hedvig.android.owldroid.graphql.type.TokenizationResultType
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import org.json.JSONObject
 
 class SubmitAdditionalPaymentDetailsUseCase(

--- a/app/src/main/java/com/hedvig/app/feature/chat/data/ChatRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/chat/data/ChatRepository.kt
@@ -30,6 +30,7 @@ import com.hedvig.android.owldroid.graphql.type.ChatResponseSingleSelectInput
 import com.hedvig.android.owldroid.graphql.type.ChatResponseTextInput
 import com.hedvig.app.service.FileService
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import com.hedvig.app.util.extensions.into
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/hedvig/app/feature/checkout/EditCheckoutUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/checkout/EditCheckoutUseCase.kt
@@ -12,6 +12,7 @@ import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.GraphQLQueryHandler
+import com.hedvig.app.util.apollo.toEither
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject

--- a/app/src/main/java/com/hedvig/app/feature/claimdetail/data/GetClaimDetailUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/claimdetail/data/GetClaimDetailUseCase.kt
@@ -10,6 +10,7 @@ import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.hedvig.android.owldroid.graphql.ClaimDetailsQuery
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetClaimDetailUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/embark/EmbarkRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/EmbarkRepository.kt
@@ -6,6 +6,7 @@ import com.hedvig.android.owldroid.graphql.EmbarkStoryQuery
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class EmbarkRepository(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/embark/quotecart/CreateQuoteCartUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/embark/quotecart/CreateQuoteCartUseCase.kt
@@ -9,6 +9,7 @@ import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class CreateQuoteCartUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/genericauth/CreateOtpAttemptUseCaseImpl.kt
+++ b/app/src/main/java/com/hedvig/app/feature/genericauth/CreateOtpAttemptUseCaseImpl.kt
@@ -5,6 +5,7 @@ import arrow.core.merge
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.owldroid.graphql.CreateOtpAttemptMutation
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import e
 
 interface CreateOtpAttemptUseCase {

--- a/app/src/main/java/com/hedvig/app/feature/home/data/GetHomeUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/data/GetHomeUseCase.kt
@@ -8,6 +8,7 @@ import com.hedvig.android.owldroid.graphql.HomeQuery
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetHomeUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.feature.embark.QUOTE_CART_ID_KEY
 import com.hedvig.app.feature.embark.quotecart.CreateQuoteCartUseCase
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetAddressChangeStoryIdUseCase(
   private val createQuoteCartUseCase: CreateQuoteCartUseCase,

--- a/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
@@ -7,6 +7,7 @@ import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetContractsUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceAdapter.kt
@@ -178,8 +178,7 @@ class InsuranceAdapter(
         composeView.setContent {
           HedvigTheme {
             GenericErrorScreen(
-              description = data.message
-                ?: composeView.context.getString(hedvig.resources.R.string.home_tab_error_body),
+              description = composeView.context.getString(hedvig.resources.R.string.home_tab_error_body),
               onRetryButtonClick = { retry() },
               modifier = Modifier
                 .padding(16.dp)

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/InsuranceModel.kt
@@ -17,7 +17,7 @@ sealed class InsuranceModel {
     val inner: CrossSellData,
   ) : InsuranceModel()
 
-  data class Error(val message: String?) : InsuranceModel()
+  object Error : InsuranceModel()
 
   object TerminatedContractsHeader : InsuranceModel()
   data class TerminatedContracts(val quantity: Int) : InsuranceModel()

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.owldroid.graphql.InsuranceQuery
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetContractDetailsUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/InsuranceFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/InsuranceFragment.kt
@@ -74,10 +74,10 @@ class InsuranceFragment : Fragment(R.layout.fragment_insurance) {
             ?.also { insuranceViewModel.crossSellActionOpened() }
 
           when {
-            errorMessage != null -> insuranceAdapter.submitList(
+            hasError -> insuranceAdapter.submitList(
               listOf(
                 InsuranceModel.Header,
-                InsuranceModel.Error(errorMessage),
+                InsuranceModel.Error,
               ),
             )
             items != null -> insuranceAdapter.submitList(items)

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/InsuranceViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/tab/InsuranceViewModel.kt
@@ -30,7 +30,7 @@ class InsuranceViewModel(
     val items: List<InsuranceModel>? = null,
     val navigateEmbark: NavigateEmbark? = null,
     val navigateChat: NavigateChat? = null,
-    val errorMessage: String? = null,
+    val hasError: Boolean = false,
     val loading: Boolean = false,
   )
 
@@ -41,7 +41,7 @@ class InsuranceViewModel(
     viewModelScope.launch {
       _viewState.value = ViewState(loading = true)
       when (val result = getContractsUseCase.invoke()) {
-        is Either.Left -> _viewState.value = ViewState(errorMessage = result.value.message, items = null)
+        is Either.Left -> _viewState.value = ViewState(hasError = true, items = null)
         is Either.Right -> _viewState.value = ViewState(items = createInsuranceItems(result))
       }
     }
@@ -89,7 +89,7 @@ class InsuranceViewModel(
 
   private suspend fun CrossSellData.Action.Embark.toViewState(): ViewState {
     return when (val result = createQuoteCartUseCase.invoke()) {
-      is Either.Left -> _viewState.value.copy(errorMessage = result.value.message)
+      is Either.Left -> _viewState.value.copy(hasError = true)
       is Either.Right -> {
         val embarkStoryId = appendQuoteCartId(embarkStoryId, result.value.id)
         val navigateEmbark = NavigateEmbark(embarkStoryId, title)

--- a/app/src/main/java/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
+++ b/app/src/main/java/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
@@ -58,7 +58,7 @@ class TerminatedContractsActivity : BaseActivity(R.layout.terminated_contracts_a
         .onEach { viewState ->
           when (viewState) {
             is TerminatedContractsViewModel.ViewState.Error -> {
-              adapter.submitList(listOf(InsuranceModel.Error(viewState.message)))
+              adapter.submitList(listOf(InsuranceModel.Error))
             }
             is TerminatedContractsViewModel.ViewState.Success -> {
               adapter.submitList(

--- a/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/loggedin/ui/LoggedInRepository.kt
@@ -6,6 +6,7 @@ import com.hedvig.android.owldroid.graphql.LoggedInQuery
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class LoggedInRepository(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/marketing/data/GetInitialMarketPickerValuesUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/data/GetInitialMarketPickerValuesUseCase.kt
@@ -10,6 +10,7 @@ import com.hedvig.android.market.Market
 import com.hedvig.android.market.MarketManager
 import com.hedvig.android.owldroid.graphql.GeoQuery
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetInitialMarketPickerValuesUseCase(
   private val marketManager: MarketManager,

--- a/app/src/main/java/com/hedvig/app/feature/marketing/data/GetMarketingBackgroundUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/data/GetMarketingBackgroundUseCase.kt
@@ -5,6 +5,7 @@ import com.hedvig.android.owldroid.graphql.MarketingBackgroundQuery
 import com.hedvig.android.owldroid.graphql.type.UserInterfaceStyle
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import com.hedvig.app.util.safeLet
 
 class GetMarketingBackgroundUseCase(

--- a/app/src/main/java/com/hedvig/app/feature/marketing/data/SubmitMarketAndLanguagePreferencesUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketing/data/SubmitMarketAndLanguagePreferencesUseCase.kt
@@ -9,6 +9,7 @@ import com.hedvig.android.owldroid.graphql.UpdateLanguageMutation
 import com.hedvig.app.makeLocaleString
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class SubmitMarketAndLanguagePreferencesUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/marketpicker/LanguageRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/marketpicker/LanguageRepository.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.owldroid.graphql.UpdateLanguageMutation
 import com.hedvig.android.owldroid.graphql.type.Locale
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import e
 import i
 

--- a/app/src/main/java/com/hedvig/app/feature/offer/OfferRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/OfferRepository.kt
@@ -13,6 +13,7 @@ import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import com.hedvig.hanalytics.HAnalytics
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/QuoteCartEditStartDateUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/ui/changestartdate/QuoteCartEditStartDateUseCase.kt
@@ -9,6 +9,7 @@ import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/AddPaymentTokenUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/AddPaymentTokenUseCase.kt
@@ -9,6 +9,7 @@ import com.hedvig.android.owldroid.graphql.AddPaymentTokenIdMutation
 import com.hedvig.app.feature.adyen.PaymentTokenId
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class AddPaymentTokenUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/CreateAccessTokenUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/CreateAccessTokenUseCase.kt
@@ -8,6 +8,7 @@ import com.hedvig.app.authenticate.AuthenticationTokenService
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 interface CreateAccessTokenUseCase {
   object Success

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/EditCampaignUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/EditCampaignUseCase.kt
@@ -10,6 +10,7 @@ import com.hedvig.app.feature.offer.OfferRepository
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 @JvmInline
 value class CampaignCode(val code: String)

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/GetQuoteCartCheckoutUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/GetQuoteCartCheckoutUseCase.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.feature.offer.model.toCheckout
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class GetQuoteCartCheckoutUseCase(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/ObserveQuoteCartCheckoutUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/ObserveQuoteCartCheckoutUseCase.kt
@@ -23,10 +23,10 @@ class ObserveQuoteCartCheckoutUseCaseImpl(
   override fun invoke(quoteCartId: QuoteCartId): Flow<Either<QueryResult.Error, Checkout>> {
     return flow {
       while (currentCoroutineContext().isActive) {
-        val result = either<QueryResult.Error, Checkout> {
+        val result = either {
           val checkout = getQuoteCartCheckoutUseCase.invoke(quoteCartId).bind()
           ensureNotNull(checkout) {
-            QueryResult.Error.NoDataError(null)
+            QueryResult.Error.NoDataError("Checkout was null")
           }
           checkout
         }

--- a/app/src/main/java/com/hedvig/app/feature/offer/usecase/StartCheckoutUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/offer/usecase/StartCheckoutUseCase.kt
@@ -9,6 +9,7 @@ import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.apollo.NetworkCacheManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 import com.hedvig.hanalytics.HAnalytics
 
 class StartCheckoutUseCase(

--- a/app/src/main/java/com/hedvig/app/feature/profile/data/ProfileRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/data/ProfileRepository.kt
@@ -9,6 +9,7 @@ import com.hedvig.android.owldroid.graphql.UpdateEmailMutation
 import com.hedvig.android.owldroid.graphql.UpdatePhoneNumberMutation
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeWatch
+import com.hedvig.app.util.apollo.toEither
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/ProfileViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/ProfileViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -59,10 +58,6 @@ class ProfileViewModel(
               ViewState.Success(profileUiStateResult.value)
             }
           }
-        }
-        .catch { exception ->
-          e(exception)
-          ViewState.Error
         }
     }
     .stateIn(

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/ProfileViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/ProfileViewModel.kt
@@ -133,7 +133,7 @@ class ProfileViewModel(
 
   fun onLogout() {
     viewModelScope.launch {
-      when (val result = logoutUseCase.logout()) {
+      when (val result = logoutUseCase.invoke()) {
         is LogoutUseCase.LogoutResult.Error -> _events.trySend(Event.Error(result.message))
         LogoutUseCase.LogoutResult.Success -> _events.trySend(Event.Logout)
       }

--- a/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/profile/ui/tab/ProfileAdapter.kt
@@ -24,14 +24,14 @@ import e
 class ProfileAdapter(
   private val lifecycleOwner: LifecycleOwner,
   private val retry: () -> Unit,
-  private val onLogoutListener: () -> Unit,
+  private val logout: () -> Unit,
 ) : ListAdapter<ProfileModel, ProfileAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
     R.layout.profile_title -> ViewHolder.Title(parent)
     R.layout.profile_row -> ViewHolder.Row(parent)
     R.layout.profile_subtitle -> ViewHolder.Subtitle(parent)
-    R.layout.profile_logout -> ViewHolder.Logout(parent, onLogoutListener)
+    R.layout.profile_logout -> ViewHolder.Logout(parent, logout)
     ERROR -> ViewHolder.Error(ComposeView(parent.context), retry)
     else -> throw Error("Invalid viewType")
   }
@@ -81,12 +81,12 @@ class ProfileAdapter(
 
     class Logout(
       parent: ViewGroup,
-      private val onLogoutListener: () -> Unit,
+      private val logout: () -> Unit,
     ) : ViewHolder(parent.inflate(R.layout.profile_logout)) {
       private val binding by viewBinding(ProfileLogoutBinding::bind)
       override fun bind(data: ProfileModel, lifecycleOwner: LifecycleOwner) = with(binding) {
         root.setHapticClickListener {
-          onLogoutListener()
+          logout()
         }
       }
     }

--- a/app/src/main/java/com/hedvig/app/feature/referrals/data/RedeemReferralCodeRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/data/RedeemReferralCodeRepository.kt
@@ -7,6 +7,7 @@ import com.hedvig.app.feature.offer.usecase.CampaignCode
 import com.hedvig.app.util.ErrorMessage
 import com.hedvig.app.util.LocaleManager
 import com.hedvig.app.util.apollo.safeQuery
+import com.hedvig.app.util.apollo.toEither
 
 class RedeemReferralCodeRepository(
   private val apolloClient: ApolloClient,

--- a/app/src/main/java/com/hedvig/app/feature/referrals/data/ReferralsRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/data/ReferralsRepository.kt
@@ -5,9 +5,10 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
-import com.apollographql.apollo3.cache.normalized.watch
 import com.hedvig.android.owldroid.graphql.ReferralsQuery
 import com.hedvig.android.owldroid.graphql.UpdateReferralCampaignCodeMutation
+import com.hedvig.app.util.apollo.QueryResult
+import com.hedvig.app.util.apollo.safeWatch
 import kotlinx.coroutines.flow.Flow
 
 class ReferralsRepository(
@@ -15,9 +16,9 @@ class ReferralsRepository(
 ) {
   private val referralsQuery = ReferralsQuery()
 
-  fun referrals(): Flow<ApolloResponse<ReferralsQuery.Data>> = apolloClient
+  fun referrals(): Flow<QueryResult<ReferralsQuery.Data>> = apolloClient
     .query(referralsQuery)
-    .watch()
+    .safeWatch()
 
   suspend fun reloadReferrals(): ApolloResponse<ReferralsQuery.Data> = apolloClient
     .query(referralsQuery)

--- a/app/src/main/java/com/hedvig/app/feature/referrals/data/ReferralsRepository.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/data/ReferralsRepository.kt
@@ -2,9 +2,7 @@ package com.hedvig.app.feature.referrals.data
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.apolloStore
-import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.hedvig.android.owldroid.graphql.ReferralsQuery
 import com.hedvig.android.owldroid.graphql.UpdateReferralCampaignCodeMutation
 import com.hedvig.app.util.apollo.QueryResult
@@ -16,14 +14,9 @@ class ReferralsRepository(
 ) {
   private val referralsQuery = ReferralsQuery()
 
-  fun referrals(): Flow<QueryResult<ReferralsQuery.Data>> = apolloClient
+  fun watchReferralsQueryData(): Flow<QueryResult<ReferralsQuery.Data>> = apolloClient
     .query(referralsQuery)
     .safeWatch()
-
-  suspend fun reloadReferrals(): ApolloResponse<ReferralsQuery.Data> = apolloClient
-    .query(referralsQuery)
-    .fetchPolicy(FetchPolicy.NetworkOnly)
-    .execute()
 
   suspend fun updateCode(newCode: String): ApolloResponse<UpdateReferralCampaignCodeMutation.Data> {
     val response = apolloClient

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsAdapter.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsAdapter.kt
@@ -63,25 +63,20 @@ class ReferralsAdapter(
     R.layout.referrals_code -> ViewHolder.CodeViewHolder(parent)
     R.layout.referrals_invites_header -> ViewHolder.InvitesHeaderViewHolder(parent)
     R.layout.referrals_row -> ViewHolder.ReferralViewHolder(parent)
-    ERROR -> ViewHolder.ErrorViewHolder(ComposeView(parent.context))
+    ERROR -> ViewHolder.ErrorViewHolder(ComposeView(parent.context), reload)
     else -> throw Error("Invalid viewType")
   }
 
   override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-    holder.bind(getItem(position), reload, marketManager)
+    holder.bind(getItem(position), marketManager)
   }
 
   sealed class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-    abstract fun bind(
-      data: ReferralsModel,
-      reload: () -> Unit,
-      marketManager: MarketManager,
-    )
+    abstract fun bind(data: ReferralsModel, marketManager: MarketManager)
 
     class TitleViewHolder(parent: ViewGroup) : ViewHolder(parent.inflate(R.layout.referrals_title)) {
       override fun bind(
         data: ReferralsModel,
-        reload: () -> Unit,
         marketManager: MarketManager,
       ) =
         Unit
@@ -91,7 +86,6 @@ class ReferralsAdapter(
       private val binding by viewBinding(ReferralsHeaderBinding::bind)
       override fun bind(
         data: ReferralsModel,
-        reload: () -> Unit,
         marketManager: MarketManager,
       ) {
         binding.apply {
@@ -306,7 +300,6 @@ class ReferralsAdapter(
       private val binding by viewBinding(ReferralsCodeBinding::bind)
       override fun bind(
         data: ReferralsModel,
-        reload: () -> Unit,
         marketManager: MarketManager,
       ) {
         binding.apply {
@@ -370,7 +363,6 @@ class ReferralsAdapter(
       ViewHolder(parent.inflate(R.layout.referrals_invites_header)) {
       override fun bind(
         data: ReferralsModel,
-        reload: () -> Unit,
         marketManager: MarketManager,
       ) = Unit
     }
@@ -379,7 +371,6 @@ class ReferralsAdapter(
       private val binding by viewBinding(ReferralsRowBinding::bind)
       override fun bind(
         data: ReferralsModel,
-        reload: () -> Unit,
         marketManager: MarketManager,
       ) {
         binding.apply {
@@ -451,10 +442,12 @@ class ReferralsAdapter(
       }
     }
 
-    class ErrorViewHolder(val composeView: ComposeView) : ViewHolder(composeView) {
+    class ErrorViewHolder(
+      val composeView: ComposeView,
+      val reload: () -> Unit,
+    ) : ViewHolder(composeView) {
       override fun bind(
         data: ReferralsModel,
-        reload: () -> Unit,
         marketManager: MarketManager,
       ) {
         composeView.setContent {

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -95,20 +95,14 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
       }
 
       swipeToRefresh.setOnRefreshListener {
-        referralsViewModel.setRefreshing(true)
-        referralsViewModel.load()
-      }
-
-      referralsViewModel.isRefreshing.observe(viewLifecycleOwner) { isRefreshing ->
-        swipeToRefresh.isRefreshing = isRefreshing
+        referralsViewModel.reload()
       }
 
       referralsViewModel
         .data
         .flowWithLifecycle(viewLifecycle)
-        .onEach { viewState ->
-          when (viewState) {
-            ReferralsViewModel.ViewState.Error -> {
+        .onEach { uiState ->
+          swipeToRefresh.isRefreshing = uiState.isLoading
               adapter.submitList(ERROR_STATE)
             }
             ReferralsViewModel.ViewState.Loading -> {

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsFragment.kt
@@ -80,7 +80,7 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
 
       invites.itemAnimator = ViewHolderReusingDefaultItemAnimator()
       val adapter = ReferralsAdapter(
-        referralsViewModel::load,
+        referralsViewModel::reload,
         marketManager,
       )
       invites.adapter = adapter
@@ -103,14 +103,16 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
         .flowWithLifecycle(viewLifecycle)
         .onEach { uiState ->
           swipeToRefresh.isRefreshing = uiState.isLoading
+          when (uiState) {
+            is ReferralsUiState.Error -> {
               adapter.submitList(ERROR_STATE)
             }
-            ReferralsViewModel.ViewState.Loading -> {
+            ReferralsUiState.Loading -> {
               adapter.submitList(LOADING_STATE)
             }
-            is ReferralsViewModel.ViewState.Success -> {
+            is ReferralsUiState.Success -> {
               val incentive =
-                viewState
+                uiState
                   .data
                   .referralInformation
                   .campaign
@@ -123,7 +125,7 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
               if (incentive == null) {
                 e { "Invariant detected: referralInformation.campaign.incentive is null" }
               } else {
-                val code = viewState.data.referralInformation.campaign.code
+                val code = uiState.data.referralInformation.campaign.code
                 share.setHapticClickListener {
                   requireContext().showShareSheet(hedvig.resources.R.string.REFERRALS_SHARE_SHEET_TITLE) { intent ->
                     intent.putExtra(
@@ -156,14 +158,14 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
               }
 
               if (
-                viewState.data.referralInformation.invitations.isEmpty() &&
-                viewState.data.referralInformation.referredBy == null
+                uiState.data.referralInformation.invitations.isEmpty() &&
+                uiState.data.referralInformation.referredBy == null
               ) {
                 (invites.adapter as? ReferralsAdapter)?.submitList(
                   listOfNotNull(
                     ReferralsModel.Title,
-                    ReferralsModel.Header.LoadedEmptyHeader(viewState.data),
-                    ReferralsModel.Code.LoadedCode(viewState.data),
+                    ReferralsModel.Header.LoadedEmptyHeader(uiState.data),
+                    ReferralsModel.Code.LoadedCode(uiState.data),
                   ),
                 )
                 return@onEach
@@ -171,12 +173,12 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
 
               val items = listOfNotNull(
                 ReferralsModel.Title,
-                ReferralsModel.Header.LoadedHeader(viewState.data),
-                ReferralsModel.Code.LoadedCode(viewState.data),
+                ReferralsModel.Header.LoadedHeader(uiState.data),
+                ReferralsModel.Code.LoadedCode(uiState.data),
                 ReferralsModel.InvitesHeader,
               ).toMutableList()
 
-              items += viewState.data.referralInformation.invitations
+              items += uiState.data.referralInformation.invitations
                 .filter {
                   it.fragments.referralFragment.asActiveReferral != null ||
                     it.fragments.referralFragment.asInProgressReferral != null ||
@@ -188,7 +190,7 @@ class ReferralsFragment : Fragment(R.layout.fragment_referrals) {
                   )
                 }
 
-              viewState.data.referralInformation.referredBy?.let {
+              uiState.data.referralInformation.referredBy?.let {
                 items.add(ReferralsModel.Referral.Referee(it.fragments.referralFragment))
               }
 

--- a/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/referrals/ui/tab/ReferralsViewModel.kt
@@ -1,70 +1,70 @@
 package com.hedvig.app.feature.referrals.ui.tab
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hedvig.android.owldroid.graphql.ReferralsQuery
 import com.hedvig.app.feature.referrals.data.ReferralsRepository
 import com.hedvig.app.util.apollo.QueryResult
+import com.hedvig.app.util.coroutines.RetryChannel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlin.time.Duration.Companion.seconds
 
 abstract class ReferralsViewModel : ViewModel() {
-  sealed class ViewState {
-    data class Success(
-      val data: ReferralsQuery.Data,
-    ) : ViewState()
 
-    object Loading : ViewState()
-    object Error : ViewState()
-  }
+  abstract val data: StateFlow<ReferralsUiState>
 
-  protected val _data = MutableStateFlow<ViewState>(ViewState.Loading)
-  val data = _data.asStateFlow()
-
-  protected val _isRefreshing = MutableLiveData<Boolean>()
-
-  val isRefreshing: LiveData<Boolean> = _isRefreshing
-
-  fun setRefreshing(refreshing: Boolean) {
-    _isRefreshing.postValue(refreshing)
-  }
-
-  abstract fun load()
-
-  fun retry() {
-    load()
-  }
+  abstract fun reload()
 }
 
 class ReferralsViewModelImpl(
   private val referralsRepository: ReferralsRepository,
 ) : ReferralsViewModel() {
-  init {
-    viewModelScope.launch {
-      referralsRepository
-        .referrals()
-        .collect { response ->
-          when (response) {
-            is QueryResult.Error -> {
-              _data.value = ViewState.Error
-            }
-            is QueryResult.Success -> {
-              _data.value = ViewState.Success(
-                data = response.data,
-              )
-            }
-          }
-        }
+  private val retryChannel = RetryChannel()
+
+  private var isLoading = MutableStateFlow(false)
+
+  private val referralsResult = retryChannel.flatMapLatest {
+    referralsRepository.watchReferralsQueryData().onEach {
+      isLoading.update { false }
     }
   }
 
-  override fun load() {
-    viewModelScope.launch {
-      runCatching { referralsRepository.reloadReferrals() }
-      _isRefreshing.postValue(false)
+  override val data: StateFlow<ReferralsUiState> = combine(
+    isLoading,
+    referralsResult,
+  ) { isLoading, referralsResult ->
+    val referralsData: ReferralsQuery.Data? = (referralsResult as? QueryResult.Success)?.data
+    if (referralsData == null) {
+      ReferralsUiState.Error(isLoading)
+    } else {
+      ReferralsUiState.Success(referralsData, isLoading)
     }
+  }
+    .stateIn(
+      viewModelScope,
+      SharingStarted.WhileSubscribed(5.seconds),
+      ReferralsUiState.Loading,
+    )
+
+  override fun reload() {
+    isLoading.update { true }
+    retryChannel.retry()
+  }
+}
+
+sealed interface ReferralsUiState {
+  val isLoading: Boolean
+
+  data class Success(val data: ReferralsQuery.Data, override val isLoading: Boolean) : ReferralsUiState
+  data class Error(override val isLoading: Boolean) : ReferralsUiState
+  object Loading : ReferralsUiState {
+    override val isLoading: Boolean = true
   }
 }

--- a/app/src/main/java/com/hedvig/app/feature/whatsnew/WhatsNewViewModel.kt
+++ b/app/src/main/java/com/hedvig/app/feature/whatsnew/WhatsNewViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import arrow.core.Either
 import com.hedvig.android.owldroid.graphql.WhatsNewQuery
 import com.hedvig.app.util.LiveEvent
+import com.hedvig.app.util.apollo.toEither
 import e
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/hedvig/app/feature/zignsec/usecase/SubscribeToAuthResultUseCase.kt
+++ b/app/src/main/java/com/hedvig/app/feature/zignsec/usecase/SubscribeToAuthResultUseCase.kt
@@ -6,6 +6,7 @@ import com.hedvig.android.owldroid.graphql.AuthStatusSubscription
 import com.hedvig.android.owldroid.graphql.type.AuthState
 import com.hedvig.app.util.apollo.QueryResult
 import com.hedvig.app.util.apollo.safeSubscription
+import com.hedvig.app.util.apollo.toEither
 import d
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/hedvig/app/util/apollo/QueryResult.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/QueryResult.kt
@@ -6,15 +6,73 @@ import arrow.core.Option
 import arrow.core.Some
 
 sealed interface QueryResult<out T> {
+
   data class Success<T>(val data: T) : QueryResult<T>
-  sealed class Error : QueryResult<Nothing> {
 
-    abstract val message: String?
+  sealed interface Error : QueryResult<Nothing> {
 
-    data class NoDataError(override val message: String?) : Error()
-    data class GeneralError(override val message: String?) : Error()
-    data class QueryError(override val message: String?) : Error()
-    data class NetworkError(override val message: String?) : Error()
+    val throwable: Throwable?
+    val message: String?
+
+    data class NoDataError(
+      override val throwable: Throwable?,
+      override val message: String?,
+    ) : Error {
+      companion object {
+        operator fun invoke(message: String?): NoDataError {
+          return NoDataError(null, message)
+        }
+
+        operator fun invoke(throwable: Throwable?): NoDataError {
+          return NoDataError(throwable, throwable?.localizedMessage)
+        }
+      }
+    }
+
+    data class GeneralError(
+      override val throwable: Throwable?,
+      override val message: String?,
+    ) : Error {
+      companion object {
+        operator fun invoke(message: String?): GeneralError {
+          return GeneralError(null, message)
+        }
+
+        operator fun invoke(throwable: Throwable?): GeneralError {
+          return GeneralError(throwable, throwable?.localizedMessage)
+        }
+      }
+    }
+
+    data class QueryError(
+      override val throwable: Throwable?,
+      override val message: String?,
+    ) : Error {
+      companion object {
+        operator fun invoke(message: String?): QueryError {
+          return QueryError(null, message)
+        }
+
+        operator fun invoke(throwable: Throwable?): QueryError {
+          return QueryError(throwable, throwable?.localizedMessage)
+        }
+      }
+    }
+
+    data class NetworkError(
+      override val throwable: Throwable?,
+      override val message: String?,
+    ) : Error {
+      companion object {
+        operator fun invoke(message: String?): NetworkError {
+          return NetworkError(null, message)
+        }
+
+        operator fun invoke(throwable: Throwable?): NetworkError {
+          return NetworkError(throwable, throwable?.localizedMessage)
+        }
+      }
+    }
   }
 }
 

--- a/app/src/main/java/com/hedvig/app/util/apollo/QueryResult.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/QueryResult.kt
@@ -1,0 +1,36 @@
+package com.hedvig.app.util.apollo
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+
+sealed interface QueryResult<out T> {
+  data class Success<T>(val data: T) : QueryResult<T>
+  sealed class Error : QueryResult<Nothing> {
+
+    abstract val message: String?
+
+    data class NoDataError(override val message: String?) : Error()
+    data class GeneralError(override val message: String?) : Error()
+    data class QueryError(override val message: String?) : Error()
+    data class NetworkError(override val message: String?) : Error()
+  }
+}
+
+fun <T> QueryResult<T>.toOption(): Option<T> = when (this) {
+  is QueryResult.Error -> None
+  is QueryResult.Success -> Some(this.data)
+}
+
+fun <T> QueryResult<T>.toEither(): Either<QueryResult.Error, T> = when (this) {
+  is QueryResult.Error -> Either.Left(this)
+  is QueryResult.Success -> Either.Right(this.data)
+}
+
+inline fun <ErrorType, T> QueryResult<T>.toEither(
+  ifEmpty: (message: String?) -> ErrorType,
+): Either<ErrorType, T> = when (this) {
+  is QueryResult.Error -> Either.Left(ifEmpty(message))
+  is QueryResult.Success -> Either.Right(this.data)
+}

--- a/app/src/main/java/com/hedvig/app/util/apollo/SafeQuery.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/SafeQuery.kt
@@ -22,12 +22,12 @@ suspend fun <D : Operation.Data> ApolloCall<D>.safeQuery(): QueryResult<D> {
   return try {
     execute().toQueryResult()
   } catch (apolloException: ApolloException) {
-    QueryResult.Error.NetworkError(apolloException.localizedMessage)
+    QueryResult.Error.NetworkError(apolloException)
   } catch (throwable: Throwable) {
     if (throwable is CancellationException) {
       throw throwable
     }
-    QueryResult.Error.GeneralError(throwable.localizedMessage)
+    QueryResult.Error.GeneralError(throwable)
   }
 }
 
@@ -36,9 +36,9 @@ fun <D : Subscription.Data> ApolloCall<D>.safeSubscription(): Flow<QueryResult<D
     .map(ApolloResponse<D>::toQueryResult)
     .catch { exception ->
       if (exception is ApolloException) {
-        emit(QueryResult.Error.NetworkError(exception.localizedMessage))
+        emit(QueryResult.Error.NetworkError(exception))
       } else {
-        emit(QueryResult.Error.GeneralError(exception.localizedMessage))
+        emit(QueryResult.Error.GeneralError(exception))
       }
     }
 }
@@ -48,9 +48,9 @@ fun <D : Query.Data> ApolloCall<D>.safeWatch(): Flow<QueryResult<D>> {
     .map(ApolloResponse<D>::toQueryResult)
     .catch { exception ->
       if (exception is ApolloException) {
-        emit(QueryResult.Error.NetworkError(exception.localizedMessage))
+        emit(QueryResult.Error.NetworkError(exception))
       } else {
-        emit(QueryResult.Error.GeneralError(exception.localizedMessage))
+        emit(QueryResult.Error.GeneralError(exception))
       }
     }
 }

--- a/app/src/main/java/com/hedvig/app/util/apollo/SafeQuery.kt
+++ b/app/src/main/java/com/hedvig/app/util/apollo/SafeQuery.kt
@@ -1,9 +1,5 @@
 package com.hedvig.app.util.apollo
 
-import arrow.core.Either
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.Some
 import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
@@ -96,33 +92,5 @@ suspend fun Call.safeGraphqlCall(): QueryResult<JSONObject> = withContext(Dispat
     QueryResult.Success(jsonObject)
   } catch (ioException: IOException) {
     QueryResult.Error.GeneralError(ioException.localizedMessage)
-  }
-}
-
-sealed class QueryResult<out T> {
-  data class Success<T>(val data: T) : QueryResult<T>()
-  sealed class Error : QueryResult<Nothing>() {
-
-    abstract val message: String?
-
-    data class NoDataError(override val message: String?) : Error()
-    data class GeneralError(override val message: String?) : Error()
-    data class QueryError(override val message: String?) : Error()
-    data class NetworkError(override val message: String?) : Error()
-  }
-
-  fun toOption(): Option<T> = when (this) {
-    is Error -> None
-    is Success -> Some(this.data)
-  }
-
-  fun toEither(): Either<Error, T> = when (this) {
-    is Error -> Either.Left(this)
-    is Success -> Either.Right(this.data)
-  }
-
-  inline fun <ErrorType> toEither(ifEmpty: (message: String?) -> ErrorType): Either<ErrorType, T> = when (this) {
-    is Error -> Either.Left(ifEmpty(message))
-    is Success -> Either.Right(this.data)
   }
 }


### PR DESCRIPTION
The user facing changes are that now when one goes into the settings screen and they've got no internet (the network request fails) they will actually get the error screen which lets them retry instead of getting a clean screen which does nothing.
Same for the forever tab because it was getting stuck on the shimmer effect forever since watching the query never finished or failed.