### PR TITLE
Feature Notification service register device notification

### DIFF
--- a/apollo/src/main/graphql/com/hedvig/android/apollo/graphql/NotificationRegisterDevice.graphql
+++ b/apollo/src/main/graphql/com/hedvig/android/apollo/graphql/NotificationRegisterDevice.graphql
@@ -1,0 +1,3 @@
+mutation NotificationRegisterDevice($token: String!) {
+  notification_registerDevice(input: {device: ANDROID, token: $token})
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -210,6 +210,7 @@ dependencies {
   testImplementation(libs.apollo.testingSupport)
 
   implementation(libs.arrowKt.core)
+  implementation(libs.arrowKt.fx)
 
   implementation(libs.materialComponents)
   implementation(libs.flexbox)

--- a/app/src/main/kotlin/com/hedvig/app/service/push/PushNotificationService.kt
+++ b/app/src/main/kotlin/com/hedvig/app/service/push/PushNotificationService.kt
@@ -2,7 +2,9 @@ package com.hedvig.app.service.push
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import androidx.work.Constraints
 import androidx.work.Data
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -32,6 +34,11 @@ class PushNotificationService : FirebaseMessagingService() {
   override fun onNewToken(token: String) {
     val work = OneTimeWorkRequest
       .Builder(PushNotificationWorker::class.java)
+      .setConstraints(
+        Constraints.Builder()
+          .setRequiredNetworkType(NetworkType.CONNECTED)
+          .build(),
+      )
       .setBackoffCriteria(BackoffPolicy.LINEAR, 1, TimeUnit.SECONDS)
       .setInputData(
         Data.Builder()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -147,6 +147,7 @@ apollo-normalizedCache = { module = "com.apollographql.apollo3:apollo-normalized
 apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime", version.ref = "apollo" }
 apollo-testingSupport = { module = "com.apollographql.apollo3:apollo-testing-support", version.ref = "apollo" }
 arrowKt-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrowKt" }
+arrowKt-fx = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrowKt" }
 assertK = { module = "com.willowtreeapps.assertk:assertk-jvm", version.ref = "assertK" }
 coil-coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose-base", version.ref = "coil" }


### PR DESCRIPTION
Adds the second mutation to run along with the previous one when registering a new push notification token.

Also added a constraint on the worker to only work when there's internet. Since there's no way we'd ever want this work to run without internet.