### PR TITLE
Report to Firebase Crashlytics for staging builds

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
@@ -32,10 +32,9 @@ open class HedvigApplication : Application() {
 
     if (isDebug()) {
       Timber.plant(Timber.DebugTree())
-    } else {
-      Timber.plant(FirebaseBreadcrumbTimberTree())
-      Timber.plant(FirebaseCrashlyticsLogExceptionTree())
     }
+    Timber.plant(FirebaseBreadcrumbTimberTree())
+    Timber.plant(FirebaseCrashlyticsLogExceptionTree())
 
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
 


### PR DESCRIPTION
This can allow us to get more data on crashes, errors etc even in the staging builds coming from firebase app tester.