### PR TITLE
Make insurance details read cache first before network

### DIFF
--- a/apollo/core/src/main/kotlin/com/hedvig/android/apollo/ApolloCallExt.kt
+++ b/apollo/core/src/main/kotlin/com/hedvig/android/apollo/ApolloCallExt.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.exception.ApolloException
 import kotlinx.coroutines.CancellationException
@@ -25,14 +24,14 @@ suspend fun <D : Operation.Data> ApolloCall<D>.safeExecute(): OperationResult<D>
   }
 }
 
-fun <D : Subscription.Data> ApolloCall<D>.toSafeFlow(): Flow<OperationResult<D>> {
+fun <D : Operation.Data> ApolloCall<D>.safeFlow(): Flow<OperationResult<D>> {
   return toFlow()
     .map(ApolloResponse<D>::toOperationResult)
-    .catch { exception ->
-      if (exception is ApolloException) {
-        emit(OperationResult.Error.NetworkError(exception))
+    .catch { throwable ->
+      if (throwable is ApolloException) {
+        OperationResult.Error.NetworkError(throwable)
       } else {
-        emit(OperationResult.Error.GeneralError(exception))
+        OperationResult.Error.GeneralError(throwable)
       }
     }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewModel.kt
@@ -5,11 +5,12 @@ import androidx.lifecycle.viewModelScope
 import com.hedvig.android.core.common.RetryChannel
 import com.hedvig.hanalytics.AppScreen
 import com.hedvig.hanalytics.HAnalytics
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlin.time.Duration.Companion.seconds
 
 class ContractDetailViewModel(
   contractId: String,
@@ -28,11 +29,14 @@ class ContractDetailViewModel(
 
   private val retryChannel = RetryChannel()
   val viewState: StateFlow<ViewState> = retryChannel
-    .mapLatest {
-      getContractDetailsUseCase.invoke(contractId).fold(
-        ifLeft = { ViewState.Error },
-        ifRight = { ViewState.Success(it) },
-      )
+    .flatMapLatest {
+      getContractDetailsUseCase.invoke(contractId)
+        .map { result ->
+          result.fold(
+            ifLeft = { ViewState.Error },
+            ifRight = { ViewState.Success(it) },
+          )
+        }
     }
     .stateIn(
       viewModelScope,

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
@@ -6,31 +6,34 @@ import arrow.core.continuations.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
-import com.hedvig.android.apollo.safeExecute
+import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.flags.Feature
 import com.hedvig.android.language.LanguageService
 import giraffe.InsuranceQuery
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class GetContractDetailsUseCase(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
   private val featureManager: FeatureManager,
 ) {
-
-  suspend fun invoke(contractId: String): Either<ContractDetailError, ContractDetailViewState> {
-    return either {
-      val data = apolloClient
-        .query(InsuranceQuery(languageService.getGraphQLLocale()))
-        .fetchPolicy(FetchPolicy.NetworkOnly)
-        .safeExecute()
-        .toEither { ContractDetailError.NetworkError }
-        .bind()
-      val contract = data.contracts.firstOrNull { it.id == contractId }
-      ensureNotNull(contract) { ContractDetailError.ContractNotFoundError }
-      contract.toContractDetailViewState(featureManager.isFeatureEnabled(Feature.TERMINATION_FLOW))
-    }
+  fun invoke(contractId: String): Flow<Either<ContractDetailError, ContractDetailViewState>> {
+    return apolloClient
+      .query(InsuranceQuery(languageService.getGraphQLLocale()))
+      .fetchPolicy(FetchPolicy.CacheAndNetwork)
+      .safeFlow()
+      .map { it.toEither { ContractDetailError.NetworkError } }
+      .map { result ->
+        either {
+          val data = result.bind()
+          val contract = data.contracts.firstOrNull { it.id == contractId }
+          ensureNotNull(contract) { ContractDetailError.ContractNotFoundError }
+          contract.toContractDetailViewState(featureManager.isFeatureEnabled(Feature.TERMINATION_FLOW))
+        }
+      }
   }
 
   sealed class ContractDetailError {


### PR DESCRIPTION
This makes it so that the shared element transition does not look super ugly as the new screen does not have the ready to serve data, but can use what's in the cache already, while still making sure to not show stale data when coming back from the termination flow if the insurance was terminated

What the issue was basically is that as the card was animating to the next screen, it was white until the network request returned, which was ugly. And this was as a result of me recently changing the fetching so that it always hits the network, since we did not want stale data.
Well, apollo gives us the `fetchPolicy(FetchPolicy.CacheAndNetwork)` which does *exactly* what we really want here. Hit the cache to get the latest data instantly, and then also hit the network to get the real latest data. If these two are the same, nothing will happen anyway and the UI will not update.

The way this works in apollo is that instead of returning 1 item, it returns a Flow<> of that response, so that it is able to first emit the cached value, and then the value from the web.

We can start using this in more places going forward as it's super convenient. At least in those places where we know we get stale data often.