### PR TITLE
Add crashlytics analytics back to more easily see firebase crash free stats

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -227,6 +227,7 @@ dependencies {
 
   implementation(platform(libs.firebase.bom))
   implementation(libs.firebase.playServicesBase)
+  implementation(libs.firebase.analytics)
   implementation(libs.firebase.crashlytics)
   implementation(libs.firebase.dynamicLinks)
   implementation(libs.firebase.messaging)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -181,6 +181,7 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 datadog-sdk = { module = "com.datadoghq:dd-sdk-android", version.ref = "datadog" }
 firebase-bom = "com.google.firebase:firebase-bom:31.2.3"
+firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 firebase-dynamicLinks = { module = "com.google.firebase:firebase-dynamic-links" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }


### PR DESCRIPTION
For some time now, we are getting the crash reports as we should, but we are not getting a picture of how this looks like in perspective of how many users are experiencing these crashes in proportion to the entire user base. Enabling this again should populate this table in crashlytics which is not enabled right now (pic attached)

<img width="358" alt="image" src="https://user-images.githubusercontent.com/44558292/227265147-04ce0e31-9c16-475b-9fbf-ba91c25dd39d.png">
