### PR TITLE
Adjust hedvig buttons to the new changes for M3

### DIFF
--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
@@ -3,16 +3,23 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonColors
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.designsystem.theme.containedButtonContainer
+import com.hedvig.android.core.designsystem.theme.onContainedButtonContainer
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeContainedTextButton(
@@ -36,26 +43,35 @@ fun LargeContainedButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   colors: ButtonColors = ButtonDefaults.buttonColors(
-    backgroundColor = if (MaterialTheme.colors.isLight) {
-      MaterialTheme.colors.primary
-    } else {
-      MaterialTheme.colors.secondary
-    },
-    contentColor = MaterialTheme.colors.onPrimary,
+    containerColor = Material3Theme.colorScheme.containedButtonContainer,
+    contentColor = Material3Theme.colorScheme.onContainedButtonContainer,
+    disabledContainerColor = Material3Theme.colorScheme.containedButtonContainer.copy(
+      alpha = 0.12f,
+    ),
+    disabledContentColor = Material3Theme.colorScheme.onContainedButtonContainer.copy(
+      alpha = 0.38f,
+    ),
   ),
   content: @Composable RowScope.() -> Unit,
 ) {
   Button(
     onClick = onClick,
     enabled = enabled,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
-    shape = MaterialTheme.shapes.large,
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
     colors = colors,
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      androidx.compose.material.LocalContentColor provides LocalContentColor.current,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }
 
 @Preview(

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
@@ -3,17 +3,19 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.Text
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeOutlinedTextButton(
@@ -34,20 +36,24 @@ fun LargeOutlinedTextButton(
 fun LargeOutlinedButton(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
-  backgroundColor: Color = Color.Transparent,
   content: @Composable RowScope.() -> Unit,
 ) {
   OutlinedButton(
     onClick = onClick,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
-    border = ButtonDefaults.outlinedBorder.copy(brush = SolidColor(MaterialTheme.colors.primary)),
-    colors = ButtonDefaults.outlinedButtonColors(backgroundColor = backgroundColor),
-    shape = MaterialTheme.shapes.large,
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides Material2Theme.colors.onBackground,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }
 
 @Preview(
@@ -56,7 +62,7 @@ fun LargeOutlinedButton(
   showBackground = true,
 )
 @Composable
-fun LargeOutlinedButtonPreview() {
+private fun LargeOutlinedButtonPreview() {
   HedvigTheme {
     LargeOutlinedTextButton(text = "Outlined Button (Large)", onClick = {})
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
@@ -3,10 +3,15 @@ package com.hedvig.android.core.designsystem.component.button
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.TextButton
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 
 @Composable
 fun LargeTextButton(
@@ -16,10 +21,18 @@ fun LargeTextButton(
 ) {
   TextButton(
     onClick = onClick,
-    modifier = Modifier
-      .fillMaxWidth()
-      .then(modifier),
+    modifier = modifier.fillMaxWidth(),
+    shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
-    content = content,
-  )
+  ) {
+    CompositionLocalProvider(
+      androidx.compose.material.LocalContentColor provides Material2Theme.colors.onBackground,
+    ) {
+      ProvideTextStyleM3(Material3Theme.typography.bodyLarge) {
+        ProvideTextStyleM2(Material2Theme.typography.button) {
+          content()
+        }
+      }
+    }
+  }
 }

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   implementation(libs.androidx.compose.foundationLayout)
   implementation(libs.androidx.compose.material)
   implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.runtime)
   implementation(libs.androidx.other.activityCompose)
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/DesignShowcaseActivity.kt
@@ -3,15 +3,18 @@ package com.hedvig.android.sample.design.showcase
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.MaterialComponents
 
 class DesignShowcaseActivity : ComponentActivity() {
+  @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      HedvigMaterial3Theme {
-        MaterialComponents()
+      HedvigTheme {
+        MaterialComponents(calculateWindowSizeClass(this))
       }
     }
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
@@ -4,14 +4,19 @@ import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,8 +25,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.material3.HedvigMaterial3Theme
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Buttons
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Cards
@@ -30,7 +35,6 @@ import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Chips
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Divider
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2ProgressBar
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Slider
-import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Switch
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Tab
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TextFields
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2TopAppBars
@@ -49,7 +53,30 @@ import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TextFields
 import com.hedvig.android.sample.design.showcase.ui.m3.components.M3TopAppBars
 
 @Composable
-fun MaterialComponents() {
+fun MaterialComponents(windowSizeClass: WindowSizeClass) {
+  if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
+    BothThemes()
+  } else {
+    ThemeSelection()
+  }
+}
+
+@Composable
+private fun BothThemes() {
+  Row(Modifier.fillMaxSize()) {
+    Column(Modifier.weight(1f)) {
+      Text("M2")
+      M2()
+    }
+    Column(Modifier.weight(1f)) {
+      Text("M3")
+      M3()
+    }
+  }
+}
+
+@Composable
+private fun ThemeSelection() {
   var isM3: Boolean? by remember { mutableStateOf(null) }
   when (isM3) {
     true -> {
@@ -91,7 +118,6 @@ private fun M2() {
     M2LightAndDarkItem { M2Buttons() }
     M2LightAndDarkItem { M2TextFields() }
     M2LightAndDarkItem { M2Chips() }
-    M2LightAndDarkItem { M2Switch() }
     M2LightAndDarkItem { M2Checkbox() }
     M2LightAndDarkItem { M2Slider() }
     M2LightAndDarkItem { M2ProgressBar() }
@@ -108,11 +134,9 @@ private fun M3() {
     modifier = Modifier.fillMaxSize(),
     state = rememberLazyListState(),
   ) {
-    LightAndDarkItem { M3DatePicker() }
     LightAndDarkItem { M3Buttons() }
     LightAndDarkItem { M3TextFields() }
     LightAndDarkItem { M3Chips() }
-    LightAndDarkItem { M3Switch() }
     LightAndDarkItem { M3Checkbox() }
     LightAndDarkItem { M3Slider() }
     LightAndDarkItem { M3ProgressBar() }
@@ -121,19 +145,27 @@ private fun M3() {
     LightAndDarkItem { M3TopAppBars() }
     LightAndDarkItem { M3NavigationBars() }
     LightAndDarkItem { M3Tab() }
+    LightAndDarkItem { M3Switch() } // We don't use this in m2
+    LightAndDarkItem { M3DatePicker() } // We don't use this in m2
   }
 }
 
 @Suppress("FunctionName")
 fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
   item {
-    Row {
-      Surface(Modifier.weight(1f)) {
-        content()
+    Row(Modifier.fillMaxWidth()) {
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(false) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
+        }
       }
-      HedvigTheme(/* todo dark theme when adapter doesn't exist */) {
-        Surface(Modifier.weight(1f)) {
-          content()
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(true) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
         }
       }
     }
@@ -143,26 +175,33 @@ fun LazyListScope.M2LightAndDarkItem(content: @Composable () -> Unit) {
 @Suppress("FunctionName")
 fun LazyListScope.LightAndDarkItem(content: @Composable () -> Unit) {
   item {
-    Row {
-      Surface(Modifier.weight(1f)) {
-        content()
+    Row(Modifier.fillMaxWidth()) {
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(false) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
+        }
       }
-      HedvigMaterial3Theme(true) {
-        Surface(Modifier.weight(1f)) {
-          content()
+      Box(Modifier.weight(1f)) {
+        HedvigTheme(true) {
+          Surface(Modifier.fillMaxWidth()) {
+            content()
+          }
         }
       }
     }
   }
 }
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun MaterialComponentsPreview() {
-  HedvigMaterial3Theme {
+  HedvigTheme {
     Surface {
-      MaterialComponents()
+      MaterialComponents(WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)))
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/Buttons.kt
@@ -2,10 +2,9 @@ package com.hedvig.android.sample.design.showcase.ui.m2.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
-import androidx.compose.material.ExtendedFloatingActionButton
-import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
@@ -16,6 +15,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 
 @Composable
 internal fun M2Buttons() {
@@ -26,6 +28,19 @@ internal fun M2Buttons() {
       text = "Buttons",
       style = MaterialTheme.typography.h5,
     )
+    Spacer(Modifier.size(16.dp))
+    LargeContainedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeOutlinedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeTextButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+
     Spacer(Modifier.size(16.dp))
     Button(
       onClick = {},
@@ -47,16 +62,5 @@ internal fun M2Buttons() {
     ) {
       Text("Text button")
     }
-    Spacer(Modifier.size(16.dp))
-    FloatingActionButton(onClick = {}) {
-      Text("FAB")
-    }
-    Spacer(Modifier.size(16.dp))
-    ExtendedFloatingActionButton(
-      onClick = {},
-      text = {
-        Text("Extended FAB")
-      },
-    )
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m2/components/TopAppBar.kt
@@ -3,13 +3,13 @@ package com.hedvig.android.sample.design.showcase.ui.m2.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -31,11 +31,6 @@ internal fun M2TopAppBars() {
     TopAppBar(
       title = { Text("Small top app bar") },
       navigationIcon = { NavigationIcon() },
-    )
-    Spacer(modifier = Modifier.size(16.dp))
-    M2OnSurfaceText(
-      text = "Scrolled State",
-      style = MaterialTheme.typography.subtitle2,
     )
     Spacer(Modifier.size(4.dp))
   }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/Buttons.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/Buttons.kt
@@ -21,10 +21,9 @@ package com.hedvig.android.sample.design.showcase.ui.m3.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -35,6 +34,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 
 @Composable
 internal fun M3Buttons() {
@@ -45,6 +47,19 @@ internal fun M3Buttons() {
       text = "Buttons",
       style = MaterialTheme.typography.headlineSmall,
     )
+    Spacer(Modifier.size(16.dp))
+    LargeContainedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeOutlinedButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+    Spacer(Modifier.size(16.dp))
+    LargeTextButton({}, Modifier.padding(horizontal = 8.dp)) {
+      Text("Hedvig LargeTextButton")
+    }
+
     Spacer(Modifier.size(16.dp))
     Button(
       onClick = {},
@@ -65,14 +80,6 @@ internal fun M3Buttons() {
       enabled = enabled,
     ) {
       Text("Text button")
-    }
-    Spacer(Modifier.size(16.dp))
-    FloatingActionButton(onClick = {}) {
-      Text("FAB")
-    }
-    Spacer(Modifier.size(16.dp))
-    ExtendedFloatingActionButton(onClick = {}) {
-      Text("Extended FAB")
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/DatePicker.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/m3/components/DatePicker.kt
@@ -29,6 +29,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +43,11 @@ internal fun M3DatePicker() {
       style = MaterialTheme.typography.headlineSmall,
     )
     Spacer(Modifier.size(16.dp))
-    HedvigDatePicker(rememberDatePickerState(), Modifier.size(500.dp))
+    HedvigDatePicker(
+      rememberDatePickerState(
+        LocalDate.now().atTime(LocalTime.MIDNIGHT).plusDays(1).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+      ),
+      Modifier.size(500.dp),
+    )
   }
 }


### PR DESCRIPTION
Use containedButtonContainer and onContainedButtonContainer for the contained button.
Use m3 under the hood for the buttons, while still providing the correct
composition locals so that if m2 components are used in the `content`,
the correct textStyle and contentColor will be used.

Also provide bodyLarge text for m3 button text style as that's what our DS expects on the size of the text inside buttons.