### PR TITLE
Offpiste: Predictive back gesture

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
     <application
         android:name=".HedvigApplication"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupOnly="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/APP_NAME"
@@ -263,6 +264,7 @@
             android:name="com.hedvig.android.odyssey.ClaimsFlowActivity"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize" />
+
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_hedvig_h" />


### PR DESCRIPTION
Will for now only be visible for phones who have developer options on *AND* they've explicitly opted-in to the preview of this feature in the developer settings. For future OS versions however this will be expected.
Turns out we're not fiddling with back handling almost at all, so migration for us is simply opting in to this feature and we get this functionality for free! https://developer.android.com/guide/navigation/predictive-back-gesture#update-custom

https://user-images.githubusercontent.com/44558292/221212255-18162305-0478-4028-ae31-1fb6d33da395.mov

