### PR TITLE
Remove themeAdapter dependency and do it ourselves

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,7 +195,6 @@ dependencies {
   implementation(libs.accompanist.pager)
   implementation(libs.accompanist.pagerIndicators)
   implementation(libs.accompanist.systemUiController)
-  implementation(libs.accompanist.themeAdapter.material)
 
   implementation(libs.apollo.adapters)
   implementation(libs.apollo.normalizedCache)

--- a/app/src/main/kotlin/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalComposeUiApi::class, ExperimentalUnitApi::class)
-
 package com.hedvig.app.feature.genericauth.otpinput
 
 import androidx.compose.animation.AnimatedVisibility
@@ -45,10 +43,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.ExperimentalUnitApi
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.text.isDigitsOnly
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
@@ -102,6 +100,7 @@ fun OtpInputScreen(
   }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun OtpInputScreenContents(
   credential: String,
@@ -146,6 +145,7 @@ private fun OtpInputScreenContents(
   }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun ColumnScope.SixDigitCodeInputField(
   inputValue: String,
@@ -170,7 +170,7 @@ private fun ColumnScope.SixDigitCodeInputField(
     isError = otpErrorMessage != null,
     shape = MaterialTheme.shapes.medium,
     textStyle = LocalTextStyle.current.copy(
-      letterSpacing = TextUnit(20f, TextUnitType.Sp),
+      letterSpacing = 20.sp,
       fontWeight = FontWeight(400),
       fontSize = TextUnit(28f, TextUnitType.Sp),
       textAlign = TextAlign.Center,
@@ -192,6 +192,7 @@ private fun ColumnScope.SixDigitCodeInputField(
   }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun ResendCodeItem(
   onResendCode: () -> Unit,
@@ -248,26 +249,6 @@ private fun RotatingIcon(isLoading: Boolean) {
 @Preview(showBackground = true)
 @Composable
 fun OtpInputScreenValidPreview() {
-  HedvigTheme {
-    OtpInputScreen(
-      onInputChanged = {},
-      onOpenExternalApp = {},
-      onSubmitCode = {},
-      onResendCode = {},
-      onBackPressed = {},
-      inputValue = "0123456",
-      credential = "john@doe.com",
-      networkErrorMessage = null,
-      loadingResend = false,
-      loadingCode = false,
-      snackbarHostState = SnackbarHostState(),
-    )
-  }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun OtpInputScreenInvalidPreview() {
   HedvigTheme {
     OtpInputScreen(
       onInputChanged = {},

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt
@@ -16,8 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import coil.ImageLoader
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.core.designsystem.theme.hedvig_black
-import com.hedvig.android.core.designsystem.theme.hedvig_off_white
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
@@ -46,16 +44,7 @@ class MarketingActivity : AppCompatActivity() {
     val viewModel = getViewModel<MarketingViewModel>()
     val imageLoader: ImageLoader = get()
     setContent {
-      HedvigTheme(
-        colorOverrides = { colors ->
-          colors.copy(
-            primary = hedvig_off_white,
-            onPrimary = hedvig_black,
-            secondary = hedvig_off_white,
-            onBackground = hedvig_off_white,
-          )
-        },
-      ) {
+      HedvigTheme(darkTheme = true) { // Force dark theme as the background is dark
         val marketingBackground by viewModel.marketingBackground.collectAsState()
         val state by viewModel.state.collectAsState()
         MarketingScreen(
@@ -93,6 +82,7 @@ class MarketingActivity : AppCompatActivity() {
       supportFragmentManager,
       BankIdLoginDialog.TAG,
     )
+
     LoginMethod.NEM_ID, LoginMethod.BANK_ID_NORWAY -> {
       startActivity(
         SimpleSignAuthenticationActivity.newInstance(
@@ -101,9 +91,11 @@ class MarketingActivity : AppCompatActivity() {
         ),
       )
     }
+
     LoginMethod.OTP -> {
       // Not implemented
     }
+
     null -> {}
   }
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
@@ -8,10 +8,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,9 +56,7 @@ fun MarketPickedScreen(
     ) {
       LargeContainedButton(
         onClick = onClickSignUp,
-        colors = ButtonDefaults.buttonColors(
-          backgroundColor = MaterialTheme.colors.primary,
-        ),
+        colors = ButtonDefaults.buttonColors(),
       ) {
         Text(
           text = stringResource(hedvig.resources.R.string.MARKETING_GET_HEDVIG),

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.marketing.pickmarket
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +34,7 @@ import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,7 +42,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -82,6 +83,11 @@ fun PickMarketScreen(
 
   ModalBottomSheetLayout(
     sheetState = modalBottomSheetState,
+    sheetBackgroundColor = if (isSystemInDarkTheme()) {
+      MaterialTheme.colors.surface
+    } else {
+      MaterialTheme.colors.onSurface
+    },
     sheetContent = {
       HedvigTheme { // Use standard theme again inside the sheet.
         BottomSheetContent(
@@ -113,7 +119,7 @@ fun PickMarketScreen(
   }
 }
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun ScreenContent(
   setSheet: (PickMarketSheet?) -> Unit,
@@ -172,6 +178,7 @@ private fun ScreenContent(
       LargeContainedButton(
         onClick = onSubmit,
         enabled = enabled,
+        colors = ButtonDefaults.buttonColors(),
         modifier = Modifier
           .padding(horizontal = 16.dp)
           .testTag("continueButton"),
@@ -216,6 +223,7 @@ private fun BottomSheetContent(
         selectedMarket = selectedMarket,
         markets = markets,
       )
+
       PickMarketSheet.COUNTRY -> PickLanguageSheetContent(
         onSelectLanguage = { language ->
           coroutineScope.launch {
@@ -226,6 +234,7 @@ private fun BottomSheetContent(
         selectedLanguage = selectedLanguage,
         selectedMarket = selectedMarket,
       )
+
       null -> {}
     }
     Spacer(Modifier.height(24.dp))
@@ -240,7 +249,7 @@ private fun LanguageFlag() {
   )
 }
 
-@Suppress("unused")
+@Suppress("UnusedReceiverParameter")
 @Composable
 private fun ColumnScope.PickMarketSheetContent(
   onSelectMarket: (Market) -> Unit,
@@ -264,7 +273,7 @@ private fun ColumnScope.PickMarketSheetContent(
   }
 }
 
-@Suppress("unused")
+@Suppress("UnusedReceiverParameter")
 @Composable
 private fun ColumnScope.PickLanguageSheetContent(
   onSelectLanguage: (Language) -> Unit,

--- a/app/src/main/res/layout/header_item_layout.xml
+++ b/app/src/main/res/layout/header_item_layout.xml
@@ -7,5 +7,5 @@
         android:id="@+id/header_item"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/Hedvig.TextAppearance.Headline5"
+        android:textAppearance="?textAppearanceHeadline5"
         tools:text="Make changes" />

--- a/app/src/main/res/layout/offer_header.xml
+++ b/app/src/main/res/layout/offer_header.xml
@@ -23,7 +23,8 @@
 
             <TextView
                 android:id="@+id/campaign"
-                style="@style/Hedvig.TextAppearance.Discount"
+                style="?textAppearanceCaption"
+                android:textColor="?android:textColorSecondary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/base_margin_half"
@@ -91,11 +92,11 @@
                 android:id="@+id/startDateContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingVertical="@dimen/base_margin_double"
                 android:layout_marginHorizontal="@dimen/base_margin"
-                android:paddingHorizontal="@dimen/base_margin"
                 android:layout_marginTop="@dimen/base_margin_quintuple"
-                android:background="@drawable/background_rounded_corners_ripple">
+                android:background="@drawable/background_rounded_corners_ripple"
+                android:paddingHorizontal="@dimen/base_margin"
+                android:paddingVertical="@dimen/base_margin_double">
 
                 <TextView
                     android:id="@+id/startDateLabel"

--- a/app/src/main/res/values/text_themes.xml
+++ b/app/src/main/res/values/text_themes.xml
@@ -1,10 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="Hedvig.TextAppearance.Headline3" parent="TextAppearance.MaterialComponents.Headline3">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">48sp</item>
+        <item name="lineHeight">58sp</item>
+    </style>
+
+    <style name="Hedvig.TextAppearance.Headline4" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="lineHeight">40sp</item>
+        <item name="android:textSize">32sp</item>
+    </style>
+
+    <style name="Hedvig.TextAppearance.Headline5" parent="TextAppearance.MaterialComponents.Headline5">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">24sp</item>
+        <item name="lineHeight">32sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
+    <dimen name="headline_5_placeholder_width">72sp</dimen>
+    <dimen name="headline_5_placeholder_height">24sp</dimen>
+
+    <style name="Hedvig.TextAppearance.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">20sp</item>
+        <item name="lineHeight">26sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
+    <style name="Hedvig.TextAppearance.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">16sp</item>
+        <item name="lineHeight">24sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
+    <dimen name="subtitle_1_placeholder_width">48sp</dimen>
+    <dimen name="subtitle_1_placeholder_height">16sp</dimen>
+
+    <style name="Hedvig.TextAppearance.Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">14sp</item>
+        <item name="lineHeight">20sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
     <style name="Hedvig.TextAppearance.Body1" parent="TextAppearance.MaterialComponents.Body1">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">26sp</item>
-        <item name="android:letterSpacing">0</item>
+        <item name="android:textSize">16sp</item>
+        <item name="lineHeight">24sp</item>
     </style>
 
     <dimen name="body_1_placeholder_width">48sp</dimen>
@@ -13,81 +59,28 @@
 
     <style name="Hedvig.TextAppearance.Body2" parent="TextAppearance.MaterialComponents.Body2">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">22sp</item>
-        <item name="android:letterSpacing">0</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-        <item name="lineHeight">24sp</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">14sp</item>
         <item name="lineHeight">20sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-    </style>
-
-    <dimen name="subtitle_1_placeholder_width">48sp</dimen>
-    <dimen name="subtitle_1_placeholder_height">16sp</dimen>
-
-    <style name="Hedvig.TextAppearance.Headline3" parent="TextAppearance.MaterialComponents.Headline3">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="android:letterSpacing">-0.05</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Headline4" parent="TextAppearance.MaterialComponents.Headline4">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">40sp</item>
-        <item name="android:textSize">32sp</item>
-        <item name="android:letterSpacing">-0.025</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Headline5" parent="TextAppearance.MaterialComponents.Headline5">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">32sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-        <item name="android:letterSpacing">0</item>
-    </style>
-
-    <dimen name="headline_5_placeholder_width">72sp</dimen>
-    <dimen name="headline_5_placeholder_height">24sp</dimen>
-
-    <style name="Hedvig.TextAppearance.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">26sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-        <item name="android:letterSpacing">0</item>
     </style>
 
     <style name="Hedvig.TextAppearance.Button" parent="TextAppearance.MaterialComponents.Button">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">16sp</item>
         <item name="lineHeight">24sp</item>
-        <item name="android:textSize">17sp</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:letterSpacing">-0.01</item>
     </style>
 
     <style name="Hedvig.TextAppearance.Caption" parent="TextAppearance.MaterialComponents.Caption">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">12sp</item>
         <item name="lineHeight">16sp</item>
-        <item name="android:letterSpacing">0</item>
         <item name="android:textColor">?android:textColorTertiary</item>
     </style>
 
-    <style name="Hedvig.TextAppearance.Discount" parent="TextAppearance.MaterialComponents.Caption">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">16sp</item>
-        <item name="android:letterSpacing">0.1</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-    </style>
-
-
     <style name="Hedvig.TextAppearance.Overline" parent="TextAppearance.MaterialComponents.Overline">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">10sp</item>
         <item name="lineHeight">16sp</item>
-        <item name="android:letterSpacing">0.05</item>
     </style>
 
 </resources>

--- a/core-design-system/build.gradle.kts
+++ b/core-design-system/build.gradle.kts
@@ -10,9 +10,7 @@ dependencies {
   api(libs.accompanist.insetsUi)
   api(libs.androidx.compose.foundation)
   api(libs.androidx.compose.material)
-
-  implementation(libs.accompanist.themeAdapter.material)
-  implementation(libs.androidx.compose.material3)
+  api(libs.androidx.compose.material3)
 }
 
 android {

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
@@ -3,16 +3,23 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonColors
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.containedButtonContainer
+import com.hedvig.android.core.designsystem.theme.onContainedButtonContainer
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeContainedTextButton(
@@ -36,26 +43,35 @@ fun LargeContainedButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   colors: ButtonColors = ButtonDefaults.buttonColors(
-    backgroundColor = if (MaterialTheme.colors.isLight) {
-      MaterialTheme.colors.primary
-    } else {
-      MaterialTheme.colors.secondary
-    },
-    contentColor = MaterialTheme.colors.onPrimary,
+    containerColor = Material3Theme.colorScheme.containedButtonContainer,
+    contentColor = Material3Theme.colorScheme.onContainedButtonContainer,
+    disabledContainerColor = Material3Theme.colorScheme.containedButtonContainer.copy(
+      alpha = 0.12f,
+    ),
+    disabledContentColor = Material3Theme.colorScheme.onContainedButtonContainer.copy(
+      alpha = 0.38f,
+    ),
   ),
   content: @Composable RowScope.() -> Unit,
 ) {
   Button(
     onClick = onClick,
     enabled = enabled,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
-    shape = MaterialTheme.shapes.large,
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
     colors = colors,
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      androidx.compose.material.LocalContentColor provides LocalContentColor.current,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }
 
 @Preview(

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
@@ -3,17 +3,19 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.Text
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeOutlinedTextButton(
@@ -34,20 +36,24 @@ fun LargeOutlinedTextButton(
 fun LargeOutlinedButton(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
-  backgroundColor: Color = Color.Transparent,
   content: @Composable RowScope.() -> Unit,
 ) {
   OutlinedButton(
     onClick = onClick,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
-    border = ButtonDefaults.outlinedBorder.copy(brush = SolidColor(MaterialTheme.colors.primary)),
-    colors = ButtonDefaults.outlinedButtonColors(backgroundColor = backgroundColor),
-    shape = MaterialTheme.shapes.large,
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides Material2Theme.colors.onBackground,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }
 
 @Preview(
@@ -56,7 +62,7 @@ fun LargeOutlinedButton(
   showBackground = true,
 )
 @Composable
-fun LargeOutlinedButtonPreview() {
+private fun LargeOutlinedButtonPreview() {
   HedvigTheme {
     LargeOutlinedTextButton(text = "Outlined Button (Large)", onClick = {})
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
@@ -3,10 +3,15 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.TextButton
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeTextButton(
@@ -16,10 +21,18 @@ fun LargeTextButton(
 ) {
   TextButton(
     onClick = onClick,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      androidx.compose.material.LocalContentColor provides Material2Theme.colors.onBackground,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigMaterial2Theme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigMaterial2Theme.kt
@@ -1,0 +1,85 @@
+package com.hedvig.android.core.designsystem.material2
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.Colors
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.hedvig.android.core.designsystem.theme.dark_background
+import com.hedvig.android.core.designsystem.theme.dark_error
+import com.hedvig.android.core.designsystem.theme.dark_onBackground
+import com.hedvig.android.core.designsystem.theme.dark_onError
+import com.hedvig.android.core.designsystem.theme.dark_onPrimary
+import com.hedvig.android.core.designsystem.theme.dark_onSecondary
+import com.hedvig.android.core.designsystem.theme.dark_onSurface
+import com.hedvig.android.core.designsystem.theme.dark_primary
+import com.hedvig.android.core.designsystem.theme.dark_primaryVariant
+import com.hedvig.android.core.designsystem.theme.dark_secondary
+import com.hedvig.android.core.designsystem.theme.dark_surface
+import com.hedvig.android.core.designsystem.theme.light_background
+import com.hedvig.android.core.designsystem.theme.light_error
+import com.hedvig.android.core.designsystem.theme.light_onBackground
+import com.hedvig.android.core.designsystem.theme.light_onError
+import com.hedvig.android.core.designsystem.theme.light_onPrimary
+import com.hedvig.android.core.designsystem.theme.light_onSecondary
+import com.hedvig.android.core.designsystem.theme.light_onSurface
+import com.hedvig.android.core.designsystem.theme.light_primary
+import com.hedvig.android.core.designsystem.theme.light_primaryVariant
+import com.hedvig.android.core.designsystem.theme.light_secondary
+import com.hedvig.android.core.designsystem.theme.light_surface
+
+@Composable
+internal fun HedvigMaterial2Theme(
+  darkTheme: Boolean = isSystemInDarkTheme(),
+  colorOverrides: (Colors) -> Colors = { it },
+  content: @Composable () -> Unit,
+) {
+  val colorScheme = when {
+    darkTheme -> DarkColors
+    else -> LightColors
+  }
+  MaterialTheme(
+    colors = colorOverrides.invoke(colorScheme),
+    shapes = HedvigShapes,
+    typography = HedvigTypography,
+  ) {
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colors.onBackground) {
+      content()
+    }
+  }
+}
+
+private val LightColors = lightColors(
+  primary = light_primary,
+  primaryVariant = light_primaryVariant,
+  secondary = light_secondary,
+// we are not using secondaryVariant https://github.com/HedvigInsurance/android/blob/develop/app/src/main/res/values/theme.xml#L12
+//  secondaryVariant = ...,
+  background = light_background,
+  surface = light_surface,
+  error = light_error,
+  onPrimary = light_onPrimary,
+  onSecondary = light_onSecondary,
+  onBackground = light_onBackground,
+  onSurface = light_onSurface,
+  onError = light_onError,
+)
+
+private val DarkColors = darkColors(
+  primary = dark_primary,
+  primaryVariant = dark_primaryVariant,
+  secondary = dark_secondary,
+// we are not using secondaryVariant https://github.com/HedvigInsurance/android/blob/develop/app/src/main/res/values/theme.xml#L12
+//  secondaryVariant = ...,
+  background = dark_background,
+  surface = dark_surface,
+  error = dark_error,
+  onPrimary = dark_onPrimary,
+  onSecondary = dark_onSecondary,
+  onBackground = dark_onBackground,
+  onSurface = dark_onSurface,
+  onError = dark_onError,
+)

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigShapes.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigShapes.kt
@@ -1,0 +1,17 @@
+package com.hedvig.android.core.designsystem.material2
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Shapes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+
+// Take shapes from existing theme setup
+// https://github.com/HedvigInsurance/android/blob/ced77986fac0fd7867c8e24ba05d0176a112050e/app/src/main/res/values/theme.xml#L27-L33
+// https://github.com/HedvigInsurance/android/blob/0dfcbd61bd6b4f4b0d5bbd93e339deff3e15b5a9/app/src/main/res/values/shape_themes.xml#L4-L10
+internal val HedvigShapes: Shapes
+  @Composable
+  get() = MaterialTheme.shapes.copy(
+    medium = RoundedCornerShape(8.0.dp),
+    large = RoundedCornerShape(8.0.dp),
+  )

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigTypography.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigTypography.kt
@@ -1,71 +1,92 @@
 package com.hedvig.android.core.designsystem.material2
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.material.Typography
-import androidx.compose.ui.text.TextStyle
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.hedvig.android.core.designsystem.theme.SansStandard
 
-@Suppress("unused")
-internal val HedvigTypography = Typography(
-  defaultFontFamily = SansStandard,
-  h4 = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 34.sp,
-    letterSpacing = (-0.025).sp,
-    lineHeight = 41.sp,
-  ),
-  h5 = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 24.sp,
-    letterSpacing = 0.sp,
-    lineHeight = 32.sp,
-  ),
-  h6 = TextStyle(
-    fontWeight = FontWeight.Medium,
-    fontSize = 20.sp,
-    letterSpacing = 0.sp,
-    lineHeight = 26.sp,
-  ),
-  subtitle1 = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 16.sp,
-    letterSpacing = 0.15.sp,
-    lineHeight = 24.sp,
-  ),
-  subtitle2 = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 14.sp,
-    letterSpacing = 0.1.sp,
-    lineHeight = 20.sp,
-  ),
-  body1 = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 16.sp,
-    letterSpacing = 0.sp,
-    lineHeight = 26.sp,
-  ),
-  body2 = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 14.sp,
-    letterSpacing = 0.sp,
-    lineHeight = 22.sp,
-  ),
-  button = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 17.sp,
-    letterSpacing = -(0.01).sp,
-    lineHeight = 24.sp,
-  ),
-  caption = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 12.sp,
-    letterSpacing = 0.sp,
-    lineHeight = 16.sp,
-  ),
-  overline = TextStyle(
-    fontWeight = FontWeight.Normal,
-    fontSize = 12.sp,
-    letterSpacing = 1.sp,
-  ),
-)
+internal val HedvigTypography: Typography
+  @Composable
+  get() = Typography(
+    defaultFontFamily = SansStandard,
+    h3 = MaterialTheme.typography.h3.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 48.sp,
+      lineHeight = 58.sp,
+    ),
+    h4 = MaterialTheme.typography.h4.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 32.sp,
+      lineHeight = 40.sp,
+    ),
+    h5 = MaterialTheme.typography.h5.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 24.sp,
+      lineHeight = 32.sp,
+    ),
+    h6 = MaterialTheme.typography.h6.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 20.sp,
+      lineHeight = 26.sp,
+    ),
+    subtitle1 = MaterialTheme.typography.subtitle1.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 16.sp,
+      lineHeight = 24.sp,
+    ),
+    subtitle2 = MaterialTheme.typography.subtitle2.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 14.sp,
+      lineHeight = 20.sp,
+    ),
+    body1 = MaterialTheme.typography.body1.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 16.sp,
+      lineHeight = 24.sp,
+    ),
+    body2 = MaterialTheme.typography.body2.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 14.sp,
+      lineHeight = 20.sp,
+    ),
+    button = MaterialTheme.typography.button.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 16.sp,
+      lineHeight = 24.sp,
+    ),
+    caption = MaterialTheme.typography.caption.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 12.sp,
+      lineHeight = 16.sp,
+    ),
+    overline = MaterialTheme.typography.overline.copy(
+      fontWeight = FontWeight.Normal,
+      fontSize = 10.sp,
+      lineHeight = 16.sp,
+    ),
+  )
+
+@Preview
+@Composable
+private fun TypographyPreview() {
+  MaterialTheme(typography = HedvigTypography) {
+    Column {
+      Text("Headline 3", style = MaterialTheme.typography.h3)
+      Text("Headline 4", style = MaterialTheme.typography.h4)
+      Text("Headline 5", style = MaterialTheme.typography.h5)
+      Text("Headline 6", style = MaterialTheme.typography.h6)
+      Text("Subtitle 1", style = MaterialTheme.typography.subtitle1)
+      Text("Subtitle 2", style = MaterialTheme.typography.subtitle2)
+      Text("Body 1", style = MaterialTheme.typography.body1)
+      Text("Body 2", style = MaterialTheme.typography.body2)
+      Text("Button", style = MaterialTheme.typography.button)
+      Text("Caption", style = MaterialTheme.typography.caption)
+      Text("Overline", style = MaterialTheme.typography.overline)
+    }
+  }
+}

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3ColorScheme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3ColorScheme.kt
@@ -1,0 +1,29 @@
+package com.hedvig.android.core.designsystem.material3
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+@Suppress("RemoveExplicitTypeArguments")
+internal val LocalHedvigMaterial3ColorScheme = staticCompositionLocalOf<HedvigMaterial3ColorScheme> {
+  lightHedvigColorScheme(LightColorScheme)
+}
+
+class HedvigMaterial3ColorScheme(
+  val containedButtonContainer: Color,
+  val onContainedButtonContainer: Color,
+)
+
+internal fun darkHedvigColorScheme(
+  colorScheme: ColorScheme,
+) = HedvigMaterial3ColorScheme(
+  containedButtonContainer = colorScheme.tertiary,
+  onContainedButtonContainer = colorScheme.onTertiary,
+)
+
+internal fun lightHedvigColorScheme(
+  colorScheme: ColorScheme,
+) = HedvigMaterial3ColorScheme(
+  containedButtonContainer = colorScheme.primary,
+  onContainedButtonContainer = colorScheme.onPrimary,
+)

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
@@ -36,21 +36,24 @@ import com.hedvig.android.core.designsystem.theme.light_surface
 import com.hedvig.android.core.designsystem.theme.light_surfaceVariant
 
 @Composable
-fun HedvigMaterial3Theme(
+internal fun HedvigMaterial3Theme(
   darkTheme: Boolean = isSystemInDarkTheme(),
   colorOverrides: (ColorScheme) -> ColorScheme = { it },
   content: @Composable () -> Unit,
 ) {
-  val colorScheme = when {
-    darkTheme -> DarkColorScheme
-    else -> LightColorScheme
+  val (colorScheme, hedvigColorTheme) = when {
+    darkTheme -> DarkColorScheme to darkHedvigColorScheme(DarkColorScheme)
+    else -> LightColorScheme to lightHedvigColorScheme(LightColorScheme)
   }
   MaterialTheme(
     colorScheme = colorOverrides.invoke(colorScheme),
     shapes = HedvigShapes,
     typography = HedvigTypography,
   ) {
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+    CompositionLocalProvider(
+      LocalContentColor provides MaterialTheme.colorScheme.onBackground,
+      LocalHedvigMaterial3ColorScheme provides hedvigColorTheme,
+    ) {
       content()
     }
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
@@ -8,6 +8,32 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import com.hedvig.android.core.designsystem.theme.dark_background
+import com.hedvig.android.core.designsystem.theme.dark_error
+import com.hedvig.android.core.designsystem.theme.dark_onBackground
+import com.hedvig.android.core.designsystem.theme.dark_onError
+import com.hedvig.android.core.designsystem.theme.dark_onPrimary
+import com.hedvig.android.core.designsystem.theme.dark_onSecondary
+import com.hedvig.android.core.designsystem.theme.dark_onSurface
+import com.hedvig.android.core.designsystem.theme.dark_onSurfaceVariant
+import com.hedvig.android.core.designsystem.theme.dark_primary
+import com.hedvig.android.core.designsystem.theme.dark_primaryVariant
+import com.hedvig.android.core.designsystem.theme.dark_secondary
+import com.hedvig.android.core.designsystem.theme.dark_surface
+import com.hedvig.android.core.designsystem.theme.dark_surfaceVariant
+import com.hedvig.android.core.designsystem.theme.light_background
+import com.hedvig.android.core.designsystem.theme.light_error
+import com.hedvig.android.core.designsystem.theme.light_onBackground
+import com.hedvig.android.core.designsystem.theme.light_onError
+import com.hedvig.android.core.designsystem.theme.light_onPrimary
+import com.hedvig.android.core.designsystem.theme.light_onSecondary
+import com.hedvig.android.core.designsystem.theme.light_onSurface
+import com.hedvig.android.core.designsystem.theme.light_onSurfaceVariant
+import com.hedvig.android.core.designsystem.theme.light_primary
+import com.hedvig.android.core.designsystem.theme.light_primaryVariant
+import com.hedvig.android.core.designsystem.theme.light_secondary
+import com.hedvig.android.core.designsystem.theme.light_surface
+import com.hedvig.android.core.designsystem.theme.light_surfaceVariant
 
 @Composable
 fun HedvigMaterial3Theme(
@@ -30,8 +56,7 @@ fun HedvigMaterial3Theme(
   }
 }
 
-@Suppress("PrivatePropertyName")
-private val LightColorScheme = lightColorScheme(
+internal val LightColorScheme = lightColorScheme(
   primary = light_primary,
   onPrimary = light_onPrimary,
   inversePrimary = light_primaryVariant,
@@ -63,7 +88,6 @@ private val LightColorScheme = lightColorScheme(
 //  scrim = no equivalent,
 )
 
-@Suppress("PrivatePropertyName")
 private val DarkColorScheme = darkColorScheme(
   primary = dark_primary,
   onPrimary = dark_onPrimary,

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigTypography.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigTypography.kt
@@ -1,8 +1,12 @@
 package com.hedvig.android.core.designsystem.material3
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.hedvig.android.core.designsystem.theme.SansStandard
 
@@ -11,92 +15,116 @@ internal val HedvigTypography: Typography
   get() = Typography(
     displayLarge = MaterialTheme.typography.displayLarge.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 57.sp,
       lineHeight = 64.sp,
-      letterSpacing = (-1.0).sp,
     ),
     displayMedium = MaterialTheme.typography.displayMedium.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 45.sp,
       lineHeight = 52.sp,
-      letterSpacing = (-0.5).sp,
     ),
     displaySmall = MaterialTheme.typography.displaySmall.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 36.sp,
       lineHeight = 44.sp,
-      letterSpacing = (-0.5).sp,
     ),
     headlineLarge = MaterialTheme.typography.headlineLarge.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 32.sp,
       lineHeight = 40.sp,
-      letterSpacing = (-0.25).sp,
     ),
     headlineMedium = MaterialTheme.typography.headlineMedium.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 28.sp,
       lineHeight = 36.sp,
-      letterSpacing = 0.sp,
     ),
     headlineSmall = MaterialTheme.typography.headlineSmall.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 24.sp,
       lineHeight = 32.sp,
-      letterSpacing = 0.sp,
     ),
     titleLarge = MaterialTheme.typography.titleLarge.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 22.sp,
       lineHeight = 28.sp,
-      letterSpacing = 0.sp,
     ),
     titleMedium = MaterialTheme.typography.titleMedium.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 16.sp,
       lineHeight = 24.sp,
-      letterSpacing = 0.15.sp,
     ),
     titleSmall = MaterialTheme.typography.titleSmall.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 14.sp,
       lineHeight = 20.sp,
-      letterSpacing = 0.1.sp,
     ),
     bodyLarge = MaterialTheme.typography.bodyLarge.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 16.sp,
       lineHeight = 24.sp,
-      letterSpacing = 0.15.sp,
     ),
     bodyMedium = MaterialTheme.typography.bodyMedium.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 14.sp,
       lineHeight = 20.sp,
-      letterSpacing = 0.25.sp,
     ),
     bodySmall = MaterialTheme.typography.bodySmall.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 12.sp,
       lineHeight = 16.sp,
-      letterSpacing = 0.2.sp,
     ),
     labelLarge = MaterialTheme.typography.labelLarge.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 14.sp,
       lineHeight = 20.sp,
-      letterSpacing = 0.1.sp,
     ),
     labelMedium = MaterialTheme.typography.labelMedium.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 12.sp,
       lineHeight = 16.sp,
-      letterSpacing = 0.5.sp,
     ),
     labelSmall = MaterialTheme.typography.labelSmall.copy(
       fontFamily = SansStandard,
+      fontWeight = FontWeight.Normal,
       fontSize = 11.sp,
       lineHeight = 16.sp,
-      letterSpacing = 0.5.sp,
     ),
   )
+
+@Preview
+@Composable
+private fun TypographyPreview() {
+  MaterialTheme(typography = HedvigTypography) {
+    Column {
+      Text("Display Large", style = MaterialTheme.typography.displayLarge)
+      Text("Display Medium", style = MaterialTheme.typography.displayMedium)
+      Text("Display Small", style = MaterialTheme.typography.displaySmall)
+      Text("Headline Large", style = MaterialTheme.typography.headlineLarge)
+      Text("Headline Medium", style = MaterialTheme.typography.headlineMedium)
+      Text("Headline Small", style = MaterialTheme.typography.headlineSmall)
+      Text("Title Large", style = MaterialTheme.typography.titleLarge)
+      Text("Title Medium", style = MaterialTheme.typography.titleMedium)
+      Text("Title Small", style = MaterialTheme.typography.titleSmall)
+      Text("Body Large", style = MaterialTheme.typography.bodyLarge)
+      Text("Body Medium", style = MaterialTheme.typography.bodyMedium)
+      Text("Body Small", style = MaterialTheme.typography.bodySmall)
+      Text("Label Large", style = MaterialTheme.typography.labelLarge)
+      Text("Label Medium", style = MaterialTheme.typography.labelMedium)
+      Text("Label Small", style = MaterialTheme.typography.labelSmall)
+    }
+  }
+}

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/Colors.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/Colors.kt
@@ -1,7 +1,10 @@
 package com.hedvig.android.core.designsystem.theme
 
 import androidx.compose.material.Colors
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.hedvig.android.core.designsystem.material3.LocalHedvigMaterial3ColorScheme
 
 // colors https://github.com/HedvigInsurance/android/blob/e86158084061de59a9f1b6d71dda3b234057883d/app/src/main/res/values/colors.xml#L2
 internal val black = Color(0xFF000000)
@@ -59,3 +62,13 @@ val Colors.textColorLink: Color
   } else {
     secondary
   }
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.containedButtonContainer: Color
+  @Composable
+  get() = LocalHedvigMaterial3ColorScheme.current.containedButtonContainer
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.onContainedButtonContainer: Color
+  @Composable
+  get() = LocalHedvigMaterial3ColorScheme.current.onContainedButtonContainer

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigMaterialColors.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigMaterialColors.kt
@@ -1,13 +1,6 @@
-package com.hedvig.android.core.designsystem.material3
+package com.hedvig.android.core.designsystem.theme
 
 import androidx.compose.ui.graphics.Color
-import com.hedvig.android.core.designsystem.theme.hedvig_black
-import com.hedvig.android.core.designsystem.theme.hedvig_dark_gray
-import com.hedvig.android.core.designsystem.theme.hedvig_light_gray
-import com.hedvig.android.core.designsystem.theme.hedvig_off_white
-import com.hedvig.android.core.designsystem.theme.hedvig_white
-import com.hedvig.android.core.designsystem.theme.lavender_300
-import com.hedvig.android.core.designsystem.theme.lavender_400
 
 // Light from xml | https://github.com/HedvigInsurance/android/blob/e86158084061de59a9f1b6d71dda3b234057883d/app/src/main/res/values/colors.xml#L26
 internal val light_primary = hedvig_black

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigTheme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigTheme.kt
@@ -1,106 +1,39 @@
 package com.hedvig.android.core.designsystem.theme
 
-import android.content.res.Resources
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.Colors
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import com.google.accompanist.themeadapter.material.createMdcTheme
+import com.hedvig.android.core.designsystem.material2.HedvigMaterial2Theme
 import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
-import java.lang.reflect.Method
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun HedvigTheme(
+  darkTheme: Boolean = isSystemInDarkTheme(),
   colorOverrides: (Colors) -> Colors = { it },
   m3ColorOverrides: (ColorScheme) -> ColorScheme = { it },
   content: @Composable () -> Unit,
 ) {
-  val context = LocalContext.current
-  val key = context.theme.key ?: context.theme
-  val layoutDirection = LocalLayoutDirection.current
-  val themeParameters = remember(key) {
-    createMdcTheme(
-      context = context,
-      layoutDirection = layoutDirection,
-      setDefaultFontFamily = true,
-    )
-  }
-  val colors = themeParameters.colors ?: MaterialTheme.colors
   Box(
     modifier = Modifier.semantics {
       testTagsAsResourceId = true
     },
   ) {
-    MaterialTheme(
-      colors = colorOverrides.invoke(colors),
-      typography = themeParameters.typography ?: MaterialTheme.typography,
-      shapes = themeParameters.shapes ?: MaterialTheme.shapes,
+    HedvigMaterial2Theme(
+      darkTheme = darkTheme,
+      colorOverrides = colorOverrides,
     ) {
-      CompositionLocalProvider(LocalContentColor provides MaterialTheme.colors.onBackground) {
-        HedvigMaterial3Theme(
-          colorOverrides = m3ColorOverrides,
-          content = content,
-        )
-      }
+      HedvigMaterial3Theme(
+        darkTheme = darkTheme,
+        colorOverrides = m3ColorOverrides,
+        content = content,
+      )
     }
   }
 }
-
-/*
- * Copyright 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
- * This is gross, but we need a way to check for theme equality. Theme does not implement
- * `equals()` or `hashCode()`, but it does have a hidden method called `getKey()`.
- *
- * The cost of this reflective invoke is a lot cheaper than the full theme read which can
- * happen on each re-composition.
- */
-private inline val Resources.Theme.key: Any?
-  get() {
-    if (!sThemeGetKeyMethodFetched) {
-      try {
-        @Suppress("SoonBlockedPrivateApi")
-        sThemeGetKeyMethod = Resources.Theme::class.java.getDeclaredMethod("getKey")
-          .apply { isAccessible = true }
-      } catch (e: ReflectiveOperationException) {
-        // Failed to retrieve Theme.getKey method
-      }
-      sThemeGetKeyMethodFetched = true
-    }
-    if (sThemeGetKeyMethod != null) {
-      return try {
-        sThemeGetKeyMethod?.invoke(this)
-      } catch (e: ReflectiveOperationException) {
-        // Failed to invoke Theme.getKey()
-      }
-    }
-    return null
-  }
-
-private var sThemeGetKeyMethodFetched = false
-private var sThemeGetKeyMethod: Method? = null

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   api(libs.androidx.compose.foundation)
   api(libs.androidx.compose.material)
 
-  implementation(libs.accompanist.themeAdapter.material)
   implementation(libs.androidx.compose.uiUtil)
   implementation(libs.coil.coil)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,12 +99,12 @@ accompanist-pager = { module = "com.google.accompanist:accompanist-pager", versi
 accompanist-pagerIndicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
 accompanist-placeholder = { module = "com.google.accompanist:accompanist-placeholder-material", version.ref = "accompanist" }
 accompanist-systemUiController = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
-accompanist-themeAdapter-material = { module = "com.google.accompanist:accompanist-themeadapter-material", version.ref = "accompanist" }
 adyen = { module = "com.adyen.checkout:drop-in", version.ref = "adyen" }
 androidx-arch-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-testing" }
 androidx-compose-animation = { module = "androidx.compose.animation:animation" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-composeBom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-foundationLayout = { module = "androidx.compose.foundation:foundation-layout" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-composeMaterial3" }
 androidx-compose-material3-windowSizeClass = { module = "androidx.compose.material3:material3-window-size-class" }

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
   id("hedvig.android.application")
   id("hedvig.android.application.compose")
   id("hedvig.android.ktlint")
-  id("org.jetbrains.kotlin.android")
 }
 
 @Suppress("UnstableApiUsage")
@@ -35,6 +34,10 @@ dependencies {
   implementation(projects.coreDesignSystem)
   implementation(projects.coreUi)
 
-  implementation(libs.androidx.other.activityCompose)
+  implementation(libs.androidx.compose.foundation)
+  implementation(libs.androidx.compose.foundationLayout)
+  implementation(libs.androidx.compose.material)
   implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.runtime)
+  implementation(libs.androidx.other.activityCompose)
 }

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   implementation(libs.androidx.compose.foundationLayout)
   implementation(libs.androidx.compose.material)
   implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.runtime)
   implementation(libs.androidx.other.activityCompose)
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
@@ -1,14 +1,8 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package com.hedvig.android.sample.design.showcase
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
 import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
 import com.hedvig.android.sample.design.showcase.ui.MaterialComponents
 
@@ -17,9 +11,7 @@ class DesignShowcaseActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
     setContent {
       HedvigMaterial3Theme {
-        Surface(Modifier.fillMaxSize()) {
-          MaterialComponents()
-        }
+        MaterialComponents()
       }
     }
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
@@ -3,15 +3,18 @@ package com.hedvig.android.sample.design.showcase
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.MaterialComponents
 
 class DesignShowcaseActivity : ComponentActivity() {
+  @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      HedvigMaterial3Theme {
-        MaterialComponents()
+      HedvigTheme {
+        MaterialComponents(calculateWindowSizeClass(this))
       }
     }
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
@@ -4,14 +4,19 @@ import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,8 +25,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Buttons
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Cards
@@ -30,7 +35,6 @@ import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Chips
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Divider
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2ProgressBar
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Slider
-import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Switch
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Tab
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TextFields
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TopAppBars
@@ -49,7 +53,30 @@ import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TextFields
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TopAppBars
 
 @Composable
-fun MaterialComponents() {
+fun MaterialComponents(windowSizeClass: WindowSizeClass) {
+  if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
+    BothThemes()
+  } else {
+    ThemeSelection()
+  }
+}
+
+@Composable
+private fun BothThemes() {
+  Row(Modifier.fillMaxSize()) {
+    Column(Modifier.weight(1f)) {
+      Text("M2")
+      M2()
+    }
+    Column(Modifier.weight(1f)) {
+      Text("M3")
+      M3()
+    }
+  }
+}
+
+@Composable
+private fun ThemeSelection() {
   var isM3: Boolean? by remember { mutableStateOf(null) }
   when (isM3) {
     true -> {
@@ -91,7 +118,6 @@ private fun M2() {
     M2LightAndDarkItem { M2Buttons() }
     M2LightAndDarkItem { M2TextFields() }
     M2LightAndDarkItem { M2Chips() }
-    M2LightAndDarkItem { M2Switch() }
     M2LightAndDarkItem { M2Checkbox() }
     M2LightAndDarkItem { M2Slider() }
     M2LightAndDarkItem { M2ProgressBar() }
@@ -108,11 +134,9 @@ private fun M3() {
     modifier = Modifier.fillMaxSize(),
     state = rememberLazyListState(),
   ) {
-    LightAndDarkItem { M3DatePicker() }
     LightAndDarkItem { M3Buttons() }
     LightAndDarkItem { M3TextFields() }
     LightAndDarkItem { M3Chips() }
-    LightAndDarkItem { M3Switch() }
     LightAndDarkItem { M3Checkbox() }
     LightAndDarkItem { M3Slider() }
     LightAndDarkItem { M3ProgressBar() }
@@ -121,19 +145,27 @@ private fun M3() {
     LightAndDarkItem { M3TopAppBars() }
     LightAndDarkItem { M3NavigationBars() }
     LightAndDarkItem { M3Tab() }
+    LightAndDarkItem { M3Switch() } // We don't use this in m2
+    LightAndDarkItem { M3DatePicker() } // We don't use this in m2
   }
 }
 
 @Suppress("FunctionName")
 fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
   item {
-    Row {
-      Surface(Modifier.weight(1f)) {
-        content()
+    Row(Modifier.fillMaxWidth()) {
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(false) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
+        }
       }
-      HedvigTheme(/* todo dark theme when adapter doesn't exist */) {
-        Surface(Modifier.weight(1f)) {
-          content()
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(true) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
         }
       }
     }
@@ -143,26 +175,33 @@ fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
 @Suppress("FunctionName")
 fun LazyListScope.LightAndDarkItem(content: @Composable () -> Unit) {
   item {
-    Row {
-      Surface(Modifier.weight(1f)) {
-        content()
+    Row(Modifier.fillMaxWidth()) {
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(false) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
+        }
       }
-      HedvigMaterial3Theme(true) {
-        Surface(Modifier.weight(1f)) {
-          content()
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(true) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
         }
       }
     }
   }
 }
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun MaterialComponentsPreview() {
-  HedvigMaterial3Theme {
+  HedvigTheme {
     Surface {
-      MaterialComponents()
+      MaterialComponents(WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)))
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
@@ -1,17 +1,39 @@
 package com.hedvig.android.sample.design.showcase.ui
 
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Buttons
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Cards
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Checkbox
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Chips
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Divider
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2ProgressBar
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Slider
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Switch
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Tab
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TextFields
+import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TopAppBars
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3Buttons
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3Cards
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3Checkbox
@@ -26,9 +48,62 @@ import com.hedvig.android.sample.design.showcase.ui.m3.components.M3Tab
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TextFields
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TopAppBars
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MaterialComponents() {
+  var isM3: Boolean? by remember { mutableStateOf(null) }
+  when (isM3) {
+    true -> {
+      BackHandler { isM3 = null }
+      M3()
+    }
+
+    false -> {
+      BackHandler { isM3 = null }
+      M2()
+    }
+
+    null -> {
+      Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Surface {
+          Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            Button(onClick = { isM3 = false }) {
+              Text("M2")
+            }
+            Button(onClick = { isM3 = true }) {
+              Text("M3")
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun M2() {
+  LazyColumn(
+    modifier = Modifier.fillMaxSize(),
+    state = rememberLazyListState(),
+  ) {
+    M2LightAndDarkItem { M2Buttons() }
+    M2LightAndDarkItem { M2TextFields() }
+    M2LightAndDarkItem { M2Chips() }
+    M2LightAndDarkItem { M2Switch() }
+    M2LightAndDarkItem { M2Checkbox() }
+    M2LightAndDarkItem { M2Slider() }
+    M2LightAndDarkItem { M2ProgressBar() }
+    M2LightAndDarkItem { M2Divider() }
+    M2LightAndDarkItem { M2Cards() }
+    M2LightAndDarkItem { M2TopAppBars() }
+    M2LightAndDarkItem { M2Tab() }
+  }
+}
+
+@Composable
+private fun M3() {
   LazyColumn(
     modifier = Modifier.fillMaxSize(),
     state = rememberLazyListState(),
@@ -49,7 +124,22 @@ fun MaterialComponents() {
   }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@Suppress("FunctionName")
+fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
+  item {
+    Row {
+      Surface(Modifier.weight(1f)) {
+        content()
+      }
+      HedvigTheme(/* todo dark theme when adapter doesn't exist */) {
+        Surface(Modifier.weight(1f)) {
+          content()
+        }
+      }
+    }
+  }
+}
+
 @Suppress("FunctionName")
 fun LazyListScope.LightAndDarkItem(content: @Composable () -> Unit) {
   item {

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
@@ -1,0 +1,62 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.ExtendedFloatingActionButton
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2Buttons() {
+  Column {
+    val enabled by remember { mutableStateOf(true) }
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Buttons",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    Button(
+      onClick = {},
+      enabled = enabled,
+    ) {
+      Text("Primary button")
+    }
+    Spacer(Modifier.size(16.dp))
+    OutlinedButton(
+      onClick = {},
+      enabled = enabled,
+    ) {
+      Text("Secondary button")
+    }
+    Spacer(Modifier.size(16.dp))
+    TextButton(
+      onClick = {},
+      enabled = enabled,
+    ) {
+      Text("Text button")
+    }
+    Spacer(Modifier.size(16.dp))
+    FloatingActionButton(onClick = {}) {
+      Text("FAB")
+    }
+    Spacer(Modifier.size(16.dp))
+    ExtendedFloatingActionButton(
+      onClick = {},
+      text = {
+        Text("Extended FAB")
+      },
+    )
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
@@ -2,10 +2,9 @@ package com.hedvig.android.sample.design.showcase.ui.m2.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
-import androidx.compose.material.ExtendedFloatingActionButton
-import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
@@ -16,6 +15,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 
 @Composable
 internal fun M2Buttons() {
@@ -26,6 +28,19 @@ internal fun M2Buttons() {
       text = "Buttons",
       style = MaterialTheme.typography.h5,
     )
+    Spacer(Modifier.size(16.dp))
+    LargeContainedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeOutlinedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeTextButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+
     Spacer(Modifier.size(16.dp))
     Button(
       onClick = {},
@@ -47,16 +62,5 @@ internal fun M2Buttons() {
     ) {
       Text("Text button")
     }
-    Spacer(Modifier.size(16.dp))
-    FloatingActionButton(onClick = {}) {
-      Text("FAB")
-    }
-    Spacer(Modifier.size(16.dp))
-    ExtendedFloatingActionButton(
-      onClick = {},
-      text = {
-        Text("Extended FAB")
-      },
-    )
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Cards.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Cards.kt
@@ -1,0 +1,71 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Card
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+internal fun M2Cards() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Cards",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    Card(
+      onClick = {},
+      modifier = Modifier.size(width = 180.dp, height = 100.dp),
+    ) {
+      Box(Modifier.fillMaxSize()) {
+        Text("Card", Modifier.align(Alignment.Center))
+      }
+    }
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Elevated cards",
+      style = MaterialTheme.typography.subtitle2,
+    )
+    Spacer(Modifier.size(16.dp))
+    Card(
+      onClick = {},
+      modifier = Modifier.size(width = 180.dp, height = 100.dp),
+      elevation = 8.dp,
+    ) {
+      Box(Modifier.fillMaxSize()) {
+        Text("Card 8.dp elevated", Modifier.align(Alignment.Center))
+      }
+    }
+    Spacer(Modifier.size(4.dp))
+    Card(
+      onClick = {},
+      modifier = Modifier.size(width = 180.dp, height = 100.dp),
+      elevation = 16.dp,
+    ) {
+      Box(Modifier.fillMaxSize()) {
+        Text("Card 16.dp elevated", Modifier.align(Alignment.Center))
+      }
+    }
+    Spacer(Modifier.size(16.dp))
+    Card(
+      onClick = {},
+      modifier = Modifier.size(width = 180.dp, height = 100.dp),
+      elevation = 32.dp,
+    ) {
+      Box(Modifier.fillMaxSize()) {
+        Text("Card 32.dp elevated", Modifier.align(Alignment.Center))
+      }
+    }
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Checkbox.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Checkbox.kt
@@ -1,0 +1,36 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2Checkbox() {
+  var checked by remember { mutableStateOf(true) }
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Checkbox",
+      style = MaterialTheme.typography.headlineSmall,
+    )
+    Spacer(Modifier.size(16.dp))
+    Checkbox(
+      checked = checked,
+      onCheckedChange = { checked = it },
+    )
+    Spacer(Modifier.size(8.dp))
+    Checkbox(
+      checked = !checked,
+      onCheckedChange = { checked = !it },
+    )
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Chips.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Chips.kt
@@ -1,0 +1,47 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun M2Chips() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Chips",
+      style = MaterialTheme.typography.headlineSmall,
+    )
+    Spacer(Modifier.size(16.dp))
+    var selectedId by remember { mutableStateOf(1) }
+    FilterChip(
+      label = { Text("Android") },
+      onClick = { selectedId = 1 },
+      selected = selectedId == 1,
+    )
+    Spacer(modifier = Modifier.size(4.dp))
+    FilterChip(
+      label = { Text("Material") },
+      onClick = { selectedId = 2 },
+      selected = selectedId == 2,
+    )
+    Spacer(modifier = Modifier.size(4.dp))
+    FilterChip(
+      label = { Text("Compose") },
+      onClick = { selectedId = 3 },
+      selected = selectedId == 3,
+    )
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Divider.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Divider.kt
@@ -1,0 +1,23 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2Divider() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Divider",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    Divider(thickness = 0.5.dp)
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/ProgressBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/ProgressBar.kt
@@ -1,0 +1,23 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2ProgressBar() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Progress bar ",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    CircularProgressIndicator()
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Slider.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Slider.kt
@@ -1,0 +1,28 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Slider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2Slider() {
+  var sliderPosition by remember { mutableStateOf(0.5f) }
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Slider",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    Slider(sliderPosition, { sliderPosition = it })
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Switch.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Switch.kt
@@ -1,0 +1,33 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2Switch() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Switch",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    Row {
+      var checked by remember { mutableStateOf(false) }
+      Switch(checked = checked, onCheckedChange = { checked = !checked })
+      Spacer(modifier = Modifier.size(16.dp))
+      Switch(checked = !checked, onCheckedChange = { checked = !checked })
+    }
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Tab.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Tab.kt
@@ -1,0 +1,39 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2Tab() {
+  var selectedIndex by remember { mutableStateOf(0) }
+  val tabs = listOf("Accounts", "Cards", "Funds")
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Tab",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    TabRow(selectedTabIndex = selectedIndex) {
+      tabs.forEachIndexed { index, title ->
+        Tab(
+          text = { Text(title) },
+          selected = index == selectedIndex,
+          onClick = { selectedIndex = index },
+        )
+      }
+    }
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Text.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Text.kt
@@ -1,0 +1,18 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+internal fun M2OnSurfaceText(
+  text: String,
+  style: TextStyle,
+) {
+  Text(
+    color = MaterialTheme.colors.onSurface,
+    text = text,
+    style = style,
+  )
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TextFields.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TextFields.kt
@@ -1,0 +1,66 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2TextFields() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Text Fields",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    Column {
+      val text = remember { mutableStateOf("") }
+      OutlinedTextField(
+        value = text.value,
+        onValueChange = { text.value = it },
+        placeholder = { Text("Please type a text") },
+      )
+      Spacer(Modifier.size(16.dp))
+      Column {
+        OutlinedTextField(
+          value = text.value,
+          onValueChange = { text.value = it },
+          placeholder = { Text("Please type a text") },
+          isError = true,
+        )
+        TextFieldErrorMessage()
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun TextFieldErrorMessage() {
+  val startPadding = TextFieldDefaults.textFieldWithoutLabelPadding()
+    .calculateStartPadding(layoutDirection = LocalLayoutDirection.current)
+
+  Text(
+    modifier = Modifier
+      .padding(
+        top = 4.dp,
+        start = startPadding,
+      ),
+    text = "Something went wrong",
+    style = MaterialTheme.typography.subtitle2,
+    color = MaterialTheme.colors.error,
+  )
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
@@ -1,0 +1,52 @@
+package com.hedvig.android.sample.design.showcase.ui.m2.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun M2TopAppBars() {
+  Column {
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Top app bars",
+      style = MaterialTheme.typography.h5,
+    )
+    Spacer(Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Not Scrolled State",
+      style = MaterialTheme.typography.subtitle2,
+    )
+    Spacer(Modifier.size(4.dp))
+    TopAppBar(
+      title = { Text("Small top app bar") },
+      navigationIcon = { NavigationIcon() },
+    )
+    Spacer(modifier = Modifier.size(16.dp))
+    M2OnSurfaceText(
+      text = "Scrolled State",
+      style = MaterialTheme.typography.subtitle2,
+    )
+    Spacer(Modifier.size(4.dp))
+  }
+}
+
+@Composable
+private fun NavigationIcon() {
+  IconButton(onClick = {}) {
+    Icon(
+      imageVector = Icons.Default.ArrowBack,
+      contentDescription = null,
+    )
+  }
+}

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
@@ -3,13 +3,13 @@ package com.hedvig.android.sample.design.showcase.ui.m2.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -31,11 +31,6 @@ internal fun M2TopAppBars() {
     TopAppBar(
       title = { Text("Small top app bar") },
       navigationIcon = { NavigationIcon() },
-    )
-    Spacer(modifier = Modifier.size(16.dp))
-    M2OnSurfaceText(
-      text = "Scrolled State",
-      style = MaterialTheme.typography.subtitle2,
     )
     Spacer(Modifier.size(4.dp))
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/Buttons.kt
@@ -21,10 +21,9 @@ package com.hedvig.android.sample.design.showcase.ui.m3.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -35,6 +34,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 
 @Composable
 internal fun M3Buttons() {
@@ -45,6 +47,19 @@ internal fun M3Buttons() {
       text = "Buttons",
       style = MaterialTheme.typography.headlineSmall,
     )
+    Spacer(Modifier.size(16.dp))
+    LargeContainedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeOutlinedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeTextButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+
     Spacer(Modifier.size(16.dp))
     Button(
       onClick = {},
@@ -65,14 +80,6 @@ internal fun M3Buttons() {
       enabled = enabled,
     ) {
       Text("Text button")
-    }
-    Spacer(Modifier.size(16.dp))
-    FloatingActionButton(onClick = {}) {
-      Text("FAB")
-    }
-    Spacer(Modifier.size(16.dp))
-    ExtendedFloatingActionButton(onClick = {}) {
-      Text("Extended FAB")
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/DatePicker.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/DatePicker.kt
@@ -29,6 +29,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +43,11 @@ internal fun M3DatePicker() {
       style = MaterialTheme.typography.headlineSmall,
     )
     Spacer(Modifier.size(16.dp))
-    HedvigDatePicker(rememberDatePickerState(), Modifier.size(500.dp))
+    HedvigDatePicker(
+      rememberDatePickerState(
+        LocalDate.now().atTime(LocalTime.MIDNIGHT).plusDays(1).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+      ),
+      Modifier.size(500.dp),
+    )
   }
 }


### PR DESCRIPTION
Main change is HedvigMaterial2Theme.kt now existing, using the colors + shapes directly instead of fetching them from the XML theme. HedvigTypography for m2 existed before, but wasn't used. I updated it to what XML had too.
Also our Design System in Figma specified that everything should be Weight 400 instead of some 400, some 500, so changed that too for all of our typography setup, including in XML.

A big chunk of this PR is adding the components for the design showcase sample for material2 too, so that we can compare them with m3.

This change allows us to be able to use previews with HedvigTheme{} wrapper around it on feature modules without crashing due to the theme values not being found in an xml. Previously you'd have to be inside the :app module to do this so that theme.xml was read.

This does introduce a duplication in that we have some theme stuff in XML, and some in Compose. But we had that issue by having m3 only in compose and m2 in XML. Optimally, we'd want to have everything in compose regardless, so this is a tiny step towards that. On top of this, we basically never change the colors/theme, so it's not a problem to have it in two places if it benefits us in other ways.

*note: The letter spacings were a bit off, some looked ineligible with the previous setup. For now made it use the default provided by material theme, and made a comment in Figma, where I got an answer back from Zak saying: "Letter spacing in Figma is in percent per default. I suppose that’s what Hiro refers to, -0.25%. If you can’t work with percent I can review it and translate it to pixels instead!". So I'm gonna update it further after that, for now it's ok for it to be this way as the change is barely noriceable.
