### PR TITLE
Offpiste: Material2 without theme adapter extras

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt
@@ -16,8 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import coil.ImageLoader
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.core.designsystem.theme.hedvig_black
-import com.hedvig.android.core.designsystem.theme.hedvig_off_white
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
@@ -46,16 +44,7 @@ class MarketingActivity : AppCompatActivity() {
     val viewModel = getViewModel<MarketingViewModel>()
     val imageLoader: ImageLoader = get()
     setContent {
-      HedvigTheme(
-        colorOverrides = { colors ->
-          colors.copy(
-            primary = hedvig_off_white,
-            onPrimary = hedvig_black,
-            secondary = hedvig_off_white,
-            onBackground = hedvig_off_white,
-          )
-        },
-      ) {
+      HedvigTheme(darkTheme = true) { // Force dark theme as the background is dark
         val marketingBackground by viewModel.marketingBackground.collectAsState()
         val state by viewModel.state.collectAsState()
         MarketingScreen(
@@ -93,6 +82,7 @@ class MarketingActivity : AppCompatActivity() {
       supportFragmentManager,
       BankIdLoginDialog.TAG,
     )
+
     LoginMethod.NEM_ID, LoginMethod.BANK_ID_NORWAY -> {
       startActivity(
         SimpleSignAuthenticationActivity.newInstance(
@@ -101,9 +91,11 @@ class MarketingActivity : AppCompatActivity() {
         ),
       )
     }
+
     LoginMethod.OTP -> {
       // Not implemented
     }
+
     null -> {}
   }
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
@@ -8,10 +8,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,9 +56,7 @@ fun MarketPickedScreen(
     ) {
       LargeContainedButton(
         onClick = onClickSignUp,
-        colors = ButtonDefaults.buttonColors(
-          backgroundColor = MaterialTheme.colors.primary,
-        ),
+        colors = ButtonDefaults.buttonColors(),
       ) {
         Text(
           text = stringResource(hedvig.resources.R.string.MARKETING_GET_HEDVIG),

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
@@ -3,6 +3,7 @@ package com.hedvig.app.feature.marketing.pickmarket
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +34,7 @@ import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,7 +42,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -82,6 +83,11 @@ fun PickMarketScreen(
 
   ModalBottomSheetLayout(
     sheetState = modalBottomSheetState,
+    sheetBackgroundColor = if (isSystemInDarkTheme()) {
+      MaterialTheme.colors.surface
+    } else {
+      MaterialTheme.colors.onSurface
+    },
     sheetContent = {
       HedvigTheme { // Use standard theme again inside the sheet.
         BottomSheetContent(
@@ -113,7 +119,7 @@ fun PickMarketScreen(
   }
 }
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun ScreenContent(
   setSheet: (PickMarketSheet?) -> Unit,
@@ -172,6 +178,7 @@ private fun ScreenContent(
       LargeContainedButton(
         onClick = onSubmit,
         enabled = enabled,
+        colors = ButtonDefaults.buttonColors(),
         modifier = Modifier
           .padding(horizontal = 16.dp)
           .testTag("continueButton"),
@@ -216,6 +223,7 @@ private fun BottomSheetContent(
         selectedMarket = selectedMarket,
         markets = markets,
       )
+
       PickMarketSheet.COUNTRY -> PickLanguageSheetContent(
         onSelectLanguage = { language ->
           coroutineScope.launch {
@@ -226,6 +234,7 @@ private fun BottomSheetContent(
         selectedLanguage = selectedLanguage,
         selectedMarket = selectedMarket,
       )
+
       null -> {}
     }
     Spacer(Modifier.height(24.dp))
@@ -240,7 +249,7 @@ private fun LanguageFlag() {
   )
 }
 
-@Suppress("unused")
+@Suppress("UnusedReceiverParameter")
 @Composable
 private fun ColumnScope.PickMarketSheetContent(
   onSelectMarket: (Market) -> Unit,
@@ -264,7 +273,7 @@ private fun ColumnScope.PickMarketSheetContent(
   }
 }
 
-@Suppress("unused")
+@Suppress("UnusedReceiverParameter")
 @Composable
 private fun ColumnScope.PickLanguageSheetContent(
   onSelectLanguage: (Language) -> Unit,

--- a/app/src/main/res/layout/header_item_layout.xml
+++ b/app/src/main/res/layout/header_item_layout.xml
@@ -7,5 +7,5 @@
         android:id="@+id/header_item"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/Hedvig.TextAppearance.Headline5"
+        android:textAppearance="?textAppearanceHeadline5"
         tools:text="Make changes" />

--- a/app/src/main/res/layout/offer_header.xml
+++ b/app/src/main/res/layout/offer_header.xml
@@ -23,7 +23,8 @@
 
             <TextView
                 android:id="@+id/campaign"
-                style="@style/Hedvig.TextAppearance.Discount"
+                style="?textAppearanceCaption"
+                android:textColor="?android:textColorSecondary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/base_margin_half"
@@ -91,11 +92,11 @@
                 android:id="@+id/startDateContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingVertical="@dimen/base_margin_double"
                 android:layout_marginHorizontal="@dimen/base_margin"
-                android:paddingHorizontal="@dimen/base_margin"
                 android:layout_marginTop="@dimen/base_margin_quintuple"
-                android:background="@drawable/background_rounded_corners_ripple">
+                android:background="@drawable/background_rounded_corners_ripple"
+                android:paddingHorizontal="@dimen/base_margin"
+                android:paddingVertical="@dimen/base_margin_double">
 
                 <TextView
                     android:id="@+id/startDateLabel"

--- a/app/src/main/res/values/text_themes.xml
+++ b/app/src/main/res/values/text_themes.xml
@@ -1,10 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="Hedvig.TextAppearance.Headline3" parent="TextAppearance.MaterialComponents.Headline3">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">48sp</item>
+        <item name="lineHeight">58sp</item>
+    </style>
+
+    <style name="Hedvig.TextAppearance.Headline4" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="lineHeight">40sp</item>
+        <item name="android:textSize">32sp</item>
+    </style>
+
+    <style name="Hedvig.TextAppearance.Headline5" parent="TextAppearance.MaterialComponents.Headline5">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">24sp</item>
+        <item name="lineHeight">32sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
+    <dimen name="headline_5_placeholder_width">72sp</dimen>
+    <dimen name="headline_5_placeholder_height">24sp</dimen>
+
+    <style name="Hedvig.TextAppearance.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">20sp</item>
+        <item name="lineHeight">26sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
+    <style name="Hedvig.TextAppearance.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">16sp</item>
+        <item name="lineHeight">24sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
+    <dimen name="subtitle_1_placeholder_width">48sp</dimen>
+    <dimen name="subtitle_1_placeholder_height">16sp</dimen>
+
+    <style name="Hedvig.TextAppearance.Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2">
+        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">14sp</item>
+        <item name="lineHeight">20sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
     <style name="Hedvig.TextAppearance.Body1" parent="TextAppearance.MaterialComponents.Body1">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">26sp</item>
-        <item name="android:letterSpacing">0</item>
+        <item name="android:textSize">16sp</item>
+        <item name="lineHeight">24sp</item>
     </style>
 
     <dimen name="body_1_placeholder_width">48sp</dimen>
@@ -13,81 +59,28 @@
 
     <style name="Hedvig.TextAppearance.Body2" parent="TextAppearance.MaterialComponents.Body2">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">22sp</item>
-        <item name="android:letterSpacing">0</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-        <item name="lineHeight">24sp</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">14sp</item>
         <item name="lineHeight">20sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-    </style>
-
-    <dimen name="subtitle_1_placeholder_width">48sp</dimen>
-    <dimen name="subtitle_1_placeholder_height">16sp</dimen>
-
-    <style name="Hedvig.TextAppearance.Headline3" parent="TextAppearance.MaterialComponents.Headline3">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="android:letterSpacing">-0.05</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Headline4" parent="TextAppearance.MaterialComponents.Headline4">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">40sp</item>
-        <item name="android:textSize">32sp</item>
-        <item name="android:letterSpacing">-0.025</item>
-    </style>
-
-    <style name="Hedvig.TextAppearance.Headline5" parent="TextAppearance.MaterialComponents.Headline5">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">32sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-        <item name="android:letterSpacing">0</item>
-    </style>
-
-    <dimen name="headline_5_placeholder_width">72sp</dimen>
-    <dimen name="headline_5_placeholder_height">24sp</dimen>
-
-    <style name="Hedvig.TextAppearance.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">26sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-        <item name="android:letterSpacing">0</item>
     </style>
 
     <style name="Hedvig.TextAppearance.Button" parent="TextAppearance.MaterialComponents.Button">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">16sp</item>
         <item name="lineHeight">24sp</item>
-        <item name="android:textSize">17sp</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:letterSpacing">-0.01</item>
     </style>
 
     <style name="Hedvig.TextAppearance.Caption" parent="TextAppearance.MaterialComponents.Caption">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">12sp</item>
         <item name="lineHeight">16sp</item>
-        <item name="android:letterSpacing">0</item>
         <item name="android:textColor">?android:textColorTertiary</item>
     </style>
 
-    <style name="Hedvig.TextAppearance.Discount" parent="TextAppearance.MaterialComponents.Caption">
-        <item name="fontFamily">@font/hedvig_letters_standard</item>
-        <item name="lineHeight">16sp</item>
-        <item name="android:letterSpacing">0.1</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
-    </style>
-
-
     <style name="Hedvig.TextAppearance.Overline" parent="TextAppearance.MaterialComponents.Overline">
         <item name="fontFamily">@font/hedvig_letters_standard</item>
+        <item name="android:textSize">10sp</item>
         <item name="lineHeight">16sp</item>
-        <item name="android:letterSpacing">0.05</item>
     </style>
 
 </resources>

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
@@ -3,16 +3,23 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonColors
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.containedButtonContainer
+import com.hedvig.android.core.designsystem.theme.onContainedButtonContainer
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeContainedTextButton(
@@ -36,26 +43,35 @@ fun LargeContainedButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   colors: ButtonColors = ButtonDefaults.buttonColors(
-    backgroundColor = if (MaterialTheme.colors.isLight) {
-      MaterialTheme.colors.primary
-    } else {
-      MaterialTheme.colors.secondary
-    },
-    contentColor = MaterialTheme.colors.onPrimary,
+    containerColor = Material3Theme.colorScheme.containedButtonContainer,
+    contentColor = Material3Theme.colorScheme.onContainedButtonContainer,
+    disabledContainerColor = Material3Theme.colorScheme.containedButtonContainer.copy(
+      alpha = 0.12f,
+    ),
+    disabledContentColor = Material3Theme.colorScheme.onContainedButtonContainer.copy(
+      alpha = 0.38f,
+    ),
   ),
   content: @Composable RowScope.() -> Unit,
 ) {
   Button(
     onClick = onClick,
     enabled = enabled,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
-    shape = MaterialTheme.shapes.large,
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
     colors = colors,
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      androidx.compose.material.LocalContentColor provides LocalContentColor.current,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }
 
 @Preview(

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
@@ -3,17 +3,19 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.Text
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeOutlinedTextButton(
@@ -34,20 +36,24 @@ fun LargeOutlinedTextButton(
 fun LargeOutlinedButton(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
-  backgroundColor: Color = Color.Transparent,
   content: @Composable RowScope.() -> Unit,
 ) {
   OutlinedButton(
     onClick = onClick,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
-    border = ButtonDefaults.outlinedBorder.copy(brush = SolidColor(MaterialTheme.colors.primary)),
-    colors = ButtonDefaults.outlinedButtonColors(backgroundColor = backgroundColor),
-    shape = MaterialTheme.shapes.large,
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides Material2Theme.colors.onBackground,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }
 
 @Preview(
@@ -56,7 +62,7 @@ fun LargeOutlinedButton(
   showBackground = true,
 )
 @Composable
-fun LargeOutlinedButtonPreview() {
+private fun LargeOutlinedButtonPreview() {
   HedvigTheme {
     LargeOutlinedTextButton(text = "Outlined Button (Large)", onClick = {})
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
@@ -3,10 +3,15 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.TextButton
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeTextButton(
@@ -16,10 +21,18 @@ fun LargeTextButton(
 ) {
   TextButton(
     onClick = onClick,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      androidx.compose.material.LocalContentColor provides Material2Theme.colors.onBackground,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3ColorScheme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3ColorScheme.kt
@@ -1,0 +1,29 @@
+package com.hedvig.android.core.designsystem.material3
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+@Suppress("RemoveExplicitTypeArguments")
+internal val LocalHedvigMaterial3ColorScheme = staticCompositionLocalOf<HedvigMaterial3ColorScheme> {
+  lightHedvigColorScheme(LightColorScheme)
+}
+
+class HedvigMaterial3ColorScheme(
+  val containedButtonContainer: Color,
+  val onContainedButtonContainer: Color,
+)
+
+internal fun darkHedvigColorScheme(
+  colorScheme: ColorScheme,
+) = HedvigMaterial3ColorScheme(
+  containedButtonContainer = colorScheme.tertiary,
+  onContainedButtonContainer = colorScheme.onTertiary,
+)
+
+internal fun lightHedvigColorScheme(
+  colorScheme: ColorScheme,
+) = HedvigMaterial3ColorScheme(
+  containedButtonContainer = colorScheme.primary,
+  onContainedButtonContainer = colorScheme.onPrimary,
+)

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
@@ -36,21 +36,24 @@ import com.hedvig.android.core.designsystem.theme.light_surface
 import com.hedvig.android.core.designsystem.theme.light_surfaceVariant
 
 @Composable
-fun HedvigMaterial3Theme(
+internal fun HedvigMaterial3Theme(
   darkTheme: Boolean = isSystemInDarkTheme(),
   colorOverrides: (ColorScheme) -> ColorScheme = { it },
   content: @Composable () -> Unit,
 ) {
-  val colorScheme = when {
-    darkTheme -> DarkColorScheme
-    else -> LightColorScheme
+  val (colorScheme, hedvigColorTheme) = when {
+    darkTheme -> DarkColorScheme to darkHedvigColorScheme(DarkColorScheme)
+    else -> LightColorScheme to lightHedvigColorScheme(LightColorScheme)
   }
   MaterialTheme(
     colorScheme = colorOverrides.invoke(colorScheme),
     shapes = HedvigShapes,
     typography = HedvigTypography,
   ) {
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+    CompositionLocalProvider(
+      LocalContentColor provides MaterialTheme.colorScheme.onBackground,
+      LocalHedvigMaterial3ColorScheme provides hedvigColorTheme,
+    ) {
       content()
     }
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/Colors.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/Colors.kt
@@ -1,7 +1,10 @@
 package com.hedvig.android.core.designsystem.theme
 
 import androidx.compose.material.Colors
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.hedvig.android.core.designsystem.material3.LocalHedvigMaterial3ColorScheme
 
 // colors https://github.com/HedvigInsurance/android/blob/e86158084061de59a9f1b6d71dda3b234057883d/app/src/main/res/values/colors.xml#L2
 internal val black = Color(0xFF000000)
@@ -59,3 +62,13 @@ val Colors.textColorLink: Color
   } else {
     secondary
   }
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.containedButtonContainer: Color
+  @Composable
+  get() = LocalHedvigMaterial3ColorScheme.current.containedButtonContainer
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.onContainedButtonContainer: Color
+  @Composable
+  get() = LocalHedvigMaterial3ColorScheme.current.onContainedButtonContainer

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   implementation(libs.androidx.compose.foundationLayout)
   implementation(libs.androidx.compose.material)
   implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.runtime)
   implementation(libs.androidx.other.activityCompose)
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
@@ -3,15 +3,18 @@ package com.hedvig.android.sample.design.showcase
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.MaterialComponents
 
 class DesignShowcaseActivity : ComponentActivity() {
+  @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      HedvigMaterial3Theme {
-        MaterialComponents()
+      HedvigTheme {
+        MaterialComponents(calculateWindowSizeClass(this))
       }
     }
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
@@ -4,14 +4,19 @@ import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,8 +25,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Buttons
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Cards
@@ -30,7 +35,6 @@ import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Chips
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Divider
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2ProgressBar
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Slider
-import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Switch
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Tab
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TextFields
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TopAppBars
@@ -49,7 +53,30 @@ import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TextFields
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TopAppBars
 
 @Composable
-fun MaterialComponents() {
+fun MaterialComponents(windowSizeClass: WindowSizeClass) {
+  if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
+    BothThemes()
+  } else {
+    ThemeSelection()
+  }
+}
+
+@Composable
+private fun BothThemes() {
+  Row(Modifier.fillMaxSize()) {
+    Column(Modifier.weight(1f)) {
+      Text("M2")
+      M2()
+    }
+    Column(Modifier.weight(1f)) {
+      Text("M3")
+      M3()
+    }
+  }
+}
+
+@Composable
+private fun ThemeSelection() {
   var isM3: Boolean? by remember { mutableStateOf(null) }
   when (isM3) {
     true -> {
@@ -91,7 +118,6 @@ private fun M2() {
     M2LightAndDarkItem { M2Buttons() }
     M2LightAndDarkItem { M2TextFields() }
     M2LightAndDarkItem { M2Chips() }
-    M2LightAndDarkItem { M2Switch() }
     M2LightAndDarkItem { M2Checkbox() }
     M2LightAndDarkItem { M2Slider() }
     M2LightAndDarkItem { M2ProgressBar() }
@@ -108,11 +134,9 @@ private fun M3() {
     modifier = Modifier.fillMaxSize(),
     state = rememberLazyListState(),
   ) {
-    LightAndDarkItem { M3DatePicker() }
     LightAndDarkItem { M3Buttons() }
     LightAndDarkItem { M3TextFields() }
     LightAndDarkItem { M3Chips() }
-    LightAndDarkItem { M3Switch() }
     LightAndDarkItem { M3Checkbox() }
     LightAndDarkItem { M3Slider() }
     LightAndDarkItem { M3ProgressBar() }
@@ -121,19 +145,27 @@ private fun M3() {
     LightAndDarkItem { M3TopAppBars() }
     LightAndDarkItem { M3NavigationBars() }
     LightAndDarkItem { M3Tab() }
+    LightAndDarkItem { M3Switch() } // We don't use this in m2
+    LightAndDarkItem { M3DatePicker() } // We don't use this in m2
   }
 }
 
 @Suppress("FunctionName")
 fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
   item {
-    Row {
-      Surface(Modifier.weight(1f)) {
-        content()
+    Row(Modifier.fillMaxWidth()) {
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(false) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
+        }
       }
-      HedvigTheme(/* todo dark theme when adapter doesn't exist */) {
-        Surface(Modifier.weight(1f)) {
-          content()
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(true) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
         }
       }
     }
@@ -143,26 +175,33 @@ fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
 @Suppress("FunctionName")
 fun LazyListScope.LightAndDarkItem(content: @Composable () -> Unit) {
   item {
-    Row {
-      Surface(Modifier.weight(1f)) {
-        content()
+    Row(Modifier.fillMaxWidth()) {
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(false) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
+        }
       }
-      HedvigMaterial3Theme(true) {
-        Surface(Modifier.weight(1f)) {
-          content()
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(true) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
         }
       }
     }
   }
 }
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun MaterialComponentsPreview() {
-  HedvigMaterial3Theme {
+  HedvigTheme {
     Surface {
-      MaterialComponents()
+      MaterialComponents(WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)))
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
@@ -2,10 +2,9 @@ package com.hedvig.android.sample.design.showcase.ui.m2.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
-import androidx.compose.material.ExtendedFloatingActionButton
-import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
@@ -16,6 +15,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 
 @Composable
 internal fun M2Buttons() {
@@ -26,6 +28,19 @@ internal fun M2Buttons() {
       text = "Buttons",
       style = MaterialTheme.typography.h5,
     )
+    Spacer(Modifier.size(16.dp))
+    LargeContainedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeOutlinedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeTextButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+
     Spacer(Modifier.size(16.dp))
     Button(
       onClick = {},
@@ -47,16 +62,5 @@ internal fun M2Buttons() {
     ) {
       Text("Text button")
     }
-    Spacer(Modifier.size(16.dp))
-    FloatingActionButton(onClick = {}) {
-      Text("FAB")
-    }
-    Spacer(Modifier.size(16.dp))
-    ExtendedFloatingActionButton(
-      onClick = {},
-      text = {
-        Text("Extended FAB")
-      },
-    )
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
@@ -3,13 +3,13 @@ package com.hedvig.android.sample.design.showcase.ui.m2.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -31,11 +31,6 @@ internal fun M2TopAppBars() {
     TopAppBar(
       title = { Text("Small top app bar") },
       navigationIcon = { NavigationIcon() },
-    )
-    Spacer(modifier = Modifier.size(16.dp))
-    M2OnSurfaceText(
-      text = "Scrolled State",
-      style = MaterialTheme.typography.subtitle2,
     )
     Spacer(Modifier.size(4.dp))
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/Buttons.kt
@@ -21,10 +21,9 @@ package com.hedvig.android.sample.design.showcase.ui.m3.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -35,6 +34,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 
 @Composable
 internal fun M3Buttons() {
@@ -45,6 +47,19 @@ internal fun M3Buttons() {
       text = "Buttons",
       style = MaterialTheme.typography.headlineSmall,
     )
+    Spacer(Modifier.size(16.dp))
+    LargeContainedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeOutlinedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeTextButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+
     Spacer(Modifier.size(16.dp))
     Button(
       onClick = {},
@@ -65,14 +80,6 @@ internal fun M3Buttons() {
       enabled = enabled,
     ) {
       Text("Text button")
-    }
-    Spacer(Modifier.size(16.dp))
-    FloatingActionButton(onClick = {}) {
-      Text("FAB")
-    }
-    Spacer(Modifier.size(16.dp))
-    ExtendedFloatingActionButton(onClick = {}) {
-      Text("Extended FAB")
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/DatePicker.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/DatePicker.kt
@@ -29,6 +29,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +43,11 @@ internal fun M3DatePicker() {
       style = MaterialTheme.typography.headlineSmall,
     )
     Spacer(Modifier.size(16.dp))
-    HedvigDatePicker(rememberDatePickerState(), Modifier.size(500.dp))
+    HedvigDatePicker(
+      rememberDatePickerState(
+        LocalDate.now().atTime(LocalTime.MIDNIGHT).plusDays(1).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+      ),
+      Modifier.size(500.dp),
+    )
   }
 }


### PR DESCRIPTION
For the XML theme setup. The "Discount" text style was removed as it was only used in one spot and that one spot was adjusted accordingly.

Also remove some rogue direct calls on Hedvig styles. Instead use
material's ?textAppearanceFoo to properly fetch from the theme.

---

Change marketing screen to simply use Dark theme style

Instead of manually providing and overriding some color values, do this:
Since the background image right now is dark, it needs content on top
which acts more like what content would act on a dark background,
therefore how the dark theme handles this. Lean into that and "force"
dark theme style for this screen only, while allowing the bottom sheet
to follow the device's theme normally.

---

Provide custom theme for contained buttons

For contained buttons, we got the special case where for light mode we
want primary color, but for dark mode we want tertiary color. Material3
colorScheme however does not hold information about light/dark mode
available for us to use like we did with material2.
This makes us have to make a new composition local, which decides which
color to use at the time of when our original colorScheme is generated
by giving the same scheme and then providing that down through a
composition local.

Then by utilizing extension functions on ColorScheme, we can make these
extra options look like they come from the normal ColorScheme.

Relevant discussion at:
https://issuetracker.google.com/issues/208860800#comment7