### PR TITLE
Fix: do not get stale contract detail data

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailActivity.kt
@@ -79,7 +79,7 @@ class ContractDetailActivity : AppCompatActivity(R.layout.contract_detail_activi
       }.attach()
       cardContainer.arrow.isInvisible = true
       cardContainer.card.transitionName = "contract_card"
-      error.onClick = { viewModel.loadContract(contractId) }
+      error.onClick = { viewModel.retryLoadingContract() }
 
       viewModel
         .viewState

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
@@ -4,6 +4,8 @@ import arrow.core.Either
 import arrow.core.continuations.either
 import arrow.core.continuations.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
@@ -21,6 +23,7 @@ class GetContractDetailsUseCase(
     return either {
       val data = apolloClient
         .query(InsuranceQuery(languageService.getGraphQLLocale()))
+        .fetchPolicy(FetchPolicy.NetworkOnly)
         .safeExecute()
         .toEither { ContractDetailError.NetworkError }
         .bind()


### PR DESCRIPTION
Avoids showing stale data when just finishing the termination flow which
 would also mean the button is shown again.
By using WhileSubscribed, it means that when coming back from the flow, the timeout has occurred, starting the flow again, and triggering the query again to refresh the data automatically, while still showing the old data initially while the new query is being executed.

In practice this basically just means that when you're done terminating your insurance, as you go back to the insurance detail screen, it automatically fetches the latest information, showing that your insurance is terminated, instead of having to go back in the insurance tab and pull to refresh for it to show.