### PR TITLE
Make settings screen not show "not set" initially

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/settings/SettingsActivity.kt
@@ -14,6 +14,7 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.hedvig.android.core.common.preferences.PreferenceKey
+import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
 import com.hedvig.android.market.MarketManager
@@ -51,6 +52,7 @@ class SettingsActivity : AppCompatActivity(R.layout.activity_settings) {
     private val marketManager: MarketManager by inject()
     private val userViewModel: UserViewModel by activityViewModel()
     private val viewModel: SettingsViewModel by activityViewModel()
+    private val languageService: LanguageService by inject()
 
     @SuppressLint("ApplySharedPref")
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -75,6 +77,9 @@ class SettingsActivity : AppCompatActivity(R.layout.activity_settings) {
         .launchIn(lifecycleScope)
 
       val market = marketManager.market
+      if (market == null) {
+        startActivity(MarketingActivity.newInstance(requireContext()))
+      }
 
       val themePreference = findPreference<ListPreference>(SETTING_THEME)
       themePreference?.let { tp ->
@@ -92,9 +97,6 @@ class SettingsActivity : AppCompatActivity(R.layout.activity_settings) {
       }
 
       val marketPreference = findPreference<Preference>(SETTINGS_MARKET)
-      if (market == null) {
-        startActivity(MarketingActivity.newInstance(requireContext()))
-      }
       marketPreference?.let { mp ->
         mp.icon = market?.flag?.let { requireContext().compatDrawable(it) }
         mp.summary = market?.label?.let { getString(it) }
@@ -112,6 +114,7 @@ class SettingsActivity : AppCompatActivity(R.layout.activity_settings) {
 
       val languagePreference = findPreference<ListPreference>(PreferenceKey.SETTING_LANGUAGE)
       languagePreference?.let { lp ->
+        lp.value = languageService.getLanguage().toString()
         when (market) {
           Market.SE -> {
             lp.entries = resources.getStringArray(R.array.language_settings)
@@ -135,7 +138,7 @@ class SettingsActivity : AppCompatActivity(R.layout.activity_settings) {
             val language = Language.from(v)
             viewModel.applyLanguage(language)
           }
-          true
+          false
         }
       }
 


### PR DESCRIPTION
So the way that we use this preferences screen is kind of odd, since we do not actually store a bunch of this information inside shared preferences, so these changes may look a bit odd.
In the migration from shared prefs to the official language APIs, we did not update this screen to let the preference row know where to now fetch this information. So instead what it did is that it looked at shared prefs, which we've cleared in the migration, and didn't find anything.
Then when selecting a new language, it'd set the shared prefs again, something that we don't want, since it'd then trigger the migration again on next launch in LanguageService::performOneTimeLanguageMigration The two changes I'm introducing here, are a quick fix without changing this screen too much, but letting languagePreference update its value using the LanguageService, which uses the official language APIs under the hood to fetch the chosen language.
And the change from `true` to `false` inside the
setOnPreferenceChangeListener is so that it does not actually try and update the shared preferences again. But suffices to simply run `viewModel.applyLanguage(language)` which does properly update the LanguageService language anyway.