### PR TITLE
Do nothing if the View passed inside showKeyboard is null

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/numberactionset/NumberActionFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/numberactionset/NumberActionFragment.kt
@@ -64,8 +64,8 @@ class NumberActionFragment : Fragment(R.layout.number_action_set_fragment) {
       messages.adapter = MessageAdapter(data.messages)
       val views = createInputViews()
       views.firstOrNull()?.let {
-        val input = it.findViewById<TextInputEditText>(R.id.input)
         viewLifecycleScope.launchWhenCreated {
+          val input = it.findViewById<TextInputEditText?>(R.id.input)
           requireContext().showKeyboardWithDelay(input, 500.milliseconds)
         }
       }

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/textaction/TextActionFragment.kt
@@ -64,8 +64,8 @@ class TextActionFragment : Fragment(R.layout.fragment_text_action_set) {
       }
       val views = createInputViews()
       views.firstOrNull()?.let {
-        val input = it.findViewById<TextInputEditText>(R.id.input)
         viewLifecycleScope.launchWhenCreated {
+          val input = it.findViewById<TextInputEditText?>(R.id.input)
           requireContext().showKeyboardWithDelay(input, 500.milliseconds)
         }
       }

--- a/app/src/main/kotlin/com/hedvig/app/util/extensions/ContextExtensions.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/extensions/ContextExtensions.kt
@@ -10,7 +10,6 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.graphics.Typeface
 import android.net.Uri
 import android.util.TypedValue
 import android.view.View
@@ -20,19 +19,14 @@ import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
-import androidx.annotation.FontRes
 import androidx.annotation.StringRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.preference.PreferenceManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.hedvig.android.core.common.preferences.PreferenceKey
-import com.hedvig.android.market.Language
 import com.hedvig.app.MainActivity
 import com.hedvig.app.R
 import com.hedvig.app.feature.chat.ui.ChatActivity
@@ -67,17 +61,6 @@ fun Context.drawableAttr(
 ): Int {
   theme.resolveAttribute(drawable, typedValue, resolveRefs)
   return typedValue.resourceId
-}
-
-fun Context.compatFont(@FontRes font: Int) = ResourcesCompat.getFont(this, font)
-
-fun Context.fontAttr(
-  @AttrRes font: Int,
-  typedValue: TypedValue = TypedValue(),
-  resolveRefs: Boolean = true,
-): Typeface? {
-  theme.resolveAttribute(font, typedValue, resolveRefs)
-  return ResourcesCompat.getFont(this, typedValue.resourceId)
 }
 
 fun Context.compatDrawable(@DrawableRes drawable: Int) =
@@ -137,12 +120,6 @@ fun Context.setLastOpen(date: Long) =
 
 fun Context.getLastOpen() =
   getSharedPreferences().getLong(SHARED_PREFERENCE_LAST_OPEN, 0)
-
-fun Context.getLanguage(): Language? {
-  val pref = PreferenceManager.getDefaultSharedPreferences(this)
-  val language = pref.getString(PreferenceKey.SETTING_LANGUAGE, null)
-  return language?.let { Language.from(it) }
-}
 
 private fun Context.getSharedPreferences() =
   this.getSharedPreferences(SHARED_PREFERENCE_NAME, Context.MODE_PRIVATE)

--- a/app/src/main/kotlin/com/hedvig/app/util/extensions/ContextExtensions.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/extensions/ContextExtensions.kt
@@ -103,7 +103,8 @@ suspend fun Context.hideKeyboardWithDelay(inputView: View, delayDuration: Durati
   }
 }
 
-suspend fun Context.showKeyboardWithDelay(inputView: View, delayDuration: Duration = 0.milliseconds) {
+suspend fun Context.showKeyboardWithDelay(inputView: View?, delayDuration: Duration = 0.milliseconds) {
+  if (inputView == null) return
   val windowInsets = WindowInsetsCompat.toWindowInsetsCompat(inputView.rootView.rootWindowInsets)
   if (!windowInsets.isVisible(WindowInsetsCompat.Type.ime())) {
     delay(delayDuration)


### PR DESCRIPTION
The way it was handled before, it seems like the reference to the view
is captured, but the coroutine runs later at which point it may be null
again. Or it is never found in the first place, but we cast to non-null
but it findViewById can in fact return null.

This guards against both cases by searching for the view only when the
coroutine actually runs, but also guards against null by simply not
showing the keyboard.
Better not to show the keyboard than to crash the app in such cases.

https://console.firebase.google.com/u/0/project/hedvig-app/crashlytics/app/android:com.hedvig.app/issues/48c40244c6e862963a93a09287bf5add?time=last-ninety-days