### PR TITLE
Remove custom error messages

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginDialog.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginDialog.kt
@@ -54,7 +54,7 @@ class BankIdLoginDialog : DialogFragment(com.hedvig.app.R.layout.dialog_authenti
   private fun bindViewState(viewState: BankIdLoginViewState) {
     when (viewState) {
       is BankIdLoginViewState.Error -> {
-        binding.authTitle.text = viewState.errorMessage ?: getString(R.string.NETWORK_ERROR_ALERT_MESSAGE)
+        binding.authTitle.text = getString(R.string.NETWORK_ERROR_ALERT_MESSAGE)
         dialog?.setCanceledOnTouchOutside(true)
       }
       BankIdLoginViewState.Loading -> {}

--- a/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
@@ -90,13 +90,13 @@ class BankIdLoginViewModel(
       processedNavigationToLoggedIn,
     ->
     if (startLoginAttemptFailed) {
-      return@combine BankIdLoginViewState.Error(null)
+      return@combine BankIdLoginViewState.Error
     }
     if (bankIdProperties == null || loginStatusResult == null) {
       return@combine BankIdLoginViewState.Loading
     }
     if (loginStatusResult is LoginStatusResult.Failed) {
-      return@combine BankIdLoginViewState.Error(loginStatusResult.message)
+      return@combine BankIdLoginViewState.Error
     }
     BankIdLoginViewState.HandlingBankId(
       bankIdProperties.autoStartToken,
@@ -132,7 +132,7 @@ class BankIdLoginViewModel(
 
 sealed interface BankIdLoginViewState {
   object Loading : BankIdLoginViewState
-  data class Error(val errorMessage: String?) : BankIdLoginViewState
+  object Error : BankIdLoginViewState
   data class HandlingBankId(
     val autoStartToken: String,
     val processedAutoStartToken: Boolean,

--- a/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
@@ -51,7 +51,7 @@ class BankIdLoginViewModelTest {
     authRepository.authAttemptResponse.add(AuthAttemptResult.Error(""))
     assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Loading)
     runCurrent()
-    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error(null))
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error)
   }
 
   @Test
@@ -121,9 +121,9 @@ class BankIdLoginViewModelTest {
       .isEqualTo(LoginStatusResult.Pending(null))
     authRepository.loginStatusResponse.add(LoginStatusResult.Completed(AuthorizationCodeGrant("grant")))
     // Exchange fails
-    authRepository.exchangeResponse.add(AuthTokenResult.Error("err"))
+    authRepository.exchangeResponse.add(AuthTokenResult.Error(""))
     runCurrent()
-    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error("err"))
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error)
     assertThat(authTokenService.getTokens()).isNull()
   }
 
@@ -142,9 +142,9 @@ class BankIdLoginViewModelTest {
     runCurrent()
     assertThat((viewModel.viewState.value as BankIdLoginViewState.HandlingBankId).authStatus)
       .isEqualTo(LoginStatusResult.Pending(null))
-    authRepository.loginStatusResponse.add(LoginStatusResult.Failed("Failed login"))
+    authRepository.loginStatusResponse.add(LoginStatusResult.Failed(""))
     runCurrent()
-    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error("Failed login"))
+    assertThat(viewModel.viewState.value).isEqualTo(BankIdLoginViewState.Error)
     assertThat(authTokenService.getTokens()).isNull()
   }
 


### PR DESCRIPTION
Turns out backend does sometimes return non human-readable error messages so we should rather not depend on that, but a local more generic error message

This is due to places like these https://github.com/HedvigInsurance/authlib/blob/54470fbd1c01574c6d7dd8a25f171c6bee416875/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt#L73 where we're simply appending the exception, so I don't think we want to show this to the members if possible.