### PR TITLE
Fix crash on chat open from Odyssey

### DIFF
--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ClaimsFlowActivity.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ClaimsFlowActivity.kt
@@ -35,13 +35,18 @@ class ClaimsFlowActivity : ComponentActivity() {
         locale = locale,
         imageLoader = imageLoader,
         initialUrl = ROOT_URL,
-        onExternalNavigation = { url ->
-          when (url) {
-            CLOSE_URL -> finish()
-            CHAT_URL -> navigator.navigateToChat(this)
-          }
-        },
+        onExternalNavigation = ::onExternalNavigation,
       )
+    }
+  }
+
+  private fun onExternalNavigation(url: String) {
+    when (url) {
+      CLOSE_URL -> finish()
+      CHAT_URL -> {
+        finish()
+        navigator.navigateToChat(this@ClaimsFlowActivity)
+      }
     }
   }
 


### PR DESCRIPTION
Finish claims flow activity when going to chat.
Otherwise we get a `TransactionTooLargeException`, probably from trying to save the odyssey current activity state or something like that. We don't need this in our case.