### PR TITLE
Put breadcrumbs in firebase crashalytics

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
@@ -13,6 +13,7 @@ import com.datadog.android.rum.RumMonitor
 import com.hedvig.android.hanalytics.android.tracking.ApplicationLifecycleTracker
 import com.hedvig.app.feature.settings.Theme
 import com.hedvig.app.feature.whatsnew.WhatsNewRepository
+import com.hedvig.app.util.firebase.FirebaseBreadcrumbTimberTree
 import com.hedvig.app.util.firebase.FirebaseCrashlyticsLogExceptionTree
 import org.koin.android.ext.android.inject
 import timber.log.Timber
@@ -32,6 +33,7 @@ open class HedvigApplication : Application() {
     if (isDebug()) {
       Timber.plant(Timber.DebugTree())
     } else {
+      Timber.plant(FirebaseBreadcrumbTimberTree())
       Timber.plant(FirebaseCrashlyticsLogExceptionTree())
     }
 

--- a/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
@@ -13,7 +13,7 @@ import com.datadog.android.rum.RumMonitor
 import com.hedvig.android.hanalytics.android.tracking.ApplicationLifecycleTracker
 import com.hedvig.app.feature.settings.Theme
 import com.hedvig.app.feature.whatsnew.WhatsNewRepository
-import com.hedvig.app.util.FirebaseCrashlyticsLogExceptionTree
+import com.hedvig.app.util.firebase.FirebaseCrashlyticsLogExceptionTree
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 
@@ -25,9 +25,7 @@ open class HedvigApplication : Application() {
   override fun onCreate() {
     super.onCreate()
     ProcessLifecycleOwner.get().lifecycle.addObserver(applicationLifecycleTracker)
-    Theme
-      .fromSettings(this)
-      ?.apply()
+    Theme.fromSettings(this)?.apply()
 
     whatsNewRepository.removeNewsForNewUser()
 

--- a/app/src/main/kotlin/com/hedvig/app/util/firebase/FirebaseBreadcrumbTimberTree.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/firebase/FirebaseBreadcrumbTimberTree.kt
@@ -1,0 +1,29 @@
+package com.hedvig.app.util.firebase
+
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import timber.log.Timber
+
+class FirebaseBreadcrumbTimberTree : Timber.Tree() {
+  override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+    if (t != null) return
+    val tagFormatted = tag?.let { "[$tag]" }.orEmpty()
+    Firebase.crashlytics.log("${prefix(priority)} $tagFormatted $message")
+  }
+
+  private fun prefix(priority: Int) = buildString {
+    append("[")
+    append(
+      when (priority) {
+        2 -> "VERBOSE"
+        3 -> "DEBUG"
+        4 -> "INFO"
+        5 -> "WARN"
+        6 -> "ERROR"
+        7 -> "ASSERT"
+        else -> "UNKNOWN"
+      },
+    )
+    append("]")
+  }
+}

--- a/app/src/main/kotlin/com/hedvig/app/util/firebase/FirebaseCrashlyticsLogExceptionTree.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/firebase/FirebaseCrashlyticsLogExceptionTree.kt
@@ -1,4 +1,4 @@
-package com.hedvig.app.util
+package com.hedvig.app.util.firebase
 
 import android.util.Log
 import com.google.firebase.crashlytics.FirebaseCrashlytics

--- a/app/src/main/kotlin/com/hedvig/app/util/firebase/FirebaseCrashlyticsLogExceptionTree.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/firebase/FirebaseCrashlyticsLogExceptionTree.kt
@@ -1,7 +1,8 @@
 package com.hedvig.app.util.firebase
 
 import android.util.Log
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
 import timber.log.Timber
 
 class FirebaseCrashlyticsLogExceptionTree : Timber.Tree() {
@@ -9,10 +10,10 @@ class FirebaseCrashlyticsLogExceptionTree : Timber.Tree() {
 
   override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
     if (t != null) {
-      FirebaseCrashlytics.getInstance().recordException(t)
+      Firebase.crashlytics.recordException(t)
     } else {
       val tagFormatted = tag?.let { "[$tag]" }.orEmpty()
-      FirebaseCrashlytics.getInstance().log("${prefix(priority)}${tagFormatted}$message")
+      Firebase.crashlytics.log("${prefix(priority)}${tagFormatted}$message")
     }
   }
 

--- a/auth/auth-android/src/main/kotlin/com/hedvig/android/auth/android/AuthenticatedObserver.kt
+++ b/auth/auth-android/src/main/kotlin/com/hedvig/android/auth/android/AuthenticatedObserver.kt
@@ -31,7 +31,7 @@ class AuthenticatedObserver : DefaultLifecycleObserver {
     }
   }
 
-  override fun onPause(ownerr: LifecycleOwner) {
+  override fun onPause(owner: LifecycleOwner) {
     authObservingJob?.cancel()
     authObservingJob = null
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -166,7 +166,7 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 datadog-sdk = { module = "com.datadoghq:dd-sdk-android", version.ref = "datadog" }
 firebase-bom = "com.google.firebase:firebase-bom:31.0.2"
-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 firebase-dynamicLinks = { module = "com.google.firebase:firebase-dynamic-links" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 firebase-playServicesBase = { module = "com.google.android.gms:play-services-base" }


### PR DESCRIPTION
The "Logs" tab in Firebase crashlytics is completely empty which sometimes can make it hard to figure out what exactly lead up to the crash.
This can serve as a tool to at least take the logs and put them there, leaving some sort of "breadcrumbs" which can help us figure out which path was taken until they reached the point of the crash.
It will log all timber logs we write down. Follow up PRs can make this more useful by adding more logs in key places.