### PR TITLE
Also add a "Done" button to more easily exit the screen

### DIFF
--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationsuccess/TerminationSuccessDestination.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationsuccess/TerminationSuccessDestination.kt
@@ -1,14 +1,20 @@
 package com.hedvig.android.feature.terminateinsurance.step.terminationsuccess
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedTextButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.preview.calculateForPreview
@@ -27,7 +33,7 @@ internal fun TerminationSuccessDestination(
   TerminationSuccessScreen(
     terminationDate = terminationDate,
     windowSizeClass = windowSizeClass,
-    onPrimaryButtonClick = { uriHandler.openUri(surveyUrl) },
+    onOpenSurvey = { uriHandler.openUri(surveyUrl) },
     navigateBack = navigateBack,
   )
 }
@@ -36,7 +42,7 @@ internal fun TerminationSuccessDestination(
 private fun TerminationSuccessScreen(
   terminationDate: LocalDate,
   windowSizeClass: WindowSizeClass,
-  onPrimaryButtonClick: () -> Unit,
+  onOpenSurvey: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   TerminationInfoScreen(
@@ -50,10 +56,17 @@ private fun TerminationSuccessScreen(
       "Hedvig",
     ),
     bottomContent = {
-      LargeContainedTextButton(
-        text = stringResource(R.string.TERMINATION_OPEN_SURVEY_LABEL),
-        onClick = onPrimaryButtonClick,
-      )
+      Column {
+        LargeOutlinedTextButton(
+          text = stringResource(R.string.general_done_button),
+          onClick = navigateBack,
+        )
+        Spacer(Modifier.height(16.dp))
+        LargeContainedTextButton(
+          text = stringResource(R.string.TERMINATION_OPEN_SURVEY_LABEL),
+          onClick = onOpenSurvey,
+        )
+      }
     },
     icon = Icons.Outlined.CheckCircle,
   )


### PR DESCRIPTION
Before, it felt a bit unintuitive to leave the success screen. You had to either go back, or press the back arrow on the top left, but there wasn't any "ok I am done now" action, and the survey might feel like a dead end, since clicking it doesn't also leave this screen, only opens a website, and going back may feel like they're going back into the flow, so I thought this makes sense.

<img width="581" alt="image" src="https://user-images.githubusercontent.com/44558292/226554594-9db71472-3bab-4012-8f05-f9b7349c27da.png">
