### PR TITLE
Add "open chat" button in the failed termination screens

### DIFF
--- a/feature-terminate-insurance/build.gradle.kts
+++ b/feature-terminate-insurance/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   implementation(projects.coreDesignSystem)
   implementation(projects.coreResources)
   implementation(projects.coreUi)
+  implementation(projects.navigation.navigationActivity)
   implementation(projects.navigation.navigationComposeTyped)
 
   implementation(libs.accompanist.navigationAnimation)

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/TerminateInsuranceActivity.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/TerminateInsuranceActivity.kt
@@ -11,8 +11,13 @@ import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.feature.terminateinsurance.ui.TerminateInsuranceNavHost
+import com.hedvig.android.navigation.activity.Navigator
+import org.koin.android.ext.android.inject
 
 class TerminateInsuranceActivity : AppCompatActivity() {
+
+  private val activityNavigator: Navigator by inject()
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     lifecycle.addObserver(AuthenticatedObserver())
@@ -27,6 +32,10 @@ class TerminateInsuranceActivity : AppCompatActivity() {
           windowSizeClass = calculateWindowSizeClass(this),
           navController = rememberAnimatedNavController(),
           insuranceId = insuranceId,
+          openChat = {
+            onSupportNavigateUp()
+            activityNavigator.navigateToChat(this)
+          },
           navigateUp = { onSupportNavigateUp() },
           finishTerminationFlow = { finish() },
         )

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
@@ -29,6 +29,7 @@ internal fun NavGraphBuilder.terminateInsuranceGraph(
   navController: NavHostController,
   insuranceId: InsuranceId,
   navigateUp: () -> Boolean,
+  openChat: () -> Unit,
   finishTerminationFlow: () -> Unit,
 ) {
   animatedNavigation<Destinations.TerminateInsurance>(
@@ -88,6 +89,7 @@ internal fun NavGraphBuilder.terminateInsuranceGraph(
       TerminationFailureDestination(
         windowSizeClass = windowSizeClass,
         errorMessage = ErrorMessage(this.message),
+        openChat = openChat,
         navigateBack = finishTerminationFlow,
       )
     }
@@ -95,6 +97,7 @@ internal fun NavGraphBuilder.terminateInsuranceGraph(
       BackHandler { finishTerminationFlow() }
       UnknownScreenDestination(
         windowSizeClass = windowSizeClass,
+        openChat = openChat,
         navigateBack = finishTerminationFlow,
       )
     }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationfailure/TerminationFailureDestination.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationfailure/TerminationFailureDestination.kt
@@ -1,13 +1,20 @@
 package com.hedvig.android.feature.terminateinsurance.step.terminationfailure
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedTextButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.preview.calculateForPreview
@@ -18,11 +25,13 @@ import hedvig.resources.R
 internal fun TerminationFailureDestination(
   windowSizeClass: WindowSizeClass,
   errorMessage: ErrorMessage,
+  openChat: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   TerminationFailureScreen(
     windowSizeClass = windowSizeClass,
     errorMessage = errorMessage,
+    openChat = openChat,
     navigateBack = navigateBack,
   )
 }
@@ -31,16 +40,29 @@ internal fun TerminationFailureDestination(
 internal fun TerminationFailureScreen(
   windowSizeClass: WindowSizeClass,
   errorMessage: ErrorMessage,
+  openChat: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   TerminationInfoScreen(
     windowSizeClass = windowSizeClass,
-    navigateBack = navigateBack,
     title = "",
     headerText = stringResource(R.string.TERMINATION_NOT_SUCCESSFUL_TITLE),
     bodyText = errorMessage.message ?: stringResource(R.string.something_went_wrong),
-    onPrimaryButton = navigateBack,
     icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+    bottomContent = {
+      Column {
+        LargeOutlinedTextButton(
+          text = stringResource(id = R.string.open_chat),
+          onClick = openChat,
+        )
+        Spacer(Modifier.height(16.dp))
+        LargeContainedTextButton(
+          text = stringResource(R.string.general_done_button),
+          onClick = navigateBack,
+        )
+      }
+    },
+    navigateBack = navigateBack,
   )
 }
 
@@ -49,7 +71,7 @@ internal fun TerminationFailureScreen(
 private fun PreviewTerminationFailureScreen() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-      TerminationFailureScreen(WindowSizeClass.calculateForPreview(), ErrorMessage()) {}
+      TerminationFailureScreen(WindowSizeClass.calculateForPreview(), ErrorMessage(), {}) {}
     }
   }
 }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationsuccess/TerminationSuccessDestination.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationsuccess/TerminationSuccessDestination.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.preview.calculateForPreview
@@ -48,8 +49,12 @@ private fun TerminationSuccessScreen(
       terminationDate,
       "Hedvig",
     ),
-    buttonText = stringResource(R.string.TERMINATION_OPEN_SURVEY_LABEL),
-    onPrimaryButton = onPrimaryButtonClick,
+    bottomContent = {
+      LargeContainedTextButton(
+        text = stringResource(R.string.TERMINATION_OPEN_SURVEY_LABEL),
+        onClick = onPrimaryButtonClick,
+      )
+    },
     icon = Icons.Outlined.CheckCircle,
   )
 }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/unknown/UnknownScreenDestination.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/unknown/UnknownScreenDestination.kt
@@ -1,20 +1,29 @@
 package com.hedvig.android.feature.terminateinsurance.step.unknown
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedTextButton
 import com.hedvig.android.feature.terminateinsurance.ui.TerminationInfoScreen
 import hedvig.resources.R
 
 @Composable
 internal fun UnknownScreenDestination(
   windowSizeClass: WindowSizeClass,
+  openChat: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   UnknownScreenScreen(
     windowSizeClass = windowSizeClass,
+    openChat = openChat,
     navigateBack = navigateBack,
   )
 }
@@ -22,6 +31,7 @@ internal fun UnknownScreenDestination(
 @Composable
 private fun UnknownScreenScreen(
   windowSizeClass: WindowSizeClass,
+  openChat: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   TerminationInfoScreen(
@@ -30,7 +40,19 @@ private fun UnknownScreenScreen(
     title = "",
     headerText = stringResource(R.string.TERMINATION_NOT_SUCCESSFUL_TITLE),
     bodyText = "Could not find next step in flow. Please try again.",
-    onPrimaryButton = navigateBack,
+    bottomContent = {
+      Column {
+        LargeOutlinedTextButton(
+          text = stringResource(id = R.string.open_chat),
+          onClick = openChat,
+        )
+        Spacer(Modifier.height(16.dp))
+        LargeContainedTextButton(
+          text = stringResource(R.string.general_done_button),
+          onClick = navigateBack,
+        )
+      }
+    },
     icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
   )
 }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminateInsuranceNavHost.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminateInsuranceNavHost.kt
@@ -15,6 +15,7 @@ internal fun TerminateInsuranceNavHost(
   windowSizeClass: WindowSizeClass,
   navController: NavHostController,
   insuranceId: InsuranceId,
+  openChat: () -> Unit,
   navigateUp: () -> Boolean,
   finishTerminationFlow: () -> Unit,
 ) {
@@ -29,6 +30,7 @@ internal fun TerminateInsuranceNavHost(
       navController = navController,
       insuranceId = insuranceId,
       navigateUp = navigateUp,
+      openChat = openChat,
       finishTerminationFlow = finishTerminationFlow,
     )
   }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationInfo.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationInfo.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.terminateinsurance.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -47,8 +48,7 @@ internal fun TerminationInfoScreen(
   headerText: String,
   bodyText: String,
   icon: ImageVector,
-  buttonText: String = stringResource(hedvig.resources.R.string.general_done_button),
-  onPrimaryButton: () -> Unit,
+  bottomContent: @Composable () -> Unit,
   navigateBack: () -> Unit,
 ) {
   Column {
@@ -93,11 +93,9 @@ internal fun TerminationInfoScreen(
       )
       Spacer(Modifier.height(16.dp))
       Spacer(Modifier.weight(1f))
-      LargeContainedTextButton(
-        text = buttonText,
-        onClick = onPrimaryButton,
-        modifier = sideSpacingModifier,
-      )
+      Box(sideSpacingModifier) {
+        bottomContent()
+      }
       Spacer(Modifier.height(16.dp))
       Spacer(
         Modifier.windowInsetsPadding(
@@ -122,8 +120,13 @@ private fun PreviewTerminationInfoScreen() {
 
           Thanks for being part of Hedvig and trusting us to protect you and your loved ones when needed. The doors are always open if you decide to come back in the near future.
         """.trimIndent(),
-        onPrimaryButton = {},
         icon = Icons.Outlined.CheckCircle,
+        {
+          LargeContainedTextButton(
+            text = stringResource(hedvig.resources.R.string.general_done_button),
+            onClick = { },
+          )
+        },
       ) {}
     }
   }


### PR DESCRIPTION
To do this, allow TerminationInfoScreen to be more flexible Add a slot for the bottom attached buttons, to allow for the termination
 screen to give two buttons instead.
And add the open chat button for both the unknown screen case, and the termination failure screen.

The copy is in general weak, but it was decided on just to get something there, might need to explore better options.

| unknown screen | termination failure |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/44558292/224700779-1b2028ad-ca95-4cf9-9d47-1931184591e5.png) | ![image](https://user-images.githubusercontent.com/44558292/224700853-7d79bda2-1632-4cf3-8adc-0f4c350271b6.png) |