### PR TITLE
BankIdLoginViewModel tests

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginDialog.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginDialog.kt
@@ -54,7 +54,7 @@ class BankIdLoginDialog : DialogFragment(com.hedvig.app.R.layout.dialog_authenti
   private fun bindViewState(viewState: BankIdLoginViewState) {
     when (viewState) {
       is BankIdLoginViewState.Error -> {
-        binding.authTitle.text = viewState.errorMessage
+        binding.authTitle.text = viewState.errorMessage ?: getString(R.string.NETWORK_ERROR_ALERT_MESSAGE)
       }
       BankIdLoginViewState.Loading -> {}
       is BankIdLoginViewState.HandlingBankId -> {

--- a/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginDialog.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginDialog.kt
@@ -55,6 +55,7 @@ class BankIdLoginDialog : DialogFragment(com.hedvig.app.R.layout.dialog_authenti
     when (viewState) {
       is BankIdLoginViewState.Error -> {
         binding.authTitle.text = viewState.errorMessage ?: getString(R.string.NETWORK_ERROR_ALERT_MESSAGE)
+        dialog?.setCanceledOnTouchOutside(true)
       }
       BankIdLoginViewState.Loading -> {}
       is BankIdLoginViewState.HandlingBankId -> {

--- a/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
@@ -62,7 +62,7 @@ class BankIdLoginViewModel(
 
   init {
     viewModelScope.launch {
-      val result = authRepository.startLoginAttempt(
+      val result: AuthAttemptResult = authRepository.startLoginAttempt(
         loginMethod = LoginMethod.SE_BANKID,
         market = Market.SE.name,
       )

--- a/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
@@ -37,6 +37,7 @@ class BankIdLoginViewModel(
   private val authRepository: AuthRepository,
 ) : ViewModel() {
 
+  private val startLoginAttemptFailed: MutableStateFlow<Boolean> = MutableStateFlow(false)
   private val bankIdProperties: MutableStateFlow<AuthAttemptResult.BankIdProperties?> = MutableStateFlow(null)
   private val processedAutoStartToken: MutableStateFlow<Boolean> = MutableStateFlow(false)
   private val processedNavigationToLoggedIn: MutableStateFlow<Boolean> = MutableStateFlow(false)
@@ -66,22 +67,31 @@ class BankIdLoginViewModel(
         market = Market.SE.name,
       )
 
-      // todo make error case representable in the view state and optionally prove a retry functionality
       when (result) {
         is AuthAttemptResult.BankIdProperties -> bankIdProperties.update { result }
-        is AuthAttemptResult.Error -> e { result.message }
+        is AuthAttemptResult.Error -> e { "Got Error when signing in with BankId ${result.message}" }
         is AuthAttemptResult.ZignSecProperties -> e { "Got ZignSec properties when signing in with BankId" }
         is AuthAttemptResult.OtpProperties -> e { "Got Otp properties when signing in with BankId" }
+      }
+      if (result !is AuthAttemptResult.BankIdProperties) {
+        startLoginAttemptFailed.update { true }
       }
     }
   }
 
   val viewState: StateFlow<BankIdLoginViewState> = combine(
+    startLoginAttemptFailed,
     bankIdProperties,
     processedAutoStartToken,
     loginStatusResult,
     processedNavigationToLoggedIn,
-  ) { bankIdProperties, processedAutoStartToken, loginStatusResult, processedNavigationToLoggedIn ->
+  ) {
+      startLoginAttemptFailed, bankIdProperties, processedAutoStartToken, loginStatusResult,
+      processedNavigationToLoggedIn,
+    ->
+    if (startLoginAttemptFailed) {
+      return@combine BankIdLoginViewState.Error(null)
+    }
     if (bankIdProperties == null || loginStatusResult == null) {
       return@combine BankIdLoginViewState.Loading
     }
@@ -122,7 +132,7 @@ class BankIdLoginViewModel(
 
 sealed interface BankIdLoginViewState {
   object Loading : BankIdLoginViewState
-  data class Error(val errorMessage: String) : BankIdLoginViewState
+  data class Error(val errorMessage: String?) : BankIdLoginViewState
   data class HandlingBankId(
     val autoStartToken: String,
     val processedAutoStartToken: Boolean,

--- a/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
@@ -1,0 +1,120 @@
+package com.hedvig.app.authenticate
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import com.hedvig.android.auth.AuthTokenService
+import com.hedvig.android.auth.AuthTokenServiceImpl
+import com.hedvig.android.auth.FakeAuthRepository
+import com.hedvig.android.auth.storage.AuthTokenStorage
+import com.hedvig.android.core.datastore.TestPreferencesDataStore
+import com.hedvig.android.hanalytics.featureflags.test.FakeFeatureManager
+import com.hedvig.app.feature.marketing.data.UploadMarketAndLanguagePreferencesUseCase
+import com.hedvig.app.feature.tracking.MockHAnalytics
+import com.hedvig.app.service.push.PushTokenManager
+import com.hedvig.app.util.coroutines.MainCoroutineRule
+import com.hedvig.authlib.AccessToken
+import com.hedvig.authlib.AuthAttemptResult
+import com.hedvig.authlib.AuthRepository
+import com.hedvig.authlib.AuthTokenResult
+import com.hedvig.authlib.AuthorizationCodeGrant
+import com.hedvig.authlib.LoginStatusResult
+import com.hedvig.authlib.RefreshToken
+import com.hedvig.authlib.StatusUrl
+import com.hedvig.hanalytics.LoginMethod
+import io.mockk.mockk
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class BankIdLoginViewModelTest {
+  @get:Rule
+  val mainCoroutineRule = MainCoroutineRule()
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  @Test
+  fun `auth repository responding successfully to the exchange, results in a login`() = runTest {
+    val authTokenService = testAuthTokenService()
+    val authRepository = FakeAuthRepository()
+    val viewModel: BankIdLoginViewModel = testBankIdLoginViewModel(authTokenService, authRepository)
+    backgroundScope.launch { viewModel.viewState.collect() } // Start a subscriber since we're using WhileSubscribed
+
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
+    authRepository.authAttemptResponse.add(
+      AuthAttemptResult.BankIdProperties("", StatusUrl(""), "autoStartToken"),
+    )
+    runCurrent()
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
+
+    authRepository.loginStatusResponse.add(LoginStatusResult.Pending(null))
+    runCurrent()
+    val pendingBankIdState = BankIdLoginViewState.HandlingBankId(
+      "autoStartToken",
+      false,
+      LoginStatusResult.Pending(null),
+      false,
+    )
+    assertThat(viewModel.viewState.value).isEqualTo(pendingBankIdState)
+    authRepository.loginStatusResponse.add(LoginStatusResult.Completed(AuthorizationCodeGrant("grant")))
+    runCurrent()
+    // Before exchange resolves, still in pending state
+    assertThat(viewModel.viewState.value).isEqualTo(pendingBankIdState)
+
+    // When exchange succeeds
+    authRepository.exchangeResponse.add(AuthTokenResult.Success(AccessToken("123", 90), RefreshToken("456", 90)))
+    runCurrent()
+    assertThat(viewModel.viewState.value).isEqualTo(
+      BankIdLoginViewState.HandlingBankId(
+        "autoStartToken",
+        false,
+        LoginStatusResult.Completed(AuthorizationCodeGrant("grant")),
+        false,
+      ),
+    )
+    viewModel.didNavigateToLoginScreen()
+    runCurrent()
+    assertThat((viewModel.viewState.value as BankIdLoginViewState.HandlingBankId).processedNavigationToLoggedIn)
+      .isTrue()
+    val resultingTokens = authTokenService.getTokens()
+    assertThat(resultingTokens).isNotNull()
+    resultingTokens!!
+    assertThat(resultingTokens.accessToken.token).isEqualTo("123")
+    assertThat(resultingTokens.refreshToken.token).isEqualTo("456")
+  }
+
+  private fun TestScope.testBankIdLoginViewModel(
+    authTokenService: AuthTokenService = testAuthTokenService(),
+    authRepository: AuthRepository = FakeAuthRepository(),
+  ): BankIdLoginViewModel {
+    @Suppress("RemoveExplicitTypeArguments")
+    return BankIdLoginViewModel(
+      MockHAnalytics(),
+      FakeFeatureManager(loginMethod = { LoginMethod.BANK_ID_SWEDEN }),
+      mockk<PushTokenManager>(relaxed = true),
+      mockk<UploadMarketAndLanguagePreferencesUseCase>(relaxed = true),
+      authTokenService,
+      authRepository,
+    )
+  }
+
+  private fun TestScope.testAuthTokenService(): AuthTokenService {
+    return AuthTokenServiceImpl(
+      AuthTokenStorage(
+        dataStore = TestPreferencesDataStore(
+          datastoreTestFileDirectory = testFolder.newFolder("datastoreTempFolder"),
+          coroutineScope = backgroundScope,
+        ),
+      ),
+      FakeAuthRepository(),
+      backgroundScope,
+    )
+  }
+}

--- a/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
@@ -41,11 +41,24 @@ class BankIdLoginViewModelTest {
   val testFolder = TemporaryFolder()
 
   @Test
-  fun `auth repository responding successfully to the exchange, results in a login`() = runTest {
+  fun `start login attempt failing results in an error state immediately`() = runTest {
     val authTokenService = testAuthTokenService()
     val authRepository = FakeAuthRepository()
     val viewModel: BankIdLoginViewModel = testBankIdLoginViewModel(authTokenService, authRepository)
     backgroundScope.launch { viewModel.viewState.collect() } // Start a subscriber since we're using WhileSubscribed
+
+    authRepository.authAttemptResponse.add(AuthAttemptResult.Error(""))
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
+    runCurrent()
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error(null))
+  }
+
+  @Test
+  fun `auth repository responding successfully to the exchange, results in a login`() = runTest {
+    val authTokenService = testAuthTokenService()
+    val authRepository = FakeAuthRepository()
+    val viewModel: BankIdLoginViewModel = testBankIdLoginViewModel(authTokenService, authRepository)
+    backgroundScope.launch { viewModel.viewState.collect() }
 
     assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
     authRepository.authAttemptResponse.add(

--- a/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
@@ -68,12 +68,12 @@ class BankIdLoginViewModelTest {
     runCurrent()
     assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
 
-    authRepository.loginStatusResponse.add(LoginStatusResult.Pending(null))
+    authRepository.loginStatusResponse.add(LoginStatusResult.Pending("pending status message"))
     runCurrent()
     val pendingBankIdState = BankIdLoginViewState.HandlingBankId(
       "autoStartToken",
       false,
-      LoginStatusResult.Pending(null),
+      LoginStatusResult.Pending("pending status message"),
       false,
     )
     assertThat(viewModel.viewState.value).isEqualTo(pendingBankIdState)
@@ -113,7 +113,7 @@ class BankIdLoginViewModelTest {
 
     assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
     authRepository.authAttemptResponse.add(
-      AuthAttemptResult.BankIdProperties("", StatusUrl(""), "autoStartToken"),
+      AuthAttemptResult.BankIdProperties("", StatusUrl(""), ""),
     )
     authRepository.loginStatusResponse.add(LoginStatusResult.Pending(null))
     runCurrent()

--- a/auth/auth-test/src/main/kotlin/com/hedvig/android/auth/FakeAuthRepository.kt
+++ b/auth/auth-test/src/main/kotlin/com/hedvig/android/auth/FakeAuthRepository.kt
@@ -12,9 +12,12 @@ import com.hedvig.authlib.RevokeResult
 import com.hedvig.authlib.StatusUrl
 import com.hedvig.authlib.SubmitOtpResult
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
 
 class FakeAuthRepository : AuthRepository {
 
+  val authAttemptResponse = Turbine<AuthAttemptResult>()
+  val loginStatusResponse = Turbine<LoginStatusResult>()
   val resendOtpResponse = Turbine<ResendOtpResult>()
   val submitOtpResponse = Turbine<SubmitOtpResult>()
   val exchangeResponse = Turbine<AuthTokenResult>()
@@ -25,11 +28,11 @@ class FakeAuthRepository : AuthRepository {
     personalNumber: String?,
     email: String?,
   ): AuthAttemptResult {
-    error("Not implemented")
+    return authAttemptResponse.awaitItem()
   }
 
   override fun observeLoginStatus(statusUrl: StatusUrl): Flow<LoginStatusResult> {
-    error("Not implemented")
+    return loginStatusResponse.asChannel().consumeAsFlow()
   }
 
   override suspend fun submitOtp(verifyUrl: String, otp: String): SubmitOtpResult {


### PR DESCRIPTION
Also made the case where the initial attempt to fetch the `BankIdProperties` also represent an Error case, with the generic `We couldn\'t reach Hedvig right now, are you sure you have an internet connection?` error message showing on the dialog, since that is most likely to happen when the network request fails, which would probably mean the internet connection is down, or our backend is dead, so it will like 100% of the time be a network error.