### PR TITLE
CLX-427: Odyssey schema in android repo pt.2

### DIFF
--- a/app/src/androidTest/kotlin/com/hedvig/app/TestApplication.kt
+++ b/app/src/androidTest/kotlin/com/hedvig/app/TestApplication.kt
@@ -1,9 +1,6 @@
 package com.hedvig.app
 
 class TestApplication : HedvigApplication() {
-  override val graphqlUrl = "http://localhost:$PORT/"
-  override val graphqlSubscriptionUrl = "http://localhost:$PORT/"
-
   companion object {
     const val PORT = 8080
   }

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <string name="APP_NAME" translatable="false">Hedvig Dev</string>
 
     <string name="APP_SCHEME" translatable="false">hedvigtest</string>
@@ -8,6 +7,7 @@
 
     <string name="GRAPHQL_URL" translatable="false">https://graphql.dev.hedvigit.com/graphql</string>
     <string name="WS_GRAPHQL_URL" translatable="false">wss://graphql.dev.hedvigit.com/subscriptions</string>
+    <string name="OCTOPUS_GRAPHQL_URL" translatable="false">https://apollo-router.dev.hedvigit.com</string>
     <string name="BASE_URL" translatable="false">https://graphql.dev.hedvigit.com</string>
     <string name="WEB_BASE_URL" translatable="false">https://www.dev.hedvigit.com</string>
     <string name="HANALYTICS_URL" translatable="false">https://hanalytics-staging.herokuapp.com</string>

--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -286,17 +286,15 @@ val apolloClientModule = module {
   single<String>(octopusGraphQLUrlQualifier) { get<Context>().getString(R.string.OCTOPUS_GRAPHQL_URL) }
 
   single<ApolloClient>(giraffeClient) {
-    // Copy builder to not edit the configuration of other ApolloClient instances.
-    val builder: ApolloClient.Builder = get<ApolloClient.Builder>().copy()
+    get<ApolloClient.Builder>().copy()
       .httpServerUrl(get(giraffeGraphQLUrlQualifier))
       .webSocketServerUrl(get(giraffeGraphQLWebSocketUrlQualifier))
-    builder.build()
+      .build()
   }
   single<ApolloClient>(octopusClient) {
-    // Copy builder to not edit the configuration of other ApolloClient instances.
-    val builder: ApolloClient.Builder = get<ApolloClient.Builder>().copy()
+    get<ApolloClient.Builder>().copy()
       .httpServerUrl(get<String>(octopusGraphQLUrlQualifier))
-    builder.build()
+      .build()
   }
 }
 
@@ -405,7 +403,7 @@ val insuranceModule = module {
 }
 
 val offerModule = module {
-  single<OfferRepository> { OfferRepository(get(), get(), get(), get()) }
+  single<OfferRepository> { OfferRepository(get<ApolloClient>(giraffeClient), get(), get(), get()) }
   viewModel<OfferViewModel> { parametersHolder: ParametersHolder ->
     OfferViewModelImpl(
       quoteCartId = parametersHolder.get(),
@@ -422,14 +420,14 @@ val offerModule = module {
     )
   }
   single { QuoteCartFragmentToOfferModelMapper(get()) }
-  single<GetQuoteCartCheckoutUseCase> { GetQuoteCartCheckoutUseCase(get()) }
+  single<GetQuoteCartCheckoutUseCase> { GetQuoteCartCheckoutUseCase(get<ApolloClient>(giraffeClient)) }
   single<ObserveQuoteCartCheckoutUseCase> { ObserveQuoteCartCheckoutUseCaseImpl(get()) }
   single<SelectedVariantStore> { SelectedVariantStore() }
 }
 
 val profileModule = module {
   single<ProfileQueryDataToProfileUiStateMapper> { ProfileQueryDataToProfileUiStateMapper(get(), get(), get()) }
-  single<ProfileRepository> { ProfileRepository(get()) }
+  single<ProfileRepository> { ProfileRepository(get<ApolloClient>(giraffeClient)) }
   viewModel<ProfileViewModel> { ProfileViewModel(get(), get(), get()) }
 }
 
@@ -539,22 +537,22 @@ val serviceModule = module {
 }
 
 val repositoriesModule = module {
-  single { ChatRepository(get(), get(), get()) }
-  single { PayinStatusRepository(get()) }
-  single { ClaimsRepository(get(), get()) }
-  single { RedeemReferralCodeRepository(get(), get()) }
-  single { UserRepository(get()) }
-  single { WhatsNewRepository(get(), get(), get()) }
-  single { WelcomeRepository(get(), get()) }
-  single { LanguageRepository(get()) }
-  single { AdyenRepository(get(), get()) }
-  single { EmbarkRepository(get(), get()) }
-  single { ReferralsRepository(get()) }
-  single { LoggedInRepository(get(), get()) }
-  single { GetHomeUseCase(get(), get()) }
-  single { TrustlyRepository(get()) }
-  single { GetMemberIdUseCase(get()) }
-  single { PaymentRepository(get(), get()) }
+  single { ChatRepository(get<ApolloClient>(giraffeClient), get(), get()) }
+  single { PayinStatusRepository(get<ApolloClient>(giraffeClient)) }
+  single { ClaimsRepository(get<ApolloClient>(giraffeClient), get()) }
+  single { RedeemReferralCodeRepository(get<ApolloClient>(giraffeClient), get()) }
+  single { UserRepository(get<ApolloClient>(giraffeClient)) }
+  single { WhatsNewRepository(get<ApolloClient>(giraffeClient), get(), get()) }
+  single { WelcomeRepository(get<ApolloClient>(giraffeClient), get()) }
+  single { LanguageRepository(get<ApolloClient>(giraffeClient)) }
+  single { AdyenRepository(get<ApolloClient>(giraffeClient), get()) }
+  single { EmbarkRepository(get<ApolloClient>(giraffeClient), get()) }
+  single { ReferralsRepository(get<ApolloClient>(giraffeClient)) }
+  single { LoggedInRepository(get<ApolloClient>(giraffeClient), get()) }
+  single { GetHomeUseCase(get<ApolloClient>(giraffeClient), get()) }
+  single { TrustlyRepository(get<ApolloClient>(giraffeClient)) }
+  single { GetMemberIdUseCase(get<ApolloClient>(giraffeClient)) }
+  single { PaymentRepository(get<ApolloClient>(giraffeClient), get()) }
 }
 
 val notificationModule = module {
@@ -568,49 +566,51 @@ val notificationModule = module {
 val clockModule = module { single { Clock.systemDefaultZone() } }
 
 val useCaseModule = module {
-  single { GetUpcomingAgreementUseCase(get(), get()) }
-  single { GetAddressChangeStoryIdUseCase(get(), get(), get()) }
-  single { StartCheckoutUseCase(get(), get(), get()) }
-  single { LogoutUseCase(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-  single { GetContractsUseCase(get(), get()) }
+  single { GetUpcomingAgreementUseCase(get<ApolloClient>(giraffeClient), get()) }
+  single { GetAddressChangeStoryIdUseCase(get<ApolloClient>(giraffeClient), get(), get()) }
+  single { StartCheckoutUseCase(get<ApolloClient>(giraffeClient), get(), get()) }
+  single { LogoutUseCase(get(), get(), get<ApolloClient>(giraffeClient), get(), get(), get(), get(), get(), get()) }
+  single { GetContractsUseCase(get<ApolloClient>(giraffeClient), get()) }
   single { GraphQLQueryUseCase(get()) }
-  single { GetCrossSellsUseCase(get(), get()) }
-  single { GetInsuranceProvidersUseCase(get(), get()) }
-  single { GetClaimDetailUseCase(get(), get()) }
+  single { GetCrossSellsUseCase(get<ApolloClient>(giraffeClient), get()) }
+  single { GetInsuranceProvidersUseCase(get<ApolloClient>(giraffeClient), get()) }
+  single { GetClaimDetailUseCase(get<ApolloClient>(giraffeClient), get()) }
   single { GetClaimDetailUiStateFlowUseCase(get()) }
-  single { GetContractDetailsUseCase(get(), get(), get()) }
-  single<GetDanishAddressAutoCompletionUseCase> { GetDanishAddressAutoCompletionUseCase(get()) }
+  single { GetContractDetailsUseCase(get<ApolloClient>(giraffeClient), get(), get()) }
+  single<GetDanishAddressAutoCompletionUseCase> {
+    GetDanishAddressAutoCompletionUseCase(get<ApolloClient>(giraffeClient))
+  }
   single<GetFinalDanishAddressSelectionUseCase> { GetFinalDanishAddressSelectionUseCase(get()) }
-  single { CreateQuoteCartUseCase(get(), get(), get()) }
+  single { CreateQuoteCartUseCase(get<ApolloClient>(giraffeClient), get(), get()) }
   single {
     UploadMarketAndLanguagePreferencesUseCase(
-      apolloClient = get(),
+      apolloClient = get<ApolloClient>(giraffeClient),
       languageService = get(),
     )
   }
-  single { GetMarketingBackgroundUseCase(get(), get()) }
+  single { GetMarketingBackgroundUseCase(get<ApolloClient>(giraffeClient), get()) }
   single {
     UpdateApplicationLanguageUseCase(
       marketManager = get(),
       languageService = get(),
     )
   }
-  single { GetInitialMarketPickerValuesUseCase(get(), get(), get(), get()) }
+  single { GetInitialMarketPickerValuesUseCase(get<ApolloClient>(giraffeClient), get(), get(), get()) }
   single<EditCheckoutUseCase> {
     EditCheckoutUseCase(
       languageService = get(),
       graphQLQueryHandler = get(),
     )
   }
-  single<QuoteCartEditStartDateUseCase> { QuoteCartEditStartDateUseCase(get(), get()) }
-  single<EditCampaignUseCase> { EditCampaignUseCase(get(), get()) }
-  single<AddPaymentTokenUseCase> { AddPaymentTokenUseCase(get()) }
+  single<QuoteCartEditStartDateUseCase> { QuoteCartEditStartDateUseCase(get<ApolloClient>(giraffeClient), get()) }
+  single<EditCampaignUseCase> { EditCampaignUseCase(get<ApolloClient>(giraffeClient), get()) }
+  single<AddPaymentTokenUseCase> { AddPaymentTokenUseCase(get<ApolloClient>(giraffeClient)) }
   single<ConnectPaymentUseCase> { ConnectPaymentUseCase(get(), get(), get()) }
   single<ConnectPayoutUseCase> { ConnectPayoutUseCase(get(), get()) }
   single<ObserveOfferStateUseCase> { ObserveOfferStateUseCase(get(), get()) }
   single<ChangeLanguageUseCase> {
     ChangeLanguageUseCase(
-      apolloClient = get(),
+      apolloClient = get<ApolloClient>(giraffeClient),
       languageService = get(),
       cacheManager = get(),
     )
@@ -618,7 +618,7 @@ val useCaseModule = module {
 }
 
 val cacheManagerModule = module {
-  single { NetworkCacheManager(get()) }
+  single { NetworkCacheManager(get<ApolloClient>(giraffeClient)) }
 }
 
 val pushTokenManagerModule = module {
@@ -688,7 +688,7 @@ val claimsRepositoryModule = module {
     NetworkClaimsFlowRepository(get<OkHttpClient>())
   }
   single<PhoneNumberRepository> {
-    PhoneNumberRepository(get<ApolloClient>())
+    PhoneNumberRepository(get<ApolloClient>(giraffeClient))
   }
 }
 

--- a/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
+++ b/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
@@ -26,7 +26,4 @@ open class HedvigApplication : Application() {
 
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
   }
-
-  open val graphqlUrl get() = getString(R.string.GRAPHQL_URL)
-  open val graphqlSubscriptionUrl get() = getString(R.string.WS_GRAPHQL_URL)
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/home/ui/changeaddress/GetAddressChangeStoryIdUseCase.kt
@@ -13,8 +13,8 @@ import com.hedvig.app.feature.embark.quotecart.CreateQuoteCartUseCase
 import com.hedvig.app.util.ErrorMessage
 
 class GetAddressChangeStoryIdUseCase(
-  private val createQuoteCartUseCase: CreateQuoteCartUseCase,
   private val apolloClient: ApolloClient,
+  private val createQuoteCartUseCase: CreateQuoteCartUseCase,
   private val featureManager: FeatureManager,
 ) {
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/GetInitialMarketPickerValuesUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/marketing/data/GetInitialMarketPickerValuesUseCase.kt
@@ -13,8 +13,8 @@ import com.hedvig.android.market.Market
 import com.hedvig.android.market.MarketManager
 
 class GetInitialMarketPickerValuesUseCase(
-  private val marketManager: MarketManager,
   private val apolloClient: ApolloClient,
+  private val marketManager: MarketManager,
   private val featureManager: FeatureManager,
   private val languageService: LanguageService,
 ) {

--- a/app/src/main/kotlin/com/hedvig/app/util/apollo/GraphQLQueryHandler.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/apollo/GraphQLQueryHandler.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
 import com.hedvig.android.apollo.OperationResult
 import com.hedvig.android.apollo.safeGraphqlCall
 import com.hedvig.android.core.common.android.jsonObjectOfNotNull
-import com.hedvig.app.HedvigApplication
 import com.hedvig.app.service.FileService
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -21,8 +20,8 @@ import java.util.concurrent.TimeUnit
 
 class GraphQLQueryHandler(
   private val okHttpClient: OkHttpClient,
-  private val application: HedvigApplication,
   private val fileService: FileService,
+  private val giraffeUrl: String,
 ) {
 
   suspend fun graphQLQuery(
@@ -48,7 +47,7 @@ class GraphQLQueryHandler(
     return modifiedOkHttpClient
       .newCall(
         Request.Builder()
-          .url(application.graphqlUrl)
+          .url(giraffeUrl)
           .header("Content-Type", "application/json")
           .post(requestBody)
           .build(),

--- a/app/src/release/res/values/strings.xml
+++ b/app/src/release/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <string name="APP_NAME" translatable="false">Hedvig</string>
 
     <string name="APP_SCHEME" translatable="false">hedvig</string>
@@ -8,6 +7,7 @@
 
     <string name="GRAPHQL_URL" translatable="false">https://giraffe.hedvig.com/graphql</string>
     <string name="WS_GRAPHQL_URL" translatable="false">wss://giraffe.hedvig.com/subscriptions</string>
+    <string name="OCTOPUS_GRAPHQL_URL" translatable="false">https://apollo-router.prod.hedvigit.com</string>
     <string name="BASE_URL" translatable="false">https://giraffe.hedvig.com</string>
     <string name="WEB_BASE_URL" translatable="false">https://www.hedvig.com</string>
     <string name="HANALYTICS_URL" translatable="false">https://hanalytics-production.herokuapp.com</string>

--- a/app/src/staging/res/values/strings.xml
+++ b/app/src/staging/res/values/strings.xml
@@ -7,6 +7,7 @@
 
     <string name="GRAPHQL_URL" translatable="false">https://graphql.dev.hedvigit.com/graphql</string>
     <string name="WS_GRAPHQL_URL" translatable="false">wss://graphql.dev.hedvigit.com/subscriptions</string>
+    <string name="OCTOPUS_GRAPHQL_URL" translatable="false">https://apollo-router.dev.hedvigit.com</string>
     <string name="BASE_URL" translatable="false">https://graphql.dev.hedvigit.com</string>
     <string name="WEB_BASE_URL" translatable="false">https://www.dev.hedvigit.com</string>
     <string name="HANALYTICS_URL" translatable="false">https://hanalytics-staging.herokuapp.com</string>

--- a/core-common/src/main/kotlin/com/hedvig/android/core/common/di/Qualifiers.kt
+++ b/core-common/src/main/kotlin/com/hedvig/android/core/common/di/Qualifiers.kt
@@ -37,7 +37,7 @@ val ioDispatcherQualifier = qualifier("ioDispatcher")
 val octopusGraphQLUrlQualifier = qualifier("octopusGraphQLUrlQualifier")
 
 // The URL for giraffe
-val giraffeGraphQLUrlQualifier = qualifier("octopusGraphQLUrlQualifier")
+val giraffeGraphQLUrlQualifier = qualifier("giraffeGraphQLUrlQualifier")
 
 // The URL for the websocket of giraffe
 val giraffeGraphQLWebSocketUrlQualifier = qualifier("giraffeGraphQLWebSocketUrlQualifier")

--- a/core-common/src/main/kotlin/com/hedvig/android/core/common/di/Qualifiers.kt
+++ b/core-common/src/main/kotlin/com/hedvig/android/core/common/di/Qualifiers.kt
@@ -32,3 +32,18 @@ typealias LogInfoType = (() -> String) -> Unit
  * [kotlinx.coroutines.Dispatchers.IO] for production code
  */
 val ioDispatcherQualifier = qualifier("ioDispatcher")
+
+// The URL for the octopus super-graph
+val octopusGraphQLUrlQualifier = qualifier("octopusGraphQLUrlQualifier")
+
+// The URL for giraffe
+val giraffeGraphQLUrlQualifier = qualifier("octopusGraphQLUrlQualifier")
+
+// The URL for the websocket of giraffe
+val giraffeGraphQLWebSocketUrlQualifier = qualifier("giraffeGraphQLWebSocketUrlQualifier")
+
+// The ApolloClient targeting Octopus
+val octopusClient = qualifier("octopusClient")
+
+// The ApolloClient targeting Giraffe
+val giraffeClient = qualifier("giraffeClient")

--- a/feature-terminate-insurance/build.gradle.kts
+++ b/feature-terminate-insurance/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(projects.apollo.core)
   implementation(projects.apollo.giraffe)
   implementation(projects.auth.authAndroid)
+  implementation(projects.coreCommon)
   implementation(projects.coreDesignSystem)
   implementation(projects.coreResources)
   implementation(projects.coreUi)

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/di/TerminateInsuranceModule.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/di/TerminateInsuranceModule.kt
@@ -1,5 +1,7 @@
 package com.hedvig.android.feature.terminateinsurance.di
 
+import com.apollographql.apollo3.ApolloClient
+import com.hedvig.android.core.common.di.giraffeClient
 import com.hedvig.android.feature.terminateinsurance.InsuranceId
 import com.hedvig.android.feature.terminateinsurance.TerminateInsuranceViewModel
 import com.hedvig.android.feature.terminateinsurance.data.TerminateInsuranceUseCase
@@ -11,5 +13,5 @@ val terminateInsuranceModule = module {
   viewModel<TerminateInsuranceViewModel> { (insuranceId: InsuranceId) ->
     TerminateInsuranceViewModel(insuranceId, get())
   }
-  single<TerminateInsuranceUseCase> { TerminateInsuranceUseCase(get()) }
+  single<TerminateInsuranceUseCase> { TerminateInsuranceUseCase(get<ApolloClient>(giraffeClient)) }
 }

--- a/notification-badge-data/build.gradle.kts
+++ b/notification-badge-data/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
   implementation(projects.apollo.core)
   implementation(projects.apollo.giraffe)
+  implementation(projects.coreCommon)
   implementation(projects.hanalytics.hanalyticsFeatureFlags)
   implementation(projects.hedvigLanguage)
 

--- a/notification-badge-data/src/main/kotlin/com/hedvig/android/notification/badge/data/di/NotificationBadgeModule.kt
+++ b/notification-badge-data/src/main/kotlin/com/hedvig/android/notification/badge/data/di/NotificationBadgeModule.kt
@@ -1,5 +1,7 @@
 package com.hedvig.android.notification.badge.data.di
 
+import com.apollographql.apollo3.ApolloClient
+import com.hedvig.android.core.common.di.giraffeClient
 import com.hedvig.android.notification.badge.data.crosssell.CrossSellNotificationBadgeService
 import com.hedvig.android.notification.badge.data.crosssell.GetCrossSellsContractTypesUseCase
 import com.hedvig.android.notification.badge.data.crosssell.GetCrossSellsContractTypesUseCaseImpl
@@ -16,7 +18,9 @@ val notificationBadgeModule = module {
   single<CrossSellBottomNavNotificationBadgeService> { CrossSellBottomNavNotificationBadgeService(get()) }
   single<CrossSellCardNotificationBadgeService> { CrossSellCardNotificationBadgeService(get()) }
   single<CrossSellNotificationBadgeService> { CrossSellNotificationBadgeService(get(), get()) }
-  single<GetCrossSellsContractTypesUseCase> { GetCrossSellsContractTypesUseCaseImpl(get(), get()) }
+  single<GetCrossSellsContractTypesUseCase> {
+    GetCrossSellsContractTypesUseCaseImpl(get<ApolloClient>(giraffeClient), get())
+  }
   single<NotificationBadgeStorage> { DatastoreNotificationBadgeStorage(get()) }
   single<ReferralsNotificationBadgeService> { ReferralsNotificationBadgeService(get(), get()) }
   single<TabNotificationBadgeService> { TabNotificationBadgeService(get(), get()) }


### PR DESCRIPTION
Adds the qualifier to all `get<ApolloClient>()` calls, and creates the octopus client too to be used in the future.

The important bit here is the now we can't do `get<ApolloClient>()` anymore without a qualifier, we need to specify which one it has to be,  a̶n̶d̶ ̶u̶s̶i̶n̶g̶ ̶t̶h̶e̶ ̶w̶r̶o̶n̶g̶ ̶c̶l̶i̶e̶n̶t̶ ̶i̶s̶ ̶t̶o̶t̶a̶l̶l̶y̶ ̶u̶p̶ ̶t̶o̶ ̶u̶s̶,̶ ̶t̶h̶e̶r̶e̶ ̶i̶s̶n̶'̶t̶ ̶a̶ ̶w̶a̶y̶ ̶t̶o̶ ̶f̶i̶x̶ ̶a̶s̶k̶i̶n̶g̶ ̶f̶o̶r̶ ̶t̶h̶e̶ ̶w̶r̶o̶n̶g̶ ̶q̶u̶e̶r̶y̶ ̶u̶s̶i̶n̶g̶ ̶t̶h̶e̶ ̶w̶r̶o̶n̶g̶ ̶c̶l̶i̶e̶n̶t̶.̶ This is fixed in https://github.com/HedvigInsurance/android/pull/1452 with :app no longer depending on :apollo:octopus.

The only way to fix this is for a module to *only* depend on `:apollo:giraffe` or only to `:apollo:octopus` which will mean that they *can't* even see the other queries/mutations etc, so you are unable to make the mistake at all.