### PR TITLE
Termination flow touches

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
@@ -3,6 +3,8 @@ package com.hedvig.app.feature.insurance.data
 import arrow.core.Either
 import arrow.core.continuations.either
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.core.common.ErrorMessage
@@ -17,6 +19,7 @@ class GetContractsUseCase(
     return either {
       val insuranceQueryData = apolloClient
         .query(InsuranceQuery(languageService.getGraphQLLocale()))
+        .fetchPolicy(FetchPolicy.NetworkFirst)
         .safeExecute()
         .toEither(::ErrorMessage)
         .bind()

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractExt.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractExt.kt
@@ -29,8 +29,15 @@ fun InsuranceQuery.Contract.toContractCardViewState() = ContractCardViewState(
   logoUrls = logo?.variants?.fragments?.iconVariantsFragment?.let { ThemedIconUrls.from(it) },
 )
 
-fun InsuranceQuery.Contract.toMemberDetailsViewState(isTerminationFlowEnabled: Boolean = true) =
-  ContractDetailViewState.MemberDetailsViewState(
+fun InsuranceQuery.Contract.toMemberDetailsViewState(
+  isTerminationFlowEnabled: Boolean = true,
+): ContractDetailViewState.MemberDetailsViewState {
+  val isContractTerminated = run {
+    val isTerminatedInTheFuture = fragments.upcomingAgreementFragment.status.asTerminatedInFutureStatus != null
+    val isTerminatedToday = fragments.upcomingAgreementFragment.status.asTerminatedTodayStatus != null
+    isTerminatedInTheFuture || isTerminatedToday
+  }
+  return ContractDetailViewState.MemberDetailsViewState(
     pendingAddressChange = fragments
       .upcomingAgreementFragment
       .toUpcomingAgreementResult()
@@ -42,8 +49,9 @@ fun InsuranceQuery.Contract.toMemberDetailsViewState(isTerminationFlowEnabled: B
       null
     },
     change = YourInfoModel.Change,
-    cancelInsurance = if (isTerminationFlowEnabled) YourInfoModel.CancelInsuranceButton(id) else null,
+    cancelInsurance = if (isTerminationFlowEnabled && !isContractTerminated) YourInfoModel.CancelInsuranceButton(id) else null,
   )
+}
 
 fun InsuranceQuery.Contract.toDocumentsViewState() = ContractDetailViewState.DocumentsViewState(
   documents = listOfNotNull(


### PR DESCRIPTION
* Fetch termination data from network

Would otherwise fetch stale data regarding the termination flow right
after coming back from the termination flow.

* Don't show termination flow when already terminated

Simply hide the button for already terminated contracts