### PR TITLE
Feature: claim flow file upload

### DIFF
--- a/apollo/octopus/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/claimflow/FragmentClaimFlowStepFragment.graphql
+++ b/apollo/octopus/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/claimflow/FragmentClaimFlowStepFragment.graphql
@@ -70,8 +70,7 @@ fragment FlowClaimSingleItemStepFragment on FlowStep {
     id
     preferredCurrency
     purchasePrice {
-      amount
-      currencyCode
+      ...MoneyFragment
     }
     purchaseDate
     selectedItemProblems

--- a/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -449,6 +449,7 @@ val navigatorModule = module {
     Navigator(
       application = get(),
       loggedOutActivityClass = MarketingActivity::class.java,
+      buildConfigApplicationId = BuildConfig.APPLICATION_ID,
       navigateToChat = { startChat() },
     )
   }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ClaimFlowActivity.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ClaimFlowActivity.kt
@@ -38,6 +38,9 @@ class ClaimFlowActivity : AppCompatActivity() {
             navController = rememberAnimatedNavController(),
             imageLoader = imageLoader,
             entryPointId = commonClaimId,
+            openAppSettings = {
+              activityNavigator.openAppSettings(this@ClaimFlowActivity)
+            },
             openChat = {
               onSupportNavigateUp()
               activityNavigator.navigateToChat(this@ClaimFlowActivity)

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/OdysseyService.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/OdysseyService.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.odyssey.data
 import arrow.core.Either
 import arrow.retrofit.adapter.either.networkhandling.CallError
 import kotlinx.serialization.Serializable
-import okhttp3.RequestBody
+import okhttp3.MultipartBody
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
@@ -14,7 +14,7 @@ interface OdysseyService {
   @POST("{flowId}/audio-recording")
   suspend fun uploadAudioRecordingFile(
     @Path("flowId") flowId: String,
-    @Part("androidAudioFile") file: RequestBody,
+    @Part file: MultipartBody.Part,
   ): Either<CallError, UploadAudioRecordingResult>
 }
 

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/di/OdysseyModule.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/di/OdysseyModule.kt
@@ -110,7 +110,8 @@ val odysseyModule = module {
   // Retrofit
   single<Retrofit> {
     Retrofit.Builder()
-      .baseUrl(get<String>(odysseyUrlQualifier))
+      .callFactory(get<OkHttpClient>())
+      .baseUrl("${get<String>(odysseyUrlQualifier)}/api/flows/")
       .addCallAdapterFactory(EitherCallAdapterFactory.create())
       .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
       .build()

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowDestination.kt
@@ -47,12 +47,12 @@ internal sealed interface ClaimFlowDestination : Destination {
   data class SingleItem(
     val preferredCurrency: CurrencyCode,
     val purchaseDate: LocalDate?,
-    val purchasePrice: ClaimFlowStepFragment.FlowClaimSingleItemStepCurrentStep.PurchasePrice?,
-    val availableItemBrands: List<ClaimFlowStepFragment.FlowClaimSingleItemStepCurrentStep.AvailableItemBrand>?,
+    val purchasePrice: UiMoney?,
+    val availableItemBrands: List<AvailableItemBrand>?,
     val selectedItemBrand: String?,
-    val availableItemModels: List<ClaimFlowStepFragment.FlowClaimSingleItemStepCurrentStep.AvailableItemModel>?,
+    val availableItemModels: List<AvailableItemModel>?,
     val selectedItemModel: String?,
-    val availableItemProblems: List<ClaimFlowStepFragment.FlowClaimSingleItemStepCurrentStep.AvailableItemProblem>?,
+    val availableItemProblems: List<AvailableItemProblem>?,
     val selectedItemProblems: List<String>?,
   ) : ClaimFlowDestination
 
@@ -83,3 +83,35 @@ internal data class LocationOption(
   val value: String,
   val displayName: String,
 )
+
+@Serializable
+internal data class AvailableItemBrand(
+  val displayName: String,
+  val itemTypeId: String,
+  val itemBrandId: String,
+)
+
+@Serializable
+internal data class AvailableItemModel(
+  val displayName: String,
+  val imageUrl: String?,
+  val itemTypeId: String,
+  val itemBrandId: String,
+  val itemModelId: String,
+)
+
+@Serializable
+internal data class AvailableItemProblem(
+  val displayName: String,
+  val itemProblemId: String,
+)
+
+@Serializable
+internal data class UiMoney(val amount: Double, val currencyCode: CurrencyCode) {
+  companion object {
+    fun fromMoneyFragment(fragment: MoneyFragment?): UiMoney? {
+      fragment ?: return null
+      return UiMoney(fragment.amount, fragment.currencyCode)
+    }
+  }
+}

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
@@ -38,6 +38,7 @@ internal fun NavGraphBuilder.claimFlowGraph(
   navController: NavHostController,
   imageLoader: ImageLoader,
   entryPointId: String?,
+  openAppSettings: () -> Unit,
   navigateUp: () -> Boolean,
   openChat: () -> Unit,
   finishClaimFlow: () -> Unit,
@@ -66,6 +67,7 @@ internal fun NavGraphBuilder.claimFlowGraph(
         viewModel = viewModel,
         windowSizeClass = windowSizeClass,
         questions = questions,
+        openAppSettings = openAppSettings,
         navigateToNextStep = { claimFlowStep ->
           viewModel.handledNextStepNavigation()
           navController.navigate(claimFlowStep.toClaimFlowDestination())

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowNavHost.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowNavHost.kt
@@ -14,6 +14,7 @@ fun ClaimFlowNavHost(
   navController: NavHostController,
   imageLoader: ImageLoader,
   entryPointId: String?,
+  openAppSettings: () -> Unit,
   openChat: () -> Unit,
   navigateUp: () -> Boolean,
 ) {
@@ -28,6 +29,7 @@ fun ClaimFlowNavHost(
       navController = navController,
       imageLoader = imageLoader,
       entryPointId = entryPointId,
+      openAppSettings = openAppSettings,
       navigateUp = navigateUp,
       openChat = openChat,
       finishClaimFlow = { navigateUp() },

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/audiorecording/AudioRecordingViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/audiorecording/AudioRecordingViewModel.kt
@@ -76,7 +76,7 @@ internal class AudioRecordingViewModel(
         setAudioSamplingRate(96_000)
         setAudioEncodingBitRate(128_000)
         val filePath = File.createTempFile(
-          "claim_${UUID.randomUUID()}",
+          "claim_android_recording_${UUID.randomUUID()}",
           ".aac",
         ).absolutePath
         setOutputFile(filePath)

--- a/navigation/navigation-activity/src/main/kotlin/com/hedvig/android/navigation/activity/Navigator.kt
+++ b/navigation/navigation-activity/src/main/kotlin/com/hedvig/android/navigation/activity/Navigator.kt
@@ -3,10 +3,13 @@ package com.hedvig.android.navigation.activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
 
 class Navigator(
   private val application: Application,
   private val loggedOutActivityClass: Class<*>,
+  private val buildConfigApplicationId: String,
   private val navigateToChat: Context.() -> Unit,
 ) {
   fun navigateToMarketingActivity() {
@@ -19,5 +22,18 @@ class Navigator(
 
   fun navigateToChat(context: Context) {
     context.navigateToChat()
+  }
+
+  @Suppress("DEPRECATION")
+  fun openAppSettings(context: Context) {
+    val permissionActivity = Intent(
+      Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+      Uri.parse("package:$buildConfigApplicationId"),
+    )
+    if (context.packageManager.resolveActivity(permissionActivity, 0) != null) {
+      context.startActivity(permissionActivity)
+      return
+    }
+    context.startActivity(Intent(Intent(Settings.ACTION_SETTINGS)))
   }
 }


### PR DESCRIPTION
File uploading now works 🎉
And after it's done uploading, just fixed being able to navigate to the single item screen afterwards, by making its destination class properly serializable.

Use the correct flow ID to be passed in, previously was using the ID from the current step which was wrong.

Also add some rough UI for the case where they've permanently denied microphone access to the app. Otherwise we show the dialog, they press "OK" and nothing happens, which would be super odd for most of our members if I were to guess. I'd like us to have a discussion for these cases, and if we can gracefully let them continue the flow without submitting an audio recording at all. Since we have other data to base our decisions off of now. Or if not, if we can get some more thoughtful copy to explain why we need the audio permission to get their recording.

<img width="353" alt="image" src="https://user-images.githubusercontent.com/44558292/225926435-46540b9c-ac30-4531-acb7-a3c7c3e1618c.png">
