### PR TITLE
AGP related fixes

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/ChatIcon.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/ChatIcon.kt
@@ -94,7 +94,7 @@ fun ChatIconPreview() {
     ) {
       Column {
         ChatIcon({}, null)
-        ChatIcon({}, null, false)
+        ChatIcon({}, null, true)
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/AndroidCompose.kt
@@ -29,6 +29,9 @@ internal fun Project.configureAndroidCompose(
       val bom = libs.androidx.compose.bom
       add("implementation", platform(bom))
       add("androidTestImplementation", platform(bom))
+
+      add("implementation", libs.androidx.compose.uiToolingPreview)
+      add("debugImplementation", libs.androidx.compose.uiTooling)
     }
   }
 }

--- a/core-design-system/build.gradle.kts
+++ b/core-design-system/build.gradle.kts
@@ -15,8 +15,5 @@ dependencies {
   api(libs.accompanist.insetsUi)
   api(libs.androidx.compose.foundation)
   api(libs.androidx.compose.material)
-  api(libs.androidx.compose.uiToolingPreview)
   implementation(libs.androidx.compose.mdcAdapter)
-
-  debugApi(libs.androidx.compose.uiTooling)
 }

--- a/core-design-system/build.gradle.kts
+++ b/core-design-system/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 android {
   defaultConfig {
+    @Suppress("UnstableApiUsage")
     vectorDrawables.useSupportLibrary = true
   }
 }
@@ -18,8 +19,4 @@ dependencies {
   implementation(libs.androidx.compose.mdcAdapter)
 
   debugApi(libs.androidx.compose.uiTooling)
-  // TODO : Remove this dependency once we upgrade to Android Studio Dolphin b/228889042
-  // More context: https://stackoverflow.com/a/71830120/9440211, https://github.com/android/nowinandroid/blob/88054edf909de54e582850fcc461b5fefb550289/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt#L65-L71
-  // This dependency is currently necessary to render Compose previews
-  debugApi(libs.androidx.customview.poolingcontainer)
 }

--- a/core-resources/build.gradle.kts
+++ b/core-resources/build.gradle.kts
@@ -17,6 +17,7 @@ lokalise {
 
 android {
   defaultConfig {
+    @Suppress("UnstableApiUsage")
     vectorDrawables.useSupportLibrary = true
   }
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -11,8 +11,6 @@ dependencies {
   api(libs.accompanist.insetsUi)
   api(libs.androidx.compose.foundation)
   api(libs.androidx.compose.material)
-  api(libs.androidx.compose.uiToolingPreview)
-  debugApi(libs.androidx.compose.uiTooling)
   implementation(libs.androidx.compose.mdcAdapter)
   implementation(libs.androidx.compose.uiUtil)
   implementation(libs.coil.coil)

--- a/datadog/build.gradle.kts
+++ b/datadog/build.gradle.kts
@@ -12,3 +12,11 @@ dependencies {
   implementation(libs.okhttp.core)
   implementation(libs.slimber)
 }
+
+android {
+  lint {
+    // Context: https://issuetracker.google.com/issues/265962219
+    @Suppress("UnstableApiUsage")
+    disable += "EnsureInitializerMetadata"
+  }
+}

--- a/feature-odyssey/build.gradle.kts
+++ b/feature-odyssey/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
 
   implementation(libs.androidx.other.activityCompose)
   implementation(libs.coil.coil)
-  implementation(libs.hedvig.odyssey)
+  implementation(libs.hedvig.odyssey) {
+    // TODO remove when Odyssey no longer exposes koin-test as a non-test dependency
+    exclude("io.insert-koin", "koin-test")
+  }
   implementation(libs.koin.android)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ androidx-other-swipeRefreshLayout = "1.1.0"
 androidx-other-transition = "1.4.1"
 androidx-other-viewPager2 = "1.0.0"
 androidx-other-workManager = "2.7.1"
-androidx-poolingcontainer = "1.0.0"
 androidx-test-core = "1.5.0"
 androidx-test-junit = "1.1.4"
 arrowKt = "1.1.3"
@@ -114,7 +113,6 @@ androidx-compose-uiTooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-uiToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-uiUtil = { module = "androidx.compose.ui:ui-util" }
 androidx-compose-uiViewBinding = { module = "androidx.compose.ui:ui-viewbinding" }
-androidx-customview-poolingcontainer = { group = "androidx.customview", name = "customview-poolingcontainer", version.ref = "androidx-poolingcontainer" }
 androidx-datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "androidx-datastore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-datastore-preferencesCore = { module = "androidx.datastore:datastore-preferences-core", version.ref = "androidx-datastore" }


### PR DESCRIPTION
With the version bump, there were some workarounds we can now avoid.
Plus fixing the debugLint problem, temporarily for odyssey bringing in koin-test as a transitive dependency, and also temporarily for startup lint having a bug which I reported.