### PR TITLE
Fix: Improve compose previews

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.addressautocompletion.model.DanishAddress
 import com.hedvig.app.feature.addressautocompletion.model.DanishAddressInput
@@ -249,7 +249,7 @@ private fun SuggestionsList(
   }
 }
 
-@HedvigPreview
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewAddressAutoCompleteScreen() {
   HedvigTheme {

--- a/app/src/main/kotlin/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/addressautocompletion/ui/AddressAutoCompleteScreen.kt
@@ -1,9 +1,7 @@
 package com.hedvig.app.feature.addressautocompletion.ui
 
-import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -47,8 +45,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.addressautocompletion.model.DanishAddress
 import com.hedvig.app.feature.addressautocompletion.model.DanishAddressInput
@@ -251,10 +249,9 @@ private fun SuggestionsList(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun AddressAutoCompleteScreenPreview() {
+private fun PreviewAddressAutoCompleteScreen() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       val previewDanishAddress = DanishAddress.previewData()

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimDetailCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimDetailCard.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.claimdetail.ui
 
-import android.content.res.Configuration
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,10 +18,9 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.R
 import com.hedvig.app.feature.claimdetail.model.ClaimDetailCardUiState
 import com.hedvig.app.ui.compose.composables.ChatIcon
 import com.hedvig.app.ui.compose.composables.claimprogress.ClaimProgressRow
@@ -107,14 +105,11 @@ private fun BottomSection(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun ClaimDetailCardPreview() {
+private fun PreviewClaimDetailCard() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       ClaimDetailCard(
         ClaimDetailCardUiState(
           claimProgressItemsUiState = ClaimProgressUiState.previewList(),

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimDetailScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimDetailScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.android.core.ui.genericinfo.GenericErrorScreen
@@ -110,7 +110,7 @@ private fun ClaimDetailScreen(
   }
 }
 
-@HedvigPreview
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewClaimDetailScreen() {
   HedvigTheme {

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimDetailScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimDetailScreen.kt
@@ -12,11 +12,12 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.android.core.ui.genericinfo.GenericErrorScreen
@@ -109,15 +110,17 @@ private fun ClaimDetailScreen(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun ClaimDetailScreenPreview() {
+private fun PreviewClaimDetailScreen() {
   HedvigTheme {
-    ClaimDetailScreen(
-      uiState = ClaimDetailUiState.previewData(),
-      onPlayClick = {},
-      locale = Locale.getDefault(),
-      onChatClick = {},
-    )
+    Surface {
+      ClaimDetailScreen(
+        uiState = ClaimDetailUiState.previewData(),
+        onPlayClick = {},
+        locale = Locale.getDefault(),
+        onChatClick = {},
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimResultSection.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimResultSection.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.claimdetail.ui
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,12 +14,11 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.R
 import com.hedvig.app.feature.claimdetail.model.ClaimDetailResult
 import com.hedvig.app.feature.home.ui.claimstatus.data.ClaimStatusColors
 import com.hedvig.app.ui.compose.composables.pill.Pill
@@ -74,22 +72,19 @@ fun ClaimResultSection(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun ClaimResultSectionPreview(
+private fun PreviewClaimResultSection(
   @PreviewParameter(ClaimDetailResultProvider::class) result: ClaimDetailResult.Closed,
 ) {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       ClaimResultSection(result, Locale.getDefault())
     }
   }
 }
 
-class ClaimDetailResultProvider : CollectionPreviewParameterProvider<ClaimDetailResult.Closed>(
+private class ClaimDetailResultProvider : CollectionPreviewParameterProvider<ClaimDetailResult.Closed>(
   listOf(
     ClaimDetailResult.Closed.Paid(PreviewData.monetaryAmount(2_500.00)),
     ClaimDetailResult.Closed.Paid(null),

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimType.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/ClaimType.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.claimdetail.ui
 
-import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -16,8 +15,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 
@@ -56,14 +55,11 @@ fun ClaimType(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun ClaimTypePreview() {
+private fun PreviewClaimType() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       Column {
         ClaimType(title = "title", subtitle = "subtitle")
         ClaimType(title = "title", subtitle = "")

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/FailedAudioPlayerCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/FailedAudioPlayerCard.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.onWarning
 import com.hedvig.app.ui.compose.theme.warning
@@ -74,9 +74,9 @@ fun FailedAudioPlayerCard(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun FailedAudioPlayerCardPreview() {
+private fun PreviewFailedAudioPlayerCard() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.warning) {
       CompositionLocalProvider(LocalContentColor provides MaterialTheme.colors.onWarning) {

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/FakeAudioWaves.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/FakeAudioWaves.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.material.math.MathUtils
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.util.ProgressPercentage
 import kotlin.math.abs
@@ -120,9 +120,9 @@ private fun FakeAudioWave(
   ) {}
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun FakeAudioWavesPreview() {
+private fun PreviewFakeAudioWaves() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       FakeAudioWaves(

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/FakeWaveAudioPlayerCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/FakeWaveAudioPlayerCard.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.claimdetail.ui
 
-import android.content.res.Configuration
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
@@ -32,10 +31,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.onWarning
 import com.hedvig.app.R
@@ -195,9 +194,9 @@ private fun AudioPlayerActionOrLoadingIcon(
   }
 }
 
-@Preview("Interactive Preview")
+@HedvigPreview
 @Composable
-fun FakeWaveAudioPlayerCardAnimationPreview() {
+private fun PreviewFakeWaveAudioPlayerCardAnimation() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       var audioPlayerState: AudioPlayerState by remember {
@@ -221,22 +220,19 @@ fun FakeWaveAudioPlayerCardAnimationPreview() {
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun FakeWaveAudioPlayerCardPreview(
+private fun PreviewFakeWaveAudioPlayerCard(
   @PreviewParameter(AudioPlayerStateProvider::class) audioPlayerState: AudioPlayerState,
 ) {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       FakeWaveAudioPlayerCard(audioPlayerState, {}, {}, {}, {})
     }
   }
 }
 
-class AudioPlayerStateProvider : CollectionPreviewParameterProvider<AudioPlayerState>(
+private class AudioPlayerStateProvider : CollectionPreviewParameterProvider<AudioPlayerState>(
   listOf(
     AudioPlayerState.Failed,
     AudioPlayerState.Ready(ReadyState.Paused, ProgressPercentage(0.4f)),

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/SubmittedAndClosedColumns.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/ui/SubmittedAndClosedColumns.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.claimdetail.ui
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,8 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.R
 import com.hedvig.app.util.HedvigDateUtils
 import com.hedvig.app.util.compose.currentTimeAsState
 import java.time.Duration
@@ -83,19 +82,16 @@ private fun SubmittedAndClosedColumn(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Preview(locale = "sv")
 @Preview(locale = "nn")
 @Preview(locale = "da")
 @Preview(locale = "fr")
 @Preview(locale = "el")
 @Composable
-fun SubmittedAndClosedInformationPreview() {
+private fun PreviewSubmittedAndClosedInformation() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       SubmittedAndClosedColumns(
         submittedAt = Instant.now().minus(Duration.ofDays(10)),
         closedAt = Instant.now().minus(Duration.ofSeconds(30)),

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/CrossSellingResultScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/CrossSellingResultScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,13 +20,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
 import com.hedvig.android.core.designsystem.component.button.LargeOutlinedTextButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 import java.time.Clock
@@ -180,30 +181,28 @@ private fun ButtonsSection(
   }
 }
 
-@Preview(
-  showSystemUi = true,
-  name = "Accident Result",
-  group = "Cross Sell result",
-)
+@HedvigPreview
 @Composable
-fun CrossSellingResultScreenPreview(
+private fun PreviewCrossSellingResultScreen(
   @PreviewParameter(ActivityResultProvider::class) crossSellingResult: CrossSellingResult,
 ) {
   HedvigTheme {
-    CrossSellingResultScreen(
-      crossSellingResult,
-      Clock.systemDefaultZone(),
-      DateTimeFormatter.ISO_LOCAL_DATE,
-      {},
-      {},
-    )
+    Surface {
+      CrossSellingResultScreen(
+        crossSellingResult,
+        Clock.systemDefaultZone(),
+        DateTimeFormatter.ISO_LOCAL_DATE,
+        {},
+        {},
+      )
+    }
   }
 }
 
-class ActivityResultProvider : PreviewParameterProvider<CrossSellingResult> {
-  override val values: Sequence<CrossSellingResult> = sequenceOf(
+private class ActivityResultProvider : CollectionPreviewParameterProvider<CrossSellingResult>(
+  listOf(
     CrossSellingResult.Error,
     CrossSellingResult.Success(LocalDate.now(), "Accident Insurance"),
     CrossSellingResult.Success(LocalDate.now().plusDays(2), "Accident Insurance"),
-  )
-}
+  ),
+)

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/ClickableListItem.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/ClickableListItem.kt
@@ -9,13 +9,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 
@@ -46,14 +47,16 @@ fun ClickableListItem(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun ClickableListItemPreview() {
+private fun PreviewClickableListItem() {
   HedvigTheme {
-    ClickableListItem(
-      onClick = {},
-      icon = R.drawable.ic_info,
-      text = "Full coverage",
-    )
+    Surface {
+      ClickableListItem(
+        onClick = {},
+        icon = R.drawable.ic_info,
+        text = "Full coverage",
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/CrossSellDetailScreen.kt
@@ -3,13 +3,12 @@ package com.hedvig.app.feature.crossselling.ui.detail
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.consumedWindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -34,7 +34,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
@@ -42,6 +41,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.list.SectionTitle
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.core.ui.scaffold.Scaffold
@@ -51,7 +51,6 @@ import com.hedvig.app.ui.compose.composables.ErrorDialog
 import com.hedvig.app.ui.compose.composables.appbar.FadingTopAppBar
 import com.hedvig.app.util.compose.rememberBlurHashPainter
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CrossSellDetailScreen(
   onCtaClick: () -> Unit,
@@ -91,7 +90,7 @@ fun CrossSellDetailScreen(
         // Since we've applied the insets on the bottomBar itself and that stays at the bottom of the screen, and the
         // height that it takes is passed down inside [paddingValues], we need to inform children that the bottom
         // insets are already consumed.
-        .consumedWindowInsets(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
+        .consumeWindowInsets(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
     ) {
       ScrollableContent(
         crossSellData = data,
@@ -192,51 +191,53 @@ private fun ScrollableContent(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun CrossSellDetailScreenPreview() {
+private fun PreviewCrossSellDetailScreen() {
   HedvigTheme {
-    CrossSellDetailScreen(
-      onCtaClick = {},
-      onUpClick = {},
-      onCoverageClick = {},
-      onFaqClick = {},
-      onDismissError = {},
-      data = CrossSellData(
-        title = "Accident Insurance",
-        description = "179 kr/mo.",
-        callToAction = "Calculate price",
-        action = CrossSellData.Action.Chat,
-        backgroundUrl = "https://images.unsplash.com/photo-1628996796855-0b056a464e06",
-        backgroundBlurHash = "LJC6\$2-:DiWB~WxuRkayMwNGo~of",
-        crossSellType = "ACCIDENT",
-        typeOfContract = "SE_ACCIDENT",
-        about = "If you or a family member is injured in an accident insurance, Hedvig is able to compensate" +
-          " you for a hospital stay, rehabilitation, therapy and dental injuries. \n\n" +
-          "In case of a permanent injury that affect your your quality of life and ability to work, an " +
-          "accident insurance can complement the support from the social welfare system and your employer.",
-        perils = emptyList(),
-        terms = emptyList(),
-        highlights = listOf(
-          CrossSellData.Highlight(
-            title = "Covers dental injuries",
-            description = "Up to 100 000 SEK per damage.",
+    Surface {
+      CrossSellDetailScreen(
+        onCtaClick = {},
+        onUpClick = {},
+        onCoverageClick = {},
+        onFaqClick = {},
+        onDismissError = {},
+        data = CrossSellData(
+          title = "Accident Insurance",
+          description = "179 kr/mo.",
+          callToAction = "Calculate price",
+          action = CrossSellData.Action.Chat,
+          backgroundUrl = "https://images.unsplash.com/photo-1628996796855-0b056a464e06",
+          backgroundBlurHash = "LJC6\$2-:DiWB~WxuRkayMwNGo~of",
+          crossSellType = "ACCIDENT",
+          typeOfContract = "SE_ACCIDENT",
+          about = "If you or a family member is injured in an accident insurance, Hedvig is able to compensate" +
+            " you for a hospital stay, rehabilitation, therapy and dental injuries. \n\n" +
+            "In case of a permanent injury that affect your your quality of life and ability to work, an " +
+            "accident insurance can complement the support from the social welfare system and your employer.",
+          perils = emptyList(),
+          terms = emptyList(),
+          highlights = listOf(
+            CrossSellData.Highlight(
+              title = "Covers dental injuries",
+              description = "Up to 100 000 SEK per damage.",
+            ),
+            CrossSellData.Highlight(
+              title = "Compensates permanent injuries",
+              description = "A fixed amount up to 2 000 000 SEK is payed out in " +
+                "the event of a permanent injury.",
+            ),
+            CrossSellData.Highlight(
+              title = "Rehabilitation and therapy is covered",
+              description = "After accidents and sudden events, such as the death of a close family member.",
+            ),
           ),
-          CrossSellData.Highlight(
-            title = "Compensates permanent injuries",
-            description = "A fixed amount up to 2 000 000 SEK is payed out in " +
-              "the event of a permanent injury.",
-          ),
-          CrossSellData.Highlight(
-            title = "Rehabilitation and therapy is covered",
-            description = "After accidents and sudden events, such as the death of a close family member.",
-          ),
+          faq = emptyList(),
+          insurableLimits = emptyList(),
         ),
-        faq = emptyList(),
-        insurableLimits = emptyList(),
-      ),
-      errorMessage = null,
-      imageLoader = rememberPreviewImageLoader(),
-    )
+        errorMessage = null,
+        imageLoader = rememberPreviewImageLoader(),
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/FaqScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/FaqScreen.kt
@@ -11,16 +11,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.app.R
@@ -85,38 +86,40 @@ fun FaqScreen(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun FaqScreenPreview() {
+private fun PreviewFaqScreen() {
   HedvigTheme {
-    FaqScreen(
-      ctaLabel = "Calculate your price",
-      onUpClick = {},
-      openSheet = {},
-      openChat = {},
-      onCtaClick = {},
-      items = listOf(
-        FAQItem(
-          headline = "What is included in my home insurance?",
-          body = "",
+    Surface {
+      FaqScreen(
+        ctaLabel = "Calculate your price",
+        onUpClick = {},
+        openSheet = {},
+        openChat = {},
+        onCtaClick = {},
+        items = listOf(
+          FAQItem(
+            headline = "What is included in my home insurance?",
+            body = "",
+          ),
+          FAQItem(
+            headline = "Why should I choose Hedvig?",
+            body = "",
+          ),
+          FAQItem(
+            headline = "Can I get Hedvig even though I already have an insurance policy?",
+            body = "",
+          ),
+          FAQItem(
+            headline = "How do I pay for my insurance?",
+            body = "",
+          ),
+          FAQItem(
+            headline = "How do I make a claim?",
+            body = "",
+          ),
         ),
-        FAQItem(
-          headline = "Why should I choose Hedvig?",
-          body = "",
-        ),
-        FAQItem(
-          headline = "Can I get Hedvig even though I already have an insurance policy?",
-          body = "",
-        ),
-        FAQItem(
-          headline = "How do I pay for my insurance?",
-          body = "",
-        ),
-        FAQItem(
-          headline = "How do I make a claim?",
-          body = "",
-        ),
-      ),
-    )
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/Highlight.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/detail/Highlight.kt
@@ -7,12 +7,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 
@@ -42,13 +43,15 @@ fun Highlight(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun HighlightPreview() {
+private fun PreviewHighlight() {
   HedvigTheme {
-    Highlight(
-      title = "Covers dental injuries",
-      description = "Up to 100 000 SEK per damage.",
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      Highlight(
+        title = "Covers dental injuries",
+        description = "Up to 100 000 SEK per damage.",
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/addressautocomplete/composables/AddressCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/addressautocomplete/composables/AddressCard.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.embark.passages.addressautocomplete.composables
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,8 +16,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -80,10 +79,9 @@ private fun AddressTextColumn(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun AddressCardPreview() {
+private fun PreviewAddressCard() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       AddressCard(

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/audiorecorder/AudioRecorderScreen.kt
@@ -26,10 +26,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeTextButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 import com.hedvig.app.util.compose.ScreenOnFlag
@@ -216,129 +216,135 @@ fun Playback(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun AudioRecorderScreenNotRecordingPreview() {
+private fun PreviewAudioRecorderScreenNotRecording() {
   HedvigTheme {
-    AudioRecorderScreen(
-      parameters = AudioRecorderParameters(
-        messages = listOf("Hello", "World"),
-        key = "key",
-        label = "label",
-        link = "link",
-      ),
-      viewState = AudioRecorderViewModel.ViewState.NotRecording,
-      startRecording = {},
-      clock = Clock.systemDefaultZone(),
-      stopRecording = {},
-      submit = {},
-      redo = {},
-      play = {},
-      pause = {},
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      AudioRecorderScreen(
+        parameters = AudioRecorderParameters(
+          messages = listOf("Hello", "World"),
+          key = "key",
+          label = "label",
+          link = "link",
+        ),
+        viewState = AudioRecorderViewModel.ViewState.NotRecording,
+        startRecording = {},
+        clock = Clock.systemDefaultZone(),
+        stopRecording = {},
+        submit = {},
+        redo = {},
+        play = {},
+        pause = {},
+      )
+    }
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun AudioRecorderScreenRecordingPreview() {
+private fun PreviewAudioRecorderScreenRecording() {
   HedvigTheme {
-    AudioRecorderScreen(
-      parameters = AudioRecorderParameters(
-        messages = listOf("Hello", "World"),
-        key = "key",
-        label = "label",
-        link = "link",
-      ),
-      viewState = AudioRecorderViewModel.ViewState.Recording(
-        listOf(
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
+    Surface(color = MaterialTheme.colors.background) {
+      AudioRecorderScreen(
+        parameters = AudioRecorderParameters(
+          messages = listOf("Hello", "World"),
+          key = "key",
+          label = "label",
+          link = "link",
         ),
-        Instant.ofEpochSecond(1634025260),
-        "",
-      ),
-      startRecording = {},
-      clock = Clock.fixed(Instant.ofEpochSecond(1634025262), ZoneId.systemDefault()),
-      stopRecording = {},
-      submit = {},
-      redo = {},
-      play = {},
-      pause = {},
-    )
+        viewState = AudioRecorderViewModel.ViewState.Recording(
+          listOf(
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+          ),
+          Instant.ofEpochSecond(1634025260),
+          "",
+        ),
+        startRecording = {},
+        clock = Clock.fixed(Instant.ofEpochSecond(1634025262), ZoneId.systemDefault()),
+        stopRecording = {},
+        submit = {},
+        redo = {},
+        play = {},
+        pause = {},
+      )
+    }
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun AudioRecorderScreenPlaybackPreview() {
+private fun PreviewAudioRecorderScreenPlayback() {
   HedvigTheme {
-    AudioRecorderScreen(
-      parameters = AudioRecorderParameters(
-        messages = listOf("Hello", "World"),
-        key = "key",
-        label = "label",
-        link = "link",
-      ),
-      viewState = AudioRecorderViewModel.ViewState.Playback(
-        "",
-        isPlaying = false,
-        isPrepared = true,
-        amplitudes = listOf(
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
-          100, 200, 150, 250, 0,
+    Surface(color = MaterialTheme.colors.background) {
+      AudioRecorderScreen(
+        parameters = AudioRecorderParameters(
+          messages = listOf("Hello", "World"),
+          key = "key",
+          label = "label",
+          link = "link",
         ),
-        progress = 0.5f,
-      ),
-      startRecording = {},
-      clock = Clock.systemDefaultZone(),
-      stopRecording = {},
-      submit = {},
-      redo = {},
-      play = {},
-      pause = {},
-    )
+        viewState = AudioRecorderViewModel.ViewState.Playback(
+          "",
+          isPlaying = false,
+          isPrepared = true,
+          amplitudes = listOf(
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+            100, 200, 150, 250, 0,
+          ),
+          progress = 0.5f,
+        ),
+        startRecording = {},
+        clock = Clock.systemDefaultZone(),
+        stopRecording = {},
+        submit = {},
+        redo = {},
+        play = {},
+        pause = {},
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/audiorecorder/PlaybackWaveForm.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/audiorecorder/PlaybackWaveForm.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -23,9 +24,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 import kotlin.math.ceil
@@ -123,68 +124,70 @@ fun PlaybackWaveForm(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun PlaybackWaveFormPreview() {
+private fun PreviewPlaybackWaveForm() {
   HedvigTheme {
-    PlaybackWaveForm(
-      isPlaying = false,
-      play = {},
-      pause = {},
-      amplitudes = listOf(
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-        200, 400, 300, 500, 0,
-      ),
-      progress = 0.5f,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      PlaybackWaveForm(
+        isPlaying = false,
+        play = {},
+        pause = {},
+        amplitudes = listOf(
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+          200, 400, 300, 500, 0,
+        ),
+        progress = 0.5f,
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/selectaction/ui/SelectActionGrid.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/selectaction/ui/SelectActionGrid.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
@@ -114,9 +114,9 @@ private fun Placeable.withCoordinates(
   y: Int,
 ): PlaceableWithCoordinates = PlaceableWithCoordinates(this, x, y)
 
-@Preview
+@HedvigPreview
 @Composable
-fun SelectActionGridPreview() {
+private fun PreviewSelectActionGrid() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       SelectActionGrid {

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/selectaction/ui/SelectActionView.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/selectaction/ui/SelectActionView.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.embark.passages.selectaction.ui
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -16,10 +15,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 import com.hedvig.app.feature.embark.passages.selectaction.SelectActionParameter
@@ -88,16 +87,13 @@ private fun BadgeText(badge: String) {
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun SelectActionViewPreview(
+private fun PreviewSelectActionView(
   @PreviewParameter(SelectActionsCollection::class) selectActions: List<Pair<String, String?>>,
 ) {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       SelectActionView(
         selectActions = selectActions.map { (text, badge) ->
           SelectActionParameter.SelectAction(
@@ -114,7 +110,7 @@ fun SelectActionViewPreview(
   }
 }
 
-class SelectActionsCollection : CollectionPreviewParameterProvider<List<Pair<String, String?>>>(
+private class SelectActionsCollection : CollectionPreviewParameterProvider<List<Pair<String, String?>>>(
   List(3) { listSize ->
     List(listSize + 1) { index ->
       if (index % 2 == 0) {

--- a/app/src/main/kotlin/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/genericauth/EmailInputScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
@@ -26,9 +27,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import com.hedvig.app.util.compose.submitOnEnter
@@ -138,34 +139,38 @@ private fun TrailingIcon(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun EmailInputScreenValidPreview() {
+private fun PreviewEmailInputScreenValid() {
   HedvigTheme {
-    EmailInputScreen(
-      onUpClick = {},
-      onInputChanged = {},
-      onSubmitEmail = {},
-      onClear = {},
-      emailInput = "example@example.com",
-      error = null,
-      loading = false,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      EmailInputScreen(
+        onUpClick = {},
+        onInputChanged = {},
+        onSubmitEmail = {},
+        onClear = {},
+        emailInput = "example@example.com",
+        error = null,
+        loading = false,
+      )
+    }
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun EmailInputScreenInvalidPreview() {
+private fun PreviewEmailInputScreenInvalid() {
   HedvigTheme {
-    EmailInputScreen(
-      onUpClick = {},
-      onInputChanged = {},
-      onSubmitEmail = {},
-      onClear = {},
-      emailInput = "example.com",
-      error = "Invalid email",
-      loading = false,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      EmailInputScreen(
+        onUpClick = {},
+        onInputChanged = {},
+        onSubmitEmail = {},
+        onClear = {},
+        emailInput = "example.com",
+        error = "Invalid email",
+        loading = false,
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/genericauth/otpinput/OtpInputScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.rememberDrawerState
@@ -42,13 +43,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.text.isDigitsOnly
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.FullScreenProgressOverlay
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
@@ -246,22 +247,24 @@ private fun RotatingIcon(isLoading: Boolean) {
   )
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun OtpInputScreenValidPreview() {
+private fun PreviewOtpInputScreenValid() {
   HedvigTheme {
-    OtpInputScreen(
-      onInputChanged = {},
-      onOpenExternalApp = {},
-      onSubmitCode = {},
-      onResendCode = {},
-      onBackPressed = {},
-      inputValue = "0123456",
-      credential = "john@doe.com",
-      networkErrorMessage = null,
-      loadingResend = false,
-      loadingCode = false,
-      snackbarHostState = SnackbarHostState(),
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      OtpInputScreen(
+        onInputChanged = {},
+        onOpenExternalApp = {},
+        onSubmitCode = {},
+        onResendCode = {},
+        onBackPressed = {},
+        inputValue = "0123456",
+        credential = "john@doe.com",
+        networkErrorMessage = null,
+        loadingResend = false,
+        loadingCode = false,
+        snackbarHostState = SnackbarHostState(),
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/ClaimPillsAndForwardArrow.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/ClaimPillsAndForwardArrow.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.home.ui.claimstatus.composables
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,10 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 import com.hedvig.app.feature.home.ui.claimstatus.data.ClaimStatusColors
@@ -69,22 +68,19 @@ private fun ClaimPill(
   }
 }
 
-@Preview
-@Preview(uiMode = UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun PillsPreview(
+private fun PreviewPills(
   @PreviewParameter(PillsUiStateProvider::class) pillsUiState: List<PillUiState>,
 ) {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       ClaimPillsAndForwardArrow(pillsUiState, isClickable = true)
     }
   }
 }
 
-class PillsUiStateProvider : CollectionPreviewParameterProvider<List<PillUiState>>(
+private class PillsUiStateProvider : CollectionPreviewParameterProvider<List<PillUiState>>(
   listOf(
     PillUiState.previewList(),
     listOf(PillUiState.PillType.CLOSED, PillUiState.PillType.PAYMENT).map { pillType ->

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/ClaimStatusCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/ClaimStatusCard.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.home.ui.claimstatus.composables
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
@@ -10,8 +9,8 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.home.ui.claimstatus.data.ClaimStatusCardUiState
 import com.hedvig.app.feature.home.ui.claimstatus.data.PillUiState
@@ -51,14 +50,11 @@ fun ClaimStatusCard(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun ClaimStatusCardPreview() {
+private fun PreviewClaimStatusCard() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       val claimStatusData = ClaimStatusCardUiState(
         id = UUID.randomUUID().toString(),
         pillsUiState = PillUiState.previewList(),

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/ClaimStatusCards.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/ClaimStatusCards.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import arrow.core.NonEmptyList
 import arrow.core.nonEmptyListOf
@@ -22,6 +21,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.rememberPagerState
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.home.ui.claimstatus.data.ClaimStatusCardUiState
 import com.hedvig.app.feature.home.ui.claimstatus.data.PillUiState
@@ -80,13 +80,11 @@ fun ClaimStatusCards(
   }
 }
 
-@Preview(name = "ClaimStatusCard", group = "Claim Status")
+@HedvigPreview
 @Composable
-fun ClaimStatusCardsPreview() {
+private fun PreviewClaimStatusCards() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       val claimStatusCardsUiState = ClaimStatusCardUiState(
         id = UUID.randomUUID().toString(),
         pillsUiState = PillUiState.previewList(),

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/TopInfo.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/claimstatus/composables/TopInfo.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.home.ui.claimstatus.composables
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -12,8 +11,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.home.ui.claimstatus.data.PillUiState
 import com.hedvig.app.util.compose.preview.previewList
@@ -40,14 +39,11 @@ fun TopInfo(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun TopInfoPreview() {
+private fun PreviewTopInfo() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       TopInfo(
         pillsUiState = PillUiState.previewList(),
         title = "All-risk",

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/connectpayincard/ConnectPayinCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/connectpayincard/ConnectPayinCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -20,8 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.ui.compose.theme.hedvigContentColorFor
 import com.hedvig.app.ui.compose.theme.warning
@@ -86,13 +87,15 @@ fun ConnectPayinCard(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun ConnectPayinCardPreview() {
+private fun PreviewConnectPayinCard() {
   HedvigTheme {
-    ConnectPayinCard(
-      onShown = {},
-      onActionClick = {},
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      ConnectPayinCard(
+        onShown = {},
+        onActionClick = {},
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/CrossSell.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/CrossSell.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material.ripple.RippleTheme
@@ -26,11 +27,11 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.hedvig_black
 import com.hedvig.android.core.designsystem.theme.hedvig_black12percent
@@ -171,19 +172,17 @@ private val previewData = CrossSellData(
   insurableLimits = emptyList(),
 )
 
-@Preview(
-  name = "Cross-Sell Card",
-  group = "Insurance Tab",
-  showBackground = true,
-)
+@HedvigPreview
 @Composable
-fun CrossSellPreview() {
+private fun PreviewCrossSell() {
   HedvigTheme {
-    CrossSell(
-      data = previewData,
-      imageLoader = rememberPreviewImageLoader(),
-      onCardClick = {},
-      onCtaClick = {},
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      CrossSell(
+        data = previewData,
+        imageLoader = rememberPreviewImageLoader(),
+        onCardClick = {},
+        onCtaClick = {},
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/NotificationSubheading.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/NotificationSubheading.kt
@@ -9,13 +9,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
@@ -49,14 +50,12 @@ fun NotificationSubheading(
   }
 }
 
-@Preview(
-  name = "Subheading with a notification Badge",
-  group = "Insurance Tab",
-  showBackground = true,
-)
+@HedvigPreview
 @Composable
-fun UnseenBadgeSubheadingPreview() {
+private fun PreviewUnseenBadgeSubheading() {
   HedvigTheme {
-    NotificationSubheading("Add more coverage", true)
+    Surface(color = MaterialTheme.colors.background) {
+      NotificationSubheading("Add more coverage", true)
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/Subheading.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/Subheading.kt
@@ -3,11 +3,12 @@ package com.hedvig.app.feature.insurance.ui
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
@@ -28,14 +29,12 @@ fun Subheading(
   )
 }
 
-@Preview(
-  name = "Subheading",
-  group = "Insurance Tab",
-  showBackground = true,
-)
+@HedvigPreview
 @Composable
-fun SubheadingPreview() {
+private fun PreviewSubheading() {
   HedvigTheme {
-    Subheading("Add more coverage")
+    Surface(color = MaterialTheme.colors.background) {
+      Subheading("Add more coverage")
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/marketpicked/MarketPickedScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
@@ -17,10 +19,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.hedvig_off_white
 import com.hedvig.app.R
@@ -69,15 +71,17 @@ fun MarketPickedScreen(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun MarketPickedPreview() {
+private fun PreviewMarketPicked() {
   HedvigTheme {
-    MarketPickedScreen(
-      onClickMarket = {},
-      onClickSignUp = {},
-      onClickLogIn = {},
-      flagRes = hedvig.resources.R.drawable.ic_flag_se,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      MarketPickedScreen(
+        onClickMarket = {},
+        onClickSignUp = {},
+        onClickLogIn = {},
+        flagRes = hedvig.resources.R.drawable.ic_flag_se,
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/pickmarket/PickMarketScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.ButtonDefaults
@@ -47,10 +48,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.BottomSheetHandle
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.market.Language
 import com.hedvig.android.market.Market
@@ -376,46 +377,54 @@ private fun PickerRow(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun RadioButtonRowPreview() {
+private fun PreviewRadioButtonRow() {
   HedvigTheme {
-    RadioButtonRow(
-      onClick = {},
-      selected = false,
-      text = "Sweden",
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      RadioButtonRow(
+        onClick = {},
+        selected = false,
+        text = "Sweden",
+      )
+    }
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun PickerRowPreviewEmpty() {
+private fun PreviewEmptyPickerRow() {
   HedvigTheme {
-    PickerRow(onClick = {}, icon = null, header = "asd", label = "efg", enabled = false)
+    Surface(color = MaterialTheme.colors.background) {
+      PickerRow(onClick = {}, icon = null, header = "asd", label = "efg", enabled = false)
+    }
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun PickerRowPreview() {
+private fun PreviewPickerRow() {
   HedvigTheme {
-    PickerRow(onClick = {}, icon = { LanguageFlag() }, header = "asd", label = "efg", enabled = false)
+    Surface(color = MaterialTheme.colors.background) {
+      PickerRow(onClick = {}, icon = { LanguageFlag() }, header = "asd", label = "efg", enabled = false)
+    }
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun PickMarketPreview() {
+private fun PreviewPickMarket() {
   HedvigTheme {
-    PickMarketScreen(
-      onSubmit = {},
-      onSelectMarket = {},
-      onSelectLanguage = {},
-      selectedMarket = Market.SE,
-      selectedLanguage = Language.SV_SE,
-      markets = emptyList(),
-      enabled = true,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      PickMarketScreen(
+        onSubmit = {},
+        onSelectMarket = {},
+        onSelectLanguage = {},
+        selectedMarket = Market.SE,
+        selectedLanguage = Language.SV_SE,
+        markets = emptyList(),
+        enabled = true,
+      )
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/FailedToRetrieveInfo.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/FailedToRetrieveInfo.kt
@@ -17,10 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.R
 
 @Composable
 fun FailedToRetrieveInfo(insuranceProviderDisplayName: String?) {
@@ -64,13 +63,11 @@ fun FailedToRetrieveInfo(insuranceProviderDisplayName: String?) {
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun FailedToRetrieveInfoPreview() {
+private fun PreviewFailedToRetrieveInfo() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       Column {
         FailedToRetrieveInfo(null)
         FailedToRetrieveInfo("FakeInsuranceProvider")

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/InsurelyCard.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/InsurelyCard.kt
@@ -12,8 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.hedvig_black12percent
 import com.hedvig.app.R
@@ -56,13 +56,11 @@ fun InsurelyCard(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun InsurelyCardPreview() {
+private fun PreviewInsurelyCard() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       Column {
         val insuranceProvider = "insuranceProvider"
         listOf(

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/LoadingRetrieval.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/LoadingRetrieval.kt
@@ -17,10 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.R
 import java.util.Locale
 
 @Composable
@@ -53,13 +52,11 @@ fun LoadingRetrieval(locale: Locale) {
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun LoadingRetrievalPreview() {
+private fun PreviewLoadingRetrieval() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       LoadingRetrieval(Locale.ENGLISH)
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/RetrievedInfo.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/RetrievedInfo.kt
@@ -22,10 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.R
 import com.hedvig.app.feature.offer.ui.OfferItems
 import com.hedvig.app.util.apollo.format
 import com.hedvig.app.util.compose.preview.previewData
@@ -135,13 +134,11 @@ private fun CurrentInsurancesList(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun RetrievedInfoPreview() {
+private fun PreviewRetrievedInfo() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       RetrievedInfo(
         OfferItems.InsurelyCard.Retrieved.previewData(),
         Locale.ENGLISH,

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/variants/VariantButton.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/variants/VariantButton.kt
@@ -19,10 +19,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.hedvig_black
 import com.hedvig.android.core.designsystem.theme.hedvig_black12percent
@@ -94,16 +94,14 @@ fun VariantButton(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun VariantButtonPreview(
+private fun PreviewVariantButton(
   @PreviewParameter(VariantButtonInputsProvider::class) inputs: Triple<String, String, Boolean>,
 ) {
   val (title, subtitle, selected) = inputs
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       VariantButton(
         id = "id",
         title = title,
@@ -117,7 +115,7 @@ fun VariantButtonPreview(
   }
 }
 
-class VariantButtonInputsProvider : CollectionPreviewParameterProvider<Triple<String, String, Boolean>>(
+private class VariantButtonInputsProvider : CollectionPreviewParameterProvider<Triple<String, String, Boolean>>(
   listOf(
     Triple("Hemförsäkring och Olyckssfall", "Test subtitle", true),
     Triple("Title".repeat(5), "Subtitle", false),

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/variants/VariantHeader.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/variants/VariantHeader.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.feature.offer.ui.composable.variants
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -8,8 +7,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
@@ -23,10 +22,9 @@ fun VariantHeader() {
   )
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun VariantHeaderPreview() {
+private fun PreviewVariantHeader() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       VariantHeader()

--- a/app/src/main/kotlin/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
@@ -13,14 +13,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.ratings.tryOpenPlayStore
 
@@ -75,10 +76,12 @@ fun UpgradeApp(
   }
 }
 
-@Preview(showBackground = true)
+@HedvigPreview
 @Composable
-fun UpgradeAppPreview() {
+private fun PreviewUpgradeApp() {
   HedvigTheme {
-    UpgradeApp(goToPlayStore = {})
+    Surface(color = MaterialTheme.colors.background) {
+      UpgradeApp(goToPlayStore = {})
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/swedishbankid/sign/SwedishBankIdSignDialog.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/swedishbankid/sign/SwedishBankIdSignDialog.kt
@@ -24,12 +24,12 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.market.MarketManager
 import com.hedvig.app.R
@@ -158,13 +158,12 @@ fun SwedishBankIdSignDialog(text: String) {
   }
 }
 
+@HedvigPreview
 @Composable
-@Preview(
-  name = "Swedish BankID Sign-Dialog",
-  group = "Offer Screen",
-)
-fun Preview() {
+private fun PreviewSwedishBankIdSignDialog() {
   HedvigTheme {
-    SwedishBankIdSignDialog(text = stringResource(id = hedvig.resources.R.string.SIGN_IN_PROGRESS))
+    Surface(color = MaterialTheme.colors.background) {
+      SwedishBankIdSignDialog(text = stringResource(id = hedvig.resources.R.string.SIGN_IN_PROGRESS))
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/BlurredFullScreenProgressOverlay.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/BlurredFullScreenProgressOverlay.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,9 +22,9 @@ import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.progressBlue
 import com.hedvig.android.core.designsystem.theme.progressYellow
@@ -136,10 +137,12 @@ private fun AnimatedCircles() {
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun TextProgressOverlayPreview() {
+private fun PreviewTextProgressOverlay() {
   HedvigTheme {
-    TextProgressOverlay(progressText = "Calculating price...")
+    Surface(color = MaterialTheme.colors.background) {
+      TextProgressOverlay(progressText = "Calculating price...")
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/CenteredContentWithTopBadge.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/CenteredContentWithTopBadge.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.ui.compose.composables
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
@@ -13,10 +12,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
@@ -88,9 +87,9 @@ fun CenteredContentWithTopBadge(
   }
 }
 
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun CenteredContentWithTopBadgePreview(
+private fun PreviewCenteredContentWithTopBadge(
   @PreviewParameter(TextAndBadgeProvider::class) textToBadgePair: Pair<String, String?>,
 ) {
   val (text, badge) = textToBadgePair
@@ -114,7 +113,7 @@ fun CenteredContentWithTopBadgePreview(
   }
 }
 
-class TextAndBadgeProvider : CollectionPreviewParameterProvider<Pair<String, String?>>(
+private class TextAndBadgeProvider : CollectionPreviewParameterProvider<Pair<String, String?>>(
   listOf(
     "Text" to "Badge #1",
     "Text".repeat(20) to "Badge #2",

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/ChatIcon.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/ChatIcon.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.ui.compose.composables
 
-import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -17,8 +16,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.R
 
@@ -84,14 +83,11 @@ fun ChatIcon(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun ChatIconPreview() {
+private fun PreviewChatIcon() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.surface,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       Column {
         ChatIcon({}, null)
         ChatIcon({}, null, true)

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/appbar/CenterAlignedTopAppBar.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/appbar/CenterAlignedTopAppBar.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.ui.compose.composables.appbar
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -26,9 +25,9 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
@@ -98,10 +97,9 @@ fun CenterAlignedTopAppBar(
 
 private val AppBarHorizontalPadding = 4.dp
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun CenterAlignedTopAppBarPreview() {
+private fun PreviewCenterAlignedTopAppBar() {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
       Column {

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/banner/InfoBanner.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/banner/InfoBanner.kt
@@ -12,8 +12,8 @@ import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.hedvig_black12percent
 import com.hedvig.app.R
@@ -46,10 +46,12 @@ fun InfoBanner(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun InfoBannerPreview() {
+private fun PreviewInfoBanner() {
   HedvigTheme {
-    InfoBanner(onClick = { }, text = "Test info banner text")
+    Surface(color = MaterialTheme.colors.background) {
+      InfoBanner(onClick = { }, text = "Test info banner text")
+    }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/claimprogress/ClaimProgressRow.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/claimprogress/ClaimProgressRow.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.ui.compose.composables.claimprogress
 
-import android.content.res.Configuration
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,8 +16,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.feature.home.ui.claimstatus.data.ClaimStatusColors
 import com.hedvig.app.util.compose.ContentAlpha
@@ -102,13 +101,11 @@ private fun ClaimProgress(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun ClaimProgressRowPreview() {
+private fun PreviewClaimProgressRow() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       ClaimProgressRow(
         listOf(
           ClaimProgressUiState(
@@ -129,14 +126,11 @@ fun ClaimProgressRowPreview() {
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun ClaimProgressPreview() {
+private fun PreviewClaimProgress() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       ClaimProgress(
         "Text",
         MaterialTheme.colors.primary,

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/pill/OutlinedPill.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/pill/OutlinedPill.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.ui.compose.composables.pill
 
-import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -14,8 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.ui.compose.theme.hedvigContentColorFor
 
@@ -51,14 +50,11 @@ fun OutlinedPill(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun OutlinedPillPreview() {
+private fun PreviewOutlinedPill() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       OutlinedPill("PillText")
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/pill/Pill.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ui/compose/composables/pill/Pill.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app.ui.compose.composables.pill
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
@@ -12,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.app.ui.compose.theme.hedvigContentColorFor
 
@@ -45,14 +44,11 @@ fun Pill(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun PillPreview() {
+private fun PreviewPill() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colors.background,
-    ) {
+    Surface(color = MaterialTheme.colors.background) {
       Pill("PillText", MaterialTheme.colors.primary)
     }
   }

--- a/app/src/main/kotlin/com/hedvig/app/util/compose/HorizontalTextsWithMaximumSpaceTaken.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/compose/HorizontalTextsWithMaximumSpaceTaken.kt
@@ -1,15 +1,17 @@
 package com.hedvig.app.util.compose
 
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import kotlin.math.max
 
@@ -88,76 +90,88 @@ fun HorizontalTextsWithMaximumSpaceTaken(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun SmallTextsPreview() {
+private fun PreviewSmallTexts() {
   HedvigTheme {
-    HorizontalTextsWithMaximumSpaceTaken(
-      startText = { Text(text = "Start") },
-      endText = { Text(text = "End", textAlign = it) },
-      modifier = Modifier.size(width = 250.dp, height = 100.dp),
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      HorizontalTextsWithMaximumSpaceTaken(
+        startText = { Text(text = "Start") },
+        endText = { Text(text = "End", textAlign = it) },
+        modifier = Modifier.size(width = 250.dp, height = 100.dp),
+      )
+    }
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun BigTextsPreview() {
+private fun PreviewBigTexts() {
   HedvigTheme {
-    HorizontalTextsWithMaximumSpaceTaken(
-      startText = { Text(text = "Start".repeat(10)) },
-      endText = { Text(text = "End".repeat(10), textAlign = it) },
-      modifier = Modifier.size(width = 250.dp, height = 100.dp),
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      HorizontalTextsWithMaximumSpaceTaken(
+        startText = { Text(text = "Start".repeat(10)) },
+        endText = { Text(text = "End".repeat(10), textAlign = it) },
+        modifier = Modifier.size(width = 250.dp, height = 100.dp),
+      )
+    }
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun BigTextsWithSpaceTextPreview() {
+private fun PreviewBigTextsWithSpaceText() {
   HedvigTheme {
-    HorizontalTextsWithMaximumSpaceTaken(
-      startText = { Text(text = "Start".repeat(10)) },
-      endText = { Text(text = "End".repeat(10), textAlign = it) },
-      modifier = Modifier.size(width = 250.dp, height = 100.dp),
-      spaceBetween = 30.dp,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      HorizontalTextsWithMaximumSpaceTaken(
+        startText = { Text(text = "Start".repeat(10)) },
+        endText = { Text(text = "End".repeat(10), textAlign = it) },
+        modifier = Modifier.size(width = 250.dp, height = 100.dp),
+        spaceBetween = 30.dp,
+      )
+    }
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun BigStartTextPreview() {
+private fun PreviewBigStartText() {
   HedvigTheme {
-    HorizontalTextsWithMaximumSpaceTaken(
-      startText = { Text(text = "Start".repeat(10)) },
-      endText = { Text(text = "End", textAlign = it) },
-      modifier = Modifier.size(width = 250.dp, height = 100.dp),
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      HorizontalTextsWithMaximumSpaceTaken(
+        startText = { Text(text = "Start".repeat(10)) },
+        endText = { Text(text = "End", textAlign = it) },
+        modifier = Modifier.size(width = 250.dp, height = 100.dp),
+      )
+    }
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun BigEndTextPreview() {
+private fun PreviewBigEndText() {
   HedvigTheme {
-    HorizontalTextsWithMaximumSpaceTaken(
-      startText = { Text(text = "Start") },
-      endText = { Text(text = "End".repeat(10), textAlign = it) },
-      modifier = Modifier.size(width = 250.dp, height = 100.dp),
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      HorizontalTextsWithMaximumSpaceTaken(
+        startText = { Text(text = "Start") },
+        endText = { Text(text = "End".repeat(10), textAlign = it) },
+        modifier = Modifier.size(width = 250.dp, height = 100.dp),
+      )
+    }
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun BigEndTextWithSpacePreview() {
+private fun PreviewBigEndTextWithSpace() {
   HedvigTheme {
-    HorizontalTextsWithMaximumSpaceTaken(
-      startText = { Text(text = "Start") },
-      endText = { Text(text = "End".repeat(10), textAlign = it) },
-      modifier = Modifier.size(width = 250.dp, height = 100.dp),
-      spaceBetween = 32.dp,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      HorizontalTextsWithMaximumSpaceTaken(
+        startText = { Text(text = "Start") },
+        endText = { Text(text = "End".repeat(10), textAlign = it) },
+        modifier = Modifier.size(width = 250.dp, height = 100.dp),
+        spaceBetween = 32.dp,
+      )
+    }
   }
 }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/FormRowButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/FormRowButton.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.core.designsystem.component.button
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,7 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
@@ -32,14 +31,11 @@ fun FormRowButton(mainText: String, secondaryText: String, onClick: () -> Unit) 
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
 private fun PreviewFormRowButton() {
   HedvigTheme {
-    Surface(
-      color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(color = MaterialTheme.colorScheme.background) {
       FormRowButton("Date of Incident", "2023-03-14", {})
     }
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeContainedButton.kt
@@ -11,8 +11,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.containedButtonContainer
 import com.hedvig.android.core.designsystem.theme.onContainedButtonContainer
@@ -74,12 +74,9 @@ fun LargeContainedButton(
   }
 }
 
-@Preview(
-  name = "Contained Button (Large)",
-  group = "Buttons",
-)
+@HedvigPreview
 @Composable
-fun LargeContainedButtonPreview() {
+private fun PreviewLargeContainedButton() {
   HedvigTheme {
     LargeContainedTextButton(text = "Contained Button (Large)", onClick = {})
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeOutlinedButton.kt
@@ -9,8 +9,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import androidx.compose.material.MaterialTheme as Material2Theme
 import androidx.compose.material.ProvideTextStyle as ProvideTextStyleM2
@@ -56,13 +56,9 @@ fun LargeOutlinedButton(
   }
 }
 
-@Preview(
-  name = "Outlined Button (Large)",
-  group = "Buttons",
-  showBackground = true,
-)
+@HedvigPreview
 @Composable
-private fun LargeOutlinedButtonPreview() {
+private fun PreviewLargeOutlinedButton() {
   HedvigTheme {
     LargeOutlinedTextButton(text = "Outlined Button (Large)", onClick = {})
   }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/information/AppStateInformation.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/information/AppStateInformation.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.core.designsystem.component.information
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
@@ -8,15 +7,16 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.R
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
@@ -71,20 +71,22 @@ private fun AppStateInformation(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun SuccessPreview() {
+private fun PreviewSuccess() {
   HedvigTheme {
-    AppStateInformation(AppStateInformationType.Success, "Title", "Description")
+    Surface(color = MaterialTheme.colors.background) {
+      AppStateInformation(AppStateInformationType.Success, "Title", "Description")
+    }
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun FailurePreview() {
+private fun PreviewFailure() {
   HedvigTheme {
-    AppStateInformation(AppStateInformationType.Failure, "Title", "Description")
+    Surface(color = MaterialTheme.colors.background) {
+      AppStateInformation(AppStateInformationType.Failure, "Title", "Description")
+    }
   }
 }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/list/SectionTitle.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/list/SectionTitle.kt
@@ -9,12 +9,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
@@ -47,29 +48,27 @@ fun SectionTitle(
   }
 }
 
-@Preview(
-  name = "Section Title, Notification = False",
-  group = "List",
-)
+@HedvigPreview
 @Composable
-fun SectionTitlePreviewNoNotification() {
+private fun PreviewSectionTitleNoNotification() {
   HedvigTheme {
-    SectionTitle(
-      text = "Section Title",
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      SectionTitle(
+        text = "Section Title",
+      )
+    }
   }
 }
 
-@Preview(
-  name = "Section Title, Notification = True",
-  group = "List",
-)
+@HedvigPreview
 @Composable
-fun SectionTitlePreviewNotification() {
+private fun PreviewSectionTitleNotification() {
   HedvigTheme {
-    SectionTitle(
-      text = "Section Title",
-      notification = true,
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      SectionTitle(
+        text = "Section Title",
+        notification = true,
+      )
+    }
   }
 }

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigTypography.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material2/HedvigTypography.kt
@@ -93,7 +93,7 @@ private val Float.percentage: Float
 
 @Preview
 @Composable
-private fun TypographyPreview() {
+private fun PreviewTypography() {
   Surface {
     Column {
       Text("Headline 3", style = HedvigTypography.h3)

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigTypography.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigTypography.kt
@@ -131,7 +131,7 @@ private val Float.percentage: Float
 
 @Preview
 @Composable
-private fun TypographyPreview() {
+private fun PreviewTypography() {
   Surface {
     Column {
       Text("Display Large", style = HedvigTypography.displayLarge)

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/preview/HedvigPreview.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/preview/HedvigPreview.kt
@@ -20,7 +20,7 @@ annotation class HedvigPreview
 )
 @Preview(
   name = "darkMode landscape",
-  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
   device = "spec:parent=pixel_5,orientation=landscape",
 )
 private annotation class HedvigLandscapePreview

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/preview/HedvigPreview.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/preview/HedvigPreview.kt
@@ -23,7 +23,7 @@ annotation class HedvigPreview
   uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
   device = "spec:parent=pixel_5,orientation=landscape",
 )
-annotation class HedvigLandscapePreview
+private annotation class HedvigLandscapePreview
 
 @Preview(
   name = "lightMode tablet portrait",

--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/preview/HedvigPreview.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/preview/HedvigPreview.kt
@@ -1,0 +1,56 @@
+package com.hedvig.android.core.designsystem.preview
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+  name = "lightMode portrait",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+)
+@Preview(
+  name = "darkMode portrait",
+  uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
+)
+annotation class HedvigPreview
+
+@Preview(
+  name = "lightMode landscape",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:parent=pixel_5,orientation=landscape",
+)
+@Preview(
+  name = "darkMode landscape",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:parent=pixel_5,orientation=landscape",
+)
+annotation class HedvigLandscapePreview
+
+@Preview(
+  name = "lightMode tablet portrait",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:width=1280dp,height=800dp,dpi=240,orientation=portrait",
+)
+@Preview(
+  name = "darkMode tablet portrait",
+  uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:width=1280dp,height=800dp,dpi=240,orientation=portrait",
+)
+private annotation class HedvigTabletPreview
+
+@Preview(
+  name = "lightMode tablet landscape",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:width=1280dp,height=800dp,dpi=240",
+)
+@Preview(
+  name = "darkMode tablet landscape",
+  uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:width=1280dp,height=800dp,dpi=240",
+)
+private annotation class HedvigTabletLandscapePreview
+
+@HedvigPreview
+@HedvigLandscapePreview
+@HedvigTabletPreview
+@HedvigTabletLandscapePreview
+annotation class HedvigMultiScreenPreview

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   api(libs.androidx.compose.material)
   api(libs.androidx.compose.material3)
 
+  implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.uiUtil)
   implementation(libs.coil.coil)
 }

--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/FullScreenHedvigProgress.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/FullScreenHedvigProgress.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
@@ -57,9 +57,9 @@ fun FullScreenHedvigProgress(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun FullScreenTransparentProgressOverlayPreview() {
+private fun PreviewFullScreenTransparentProgressOverlay() {
   HedvigTheme {
     FullScreenProgressOverlay(true)
   }

--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/FullScreenProgressOverlay.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/FullScreenProgressOverlay.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
@@ -68,9 +68,9 @@ fun FullScreenProgressOverlay(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun FullScreenProgressOverlayPreview() {
+private fun PreviewFullScreenProgressOverlay() {
   HedvigTheme {
     FullScreenProgressOverlay(true)
   }

--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/genericinfo/GenericInfoScreen.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/genericinfo/GenericInfoScreen.kt
@@ -1,26 +1,23 @@
 package com.hedvig.android.core.ui.genericinfo
 
-import android.content.res.Configuration
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedButton
 import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
 import com.hedvig.android.core.designsystem.component.information.AppStateInformation
 import com.hedvig.android.core.designsystem.component.information.AppStateInformationType
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
@@ -99,12 +96,11 @@ fun GenericInfoScreen(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
-fun GenericInfoScreenPreview() {
+private fun PreviewGenericInfoScreen() {
   HedvigTheme {
-    Surface {
+    Surface(color = MaterialTheme.colors.background) {
       GenericInfoScreen(
         title = "Title",
         description = "description test test test",
@@ -115,16 +111,5 @@ fun GenericInfoScreenPreview() {
         {},
       )
     }
-  }
-}
-
-@Preview
-@Composable
-fun GenericErrorScreenWithBackgroundPreview() {
-  HedvigTheme {
-    GenericErrorScreen(
-      onRetryButtonClick = {},
-      Modifier.background(Brush.horizontalGradient(listOf(Color(0xFFEBD2D5), Color(0xFFD9D1F1)))),
-    )
   }
 }

--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/preview/PreviewWindowClassSize.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/preview/PreviewWindowClassSize.kt
@@ -1,0 +1,13 @@
+package com.hedvig.android.core.ui.preview
+
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun WindowSizeClass.Companion.calculateForPreview(): WindowSizeClass {
+  val configuration = LocalConfiguration.current
+  return calculateFromSize(DpSize(configuration.screenWidthDp.dp, configuration.screenHeightDp.dp))
+}

--- a/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/ui/BusinessModelBottomSheet.kt
+++ b/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/ui/BusinessModelBottomSheet.kt
@@ -14,14 +14,16 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.BottomSheetHandle
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 @Composable
 internal fun BusinessModelBottomSheet(
@@ -63,8 +65,12 @@ internal fun BusinessModelBottomSheet(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-private fun BusinessModelBottomSheetPreview() {
-  BusinessModelBottomSheet({}, true)
+private fun PreviewBusinessModelBottomSheet() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colors.background) {
+      BusinessModelBottomSheet({}, true)
+    }
+  }
 }

--- a/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/ui/BusinessModelScreen.kt
+++ b/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/ui/BusinessModelScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
@@ -38,9 +39,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.textColorLink
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import kotlinx.coroutines.launch
@@ -171,11 +173,15 @@ private fun BusinessModelImage(
   )
 }
 
-@Preview
+@HedvigMultiScreenPreview
 @Composable
-private fun BusinessModelScreenPreview() {
-  BusinessModelScreen(
-    navigateBack = {},
-    windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)),
-  )
+private fun PreviewBusinessModelScreen() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colors.background) {
+      BusinessModelScreen(
+        navigateBack = {},
+        windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)),
+      )
+    }
+  }
 }

--- a/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/ui/BusinessModelScreen.kt
+++ b/feature-businessmodel/src/main/kotlin/com/hedvig/android/feature/businessmodel/ui/BusinessModelScreen.kt
@@ -39,12 +39,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.designsystem.theme.textColorLink
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
+import com.hedvig.android.core.ui.preview.calculateForPreview
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -180,7 +180,7 @@ private fun PreviewBusinessModelScreen() {
     Surface(color = MaterialTheme.colors.background) {
       BusinessModelScreen(
         navigateBack = {},
-        windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)),
+        windowSizeClass = WindowSizeClass.calculateForPreview(),
       )
     }
   }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationDate.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationDate.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.feature.terminateinsurance.ui
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -32,7 +31,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -40,6 +38,7 @@ import com.hedvig.android.core.designsystem.component.button.LargeContainedTextB
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.card.HedvigCardElevation
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
@@ -174,8 +173,7 @@ private fun DatePickerCard(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewTerminationDateScreen() {
   HedvigTheme {

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationDate.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationDate.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
@@ -41,6 +40,7 @@ import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicke
 import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
+import com.hedvig.android.core.ui.preview.calculateForPreview
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
 import com.hedvig.android.feature.terminateinsurance.TerminateInsuranceViewModel
 
@@ -179,7 +179,7 @@ private fun PreviewTerminationDateScreen() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       TerminationDateScreen(
-        WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)),
+        WindowSizeClass.calculateForPreview(),
         rememberDatePickerState(),
         false,
         { true },

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationSuccess.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationSuccess.kt
@@ -28,12 +28,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
-import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
+import com.hedvig.android.core.ui.preview.calculateForPreview
 import hedvig.resources.R
 
 @Composable
@@ -114,12 +114,12 @@ private fun TerminationSuccessScreen(
   }
 }
 
-@HedvigPreview
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewTerminationSuccessScreen() {
   HedvigTheme {
     Surface {
-      TerminationSuccessScreen(WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)), {})
+      TerminationSuccessScreen(WindowSizeClass.calculateForPreview()) {}
     }
   }
 }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationSuccess.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationSuccess.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.feature.terminateinsurance.ui
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -29,10 +28,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
 import hedvig.resources.R
@@ -115,8 +114,7 @@ private fun TerminationSuccessScreen(
   }
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@HedvigPreview
 @Composable
 private fun PreviewTerminationSuccessScreen() {
   HedvigTheme {

--- a/hanalytics/hanalytics-engineering/src/main/kotlin/com/hedvig/android/hanalytics/engineering/tracking/TrackingLogActivity.kt
+++ b/hanalytics/hanalytics-engineering/src/main/kotlin/com/hedvig/android/hanalytics/engineering/tracking/TrackingLogActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -40,10 +41,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.edit
 import com.google.accompanist.insets.ui.TopAppBar
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.hanalytics.engineering.R
 import com.hedvig.android.hanalytics.engineering.tracking.TrackDetailDialogFragment.Companion.show
@@ -185,20 +186,22 @@ private fun TrackingLogScreen(
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
-fun TrackingLogScreenPreview() {
+private fun PreviewTrackingLogScreen() {
   HedvigTheme {
-    TrackingLogScreen(
-      onNavigateUp = {},
-      onClickEvent = {},
-      onClickClearEvents = {},
-      tracks = listOf(
-        TrackEvent("example_event", "{}", LocalDateTime.now()),
-        TrackEvent("example_event", "{}", LocalDateTime.now()),
-        TrackEvent("example_event", "{}", LocalDateTime.now()),
-        TrackEvent("example_event", "{}", LocalDateTime.now()),
-      ),
-    )
+    Surface(color = MaterialTheme.colors.background) {
+      TrackingLogScreen(
+        onNavigateUp = {},
+        onClickEvent = {},
+        onClickClearEvents = {},
+        tracks = listOf(
+          TrackEvent("example_event", "{}", LocalDateTime.now()),
+          TrackEvent("example_event", "{}", LocalDateTime.now()),
+          TrackEvent("example_event", "{}", LocalDateTime.now()),
+          TrackEvent("example_event", "{}", LocalDateTime.now()),
+        ),
+      )
+    }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/MaterialComponens.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.sample.design.showcase.ui
 
-import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,8 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.sample.design.showcase.ui.m2.components.M2Buttons
@@ -189,17 +186,6 @@ fun LazyListScope.LightAndDarkItem(content: @Composable () -> Unit) {
           }
         }
       }
-    }
-  }
-}
-
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-fun MaterialComponentsPreview() {
-  HedvigTheme {
-    Surface {
-      MaterialComponents(WindowSizeClass.calculateFromSize(DpSize(500.dp, 300.dp)))
     }
   }
 }


### PR DESCRIPTION
This is a PR which basically does these things:
* Create a _HedvigPreview_ which contains both the two most common preview annotations we used, which was the standard Preview + the Preview in Dark mode. Context: https://developer.android.com/jetpack/compose/tooling/studio#preview-multipreview
* Make all previews `private` visibility. This was something that was not possible earlier on which meant that you could accidentally call previews from other places in the app which is definitely not something we ever want to do.
* Make all previews start with the `Preview...` suffix in the name, so that again while inside that file, when you want to call the composable you don't call the preview one by accident. Again a fix to improve what you can access with autocomplete to improve developer experience a bit
* Wrap all composables with `HedvigTheme {}`. This represents how they really are going to be shown in the app, and now that we don't use the m2 material theme adapter we can use that in child modules too.
* Introduce a @HedvigMultiScreenPreview as an alternative to @HedvigPreview just as a way to see how a screen looks like also in portrait mode and in bigger screens. To be used in screen-level composables.