### PR TITLE
Add cancel button

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewState.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewState.kt
@@ -19,6 +19,7 @@ data class ContractDetailViewState(
     val detailsTable: Table,
     val changeAddressButton: YourInfoModel.ChangeAddressButton?,
     val change: YourInfoModel.Change,
+    val cancelInsurance: YourInfoModel.CancelInsuranceButton
   )
 
   data class CoverageViewState(

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractExt.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractExt.kt
@@ -45,6 +45,7 @@ fun InsuranceQuery.Contract.toMemberDetailsViewState() =
       null
     },
     change = YourInfoModel.Change,
+    cancelInsurance = YourInfoModel.CancelInsuranceButton,
   )
 
 fun InsuranceQuery.Contract.toCoverageViewState() = ContractDetailViewState.CoverageViewState(

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoAdapter.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoAdapter.kt
@@ -25,12 +25,14 @@ class YourInfoAdapter(
     is YourInfoModel.ChangeAddressButton -> R.layout.change_address_button
     YourInfoModel.Change -> R.layout.your_info_change
     is YourInfoModel.PendingAddressChange -> R.layout.change_address_pending_change_card
+    YourInfoModel.CancelInsuranceButton -> R.layout.cancel_insurance_button
   }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
     R.layout.change_address_button -> ViewHolder.ChangeAddressButton(parent)
     R.layout.your_info_change -> ViewHolder.Change(parent)
     R.layout.change_address_pending_change_card -> ViewHolder.PendingAddressChange(parent)
+    R.layout.cancel_insurance_button -> ViewHolder.CancelInsuranceButton(parent)
     else -> throw Error("Invalid view type")
   }
 
@@ -79,6 +81,15 @@ class YourInfoAdapter(
           hedvig.resources.R.string.insurance_details_adress_update_body_no_address,
           data.upcomingAgreement.activeFrom,
         )
+      }
+    }
+
+    class CancelInsuranceButton(parent: ViewGroup) : ViewHolder(parent.inflate(R.layout.cancel_insurance_button)) {
+      private val binding by viewBinding(ChangeAddressButtonBinding::bind)
+      override fun bind(data: YourInfoModel, fragmentManager: FragmentManager) {
+        binding.root.setHapticClickListener {
+          // TODO
+        }
       }
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoFragment.kt
@@ -49,7 +49,13 @@ class YourInfoFragment : Fragment(R.layout.contract_detail_your_info_fragment) {
             val state = viewState.state.memberDetailsViewState
             tableAdapter.setTable(state.detailsTable)
             topYourInfoAdapter.submitList(listOfNotNull(state.pendingAddressChange))
-            bottomYourInfoAdapter.submitList(listOfNotNull(state.changeAddressButton, state.change))
+            bottomYourInfoAdapter.submitList(
+              listOfNotNull(
+                state.changeAddressButton,
+                state.change,
+                state.cancelInsurance,
+              ),
+            )
           }
         }
       }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/yourinfo/YourInfoModel.kt
@@ -10,4 +10,6 @@ sealed class YourInfoModel {
   data class PendingAddressChange(
     val upcomingAgreement: GetUpcomingAgreementUseCase.UpcomingAgreementResult.UpcomingAgreement,
   ) : YourInfoModel()
+
+  object CancelInsuranceButton : YourInfoModel()
 }

--- a/app/src/main/res/layout/cancel_insurance_button.xml
+++ b/app/src/main/res/layout/cancel_insurance_button.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cancel_insurance_button"
+    style="?materialButtonTextStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/base_margin_double"
+    android:layout_marginVertical="@dimen/base_margin"
+    android:padding="@dimen/base_margin_double"
+    android:text="@string/CANCEL_SUBSCRIPTION_BUTTON"
+    android:textColor="?colorError" />


### PR DESCRIPTION
Should rewrite this to compose. And implement new design: https://www.figma.com/file/w77DwpXFMMbt3ujLmijYZy/Terminate-Insurance-iOS?node-id=769%3A22925&t=Tk12ZFiq1dMSXcKn-0

Looks quite messy now with different kind of buttons at the bottom of this screen. But in the spirit of implementing a skateboard solution, I will keep this PR short!