### PR TITLE
Update token used by Firebase Distribution.

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -56,7 +56,7 @@ jobs:
           BUILD_TOOLS_VERSION: "30.0.2"
       - uses: wzieba/Firebase-Distribution-Github-Action@v1.4.0
         with:
-          token: ${{ secrets.FIREBASE_STAGING_TOKEN }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_CREDENTIALS_FILE_CONTENT }}
           appId: ${{ secrets.FIREBASE_STAGING_APP_ID }}
           file: ${{ steps.sign_app.outputs.signedReleaseFile }}
           groups: android-testers


### PR DESCRIPTION
The `token` approach is now deprecated. More info on the migration here https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration