### PR TITLE
Feature: claim success screen

### DIFF
--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
@@ -26,9 +26,10 @@ import com.hedvig.android.odyssey.step.phonenumber.PhoneNumberDestination
 import com.hedvig.android.odyssey.step.phonenumber.PhoneNumberViewModel
 import com.hedvig.android.odyssey.step.singleitem.SingleItemDestination
 import com.hedvig.android.odyssey.step.singleitem.SingleItemViewModel
-import com.hedvig.android.odyssey.step.singleitempayout.ClaimSuccessDestination
+import com.hedvig.android.odyssey.step.singleitempayout.SingleItemPayoutDestination
 import com.hedvig.android.odyssey.step.start.ClaimFlowStartDestination
 import com.hedvig.android.odyssey.step.start.ClaimFlowStartStepViewModel
+import com.hedvig.android.odyssey.step.success.ClaimSuccessDestination
 import com.hedvig.android.odyssey.step.summary.ClaimSummaryDestination
 import com.hedvig.android.odyssey.step.summary.ClaimSummaryViewModel
 import com.hedvig.android.odyssey.step.unknownerror.UnknownErrorDestination
@@ -167,9 +168,17 @@ internal fun NavGraphBuilder.claimFlowGraph(
         navigateBack = { navController.navigateUp() || navigateUp() },
       )
     }
+    animatedComposable<ClaimFlowDestination.SingleItemCheckout> {
+      BackHandler { finishClaimFlow() }
+      SingleItemPayoutDestination()
+    }
     animatedComposable<ClaimFlowDestination.ClaimSuccess> {
       BackHandler { finishClaimFlow() }
-      ClaimSuccessDestination()
+      ClaimSuccessDestination(
+        windowSizeClass = windowSizeClass,
+        openChat = openChat,
+        navigateBack = { finishClaimFlow() },
+      )
     }
     animatedComposable<ClaimFlowDestination.ManualHandling> {
       BackHandler { finishClaimFlow() }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/singleitempayout/SingleItemPayoutDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/singleitempayout/SingleItemPayoutDestination.kt
@@ -9,7 +9,7 @@ import com.hedvig.odyssey.remote.money.MonetaryAmount
 import hedvig.resources.R
 
 @Composable
-internal fun ClaimSuccessDestination() {
+internal fun SingleItemPayoutDestination() {
   SingleItemPayoutScreen(
     resolution = Resolution.SingleItemPayout(
       MonetaryAmount("100", "SEK"),

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/success/ClaimSuccessDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/success/ClaimSuccessDestination.kt
@@ -1,0 +1,98 @@
+package com.hedvig.android.odyssey.step.success
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.component.button.LargeContainedTextButton
+import com.hedvig.android.core.designsystem.component.button.LargeOutlinedButton
+import com.hedvig.android.core.designsystem.component.card.HedvigCard
+import com.hedvig.android.core.designsystem.component.card.HedvigCardElevation
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.preview.calculateForPreview
+import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
+import hedvig.resources.R
+
+@Composable
+internal fun ClaimSuccessDestination(
+  windowSizeClass: WindowSizeClass,
+  openChat: () -> Unit,
+  navigateBack: () -> Unit,
+) {
+  ClaimSuccessScreen(
+    windowSizeClass = windowSizeClass,
+    openChat = openChat,
+    navigateBack = navigateBack,
+  )
+}
+
+@Composable
+private fun ClaimSuccessScreen(
+  windowSizeClass: WindowSizeClass,
+  openChat: () -> Unit,
+  navigateBack: () -> Unit,
+) {
+  ClaimFlowScaffold(
+    windowSizeClass = windowSizeClass,
+    navigateBack = navigateBack,
+  ) { sideSpacingModifier ->
+    Spacer(Modifier.height(20.dp))
+    HedvigCard(
+      shape = RoundedCornerShape(12.dp),
+      elevation = HedvigCardElevation.Elevated(),
+      modifier = sideSpacingModifier
+        .fillMaxWidth(0.66f)
+        .wrapContentWidth(Alignment.Start),
+    ) {
+      Text(
+        text = stringResource(R.string.message_claims_record_ok),
+        modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
+        style = MaterialTheme.typography.bodyLarge,
+      )
+    }
+    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(16.dp))
+    LargeOutlinedButton(openChat, sideSpacingModifier) {
+      Text(stringResource(R.string.open_chat))
+    }
+    Spacer(Modifier.height(16.dp))
+    LargeContainedTextButton(
+      onClick = navigateBack,
+      text = stringResource(R.string.general_close_button),
+      modifier = sideSpacingModifier,
+    )
+    Spacer(Modifier.height(16.dp))
+    Spacer(
+      Modifier.windowInsetsPadding(
+        WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
+      ),
+    )
+  }
+}
+
+@HedvigMultiScreenPreview
+@Composable
+fun PreviewClaimSuccessScreen() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      ClaimSuccessScreen(WindowSizeClass.calculateForPreview(), {}, {})
+    }
+  }
+}

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/unknownerror/UnknownErrorDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/unknownerror/UnknownErrorDestination.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowSizeClass


### PR DESCRIPTION
Exact copy and structure from the embark success screen.
Plus prepare for the SingleItemPayoutDestination too, as these two are separate.

<img width="792" alt="image" src="https://user-images.githubusercontent.com/44558292/228237944-a19f8f09-140e-4214-ab2e-1f2c0283456f.png">
