### PR TITLE
Fix some error and loading states in claim screens

### DIFF
--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/LargeTextButton.kt
@@ -17,11 +17,13 @@ import androidx.compose.material3.ProvideTextStyle as ProvideTextStyleM3
 fun LargeTextButton(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  enabled: Boolean = true,
   content: @Composable RowScope.() -> Unit,
 ) {
   TextButton(
     onClick = onClick,
     modifier = modifier.fillMaxWidth(),
+    enabled = enabled,
     shape = Material3Theme.shapes.large,
     contentPadding = PaddingValues(16.dp),
   ) {

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/ClaimFlowRepository.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/ClaimFlowRepository.kt
@@ -10,7 +10,6 @@ import com.hedvig.android.apollo.toEither
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.odyssey.model.FlowId
 import com.hedvig.android.odyssey.retrofit.toErrorMessage
-import java.io.File
 import kotlinx.datetime.LocalDate
 import octopus.FlowClaimAudioRecordingNextMutation
 import octopus.FlowClaimDateOfOccurrenceNextMutation
@@ -27,6 +26,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import slimber.log.d
 import slimber.log.e
+import java.io.File
 
 internal interface ClaimFlowRepository {
   suspend fun startClaimFlow(entryPointId: String?): Either<ErrorMessage, ClaimFlowStep>

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/audiorecording/AudioRecordingDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/audiorecording/AudioRecordingDestination.kt
@@ -32,7 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,14 +50,15 @@ import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.card.HedvigCardElevation
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
+import com.hedvig.android.core.ui.progress.FullScreenHedvigProgress
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
 import com.hedvig.android.odyssey.data.ClaimFlowStep
 import com.hedvig.odyssey.renderers.audiorecorder.PlaybackWaveForm
 import com.hedvig.odyssey.renderers.audiorecorder.RecordingAmplitudeIndicator
 import com.hedvig.odyssey.renderers.utils.ScreenOnFlag
 import hedvig.resources.R
-import java.io.File
 import kotlinx.datetime.Clock
+import java.io.File
 
 @Composable
 internal fun AudioRecordingDestination(
@@ -168,6 +169,7 @@ private fun AudioRecordingScreen(
         )
       }
     }
+    FullScreenHedvigProgress(show = (uiState as? AudioRecordingUiState.Playback)?.isLoading == true)
     ErrorSnackbar(
       hasError = uiState.hasAudioSubmissionError,
       showedError = showedError,
@@ -193,7 +195,7 @@ private fun AudioRecordingSection(
   modifier: Modifier = Modifier,
 ) {
   val recordAudioPermissionState = rememberPermissionState(Manifest.permission.RECORD_AUDIO)
-  var openPermissionDialog by remember { mutableStateOf(false) }
+  var openPermissionDialog by rememberSaveable { mutableStateOf(false) }
 
   if (openPermissionDialog) {
     PermissionDialog(
@@ -402,11 +404,13 @@ private fun Playback(
     LargeContainedTextButton(
       onClick = submit,
       text = submitClaimText,
+      enabled = uiState.canSubmit,
       modifier = Modifier.padding(top = 16.dp),
     )
 
     LargeTextButton(
       onClick = redo,
+      enabled = uiState.canSubmit,
       modifier = Modifier.padding(top = 8.dp),
     ) {
       Text(recordAgainText)

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/dateofoccurrence/DateOfOccurrenceDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/dateofoccurrence/DateOfOccurrenceDestination.kt
@@ -34,6 +34,7 @@ import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.card.HedvigCardElevation
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
+import com.hedvig.android.core.ui.progress.FullScreenHedvigProgress
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
 import com.hedvig.android.odyssey.data.ClaimFlowStep
 import hedvig.resources.R
@@ -117,7 +118,7 @@ private fun DateOfOccurrenceScreen(
         LargeContainedTextButton(
           text = stringResource(R.string.general_continue_button),
           onClick = submitSelectedDate,
-          enabled = uiState.canContinue,
+          enabled = uiState.canSubmit,
           modifier = sideSpacingModifier,
         )
         Spacer(Modifier.height(16.dp))
@@ -128,6 +129,7 @@ private fun DateOfOccurrenceScreen(
         )
       }
     }
+    FullScreenHedvigProgress(show = uiState.isLoading)
     ErrorSnackbar(
       hasError = uiState.dateSubmissionError,
       showedError = showedError,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/dateofoccurrence/DateOfOccurrenceViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/dateofoccurrence/DateOfOccurrenceViewModel.kt
@@ -99,7 +99,7 @@ internal data class DateOfOccurrenceUiState(
   val nextStep: ClaimFlowStep?,
   val isLoading: Boolean,
 ) {
-  val canContinue: Boolean
+  val canSubmit: Boolean
     @Composable
     get() = remember(
       datePickerState.selectedDateMillis,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/dateofoccurrencepluslocation/DateOfOccurrencePlusLocationDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/dateofoccurrencepluslocation/DateOfOccurrencePlusLocationDestination.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,6 +56,7 @@ import com.hedvig.android.core.designsystem.component.button.LargeContainedTextB
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
+import com.hedvig.android.core.ui.progress.FullScreenHedvigProgress
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
 import com.hedvig.android.odyssey.data.ClaimFlowStep
 import com.hedvig.android.odyssey.navigation.LocationOption
@@ -146,6 +148,7 @@ private fun DateOfOccurrencePlusLocationScreen(
         )
       }
     }
+    FullScreenHedvigProgress(show = uiState.isLoading)
     ErrorSnackbar(
       hasError = uiState.error,
       showedError = showedError,
@@ -163,7 +166,7 @@ private fun DateOfIncident(
   dateValidator: (Long) -> Boolean,
   modifier: Modifier = Modifier,
 ) {
-  var showDatePicker by remember { mutableStateOf(false) }
+  var showDatePicker by rememberSaveable { mutableStateOf(false) }
   if (showDatePicker) {
     Dialog(onDismissRequest = { showDatePicker = false }) {
       Surface(
@@ -204,7 +207,9 @@ private fun DateOfIncident(
   HedvigCard(
     modifier = modifier.heightIn(min = 64.dp),
     onClick = {
-      showDatePicker = !showDatePicker
+      if (!uiState.isLoading) {
+        showDatePicker = true
+      }
     },
   ) {
     Row(
@@ -231,7 +236,6 @@ private fun DateOfIncident(
         }
         Text(
           text = dateText,
-          // Take the same-ish space even if there is no selection
           modifier = Modifier
             .padding(12.dp)
             .alpha(if (selectedDateMillis != null) 1f else 0f),
@@ -247,7 +251,7 @@ private fun Location(
   selectLocationOption: (LocationOption) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  var showLocationPickerDialog by remember { mutableStateOf(false) }
+  var showLocationPickerDialog by rememberSaveable { mutableStateOf(false) }
   if (showLocationPickerDialog) {
     AlertDialog(
       onDismissRequest = { showLocationPickerDialog = false },
@@ -298,7 +302,9 @@ private fun Location(
   HedvigCard(
     modifier = modifier,
     onClick = {
-      showLocationPickerDialog = true
+      if (!uiState.isLoading) {
+        showLocationPickerDialog = true
+      }
     },
   ) {
     Row(

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/location/LocationDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/location/LocationDestination.kt
@@ -39,6 +39,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
+import com.hedvig.android.core.ui.progress.FullScreenHedvigProgress
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
 import com.hedvig.android.odyssey.data.ClaimFlowStep
 import hedvig.resources.R
@@ -146,6 +147,7 @@ private fun LocationScreen(
         )
       }
     }
+    FullScreenHedvigProgress(show = uiState.isLoading)
     ErrorSnackbar(
       hasError = uiState.error,
       showedError = showedError,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/phonenumber/PhoneNumberDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/phonenumber/PhoneNumberDestination.kt
@@ -120,6 +120,7 @@ private fun PhoneNumberScreen(
           label = {
             Text(stringResource(R.string.ODYSSEY_PHONE_NUMBER_LABEL))
           },
+          enabled = uiState.status != PhoneNumberUiState.Status.LOADING,
           placeholder = { Text("070000000") },
           keyboardOptions = KeyboardOptions(
             autoCorrect = false,

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationdate/TerminationDateViewModel.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationdate/TerminationDateViewModel.kt
@@ -94,7 +94,7 @@ internal data class TerminateInsuranceUiState(
   val nextStep: TerminateInsuranceStep?,
   val isLoading: Boolean,
 ) {
-  val canContinue: Boolean
+  val canSubmit: Boolean
     @Composable
     get() = remember(
       datePickerState.selectedDateMillis,


### PR DESCRIPTION
Show the loading indicator in all the screens which did not already have it.
Check so that one is not able to click on items while there is a loading indicator at the same time.