### PR TITLE
Common claim bottom sheet redesign - remove the icon from detail activity + bottom sheets according to figma

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/CommonClaimActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/CommonClaimActivity.kt
@@ -2,7 +2,6 @@ package com.hedvig.app.feature.claims.ui.commonclaim
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -13,7 +12,6 @@ import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityCommonClaimBinding
 import com.hedvig.app.feature.claims.ui.commonclaim.bulletpoint.BulletPointsAdapter
 import com.hedvig.app.feature.claims.ui.startClaimsFlow
-import com.hedvig.app.ui.coil.load
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.view.applyNavigationBarInsets
 import com.hedvig.app.util.extensions.view.applyStatusBarInsets
@@ -60,9 +58,6 @@ class CommonClaimActivity : AppCompatActivity(R.layout.activity_common_claim) {
     }
 
     binding.apply {
-      val url = Uri.parse(data.iconUrls.iconByTheme(this@CommonClaimActivity))
-      firstMessage.commonClaimFirstMessageIcon.load(url, imageLoader)
-
       firstMessage.commonClaimFirstMessage.text = data.layoutTitle
       firstMessage.commonClaimCreateClaimButton.text = data.buttonText
       if (data.isFirstVet()) {

--- a/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/EmergencyActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claims/ui/commonclaim/EmergencyActivity.kt
@@ -7,12 +7,10 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import coil.ImageLoader
 import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.app.R
 import com.hedvig.app.databinding.ActivityEmergencyBinding
 import com.hedvig.app.feature.claims.ui.ClaimsViewModel
-import com.hedvig.app.ui.coil.load
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.makeACall
 import com.hedvig.app.util.extensions.showErrorDialog
@@ -28,14 +26,12 @@ import com.hedvig.app.util.extensions.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import slimber.log.e
 
 class EmergencyActivity : AppCompatActivity(R.layout.activity_emergency) {
   private val claimsViewModel: ClaimsViewModel by viewModel()
   private val binding by viewBinding(ActivityEmergencyBinding::bind)
-  private val imageLoader: ImageLoader by inject()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -70,9 +66,6 @@ class EmergencyActivity : AppCompatActivity(R.layout.activity_emergency) {
         onBackPressedDispatcher.onBackPressed()
       }
       scrollView.setupToolbarScrollListener(toolbar = toolbar)
-
-      val url = Uri.parse(data.iconUrls.iconByTheme(firstMessage.commonClaimFirstMessageIcon.context))
-      firstMessage.commonClaimFirstMessageIcon.load(url, imageLoader)
 
       firstMessage.commonClaimFirstMessage.text =
         getString(hedvig.resources.R.string.COMMON_CLAIM_EMERGENCY_LAYOUT_TITLE)

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/PerilAdapter.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/PerilAdapter.kt
@@ -4,30 +4,23 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import coil.ImageLoader
 import com.hedvig.app.R
 import com.hedvig.app.databinding.CoveredAndExceptionHeaderBinding
 import com.hedvig.app.databinding.CoveredAndExceptionItemBinding
 import com.hedvig.app.databinding.ExpandableBottomSheetTitleBinding
 import com.hedvig.app.databinding.PerilDescriptionBinding
-import com.hedvig.app.databinding.PerilIconBinding
 import com.hedvig.app.databinding.PerilParagraphBinding
-import com.hedvig.app.ui.coil.load
 import com.hedvig.app.util.GenericDiffUtilItemCallback
 import com.hedvig.app.util.extensions.inflate
 import com.hedvig.app.util.extensions.invalid
-import com.hedvig.app.util.extensions.isDarkThemeActive
 import com.hedvig.app.util.extensions.viewBinding
 
-class PerilAdapter(
-  private val imageLoader: ImageLoader,
-) : ListAdapter<PerilModel, PerilAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
+class PerilAdapter : ListAdapter<PerilModel, PerilAdapter.ViewHolder>(GenericDiffUtilItemCallback()) {
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = when (viewType) {
     R.layout.covered_and_exception_item -> ViewHolder.CoveredAndException(parent)
     R.layout.covered_and_exception_header -> ViewHolder.Header(parent)
     R.layout.peril_paragraph -> ViewHolder.Paragraph(parent)
-    R.layout.peril_icon -> ViewHolder.Icon(parent, imageLoader)
     R.layout.expandable_bottom_sheet_title -> ViewHolder.Title(parent)
     R.layout.peril_description -> ViewHolder.Description(parent)
     else -> {
@@ -44,7 +37,6 @@ class PerilAdapter(
     PerilModel.Header.ExceptionHeader -> R.layout.covered_and_exception_header
     PerilModel.Header.InfoHeader -> R.layout.covered_and_exception_header
     is PerilModel.Paragraph -> R.layout.peril_paragraph
-    is PerilModel.Icon -> R.layout.peril_icon
     is PerilModel.Title -> R.layout.expandable_bottom_sheet_title
     is PerilModel.Description -> R.layout.peril_description
     is PerilModel.PerilList.Covered -> R.layout.covered_and_exception_item
@@ -111,28 +103,6 @@ class PerilAdapter(
           return
         }
         binding.root.text = item.text
-      }
-    }
-
-    class Icon(parent: ViewGroup, private val imageLoader: ImageLoader) :
-      ViewHolder(parent.inflate(R.layout.peril_icon)) {
-      private val binding by viewBinding(PerilIconBinding::bind)
-
-      override fun bind(item: PerilModel) {
-        if (item !is PerilModel.Icon) {
-          invalid(item)
-          return
-        }
-        binding.root.apply {
-          val link = if (context.isDarkThemeActive) {
-            item.darkUrl
-          } else {
-            item.lightUrl
-          }
-          load(link, imageLoader) {
-            crossfade(true)
-          }
-        }
       }
     }
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/PerilModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/PerilModel.kt
@@ -1,10 +1,6 @@
 package com.hedvig.app.feature.insurance.ui.detail.coverage
 
 sealed class PerilModel {
-  data class Icon(
-    val lightUrl: String,
-    val darkUrl: String,
-  ) : PerilModel()
   data class Title(val text: String) : PerilModel()
   data class Description(val text: String) : PerilModel()
   sealed class PerilList : PerilModel() {

--- a/app/src/main/kotlin/com/hedvig/app/feature/perils/PerilBottomSheet.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/perils/PerilBottomSheet.kt
@@ -4,17 +4,13 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
 import androidx.core.view.updatePadding
-import coil.ImageLoader
 import com.hedvig.app.feature.insurance.ui.detail.coverage.PerilAdapter
 import com.hedvig.app.feature.insurance.ui.detail.coverage.PerilModel
 import com.hedvig.app.ui.view.ExpandableBottomSheet
 import com.hedvig.app.util.extensions.dp
-import org.koin.android.ext.android.inject
 import slimber.log.e
 
 class PerilBottomSheet : ExpandableBottomSheet() {
-
-  private val imageLoader: ImageLoader by inject()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
@@ -26,7 +22,7 @@ class PerilBottomSheet : ExpandableBottomSheet() {
     }
 
     binding.recycler.updatePadding(bottom = binding.recycler.paddingBottom + 56.dp)
-    binding.recycler.adapter = PerilAdapter(imageLoader).also { adapter ->
+    binding.recycler.adapter = PerilAdapter().also { adapter ->
       adapter.submitList(
         expandedList(
           peril.title,
@@ -34,8 +30,6 @@ class PerilBottomSheet : ExpandableBottomSheet() {
           peril.info,
           peril.covered,
           peril.exception,
-          peril.darkUrl,
-          peril.lightUrl,
         ),
       )
     }
@@ -47,33 +41,24 @@ class PerilBottomSheet : ExpandableBottomSheet() {
     info: String,
     covered: List<String>,
     exceptions: List<String>,
-    iconDarkLink: String,
-    iconLightLink: String,
-  ) = listOfNotNull(
-    PerilModel.Icon(iconLightLink, iconDarkLink),
-    PerilModel.Title(title),
-    PerilModel.Description(description),
-    if (covered.isNotEmpty()) {
-      PerilModel.Header.CoveredHeader
-    } else {
-      null
-    },
-    *covered.map { PerilModel.PerilList.Covered(it) }.toTypedArray(),
-    if (exceptions.isNotEmpty()) {
-      PerilModel.Header.ExceptionHeader
-    } else {
-      null
-    },
-    *exceptions.map { PerilModel.PerilList.Exception(it) }.toTypedArray(),
-    *(
-      if (info.isNotBlank()) {
-        arrayOf(PerilModel.Header.InfoHeader, PerilModel.Paragraph(info))
-      } else {
-        emptyArray()
+  ): List<PerilModel> {
+    return buildList {
+      add(PerilModel.Title(title))
+      add(PerilModel.Description(description))
+      if (covered.isNotEmpty()) {
+        add(PerilModel.Header.CoveredHeader)
       }
-      ),
-
-  )
+      addAll(covered.map { PerilModel.PerilList.Covered(it) })
+      if (exceptions.isNotEmpty()) {
+        add(PerilModel.Header.ExceptionHeader)
+      }
+      addAll(exceptions.map { PerilModel.PerilList.Exception(it) })
+      if (info.isNotBlank()) {
+        add(PerilModel.Header.InfoHeader)
+        add(PerilModel.Paragraph(info))
+      }
+    }
+  }
 
   companion object {
     private const val PERIL = "PERIL"

--- a/app/src/main/res/layout/common_claim_first_message.xml
+++ b/app/src/main/res/layout/common_claim_first_message.xml
@@ -10,14 +10,6 @@
     android:paddingBottom="@dimen/common_claim_first_message_bottom_margin"
     tools:background="#D7FDF4">
 
-    <ImageView
-        android:id="@+id/commonClaimFirstMessageIcon"
-        android:layout_width="@dimen/common_claim_icon_size"
-        android:layout_height="@dimen/common_claim_icon_size"
-        android:layout_marginStart="@dimen/base_margin_triple"
-        android:contentDescription="@null"
-        tools:src="@drawable/ic_charity" />
-
     <TextView
         android:id="@+id/commonClaimFirstMessage"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/peril_icon.xml
+++ b/app/src/main/res/layout/peril_icon.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_marginTop="@dimen/base_margin"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/peril_bottom_sheet_icon_size"
-    android:contentDescription="@null"
-    tools:src="@drawable/ic_active" />

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/resolution/ui/PayoutSummary.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/resolution/ui/PayoutSummary.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.odyssey.resolution.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/SearchActivity.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/SearchActivity.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.lifecycleScope
 import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.CenterAlignedTopAppBar


### PR DESCRIPTION
From here

<img width="482" alt="image" src="https://user-images.githubusercontent.com/44558292/224016305-f68ad82b-fb81-4196-a850-6c9b3a1e4569.png">
