### PR TITLE
Fix relying on `.first()` on list which can very well be empty

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -127,6 +127,7 @@ import com.hedvig.app.feature.marketpicker.LanguageRepository
 import com.hedvig.app.feature.offer.OfferRepository
 import com.hedvig.app.feature.offer.OfferViewModel
 import com.hedvig.app.feature.offer.OfferViewModelImpl
+import com.hedvig.app.feature.offer.SelectedVariantStore
 import com.hedvig.app.feature.offer.model.QuoteCartFragmentToOfferModelMapper
 import com.hedvig.app.feature.offer.model.QuoteCartId
 import com.hedvig.app.feature.offer.ui.changestartdate.ChangeDateBottomSheetData
@@ -411,6 +412,7 @@ val offerModule = module {
       addPaymentTokenUseCase = get(),
       getExternalInsuranceProviderUseCase = get(),
       getBundleVariantUseCase = get(),
+      selectedVariantStore = get(),
       getQuoteCartCheckoutUseCase = get(),
     )
   }
@@ -420,6 +422,7 @@ val offerModule = module {
   single { QuoteCartFragmentToOfferModelMapper(get()) }
   single<GetQuoteCartCheckoutUseCase> { GetQuoteCartCheckoutUseCase(get()) }
   single<ObserveQuoteCartCheckoutUseCase> { ObserveQuoteCartCheckoutUseCaseImpl(get()) }
+  single<SelectedVariantStore> { SelectedVariantStore() }
 }
 
 val profileModule = module {
@@ -511,6 +514,7 @@ val checkoutModule = module {
       offerRepository = get(),
       featureManager = get(),
       bundleVariantUseCase = get(),
+      selectedVariantStore = get(),
     )
   }
 }
@@ -627,7 +631,7 @@ val useCaseModule = module {
   single<ConnectPaymentUseCase> { ConnectPaymentUseCase(get(), get(), get()) }
   single<ConnectPayoutUseCase> { ConnectPayoutUseCase(get(), get()) }
   single<GetExternalInsuranceProviderUseCase> { GetExternalInsuranceProviderUseCase(get(), get(), get()) }
-  single<ObserveOfferStateUseCase> { ObserveOfferStateUseCase(get()) }
+  single<ObserveOfferStateUseCase> { ObserveOfferStateUseCase(get(), get()) }
   single<ChangeLanguageUseCase> {
     ChangeLanguageUseCase(
       apolloClient = get(),

--- a/app/src/main/kotlin/com/hedvig/app/feature/checkout/CheckoutViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/checkout/CheckoutViewModel.kt
@@ -11,6 +11,7 @@ import com.hedvig.android.market.Market
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.authenticate.LoginStatusService
 import com.hedvig.app.feature.offer.OfferRepository
+import com.hedvig.app.feature.offer.SelectedVariantStore
 import com.hedvig.app.feature.offer.model.Checkout
 import com.hedvig.app.feature.offer.model.OfferModel
 import com.hedvig.app.feature.offer.model.QuoteBundleVariant
@@ -35,7 +36,7 @@ import javax.money.MonetaryAmount
 import kotlin.time.Duration.Companion.seconds
 
 class CheckoutViewModel(
-  private val selectedVariantId: String,
+  selectedVariantId: String,
   private val quoteCartId: QuoteCartId,
   private val signQuotesUseCase: StartCheckoutUseCase,
   private val editQuotesUseCase: EditCheckoutUseCase,
@@ -45,6 +46,7 @@ class CheckoutViewModel(
   private val offerRepository: OfferRepository,
   private val featureManager: FeatureManager,
   bundleVariantUseCase: ObserveOfferStateUseCase,
+  selectedVariantStore: SelectedVariantStore,
 ) : ViewModel() {
 
   private val _titleViewState = MutableStateFlow<TitleViewState>(TitleViewState.Loading)
@@ -62,11 +64,10 @@ class CheckoutViewModel(
   private var emailInput: String = ""
   private var identityNumberInput: String = ""
 
-  private val offerState = bundleVariantUseCase.observeOfferState(quoteCartId, emptyList()).also {
-    bundleVariantUseCase.selectedVariant(selectedVariantId)
-  }
+  private val offerState = bundleVariantUseCase.invoke(quoteCartId, emptyList())
 
   init {
+    selectedVariantStore.selectVariant(selectedVariantId)
     offerState
       .onEach(::handleOfferResult)
       .launchIn(viewModelScope)
@@ -98,7 +99,7 @@ class CheckoutViewModel(
   private suspend fun createAccessToken() {
     createAccessTokenUseCase.invoke(quoteCartId)
       .tapLeft { _events.trySend(Event.Error(it.message)) }
-      .tap { offerRepository.queryAndEmitOffer(quoteCartId) }
+      .tap { offerRepository.fetchNewOffer(quoteCartId) }
   }
 
   private fun QuoteBundleVariant.mapToViewState() = TitleViewState.Loaded(
@@ -173,7 +174,7 @@ class CheckoutViewModel(
         signQuotesUseCase.startCheckoutAndClearCache(quoteCartId, quoteIds).bind()
       }.fold(
         ifLeft = { _events.trySend(Event.Error(it.message)) },
-        ifRight = { offerRepository.queryAndEmitOffer(quoteCartId) },
+        ifRight = { offerRepository.fetchNewOffer(quoteCartId) },
       )
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferRepository.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferRepository.kt
@@ -30,9 +30,8 @@ class OfferRepository(
     onBufferOverflow = BufferOverflow.DROP_OLDEST,
   )
 
-  suspend fun queryAndEmitOffer(quoteCartId: QuoteCartId) {
-    val offer = queryQuoteCart(quoteCartId)
-    offerFlow.tryEmit(offer)
+  suspend fun fetchNewOffer(quoteCartId: QuoteCartId) {
+    offerFlow.tryEmit(queryQuoteCart(quoteCartId))
   }
 
   private suspend fun queryQuoteCart(
@@ -42,7 +41,7 @@ class OfferRepository(
       .query(QuoteCartQuery(languageService.getGraphQLLocale(), id.id))
       .fetchPolicy(FetchPolicy.NetworkOnly)
       .safeExecute()
-      .toEither { ErrorMessage(it) }
+      .toEither(::ErrorMessage)
       .bind()
 
     val quoteCartFragment = result.quoteCart.fragments.quoteCartFragment

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import arrow.core.Either
 import arrow.core.continuations.either
+import arrow.core.continuations.ensureNotNull
 import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
-import com.hedvig.app.R
 import com.hedvig.app.authenticate.LoginStatus
 import com.hedvig.app.authenticate.LoginStatusService
 import com.hedvig.app.feature.adyen.PaymentTokenId
@@ -168,14 +168,16 @@ class OfferViewModelImpl(
   private val featureManager: FeatureManager,
   private val addPaymentTokenUseCase: AddPaymentTokenUseCase,
   private val getExternalInsuranceProviderUseCase: GetExternalInsuranceProviderUseCase,
-  private val getBundleVariantUseCase: ObserveOfferStateUseCase,
+  getBundleVariantUseCase: ObserveOfferStateUseCase,
+  private val selectedVariantStore: SelectedVariantStore,
   private val getQuoteCartCheckoutUseCase: GetQuoteCartCheckoutUseCase,
 ) : OfferViewModel() {
 
   private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(ViewState.Loading)
   override val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
 
-  private val offerState = getBundleVariantUseCase.observeOfferState(quoteCartId, selectedContractTypes)
+  private val offerState: Flow<Either<ErrorMessage, OfferState>> =
+    getBundleVariantUseCase.invoke(quoteCartId, selectedContractTypes)
 
   init {
     loginStatusService.isViewingOffer = shouldShowOnNextAppStart
@@ -192,7 +194,7 @@ class OfferViewModelImpl(
   private fun toViewState(offerResult: Either<ErrorMessage, OfferState>): Flow<ViewState> =
     offerResult.fold(
       ifLeft = { flowOf(ViewState.Error(it.message)) },
-      ifRight = { offerWithVariant ->
+      ifRight = { offerWithVariant: OfferState ->
         val offerModel = offerWithVariant.offerModel
         val bundle = offerWithVariant.selectedVariant
         if (bundle.externalProviderId != null) {
@@ -206,7 +208,7 @@ class OfferViewModelImpl(
                 paymentMethods = offerModel.paymentMethodsApiResponse,
                 externalProvider = externalProvider,
                 onVariantSelected = { variantId ->
-                  getBundleVariantUseCase.selectedVariant(variantId)
+                  selectedVariantStore.selectVariant(variantId)
                 },
               )
             }
@@ -220,7 +222,7 @@ class OfferViewModelImpl(
                 paymentMethods = offerModel.paymentMethodsApiResponse,
                 externalProvider = null,
                 onVariantSelected = { variantId ->
-                  getBundleVariantUseCase.selectedVariant(variantId)
+                  selectedVariantStore.selectVariant(variantId)
                 },
               ),
             )
@@ -261,24 +263,24 @@ class OfferViewModelImpl(
 
   override fun onOpenQuoteDetails(id: String) {
     viewModelScope.launch {
-      offerState
-        .first()
-        .map { it.findQuote(id) }
-        .fold(
-          ifLeft = { _viewState.value = ViewState.Error(it.message) },
-          ifRight = { quote ->
-            val quoteDetailItems = QuoteDetailItems(quote)
-            val event = Event.OpenQuoteDetails(quoteDetailItems)
-            _events.trySend(event)
-          },
-        )
+      either {
+        val currentOfferState = offerState.first().bind()
+        val quote = ensureNotNull(currentOfferState.findQuote(id), ::ErrorMessage)
+        val quoteDetailItems = QuoteDetailItems(quote)
+        Event.OpenQuoteDetails(quoteDetailItems)
+      }.fold(
+        ifLeft = { _viewState.value = ViewState.Error(it.message) },
+        ifRight = { event: Event ->
+          _events.trySend(event)
+        },
+      )
     }
   }
 
   override fun reload() {
     _viewState.value = ViewState.Loading
     viewModelScope.launch {
-      offerRepository.queryAndEmitOffer(quoteCartId)
+      offerRepository.fetchNewOffer(quoteCartId)
     }
   }
 
@@ -316,7 +318,7 @@ class OfferViewModelImpl(
 
   override fun onSwedishBankIdSign() {
     getQuoteIdsAndStartSign {
-      offerRepository.queryAndEmitOffer(quoteCartId)
+      offerRepository.fetchNewOffer(quoteCartId)
       _events.trySend(Event.StartSwedishBankIdSign)
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/SelectedVariantStore.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/SelectedVariantStore.kt
@@ -1,0 +1,14 @@
+package com.hedvig.app.feature.offer
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Storage for the offer variant from a quote bundle
+ */
+class SelectedVariantStore {
+  val selectedVariantId = MutableStateFlow<String?>(null)
+
+  fun selectVariant(variantId: String) {
+    selectedVariantId.value = variantId
+  }
+}

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheetViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/changestartdate/ChangeDateBottomSheetViewModel.kt
@@ -72,7 +72,7 @@ class ChangeDateBottomSheetViewModel(
       .fold(
         ifLeft = { ViewState.Error(it.message) },
         ifRight = {
-          offerRepository.queryAndEmitOffer(data.quoteCartId)
+          offerRepository.fetchNewOffer(data.quoteCartId)
           _viewState.value = ViewState.Dismiss
         },
       )

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/EditCampaignUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/EditCampaignUseCase.kt
@@ -33,7 +33,7 @@ class EditCampaignUseCase(
         ?.let { id -> QuoteCartId(id) }
         .rightIfNotNull { ErrorMessage(it.asBasicError?.message) }
     }
-    .tap { offerRepository.queryAndEmitOffer(quoteCartId) }
+    .tap { offerRepository.fetchNewOffer(quoteCartId) }
 
   suspend fun removeCampaignFromQuoteCart(
     quoteCartId: QuoteCartId,
@@ -48,5 +48,5 @@ class EditCampaignUseCase(
         ?.let { id -> QuoteCartId(id) }
         .rightIfNotNull { ErrorMessage(it.asBasicError?.message) }
     }
-    .tap { offerRepository.queryAndEmitOffer(quoteCartId) }
+    .tap { offerRepository.fetchNewOffer(quoteCartId) }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/ObserveOfferStateUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/ObserveOfferStateUseCase.kt
@@ -1,59 +1,66 @@
 package com.hedvig.app.feature.offer.usecase
 
 import arrow.core.Either
+import arrow.core.continuations.either
+import arrow.core.continuations.ensureNotNull
 import com.hedvig.app.feature.embark.util.SelectedContractType
 import com.hedvig.app.feature.offer.OfferRepository
+import com.hedvig.app.feature.offer.SelectedVariantStore
 import com.hedvig.app.feature.offer.model.OfferModel
 import com.hedvig.app.feature.offer.model.QuoteBundleVariant
 import com.hedvig.app.feature.offer.model.QuoteCartId
+import com.hedvig.app.feature.offer.model.quotebundle.QuoteBundle
 import com.hedvig.app.util.ErrorMessage
+import e
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onStart
 
 class ObserveOfferStateUseCase(
   private val offerRepository: OfferRepository,
+  private val selectedVariantStore: SelectedVariantStore,
 ) {
 
-  private val selectedVariantId = MutableStateFlow<String?>(null)
-
-  fun observeOfferState(
+  fun invoke(
     quoteCartId: QuoteCartId,
     selectedContractTypes: List<SelectedContractType>,
-  ): Flow<Either<ErrorMessage, OfferState>> = offerRepository
-    .offerFlow
-    .combine(selectedVariantId) { offer: Either<ErrorMessage, OfferModel>, selectedVariantId: String? ->
-      offer.map { offerModel ->
-        val bundleVariant = offerModel.getBundleVariant(selectedVariantId, selectedContractTypes)
-        OfferState(offerModel, bundleVariant)
+  ): Flow<Either<ErrorMessage, OfferState>> = combine(
+    offerRepository.offerFlow,
+    selectedVariantStore.selectedVariantId,
+  ) { offer: Either<ErrorMessage, OfferModel>, selectedVariantId: String? ->
+    either {
+      val offerModel = offer.bind()
+      val bundleVariant = offerModel.getBundleVariant(selectedVariantId, selectedContractTypes)
+      ensureNotNull(bundleVariant) {
+        e { "bundleVariant was null for quote cart id:$quoteCartId and offer:$offerModel" }
+        ErrorMessage()
       }
-    }.onStart {
-      offerRepository.queryAndEmitOffer(quoteCartId)
+      OfferState(offerModel, bundleVariant)
     }
+  }.onStart {
+    offerRepository.fetchNewOffer(quoteCartId)
+  }
 
   private fun OfferModel.getBundleVariant(
     selectedVariantId: String?,
     selectedContractTypes: List<SelectedContractType>,
-  ): QuoteBundleVariant {
-    val bundleVariant = if (selectedVariantId != null) {
-      variants.find { it.id == selectedVariantId }
+  ): QuoteBundleVariant? {
+    val bundleVariant: QuoteBundleVariant? = if (selectedVariantId != null) {
+      variants.firstOrNull { it.id == selectedVariantId }
     } else {
       getPreselectedBundleVariant(selectedContractTypes)
     }
-    return bundleVariant ?: variants.first()
+    return bundleVariant ?: variants.firstOrNull()
   }
 
   private fun OfferModel.getPreselectedBundleVariant(
     selectedContractTypes: List<SelectedContractType>,
-  ) = variants.find {
-    val insuranceTypesInBundle = it.bundle.quotes.map { it.insuranceType }.toSet()
-    val selectedContractTypeIds = selectedContractTypes.map { it.id }.toSet()
-    selectedContractTypeIds == insuranceTypesInBundle
-  }
-
-  fun selectedVariant(variantId: String) {
-    selectedVariantId.value = variantId
+  ): QuoteBundleVariant? {
+    val selectedContractTypeIds = selectedContractTypes.map(SelectedContractType::id).toSet()
+    return variants.firstOrNull { variant ->
+      val insuranceTypesInBundle = variant.bundle.quotes.map(QuoteBundle.Quote::insuranceType).toSet()
+      selectedContractTypeIds == insuranceTypesInBundle
+    }
   }
 }
 
@@ -61,7 +68,7 @@ data class OfferState(
   val offerModel: OfferModel,
   val selectedVariant: QuoteBundleVariant,
 ) {
-  val selectedQuoteIds = selectedVariant.bundle.quotes.map { it.id }
+  val selectedQuoteIds: List<String> = selectedVariant.bundle.quotes.map { it.id }
 
-  fun findQuote(id: String) = selectedVariant.bundle.quotes.first { it.id == id }
+  fun findQuote(id: String): QuoteBundle.Quote? = selectedVariant.bundle.quotes.firstOrNull { it.id == id }
 }


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/hedvig-app/crashlytics/app/android:com.hedvig.app/issues/de950c400675366c7eaca57c86487b2c?time=1661682966000:1664274966000&sessionEventKey=632A11AD02A2000179993FC3B51FDF76_1723988857574285009

main diff is changing `private fun OfferModel.getBundleVariant(` return type to a nullable one, and handle it from there.