### PR TITLE
Android libraries without staging build type

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,8 +53,15 @@ android {
 
   buildTypes {
     @Suppress("UNUSED_VARIABLE")
+    val debug by getting {
+      applicationIdSuffix = ".dev.app"
+      manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = false
+      isDebuggable = true
+    }
+
+    @Suppress("UNUSED_VARIABLE")
     val release by getting {
-//      signingConfig = signingConfigs.getByName("debug") // uncomment to run release build locally
+//      signingConfig = debug.signingConfig // uncomment to run release build locally
       applicationIdSuffix = ".app"
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = true
 
@@ -68,7 +75,7 @@ android {
     }
 
     @Suppress("UNUSED_VARIABLE")
-    val staging by getting {
+    val staging by creating {
       applicationIdSuffix = ".test.app"
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = true
       isMinifyEnabled = true
@@ -78,13 +85,6 @@ android {
           "proguard-rules.pro",
         ),
       )
-    }
-
-    @Suppress("UNUSED_VARIABLE")
-    val debug by getting {
-      applicationIdSuffix = ".dev.app"
-      manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = false
-      isDebuggable = true
     }
   }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ android {
     @Suppress("UNUSED_VARIABLE")
     val staging by creating {
       applicationIdSuffix = ".test.app"
+      matchingFallbacks.add("release")
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = true
       isMinifyEnabled = true
       setProguardFiles(

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/KotlinAndroid.kt
@@ -27,10 +27,6 @@ internal fun Project.configureKotlinAndroid(
       minSdk = libs.versions.minSdkVersion.get().toInt()
     }
 
-    buildTypes {
-      create("staging")
-    }
-
     compileOptions {
       @Suppress("UnstableApiUsage")
       isCoreLibraryDesugaringEnabled = true


### PR DESCRIPTION
Figured a way to remove build types from android library modules. They don't need to know about staging, pullrequest or whatever anyway.