### PR TITLE
Adds the logout observer to the necessary activities

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/adyen/payin/AdyenConnectPayinActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/adyen/payin/AdyenConnectPayinActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropInResult
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.app.R
 import com.hedvig.app.feature.adyen.AdyenCurrency
@@ -31,6 +32,7 @@ class AdyenConnectPayinActivity : AppCompatActivity(R.layout.fragment_container_
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val c = intent.getSerializableExtra(CURRENCY) as? AdyenCurrency
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/adyen/payout/AdyenConnectPayoutActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/adyen/payout/AdyenConnectPayoutActivity.kt
@@ -9,6 +9,7 @@ import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.dropin.DropInResult
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.app.R
 import com.hedvig.app.feature.adyen.AdyenCurrency
@@ -26,6 +27,7 @@ class AdyenConnectPayoutActivity : AppCompatActivity(R.layout.fragment_container
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val adyenCurrency = intent.getSerializableExtra(CURRENCY) as? AdyenCurrency
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import coil.ImageLoader
 import com.hedvig.android.apollo.graphql.ChatMessagesQuery
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.authenticate.LogoutUseCase
 import com.hedvig.app.databinding.ActivityChatBinding
@@ -75,6 +76,7 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     keyboardHeight = resources.getDimensionPixelSize(R.dimen.default_attach_file_height)
     isKeyboardBreakPoint =

--- a/app/src/main/kotlin/com/hedvig/app/feature/checkout/CheckoutActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/checkout/CheckoutActivity.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityCheckoutBinding
@@ -44,6 +45,7 @@ class CheckoutActivity : AppCompatActivity(R.layout.activity_checkout) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
     binding.apply {
       toolbar.setNavigationOnClickListener { onBackPressed() }
       val link = getString(

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ClaimDetailActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ClaimDetailActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.language.LanguageService
 import com.hedvig.app.feature.claimdetail.ui.ClaimDetailScreen
@@ -27,6 +28,7 @@ class ClaimDetailActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     window.compatSetDecorFitsSystemWindows(false)
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/CommonClaimActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/CommonClaimActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import coil.ImageLoader
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.odyssey.ClaimsFlowActivity.ItemType
 import com.hedvig.app.R
@@ -37,6 +38,7 @@ class CommonClaimActivity : AppCompatActivity(R.layout.activity_common_claim) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val data = intent.getParcelableExtra<CommonClaimsData>(CLAIMS_DATA) ?: return
     getViewModel<CommonClaimViewModel>()

--- a/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/EmergencyActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/EmergencyActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import coil.ImageLoader
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityEmergencyBinding
 import com.hedvig.app.feature.claims.ui.ClaimsViewModel
@@ -38,6 +39,7 @@ class EmergencyActivity : AppCompatActivity(R.layout.activity_emergency) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val data = intent.getParcelableExtra<EmergencyData>(EMERGENCY_DATA)
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/CrossSellingResultActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/CrossSellingResultActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.app.feature.loggedin.ui.LoggedInTabs
 import com.hedvig.app.util.extensions.startChat
@@ -23,6 +24,7 @@ class CrossSellingResultActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     setContent {
       CrossSellingResultScreen(

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import coil.ImageLoader
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.crossselling.ui.CrossSellData
 import com.hedvig.app.feature.offer.quotedetail.QuoteDetailActivity
@@ -26,6 +27,7 @@ class CrossSellDetailActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val viewModel = getViewModel<CrossSellDetailViewModel> {
       parametersOf(crossSell)

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/CrossSellFaqActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/CrossSellFaqActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import arrow.core.Either
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.chat.data.ChatRepository
 import com.hedvig.app.feature.crossselling.model.NavigateChat
@@ -30,7 +31,7 @@ import org.koin.core.parameter.parametersOf
 
 class CrossSellFaqActivity : AppCompatActivity() {
 
-  val crossSell by lazy {
+  private val crossSell by lazy {
     intent.getParcelableExtra<CrossSellData>(CROSS_SELL)
       ?: throw IllegalArgumentException("Programmer error: CROSS_SELL not passed to ${this.javaClass.name}")
   }
@@ -39,6 +40,7 @@ class CrossSellFaqActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     viewModel.viewState
       .flowWithLifecycle(lifecycle)

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/ui/EmbarkActivity.kt
@@ -16,6 +16,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialFadeThrough
 import com.google.android.material.transition.MaterialSharedAxis
 import com.hedvig.android.apollo.graphql.EmbarkStoryQuery
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.common.android.whenApiVersion
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.R
@@ -78,6 +79,7 @@ class EmbarkActivity : AppCompatActivity(R.layout.activity_embark) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       whenApiVersion(Build.VERSION_CODES.R) {

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/ui/MoreOptionsActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityMoreOptionsBinding
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
@@ -21,6 +22,7 @@ class MoreOptionsActivity : AppCompatActivity(R.layout.activity_more_options) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       window.compatSetDecorFitsSystemWindows(false)

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/changeaddress/ChangeAddressActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ChangeAddressActivityBinding
 import com.hedvig.app.databinding.ListTextItemBinding
@@ -43,6 +44,7 @@ class ChangeAddressActivity : AppCompatActivity(R.layout.change_address_activity
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     viewModel.events
       .flowWithLifecycle(lifecycle)

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/changeaddress/result/ChangeAddressResultActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/changeaddress/result/ChangeAddressResultActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ChangeAddressResultActivityBinding
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
@@ -24,6 +25,7 @@ class ChangeAddressResultActivity : AppCompatActivity(R.layout.change_address_re
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val result = intent.getParcelableExtra<Result>(RESULT) ?: run {
       e { "Programmer error: Missing argument RESULT in ${this.javaClass.name}" }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import coil.ImageLoader
 import com.google.android.material.tabs.TabLayoutMediator
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ContractDetailActivityBinding
@@ -51,6 +52,7 @@ class ContractDetailActivity : AppCompatActivity(R.layout.contract_detail_activi
       sharedElementExitTransition = sharedElementTransition()
     }
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
     binding.apply {
       window.compatSetDecorFitsSystemWindows(false)
       toolbar.applyStatusBarInsets()

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/terminatedcontracts/TerminatedContractsActivity.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import coil.ImageLoader
 import com.google.android.material.transition.platform.MaterialSharedAxis
 import com.hedvig.android.apollo.graphql.InsuranceQuery
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.R
 import com.hedvig.app.databinding.TerminatedContractsActivityBinding
@@ -44,6 +45,7 @@ class TerminatedContractsActivity : AppCompatActivity(R.layout.terminated_contra
     window.returnTransition = MaterialSharedAxis(MaterialSharedAxis.X, false)
     postponeEnterTransition()
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       window.compatSetDecorFitsSystemWindows(false)

--- a/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.github.florent37.viewtooltip.ViewTooltip
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.BASE_MARGIN_DOUBLE
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityLoggedInBinding
@@ -80,6 +81,7 @@ class LoggedInActivity : AppCompatActivity(R.layout.activity_logged_in) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     savedTab = savedInstanceState?.getSerializable("tab") as? LoggedInTabs
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/quotedetail/QuoteDetailActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/quotedetail/QuoteDetailActivity.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import coil.ImageLoader
 import com.carousell.concatadapterextension.ConcatItemDecoration
 import com.carousell.concatadapterextension.ConcatSpanSizeLookup
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.QuoteDetailActivityBinding
 import com.hedvig.app.feature.documents.DocumentAdapter
@@ -32,6 +33,7 @@ class QuoteDetailActivity : AppCompatActivity(R.layout.quote_detail_activity) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val title = intent.getStringExtra(TITLE)
     val perils: List<PerilItem>? = intent.getParcelableArrayListExtra<PerilItem.Peril>(PERILS)

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/OfferActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/OfferActivity.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropInResult
 import com.carousell.concatadapterextension.ConcatItemDecoration
 import com.carousell.concatadapterextension.ConcatSpanSizeLookup
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.MainActivity
@@ -87,6 +88,7 @@ class OfferActivity : AppCompatActivity(R.layout.activity_offer) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     window.compatSetDecorFitsSystemWindows(false)
     binding.offerToolbar.applyStatusBarInsets()

--- a/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/aboutapp/AboutAppActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/aboutapp/AboutAppActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityAboutAppBinding
@@ -30,6 +31,7 @@ class AboutAppActivity : AppCompatActivity(R.layout.activity_about_app) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     getViewModel<AboutAppViewModel>()
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/myinfo/MyInfoActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/myinfo/MyInfoActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.view.menu.ActionMenuItemView
 import androidx.core.view.isVisible
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.common.android.validation.validateEmail
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityMyInfoBinding
@@ -36,6 +37,7 @@ class MyInfoActivity : AppCompatActivity(R.layout.activity_my_info) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     getViewModel<MyInfoViewModel>()
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/PaymentActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/PaymentActivity.kt
@@ -10,6 +10,7 @@ import com.hedvig.android.apollo.graphql.PayinStatusQuery
 import com.hedvig.android.apollo.graphql.PaymentQuery
 import com.hedvig.android.apollo.graphql.type.PayinMethodStatus
 import com.hedvig.android.apollo.graphql.type.PayoutMethodStatus
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.R
@@ -36,6 +37,7 @@ class PaymentActivity : AppCompatActivity(R.layout.activity_payment) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       window.compatSetDecorFitsSystemWindows(false)

--- a/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/PaymentHistoryActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/PaymentHistoryActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.hedvig.android.apollo.graphql.PaymentQuery
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.R
@@ -29,6 +30,7 @@ class PaymentHistoryActivity : AppCompatActivity(R.layout.activity_payment_histo
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       window.compatSetDecorFitsSystemWindows(false)

--- a/app/src/main/kotlin/com/hedvig/app/feature/referrals/ReferralsReceiverActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/referrals/ReferralsReceiverActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ReferralsReceiverActivityBinding
 import com.hedvig.app.feature.chat.ui.ChatActivity
@@ -23,6 +24,7 @@ class ReferralsReceiverActivity : AppCompatActivity(R.layout.referrals_receiver_
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       lifecycleScope.launchWhenStarted {

--- a/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/ReferralsInformationActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/ReferralsInformationActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityReferralsInformationBinding
@@ -29,6 +30,7 @@ class ReferralsInformationActivity : AppCompatActivity(R.layout.activity_referra
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     val termsUrl = intent.getStringExtra(TERMS_URL)
     val incentiveAmount = intent.getSerializableExtra(INCENTIVE_AMOUNT) as? BigDecimal

--- a/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/activated/ReferralsActivatedActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/activated/ReferralsActivatedActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.language.LanguageService
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityReferralsActivatedBinding
@@ -28,6 +29,7 @@ class ReferralsActivatedActivity : AppCompatActivity(R.layout.activity_referrals
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       close.measure(

--- a/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/editcode/ReferralsEditCodeActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/editcode/ReferralsEditCodeActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.view.doOnLayout
 import androidx.core.view.updatePadding
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityReferralsEditCodeBinding
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
@@ -34,6 +35,7 @@ class ReferralsEditCodeActivity : AppCompatActivity(R.layout.activity_referrals_
   @SuppressLint("InflateParams")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     binding.apply {
       window.compatSetDecorFitsSystemWindows(false)

--- a/app/src/main/kotlin/com/hedvig/app/feature/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/settings/SettingsActivity.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.common.preferences.PreferenceKey
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.Language
@@ -33,6 +34,7 @@ class SettingsActivity : AppCompatActivity(R.layout.activity_settings) {
   @SuppressLint("ApplySharedPref")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
     binding.toolbar.setNavigationOnClickListener {
       onBackPressed()
     }

--- a/app/src/main/kotlin/com/hedvig/app/feature/trustly/TrustlyConnectPayinActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/trustly/TrustlyConnectPayinActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.feature.connectpayin.ConnectPayinType
 import com.hedvig.app.feature.connectpayin.ConnectPaymentResultFragment
@@ -20,6 +21,7 @@ class TrustlyConnectPayinActivity : AppCompatActivity(R.layout.fragment_containe
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
 
     if (isPostSign()) {
       connectPaymentViewModel.setInitialNavigationDestination(ConnectPaymentScreenState.Explainer)

--- a/feature-businessmodel/build.gradle.kts
+++ b/feature-businessmodel/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+  implementation(projects.auth.authAndroid)
   implementation(projects.coreCommonAndroid)
   implementation(projects.coreDesignSystem)
   implementation(projects.coreResources)

--- a/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/BusinessModelActivity.kt
+++ b/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/BusinessModelActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.view.WindowCompat
+import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.feature.businessmodel.ui.BusinessModelScreen
 import org.koin.androidx.viewmodel.ext.android.getViewModel
@@ -15,6 +16,7 @@ class BusinessModelActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    lifecycle.addObserver(AuthenticatedObserver())
     WindowCompat.setDecorFitsSystemWindows(window, false)
     getViewModel<BusinessModelViewModel>()
     setContent {


### PR DESCRIPTION
Tried to do this as carefully as I can, but I can totally see me making the mistake of adding this in a place where it doesn't need to be, or not adding it to a place where it does need to be in.
Gonna double check the activities once again to make sure.

In reality, the majority of the times, if someone opens the app after the refresh token is expired and they need to be logged out, they will have been redirected since the MainActivity will have caught the token being null. But this is so that even if we change what MainActivity does and they happen to be in any of these activities, they will still be redirected to the MarketingActivity.