### PR TITLE
More auth logs

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationActivity.kt
@@ -23,6 +23,7 @@ import com.hedvig.app.util.extensions.viewBinding
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import slimber.log.d
 
 class SimpleSignAuthenticationActivity : AppCompatActivity(R.layout.simple_sign_authentication_activity) {
   private val binding by viewBinding(SimpleSignAuthenticationActivityBinding::bind)
@@ -38,7 +39,10 @@ class SimpleSignAuthenticationActivity : AppCompatActivity(R.layout.simple_sign_
     window.compatSetDecorFitsSystemWindows(false)
     binding.toolbar.apply {
       applyStatusBarInsets()
-      setNavigationOnClickListener { finishSignInActivity() }
+      setNavigationOnClickListener {
+        d { "SimpleSignAuthenticationActivity: pressed back button and going back to marketing" }
+        finishSignInActivity()
+      }
     }
     binding.container.applyNavigationBarInsets()
     if (savedInstanceState == null) {
@@ -54,6 +58,7 @@ class SimpleSignAuthenticationActivity : AppCompatActivity(R.layout.simple_sign_
     }
 
     viewModel.events.observe(this) { event ->
+      d { "Simple sign event:$event" }
       when (event) {
         SimpleSignAuthenticationViewModel.Event.LoadWebView -> showWebView()
         SimpleSignAuthenticationViewModel.Event.Success -> goToLoggedIn()

--- a/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationViewModel.kt
@@ -19,6 +19,7 @@ import com.hedvig.authlib.LoginStatusResult
 import com.hedvig.authlib.StatusUrl
 import com.hedvig.hanalytics.HAnalytics
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import slimber.log.d
@@ -67,6 +68,7 @@ class SimpleSignAuthenticationViewModel(
   suspend fun subscribeToAuthSuccessEvent() {
     statusUrl.asFlow().collectLatest { statusUrl ->
       authRepository.observeLoginStatus(statusUrl)
+        .distinctUntilChanged()
         .onCompletion {
           d { "subscribeToAuthSuccessEvent finished" }
         }

--- a/app/src/main/kotlin/com/hedvig/app/feature/zignsec/ui/ZignSecWebViewFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/zignsec/ui/ZignSecWebViewFragment.kt
@@ -14,6 +14,7 @@ import com.hedvig.app.databinding.ActivityZignSecAuthenticationBinding
 import com.hedvig.app.feature.zignsec.SimpleSignAuthenticationViewModel
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
+import slimber.log.d
 
 class ZignSecWebViewFragment : Fragment(R.layout.activity_zign_sec_authentication) {
   private val binding by viewBinding(ActivityZignSecAuthenticationBinding::bind)
@@ -21,7 +22,7 @@ class ZignSecWebViewFragment : Fragment(R.layout.activity_zign_sec_authenticatio
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-
+    d { "Fragment:ZignSecWebViewFragment was created" }
     enterTransition = MaterialSharedAxis(MaterialSharedAxis.X, true)
     returnTransition = MaterialSharedAxis(MaterialSharedAxis.X, false)
     exitTransition = MaterialSharedAxis(MaterialSharedAxis.X, true)

--- a/datadog/src/main/kotlin/com/hedvig/android/datadog/DatadogLoggingTree.kt
+++ b/datadog/src/main/kotlin/com/hedvig/android/datadog/DatadogLoggingTree.kt
@@ -2,10 +2,18 @@ package com.hedvig.android.datadog
 
 import timber.log.Timber
 
+/**
+ * To filter specifically for only these logs locally, to emulate what one would see in datadog logs, use the following
+ * logcat filter:
+ * package:mine tag=:android
+ *
+ * This filters for only our package, plus *exactly* the "android" tag.
+ */
 internal class DatadogLoggingTree : Timber.Tree() {
   private val datadogLogger = com.datadog.android.log.Logger.Builder()
     .setNetworkInfoEnabled(true)
     .setDatadogLogsMinPriority(android.util.Log.DEBUG)
+    .setLogcatLogsEnabled(true)
     .build()
 
   override fun isLoggable(tag: String?, priority: Int): Boolean {


### PR DESCRIPTION
Add replicating datadog logs to logcat which allows us to emulate what logs we will see in datadog to know if they suffice or not.
Plus some fixes due to what  I could see from those.