### PR TITLE
Fix GenericErrorScreen to use some sane default paddings

### DIFF
--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/genericinfo/GenericErrorScreen.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/genericinfo/GenericErrorScreen.kt
@@ -2,7 +2,10 @@ package com.hedvig.android.core.ui.genericinfo
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,7 +47,13 @@ class GenericErrorScreenView @JvmOverloads constructor(
   @Composable
   override fun Content() {
     HedvigTheme {
-      GenericErrorScreen(onRetryButtonClick = onClick, Modifier.padding(top = 48.dp))
+      GenericErrorScreen(
+        onRetryButtonClick = onClick,
+        modifier = Modifier
+          .padding(top = 32.dp)
+          .padding(16.dp)
+          .windowInsetsPadding(WindowInsets.safeDrawing),
+      )
     }
   }
 }


### PR DESCRIPTION
I stumbled upon this error screen while working on this and it was lacking any padding support so this fixes it.

| before this PR                                                                                                                            | after this PR                                                                                                                             |
|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="423" alt="image" src="https://user-images.githubusercontent.com/44558292/223975435-bdd7bf5c-8cf7-4935-bb8b-14e91b84184c.png"> | <img width="421" alt="image" src="https://user-images.githubusercontent.com/44558292/223976686-47d357ca-4edc-4c9b-a685-29a310dd253a.png"> |
