### PR TITLE
APP-1816: Migrate release builds from Bitrise to Github Actions

### DIFF
--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -10,8 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Setup JDK 11
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           java-version: '11'
           distribution: 'zulu'

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -2,7 +2,8 @@ name: Build and Publish to Play Store
 on:
   push:
     branches:
-      - master
+      - release/**
+      - hotfix/**
 jobs:
   build_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -60,3 +60,5 @@ jobs:
           releaseFiles: ${{ steps.sign_app.outputs.signedReleaseFile }}
           mappingFile: app/build/outputs/mapping/release/mapping.txt
           track: internal
+      - uses: hmarr/debug-action@v2
+        if: always()

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Deploy to Play Store Internal-track
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJsonPlainText: $ {{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.hedvig.app
           releaseFiles: ${{ steps.sign_app.outputs.signedReleaseFile }}
           mappingFile: app/build/outputs/mapping/release/mapping.txt

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -5,7 +5,7 @@ on:
       - master
       - feature/APP-1816-github-actions-publish-release # Temporary, to test out this action
 jobs:
-  build_staging:
+  build_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - run: echo VERSION_CODE=$(expr 4700 + ${{ github.run_number }} + ${{ github.run_attempt }} - 1) >> $GITHUB_ENV
+      - run: echo VERSION_CODE=$(date +%s) >> $GITHUB_ENV
       - uses: chkfung/android-version-actions@v1.1
         with:
           gradlePath: app/build.gradle.kts
@@ -34,7 +34,7 @@ jobs:
         env:
           LOKALISE_ID: ${{ secrets.LOKALISE_ID }}
           LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
-          ADYEN_CLIENT_KEY: ${{ secrets.ADYEN_CLIENT_KEY_TEST }}
+          ADYEN_CLIENT_KEY: ${{ secrets.ADYEN_LIVE_CLIENT_KEY }}
           SHAKE_CLIENT_ID: ${{ secrets.SHAKE_CLIENT_ID }}
           SHAKE_CLIENT_SECRET: ${{ secrets.SHAKE_CLIENT_SECRET }}
       - name: Build
@@ -50,11 +50,11 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
           BUILD_TOOLS_VERSION: "30.0.2"
-      - name: Deploy to Alpha
+      - name: Deploy to Play Store Internal-track
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJson: service_account.json
-          packageName: com.jshvarts.flows
-          releaseFile: app/build/outputs/bundle/release/app-release.aab
-          track: alpha
-          whatsNewDirectory: distribution/
+          serviceAccountJsonPlainText: $ {{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.hedvig.app
+          releaseFiles: ${{ steps.sign_app.outputs.signedReleaseFile }}
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
+          track: internal

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "30.0.2"
       - name: Deploy to Play Store Internal-track
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.0.17
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.hedvig.app

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -1,0 +1,60 @@
+name: Build and Publish to Play Store
+on:
+  push:
+    branches:
+      - master
+      - feature/APP-1816-github-actions-publish-release # Temporary, to test out this action
+jobs:
+  build_staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup JDK 11
+        uses: actions/setup-java@v3.3.0
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+          cache: 'gradle'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - run: echo VERSION_CODE=$(expr 4700 + ${{ github.run_number }} + ${{ github.run_attempt }} - 1) >> $GITHUB_ENV
+      - uses: chkfung/android-version-actions@v1.1
+        with:
+          gradlePath: app/build.gradle.kts
+          versionCode: ${{ env.VERSION_CODE }}
+      - name: Prebuild
+        run: ./ci-release-prebuild.sh
+        env:
+          LOKALISE_ID: ${{ secrets.LOKALISE_ID }}
+          LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
+          ADYEN_CLIENT_KEY: ${{ secrets.ADYEN_CLIENT_KEY_TEST }}
+          SHAKE_CLIENT_ID: ${{ secrets.SHAKE_CLIENT_ID }}
+          SHAKE_CLIENT_SECRET: ${{ secrets.SHAKE_CLIENT_SECRET }}
+      - name: Build
+        run: "./gradlew app:assembleRelease"
+      - uses: r0adkll/sign-android-release@v1
+        name: Sign app APK
+        id: sign_app
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "30.0.2"
+      - name: Deploy to Alpha
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: service_account.json
+          packageName: com.jshvarts.flows
+          releaseFile: app/build/outputs/bundle/release/app-release.aab
+          track: alpha
+          whatsNewDirectory: distribution/

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -60,5 +60,3 @@ jobs:
           releaseFiles: ${{ steps.sign_app.outputs.signedReleaseFile }}
           mappingFile: app/build/outputs/mapping/release/mapping.txt
           track: internal
-      - uses: hmarr/debug-action@v2
-        if: always()

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - feature/APP-1816-github-actions-publish-release # Temporary, to test out this action
 jobs:
   build_release:
     runs-on: ubuntu-latest

--- a/ci-release-prebuild.sh
+++ b/ci-release-prebuild.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set +uex
+
+cat <<EOT > lokalise.properties
+id=${LOKALISE_ID}
+token=${LOKALISE_TOKEN}
+EOT
+
+
+cat <<EOT > app/src/release/res/values/adyen.xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ADYEN_CLIENT_KEY" translatable="false">${ADYEN_LIVE_CLIENT_KEY}</string>
+</resources>
+EOT
+
+
+cat <<EOT > app/src/release/res/values/shake.xml
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <string name="SHAKE_CLIENT_ID" translatable="false">${SHAKE_CLIENT_ID}</string>
+    <string name="SHAKE_CLIENT_SECRET" translatable="false">${SHAKE_CLIENT_SECRET}</string>
+</resources>
+EOT
+
+./gradlew :apollo:downloadGiraffeApolloSchemaFromIntrospection app:downloadStrings licenseReleaseReport
+

--- a/ci-release-prebuild.sh
+++ b/ci-release-prebuild.sh
@@ -23,5 +23,7 @@ cat <<EOT > app/src/release/res/values/shake.xml
 </resources>
 EOT
 
-./gradlew :apollo:downloadGiraffeApolloSchemaFromIntrospection :core-resources:downloadStrings licenseReleaseReport
+./gradlew :apollo:downloadGiraffeApolloSchemaFromIntrospection
+./gradlew :core-resources:downloadStrings
+./gradlew licenseReleaseReport
 

--- a/ci-release-prebuild.sh
+++ b/ci-release-prebuild.sh
@@ -23,5 +23,5 @@ cat <<EOT > app/src/release/res/values/shake.xml
 </resources>
 EOT
 
-./gradlew :apollo:downloadGiraffeApolloSchemaFromIntrospection app:downloadStrings licenseReleaseReport
+./gradlew :apollo:downloadGiraffeApolloSchemaFromIntrospection :core-resources:downloadStrings licenseReleaseReport
 


### PR DESCRIPTION
- Add upload to play store workflow
- Configure Play Store upload-step
- Fix release pre-build script
- Add gradle copy-step
- Split the calls up, maybe that fixes it?
- Add debugging
- Revert "Add debugging"
- smh
- Bump deploy action version
