### PR TITLE
CLX-120: fix updating language before logging in

### DIFF
--- a/app/src/engineering/kotlin/com/hedvig/app/mocks/MockMarketManager.kt
+++ b/app/src/engineering/kotlin/com/hedvig/app/mocks/MockMarketManager.kt
@@ -13,8 +13,6 @@ class MockMarketManager : MarketManager {
       mockedMarket = value
     }
 
-  override var hasSelectedMarket: Boolean = true
-
   companion object {
     var mockedMarket: Market? = null
     var mockedEnabledMarkets = Market.values().toList()

--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -118,8 +118,8 @@ import com.hedvig.app.feature.loggedin.ui.LoggedInViewModelImpl
 import com.hedvig.app.feature.marketing.MarketingViewModel
 import com.hedvig.app.feature.marketing.data.GetInitialMarketPickerValuesUseCase
 import com.hedvig.app.feature.marketing.data.GetMarketingBackgroundUseCase
-import com.hedvig.app.feature.marketing.data.SubmitMarketAndLanguagePreferencesUseCase
 import com.hedvig.app.feature.marketing.data.UpdateApplicationLanguageUseCase
+import com.hedvig.app.feature.marketing.data.UploadMarketAndLanguagePreferencesUseCase
 import com.hedvig.app.feature.marketpicker.LanguageRepository
 import com.hedvig.app.feature.offer.OfferRepository
 import com.hedvig.app.feature.offer.OfferViewModel
@@ -368,7 +368,7 @@ val viewModelModule = module {
   viewModel { TooltipViewModel(get()) }
   viewModel { MyInfoViewModel(get()) }
   viewModel { AboutAppViewModel(get()) }
-  viewModel { MarketingViewModel(get<MarketManager>().market, get(), get(), get(), get(), get(), get()) }
+  viewModel { MarketingViewModel(get<MarketManager>().market, get(), get(), get(), get(), get()) }
 }
 
 val onboardingModule = module {
@@ -570,7 +570,7 @@ val useCaseModule = module {
   single<GetFinalDanishAddressSelectionUseCase> { GetFinalDanishAddressSelectionUseCase(get()) }
   single { CreateQuoteCartUseCase(get(), get(), get()) }
   single {
-    SubmitMarketAndLanguagePreferencesUseCase(
+    UploadMarketAndLanguagePreferencesUseCase(
       apolloClient = get(),
       marketManager = get(),
       languageService = get(),

--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -311,7 +311,7 @@ val viewModelModule = module {
   viewModel { ClaimsViewModel(get(), get()) }
   viewModel { ChatViewModel(get(), get(), get(), get(), get(), get()) }
   viewModel { (quoteCartId: QuoteCartId?) -> RedeemCodeViewModel(quoteCartId, get(), get()) }
-  viewModel { UserViewModel(get(), get(), get(), get(), get(), get()) }
+  viewModel { UserViewModel(get(), get(), get(), get(), get(), get(), get()) }
   viewModel { WelcomeViewModel(get()) }
   viewModel {
     SettingsViewModel(
@@ -320,7 +320,9 @@ val viewModelModule = module {
     )
   }
   viewModel { DatePickerViewModel() }
-  viewModel { params -> SimpleSignAuthenticationViewModel(params.get(), get(), get(), get(), get(), get(), get()) }
+  viewModel { params ->
+    SimpleSignAuthenticationViewModel(params.get(), get(), get(), get(), get(), get(), get(), get())
+  }
   viewModel { (data: MultiActionParams) -> MultiActionViewModel(data) }
   viewModel { (componentState: MultiActionItem.Component?, multiActionParams: MultiActionParams) ->
     AddComponentViewModel(

--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -574,7 +574,6 @@ val useCaseModule = module {
   single {
     UploadMarketAndLanguagePreferencesUseCase(
       apolloClient = get(),
-      marketManager = get(),
       languageService = get(),
     )
   }

--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -349,6 +349,7 @@ val viewModelModule = module {
       get(),
       get(),
       get(),
+      get(),
     )
   }
   viewModel { parametersHolder: ParametersHolder ->

--- a/app/src/main/kotlin/com/hedvig/app/authenticate/LogoutUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/LogoutUseCase.kt
@@ -42,7 +42,6 @@ class LogoutUseCase(
 
   private fun clearMarket() {
     marketManager.market = null
-    marketManager.hasSelectedMarket = false
   }
 
   private fun clearLoginStatus() {

--- a/app/src/main/kotlin/com/hedvig/app/authenticate/UserViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/UserViewModel.kt
@@ -8,6 +8,7 @@ import com.hedvig.android.apollo.graphql.SwedishBankIdAuthMutation
 import com.hedvig.android.apollo.graphql.type.AuthState
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.app.feature.chat.data.UserRepository
+import com.hedvig.app.feature.marketing.data.UploadMarketAndLanguagePreferencesUseCase
 import com.hedvig.app.service.push.PushTokenManager
 import com.hedvig.hanalytics.HAnalytics
 import e
@@ -25,6 +26,7 @@ class UserViewModel(
   private val hAnalytics: HAnalytics,
   private val featureManager: FeatureManager,
   private val pushTokenManager: PushTokenManager,
+  private val uploadMarketAndLanguagePreferencesUseCase: UploadMarketAndLanguagePreferencesUseCase,
 ) : ViewModel() {
 
   val autoStartToken = MutableLiveData<SwedishBankIdAuthMutation.Data>()
@@ -83,5 +85,6 @@ class UserViewModel(
     hAnalytics.loggedIn()
     featureManager.invalidateExperiments()
     loginStatusService.isLoggedIn = true
+    uploadMarketAndLanguagePreferencesUseCase.invoke()
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/genericauth/otpinput/OtpInputViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/genericauth/otpinput/OtpInputViewModel.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.genericauth.otpinput
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hedvig.app.authenticate.AuthenticationTokenService
+import com.hedvig.app.feature.marketing.data.UploadMarketAndLanguagePreferencesUseCase
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +17,7 @@ class OtpInputViewModel(
   private val authenticationTokenService: AuthenticationTokenService,
   private val sendOtpCodeUseCase: SendOtpCodeUseCase,
   private val reSendOtpCodeUseCase: ReSendOtpCodeUseCase,
+  private val uploadMarketAndLanguagePreferencesUseCase: UploadMarketAndLanguagePreferencesUseCase,
 ) : ViewModel() {
   private val _viewState = MutableStateFlow(ViewState(credential = credential))
   val viewState = _viewState.asStateFlow()
@@ -73,12 +75,13 @@ class OtpInputViewModel(
     }
   }
 
-  private fun OtpResult.Success.handleSuccess() {
+  private suspend fun OtpResult.Success.handleSuccess() {
     authenticationTokenService.authenticationToken = authToken
     _events.trySend(Event.Success(authToken))
     _viewState.update {
       it.copy(loadingCode = false)
     }
+    uploadMarketAndLanguagePreferencesUseCase.invoke()
   }
 
   private fun ResendOtpResult.Success.handleSuccess() {

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingViewModel.kt
@@ -2,7 +2,6 @@ package com.hedvig.app.feature.marketing
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.Either
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.flags.Feature
 import com.hedvig.android.market.Language
@@ -10,7 +9,6 @@ import com.hedvig.android.market.Market
 import com.hedvig.app.feature.marketing.data.GetInitialMarketPickerValuesUseCase
 import com.hedvig.app.feature.marketing.data.GetMarketingBackgroundUseCase
 import com.hedvig.app.feature.marketing.data.MarketingBackground
-import com.hedvig.app.feature.marketing.data.SubmitMarketAndLanguagePreferencesUseCase
 import com.hedvig.app.feature.marketing.data.UpdateApplicationLanguageUseCase
 import com.hedvig.hanalytics.HAnalytics
 import com.hedvig.hanalytics.LoginMethod
@@ -22,7 +20,6 @@ import kotlinx.coroutines.launch
 class MarketingViewModel(
   market: Market?,
   private val hAnalytics: HAnalytics,
-  private val submitMarketAndLanguagePreferencesUseCase: SubmitMarketAndLanguagePreferencesUseCase,
   private val getMarketingBackgroundUseCase: GetMarketingBackgroundUseCase,
   private val updateApplicationLanguageUseCase: UpdateApplicationLanguageUseCase,
   private val getInitialMarketPickerValuesUseCase: GetInitialMarketPickerValuesUseCase,
@@ -89,22 +86,14 @@ class MarketingViewModel(
       val language = _state.value.language ?: error("Language null")
 
       _state.update { it.copy(isLoading = true) }
-
-      when (submitMarketAndLanguagePreferencesUseCase.invoke()) {
-        is Either.Left -> {
-          _state.update { it.copy(isLoading = false) }
-        }
-        is Either.Right -> {
-          updateApplicationLanguageUseCase.invoke(market, language)
-          featureManager.invalidateExperiments()
-          _state.update {
-            it.copy(
-              selectedMarket = market,
-              loginMethod = featureManager.getLoginMethod(),
-              isLoading = false,
-            )
-          }
-        }
+      updateApplicationLanguageUseCase.invoke(market, language)
+      featureManager.invalidateExperiments()
+      _state.update {
+        it.copy(
+          selectedMarket = market,
+          loginMethod = featureManager.getLoginMethod(),
+          isLoading = false,
+        )
       }
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
@@ -21,8 +21,8 @@ class UploadMarketAndLanguagePreferencesUseCase(
       .safeExecute()
       .toEither()
       .fold(
-        { i { "Succeeded uploading language preferences to language:$languageTag | locale:$locale" } },
-        { e { "Failed to to upload language preferences to language:$languageTag | locale:$locale" } },
+        ifLeft = { e { "Failed to to upload language preferences to language:$languageTag | locale:$locale" } },
+        ifRight = { i { "Succeeded uploading language preferences to language:$languageTag | locale:$locale" } },
       )
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
@@ -7,7 +7,7 @@ import com.hedvig.android.apollo.toEither
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
 
-class SubmitMarketAndLanguagePreferencesUseCase(
+class UploadMarketAndLanguagePreferencesUseCase(
   private val apolloClient: ApolloClient,
   private val marketManager: MarketManager,
   private val languageService: LanguageService,

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
@@ -2,24 +2,30 @@ package com.hedvig.app.feature.marketing.data
 
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.graphql.UpdateLanguageMutation
+import com.hedvig.android.apollo.graphql.type.Locale
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
+import e
+import i
 
 class UploadMarketAndLanguagePreferencesUseCase(
   private val apolloClient: ApolloClient,
   private val marketManager: MarketManager,
   private val languageService: LanguageService,
 ) {
-  suspend fun invoke() = apolloClient
-    .mutation(
-      UpdateLanguageMutation(
-        languageService.getLocale().toLanguageTag(),
-        languageService.getGraphQLLocale(),
-      ),
-    )
-    .safeExecute()
-    .toEither()
-    .tap { marketManager.hasSelectedMarket = true }
+  suspend fun invoke() {
+    val languageTag: String = languageService.getLocale().toLanguageTag()
+    val locale: Locale = languageService.getGraphQLLocale()
+    apolloClient
+      .mutation(UpdateLanguageMutation(languageTag, locale))
+      .safeExecute()
+      .toEither()
+      .tap { marketManager.hasSelectedMarket = true }
+      .fold(
+        { i { "Succeeded uploading language preferences to language:$languageTag | locale:$locale" } },
+        { e { "Failed to to upload language preferences to language:$languageTag | locale:$locale" } },
+      )
+  }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/UploadMarketAndLanguagePreferencesUseCase.kt
@@ -6,13 +6,11 @@ import com.hedvig.android.apollo.graphql.type.Locale
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.language.LanguageService
-import com.hedvig.android.market.MarketManager
 import e
 import i
 
 class UploadMarketAndLanguagePreferencesUseCase(
   private val apolloClient: ApolloClient,
-  private val marketManager: MarketManager,
   private val languageService: LanguageService,
 ) {
   suspend fun invoke() {
@@ -22,7 +20,6 @@ class UploadMarketAndLanguagePreferencesUseCase(
       .mutation(UpdateLanguageMutation(languageTag, locale))
       .safeExecute()
       .toEither()
-      .tap { marketManager.hasSelectedMarket = true }
       .fold(
         { i { "Succeeded uploading language preferences to language:$languageTag | locale:$locale" } },
         { e { "Failed to to upload language preferences to language:$languageTag | locale:$locale" } },

--- a/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationActivity.kt
@@ -56,9 +56,7 @@ class SimpleSignAuthenticationActivity : AppCompatActivity(R.layout.simple_sign_
     viewModel.events.observe(this) { event ->
       when (event) {
         SimpleSignAuthenticationViewModel.Event.LoadWebView -> showWebView()
-        SimpleSignAuthenticationViewModel.Event.Success -> {
-          goToLoggedIn()
-        }
+        SimpleSignAuthenticationViewModel.Event.Success -> goToLoggedIn()
         SimpleSignAuthenticationViewModel.Event.Error -> showError()
         SimpleSignAuthenticationViewModel.Event.CancelSignIn -> finishSignInActivity()
       }

--- a/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.market.Market
 import com.hedvig.app.authenticate.LoginStatusService
+import com.hedvig.app.feature.marketing.data.UploadMarketAndLanguagePreferencesUseCase
 import com.hedvig.app.feature.zignsec.usecase.AuthResult
 import com.hedvig.app.feature.zignsec.usecase.SimpleSignStartAuthResult
 import com.hedvig.app.feature.zignsec.usecase.StartDanishAuthUseCase
@@ -27,6 +28,7 @@ class SimpleSignAuthenticationViewModel(
   private val featureManager: FeatureManager,
   private val loginStatusService: LoginStatusService,
   private val subscribeToAuthResultUseCase: SubscribeToAuthResultUseCase,
+  private val uploadMarketAndLanguagePreferencesUseCase: UploadMarketAndLanguagePreferencesUseCase,
 ) : ViewModel() {
   private val _input = MutableLiveData("")
   val input: LiveData<String> = _input
@@ -125,6 +127,7 @@ class SimpleSignAuthenticationViewModel(
     hAnalytics.loggedIn()
     featureManager.invalidateExperiments()
     loginStatusService.isLoggedIn = true
+    uploadMarketAndLanguagePreferencesUseCase.invoke()
   }
 
   companion object {

--- a/app/src/test/kotlin/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
+++ b/app/src/test/kotlin/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
@@ -11,6 +11,7 @@ import com.hedvig.app.feature.genericauth.otpinput.ReSendOtpCodeUseCase
 import com.hedvig.app.feature.genericauth.otpinput.ResendOtpResult
 import com.hedvig.app.feature.genericauth.otpinput.SendOtpCodeUseCase
 import com.hedvig.app.util.coroutines.MainCoroutineRule
+import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -51,6 +52,7 @@ class OtpInputViewModelTest {
         return resendOtpResult
       }
     },
+    uploadMarketAndLanguagePreferencesUseCase = mockk(relaxed = true),
   )
 
   @Test

--- a/app/src/test/kotlin/com/hedvig/app/feature/marketing/ui/MarketingViewModelTest.kt
+++ b/app/src/test/kotlin/com/hedvig/app/feature/marketing/ui/MarketingViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.marketing.ui
 
-import arrow.core.Either
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -9,14 +8,12 @@ import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
-import com.hedvig.android.apollo.graphql.UpdateLanguageMutation
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
 import com.hedvig.app.feature.marketing.MarketingViewModel
 import com.hedvig.app.feature.marketing.data.GetInitialMarketPickerValuesUseCase
 import com.hedvig.app.feature.marketing.data.GetMarketingBackgroundUseCase
-import com.hedvig.app.feature.marketing.data.SubmitMarketAndLanguagePreferencesUseCase
 import com.hedvig.app.feature.marketing.data.UpdateApplicationLanguageUseCase
 import com.hedvig.app.util.coroutines.MainCoroutineRule
 import com.hedvig.hanalytics.HAnalytics
@@ -34,7 +31,6 @@ class MarketingViewModelTest {
   private fun createMarketingViewModel(
     market: Market? = null,
     hAnalytics: HAnalytics = mockk(relaxed = true),
-    submitMarketAndLanguagePreferencesUseCase: SubmitMarketAndLanguagePreferencesUseCase = mockk(relaxed = true),
     getMarketingBackgroundUseCase: GetMarketingBackgroundUseCase = mockk(relaxed = true),
     updateApplicationLanguageUseCase: UpdateApplicationLanguageUseCase = mockk(relaxed = true),
     getInitialMarketPickerValuesUseCase: GetInitialMarketPickerValuesUseCase = mockk(relaxed = true),
@@ -42,7 +38,6 @@ class MarketingViewModelTest {
   ) = MarketingViewModel(
     market = market,
     hAnalytics = hAnalytics,
-    submitMarketAndLanguagePreferencesUseCase = submitMarketAndLanguagePreferencesUseCase,
     getMarketingBackgroundUseCase = getMarketingBackgroundUseCase,
     updateApplicationLanguageUseCase = updateApplicationLanguageUseCase,
     getInitialMarketPickerValuesUseCase = getInitialMarketPickerValuesUseCase,
@@ -131,19 +126,8 @@ class MarketingViewModelTest {
 
   @Test
   fun `when submitting market and language preferences, should transition to market picked`() = runTest {
-    val submitMarketAndLanguagePreferencesUseCase = mockk<SubmitMarketAndLanguagePreferencesUseCase>()
-    coEvery { submitMarketAndLanguagePreferencesUseCase.invoke() } returns Either.Right(
-      UpdateLanguageMutation.Data(
-        updateLanguage = true,
-        updatePickedLocale = UpdateLanguageMutation.UpdatePickedLocale(
-          acceptLanguage = "",
-        ),
-      ),
-    )
-
     val viewModel = createMarketingViewModel(
       market = null,
-      submitMarketAndLanguagePreferencesUseCase = submitMarketAndLanguagePreferencesUseCase,
     )
     advanceUntilIdle()
     viewModel.setMarket(Market.SE)

--- a/hedvig-market/src/main/kotlin/com/hedvig/android/market/MarketManager.kt
+++ b/hedvig-market/src/main/kotlin/com/hedvig/android/market/MarketManager.kt
@@ -2,13 +2,11 @@ package com.hedvig.android.market
 
 import android.annotation.SuppressLint
 import android.content.Context
-import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 
 interface MarketManager {
   val enabledMarkets: List<Market>
   var market: Market?
-  var hasSelectedMarket: Boolean
 }
 
 internal class MarketManagerImpl(
@@ -29,15 +27,6 @@ internal class MarketManagerImpl(
     get() = getMarketLocally()
     set(value) {
       value?.let(::setMarketLocally) ?: removeMarket()
-    }
-  override var hasSelectedMarket: Boolean
-    get() {
-      return sharedPreferences.getBoolean("HAS_SELECTED_MARKET", false)
-    }
-    set(value) {
-      sharedPreferences.edit {
-        putBoolean("HAS_SELECTED_MARKET", value)
-      }
     }
 
   private fun getMarketLocally(): Market? {


### PR DESCRIPTION
Call the mutation only after there was an auth success on BankID success, and on simple sign success. Basically looked at the options that start from here https://github.com/HedvigInsurance/android/blob/ce396d51a817a5d620b5762e627e9fccb9a4ef64/app/src/main/kotlin/com/hedvig/app/util/navigation/NavUtil.kt#L20-L32 , https://github.com/HedvigInsurance/android/blob/dabb98db9d2042e9b61da630a6ab4a4e97d85e44/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt#L100-L111 and for the OTP case.

We're still setting these values in the marketing screen, and in the settings screen and the single source of truth about them is `LanguageService` where this use case is fetching the info from.

hasSelectedMarket was only being set in two places but seemingly not used anywhere, just removed that.