### PR TITLE
Fix internal claim search module

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -38,14 +38,7 @@ import com.hedvig.android.hanalytics.android.di.hAnalyticsUrlQualifier
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
 import com.hedvig.android.navigation.activity.Navigator
-import com.hedvig.android.odyssey.input.InputViewModel
-import com.hedvig.android.odyssey.model.Resolution
-import com.hedvig.android.odyssey.repository.ClaimsFlowRepository
-import com.hedvig.android.odyssey.repository.NetworkClaimsFlowRepository
-import com.hedvig.android.odyssey.repository.PhoneNumberRepository
-import com.hedvig.android.odyssey.resolution.ResolutionViewModel
-import com.hedvig.android.odyssey.search.GetNetworkClaimEntryPointsUseCase
-import com.hedvig.android.odyssey.search.SearchViewModel
+import com.hedvig.android.odyssey.di.odysseyUrlQualifier
 import com.hedvig.app.authenticate.BankIdLoginViewModel
 import com.hedvig.app.authenticate.LogoutUseCase
 import com.hedvig.app.data.debit.PayinStatusRepository
@@ -494,6 +487,7 @@ val changeDateBottomSheetModule = module {
 
 val stringConstantsModule = module {
   single<String>(hAnalyticsUrlQualifier) { get<Context>().getString(R.string.HANALYTICS_URL) }
+  single<String>(odysseyUrlQualifier) { get<Context>().getString(R.string.ODYSSEY_URL) }
   single<String>(appVersionNameQualifier) { BuildConfig.VERSION_NAME }
   single<String>(appVersionCodeQualifier) { BuildConfig.VERSION_CODE.toString() }
   single<String>(appIdQualifier) { BuildConfig.APPLICATION_ID }
@@ -604,12 +598,6 @@ val useCaseModule = module {
       cacheManager = get(),
     )
   }
-  single<GetNetworkClaimEntryPointsUseCase> {
-    GetNetworkClaimEntryPointsUseCase(
-      get(),
-      get<Context>().getString(R.string.ODYSSEY_URL),
-    )
-  }
 }
 
 val cacheManagerModule = module {
@@ -676,28 +664,4 @@ val authRepositoryModule = module {
       additionalHttpHeaders = mapOf(),
     )
   }
-}
-
-val claimsRepositoryModule = module {
-  single<ClaimsFlowRepository> {
-    NetworkClaimsFlowRepository(get<OkHttpClient>())
-  }
-  single<PhoneNumberRepository> {
-    PhoneNumberRepository(get<ApolloClient>(giraffeClient))
-  }
-}
-
-val claimsViewModelModule = module {
-  viewModel { (commonClaimId: String) ->
-    InputViewModel(
-      commonClaimId = commonClaimId,
-      repository = get<ClaimsFlowRepository>(),
-      getPhoneNumberUseCase = get<PhoneNumberRepository>(),
-    )
-  }
-  viewModel { (resolution: Resolution) -> ResolutionViewModel(get(), resolution) }
-}
-
-val claimsSearchViewModelModule = module {
-  viewModel { SearchViewModel(get<GetNetworkClaimEntryPointsUseCase>()) }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/di/KoinInitializer.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/di/KoinInitializer.kt
@@ -17,7 +17,6 @@ import com.hedvig.android.language.di.languageModule
 import com.hedvig.android.market.di.marketManagerModule
 import com.hedvig.android.notification.badge.data.di.notificationBadgeModule
 import com.hedvig.android.odyssey.di.odysseyModule
-import com.hedvig.android.odyssey.di.submitClaimModule
 import com.hedvig.app.adyenModule
 import com.hedvig.app.apolloClientUrlsModule
 import com.hedvig.app.applicationModule
@@ -27,9 +26,6 @@ import com.hedvig.app.changeAddressModule
 import com.hedvig.app.changeDateBottomSheetModule
 import com.hedvig.app.chatEventModule
 import com.hedvig.app.checkoutModule
-import com.hedvig.app.claimsRepositoryModule
-import com.hedvig.app.claimsSearchViewModelModule
-import com.hedvig.app.claimsViewModelModule
 import com.hedvig.app.clockModule
 import com.hedvig.app.coilModule
 import com.hedvig.app.connectPaymentModule
@@ -80,15 +76,12 @@ class KoinInitializer : Initializer<KoinApplication> {
         applicationModule,
         authModule,
         authRepositoryModule,
-        authRepositoryModule,
         businessModelModule,
         cacheManagerModule,
         changeAddressModule,
         changeDateBottomSheetModule,
         chatEventModule,
         checkoutModule,
-        claimsRepositoryModule,
-        claimsViewModelModule,
         clockModule,
         coilModule,
         connectPaymentModule,
@@ -123,7 +116,6 @@ class KoinInitializer : Initializer<KoinApplication> {
         serviceModule,
         sharedPreferencesModule,
         stringConstantsModule,
-        submitClaimModule,
         terminateInsuranceModule,
         textActionSetModule,
         trustlyModule,
@@ -131,11 +123,6 @@ class KoinInitializer : Initializer<KoinApplication> {
         valueStoreModule,
         viewModelModule,
         whatsNewModule,
-        authRepositoryModule,
-        submitClaimModule,
-        claimsRepositoryModule,
-        claimsViewModelModule,
-        claimsSearchViewModelModule,
       ),
     )
   }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/AndroidDatadogProvider.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/AndroidDatadogProvider.kt
@@ -13,7 +13,7 @@ import io.opentracing.tag.Tags
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
-class AndroidDatadogProvider(
+internal class AndroidDatadogProvider(
   private val tracer: Tracer,
   override val logger: DatadogLogger,
 ) : DatadogProvider {

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/di/OdysseyModule.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/di/OdysseyModule.kt
@@ -1,13 +1,59 @@
 package com.hedvig.android.odyssey.di
 
+import com.apollographql.apollo3.ApolloClient
+import com.hedvig.android.apollo.giraffe.di.giraffeClient
 import com.hedvig.android.odyssey.AndroidDatadogLogger
 import com.hedvig.android.odyssey.AndroidDatadogProvider
+import com.hedvig.android.odyssey.input.InputViewModel
+import com.hedvig.android.odyssey.input.ui.audiorecorder.AudioRecorderViewModel
+import com.hedvig.android.odyssey.model.Resolution
+import com.hedvig.android.odyssey.repository.ClaimsFlowRepository
+import com.hedvig.android.odyssey.repository.NetworkClaimsFlowRepository
+import com.hedvig.android.odyssey.repository.PhoneNumberRepository
+import com.hedvig.android.odyssey.resolution.ResolutionViewModel
+import com.hedvig.android.odyssey.search.GetNetworkClaimEntryPointsUseCase
+import com.hedvig.android.odyssey.search.SearchViewModel
 import com.hedvig.odyssey.datadog.DatadogLogger
 import com.hedvig.odyssey.datadog.DatadogProvider
+import okhttp3.OkHttpClient
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.qualifier.qualifier
 import org.koin.dsl.module
+
+/**
+ * The URL targeting odyssey backend
+ */
+val odysseyUrlQualifier = qualifier("odysseyUrlQualifier")
 
 @Suppress("RemoveExplicitTypeArguments")
 val odysseyModule = module {
   single<DatadogLogger> { AndroidDatadogLogger() }
   single<DatadogProvider> { AndroidDatadogProvider(get(), get()) }
+
+  viewModel<AudioRecorderViewModel> { AudioRecorderViewModel(get()) }
+
+  viewModel<ResolutionViewModel> { (resolution: Resolution) ->
+    ResolutionViewModel(get(), resolution)
+  }
+  viewModel<InputViewModel> { (commonClaimId: String) ->
+    InputViewModel(
+      commonClaimId = commonClaimId,
+      repository = get<ClaimsFlowRepository>(),
+      getPhoneNumberUseCase = get<PhoneNumberRepository>(),
+    )
+  }
+  single<PhoneNumberRepository> {
+    PhoneNumberRepository(get<ApolloClient>(giraffeClient))
+  }
+  single<ClaimsFlowRepository> {
+    NetworkClaimsFlowRepository(get<OkHttpClient>())
+  }
+
+  viewModel<SearchViewModel> { SearchViewModel(get<GetNetworkClaimEntryPointsUseCase>()) }
+  single<GetNetworkClaimEntryPointsUseCase> {
+    GetNetworkClaimEntryPointsUseCase(
+      get(),
+      get(odysseyUrlQualifier),
+    )
+  }
 }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/di/SubmitClaimModule.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/di/SubmitClaimModule.kt
@@ -1,9 +1,0 @@
-package com.hedvig.android.odyssey.di
-
-import com.hedvig.android.odyssey.input.ui.audiorecorder.AudioRecorderViewModel
-import org.koin.androidx.viewmodel.dsl.viewModel
-import org.koin.dsl.module
-
-val submitClaimModule = module {
-  viewModel { AudioRecorderViewModel(get()) }
-}

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/InputViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/InputViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
-class InputViewModel(
+internal class InputViewModel(
   private val commonClaimId: String?,
   private val repository: ClaimsFlowRepository,
   private val getPhoneNumberUseCase: PhoneNumberRepository,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/ui/DateOfOccurence.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/ui/DateOfOccurence.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.unit.sp
 import com.hedvig.android.odyssey.input.InputViewModel
 
 @Composable
-fun DateOfOccurrence(viewModel: InputViewModel) {
+internal fun DateOfOccurrence(viewModel: InputViewModel) {
   Column {
     Text("Date", color = MaterialTheme.colors.onPrimary, fontSize = 40.sp)
     Button(

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/ui/InputRoot.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/ui/InputRoot.kt
@@ -20,7 +20,7 @@ import com.hedvig.android.odyssey.model.Input
 import com.hedvig.app.ui.compose.composables.ErrorDialog
 
 @Composable
-fun InputRoot(
+internal fun InputRoot(
   inputViewModel: InputViewModel,
   viewState: InputViewState,
   imageLoader: ImageLoader,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/ui/Location.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/input/ui/Location.kt
@@ -16,7 +16,7 @@ import com.hedvig.android.odyssey.input.InputViewModel
 import kotlinx.coroutines.launch
 
 @Composable
-fun Location(viewModel: InputViewModel) {
+internal fun Location(viewModel: InputViewModel) {
   val coroutineScope = rememberCoroutineScope()
   Box(
     Modifier

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/repository/ClaimsFlowRepository.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/repository/ClaimsFlowRepository.kt
@@ -15,7 +15,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.json.JSONObject
 
-interface ClaimsFlowRepository {
+internal interface ClaimsFlowRepository {
   suspend fun getOrCreateClaim(
     commonClaimId: String?,
   ): ClaimResult
@@ -25,7 +25,7 @@ interface ClaimsFlowRepository {
   suspend fun openClaim(amount: MonetaryAmount? = null): ClaimResult
 }
 
-sealed interface ClaimResult {
+internal sealed interface ClaimResult {
   data class Success(
     val claimState: ClaimState,
     val inputs: List<Input>,
@@ -35,7 +35,7 @@ sealed interface ClaimResult {
   data class Error(val message: String) : ClaimResult
 }
 
-class NetworkClaimsFlowRepository(
+internal class NetworkClaimsFlowRepository(
   private val okHttpClient: OkHttpClient,
 ) : ClaimsFlowRepository {
 

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/repository/MockClaimsFlowRepository.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/repository/MockClaimsFlowRepository.kt
@@ -7,7 +7,7 @@ import com.hedvig.odyssey.remote.money.MonetaryAmount
 import kotlinx.coroutines.delay
 import java.time.LocalDate
 
-class MockClaimsFlowRepository : ClaimsFlowRepository {
+internal class MockClaimsFlowRepository : ClaimsFlowRepository {
 
   private val mockSuccessResult = ClaimResult.Success(
     ClaimState(),

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/repository/PhoneNumberRepository.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/repository/PhoneNumberRepository.kt
@@ -8,7 +8,7 @@ import com.hedvig.android.apollo.graphql.ProfileQuery
 import com.hedvig.android.apollo.graphql.UpdatePhoneNumberMutation
 import com.hedvig.android.apollo.safeExecute
 
-class PhoneNumberRepository(
+internal class PhoneNumberRepository(
   private val apolloClient: ApolloClient,
 ) {
   private val profileQuery = ProfileQuery()

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/resolution/ResolutionViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/resolution/ResolutionViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class ResolutionViewModel(
+internal class ResolutionViewModel(
   val repository: ClaimsFlowRepository,
   val resolution: Resolution,
 ) : ViewModel() {

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/resolution/ui/ResolutionRoot.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/resolution/ui/ResolutionRoot.kt
@@ -16,7 +16,7 @@ import com.hedvig.android.odyssey.resolution.ResolutionViewState
 import com.hedvig.app.ui.compose.composables.ErrorDialog
 
 @Composable
-fun ResolutionRoot(
+internal fun ResolutionRoot(
   viewModel: ResolutionViewModel,
   resolution: Resolution,
   onFinish: () -> Unit,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/CommonClaims.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/CommonClaims.kt
@@ -27,7 +27,7 @@ import com.hedvig.android.odyssey.model.ItemType
 import com.hedvig.android.odyssey.model.SearchableClaim
 
 @Composable
-fun CommonClaims(
+internal fun CommonClaims(
   selectClaim: (SearchableClaim) -> Unit,
   commonClaims: List<SearchableClaim>,
   selectOther: () -> Unit,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetClaimEntryPointsUseCase.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetClaimEntryPointsUseCase.kt
@@ -2,11 +2,11 @@ package com.hedvig.android.odyssey.search
 
 import com.hedvig.android.odyssey.model.SearchableClaim
 
-interface GetClaimEntryPointsUseCase {
+internal interface GetClaimEntryPointsUseCase {
   suspend operator fun invoke(): CommonClaimsResult
 }
 
-sealed interface CommonClaimsResult {
+internal sealed interface CommonClaimsResult {
   data class Error(val message: String) : CommonClaimsResult
   data class Success(val searchableClaims: List<SearchableClaim>) : CommonClaimsResult
 }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetLocalEntryPointsUseCase.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetLocalEntryPointsUseCase.kt
@@ -2,9 +2,9 @@ package com.hedvig.android.odyssey.search
 
 import com.hedvig.android.odyssey.model.SearchableClaim
 
-class GetLocalEntryPointsUseCase : GetClaimEntryPointsUseCase {
+internal class GetLocalEntryPointsUseCase : GetClaimEntryPointsUseCase {
 
-  override suspend operator fun invoke(): CommonClaimsResult {
+  override suspend fun invoke(): CommonClaimsResult {
     return CommonClaimsResult.Success(
       searchableClaims = listOf(
         SearchableClaim("6", displayName = "Broken phone"),

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetNetworkClaimEntryPointsUseCase.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetNetworkClaimEntryPointsUseCase.kt
@@ -12,7 +12,7 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
-class GetNetworkClaimEntryPointsUseCase(
+internal class GetNetworkClaimEntryPointsUseCase(
   private val okhttpClient: OkHttpClient,
   private val odysseyUrl: String,
 ) : GetClaimEntryPointsUseCase {
@@ -57,7 +57,7 @@ private fun List<ClaimEntryPointDTO>.toSearchableClaims() = map {
 private const val NR_OF_ENTRYPOINTS = "10"
 
 @Serializable
-data class ClaimEntryPointDTO(
+internal data class ClaimEntryPointDTO(
   val id: String,
   val displayName: String,
   val path: String,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/SearchViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/SearchViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class SearchViewModel(
+internal class SearchViewModel(
   private val getClaimEntryPoints: GetNetworkClaimEntryPointsUseCase,
 ) : ViewModel() {
   private val _viewState = MutableStateFlow(SearchViewState())

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/SearchViewState.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/SearchViewState.kt
@@ -2,7 +2,7 @@ package com.hedvig.android.odyssey.search
 
 import com.hedvig.android.odyssey.model.SearchableClaim
 
-data class SearchViewState(
+internal data class SearchViewState(
   val input: String? = null,
   val commonClaims: List<SearchableClaim> = listOf(),
   val results: List<SearchableClaim> = emptyList(),


### PR DESCRIPTION
:app which knows about the prod/dev/debug can provide the
`single<String>(odysseyUrlQualifier) { get<Context>().getString(R.string.ODYSSEY_URL) }`
and then :odyssey can provide everything else.

For now added them all to odysseyModule as I don't have all the right context to know if I should split them up in some other way.

In my opinion, splitting the modules per layer, like viewModel and repository I think doesn't really add any value, since it splits the things that logically are connected to each other (a VM and the Repository it's using for example), so if you want to see what things are together that thing makes it harder.

Think of [viewModelModule](https://github.com/HedvigInsurance/android/blob/f6e2f02260d4c5ce3f0567d77c18cc24710b94dd/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt#L302-L366) and [useCaseModule](https://github.com/HedvigInsurance/android/blob/f6e2f02260d4c5ce3f0567d77c18cc24710b94dd/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt#L551-L601). And how they don't really provide any context of how the individual things in there are used, but serve more of a parking lot for classes that aren't in a better named module 😅