### PR TITLE
CLX-468: Termination unknown step and claim unknown step open play store

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/UpgradeAppFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/UpgradeAppFragment.kt
@@ -3,9 +3,9 @@ package com.hedvig.app.feature.embark.passages
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import com.hedvig.android.core.common.android.tryOpenPlayStore
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentEmbarkUpgradeAppBinding
-import com.hedvig.android.core.common.android.tryOpenPlayStore
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/UpgradeAppFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/embark/passages/UpgradeAppFragment.kt
@@ -5,7 +5,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import com.hedvig.app.R
 import com.hedvig.app.databinding.FragmentEmbarkUpgradeAppBinding
-import com.hedvig.app.feature.ratings.tryOpenPlayStore
+import com.hedvig.android.core.common.android.tryOpenPlayStore
 import com.hedvig.app.util.extensions.view.setHapticClickListener
 import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/ContractDetailViewModel.kt
@@ -5,12 +5,12 @@ import androidx.lifecycle.viewModelScope
 import com.hedvig.android.core.common.RetryChannel
 import com.hedvig.hanalytics.AppScreen
 import com.hedvig.hanalytics.HAnalytics
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlin.time.Duration.Companion.seconds
 
 class ContractDetailViewModel(
   contractId: String,

--- a/app/src/main/kotlin/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.app.feature.ratings.tryOpenPlayStore
+import com.hedvig.android.core.common.android.tryOpenPlayStore
 
 class ForceUpgradeActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/sunsetting/ForceUpgradeActivity.kt
@@ -21,9 +21,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.common.android.tryOpenPlayStore
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.core.common.android.tryOpenPlayStore
 
 class ForceUpgradeActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/core-common-android/src/main/kotlin/com/hedvig/android/core/common/android/PlayStoreUtil.kt
+++ b/core-common-android/src/main/kotlin/com/hedvig/android/core/common/android/PlayStoreUtil.kt
@@ -1,20 +1,23 @@
-package com.hedvig.app.feature.ratings
+package com.hedvig.android.core.common.android
 
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import com.hedvig.app.R
-import com.hedvig.app.util.extensions.makeToast
-
-private fun Context.playStoreIntent() = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName"))
+import android.widget.Toast
 
 fun Context.tryOpenPlayStore() {
   if (canOpenPlayStore()) {
     openPlayStore()
   } else {
-    makeToast(hedvig.resources.R.string.TOAST_PLAY_STORE_MISSING_ON_DEVICE)
+    Toast.makeText(
+      this,
+      getString(hedvig.resources.R.string.TOAST_PLAY_STORE_MISSING_ON_DEVICE),
+      Toast.LENGTH_LONG,
+    ).show()
   }
 }
+
+private fun Context.playStoreIntent() = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName"))
 
 private fun Context.canOpenPlayStore() = playStoreIntent().resolveActivity(packageManager) != null
 

--- a/feature-odyssey/build.gradle.kts
+++ b/feature-odyssey/build.gradle.kts
@@ -13,11 +13,12 @@ dependencies {
   implementation(projects.auth.authAndroid)
   implementation(projects.auth.authCore)
   implementation(projects.coreCommon)
+  implementation(projects.coreCommonAndroid)
   implementation(projects.coreDesignSystem)
   implementation(projects.coreResources)
+  implementation(projects.coreUi)
   implementation(projects.hanalytics.hanalyticsFeatureFlags)
   implementation(projects.hedvigLanguage)
-  implementation(projects.coreUi)
   implementation(projects.navigation.navigationActivity)
   implementation(projects.navigation.navigationComposeTyped)
 

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ClaimFlowActivity.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ClaimFlowActivity.kt
@@ -13,6 +13,7 @@ import androidx.core.view.WindowCompat
 import coil.ImageLoader
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.hedvig.android.auth.android.AuthenticatedObserver
+import com.hedvig.android.core.common.android.tryOpenPlayStore
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.navigation.activity.Navigator
 import com.hedvig.android.odyssey.navigation.ClaimFlowNavHost
@@ -41,6 +42,7 @@ class ClaimFlowActivity : AppCompatActivity() {
             openAppSettings = {
               activityNavigator.openAppSettings(this@ClaimFlowActivity)
             },
+            openPlayStore = { tryOpenPlayStore() },
             openChat = {
               onSupportNavigateUp()
               activityNavigator.navigateToChat(this@ClaimFlowActivity)

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
@@ -46,6 +46,7 @@ internal fun NavGraphBuilder.claimFlowGraph(
   imageLoader: ImageLoader,
   entryPointId: String?,
   openAppSettings: () -> Unit,
+  openPlayStore: () -> Unit,
   navigateUp: () -> Boolean,
   openChat: () -> Unit,
   finishClaimFlow: () -> Unit,
@@ -191,7 +192,7 @@ internal fun NavGraphBuilder.claimFlowGraph(
       BackHandler { finishClaimFlow() }
       UnknownScreenDestination(
         windowSizeClass = windowSizeClass,
-        openChat = openChat,
+        openPlayStore = openPlayStore,
         navigateBack = finishClaimFlow,
       )
     }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowNavHost.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowNavHost.kt
@@ -15,6 +15,7 @@ fun ClaimFlowNavHost(
   imageLoader: ImageLoader,
   entryPointId: String?,
   openAppSettings: () -> Unit,
+  openPlayStore: () -> Unit,
   openChat: () -> Unit,
   navigateUp: () -> Boolean,
 ) {
@@ -30,6 +31,7 @@ fun ClaimFlowNavHost(
       imageLoader = imageLoader,
       entryPointId = entryPointId,
       openAppSettings = openAppSettings,
+      openPlayStore = openPlayStore,
       navigateUp = navigateUp,
       openChat = openChat,
       finishClaimFlow = { navigateUp() },

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/ui/CommonClaims.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/ui/CommonClaims.kt
@@ -18,14 +18,12 @@ import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.odyssey.model.ItemType
 import com.hedvig.android.odyssey.model.SearchableClaim
 import java.util.*
-import hedvig.resources.R
 
 @Composable
 internal fun CommonClaims(

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryDestination.kt
@@ -59,10 +59,10 @@ import com.hedvig.android.odyssey.step.summary.resources.HedvigDeviceUnknown
 import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
 import com.hedvig.odyssey.compose.getLocale
 import hedvig.resources.R
-import java.time.format.DateTimeFormatter
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
 import octopus.type.CurrencyCode
+import java.time.format.DateTimeFormatter
 
 @Composable
 internal fun ClaimSummaryDestination(

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/unknownerror/UnknownErrorDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/unknownerror/UnknownErrorDestination.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -25,7 +25,7 @@ import com.hedvig.android.core.ui.preview.calculateForPreview
 import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
 
 @Composable
-fun UnknownErrorDestination(
+internal fun UnknownErrorDestination(
   windowSizeClass: WindowSizeClass,
   openChat: () -> Unit,
   finishClaimFlow: () -> Unit,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/unknownscreen/UnknownScreenDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/unknownscreen/UnknownScreenDestination.kt
@@ -26,19 +26,18 @@ import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
 import hedvig.resources.R
 
 @Composable
-fun UnknownScreenDestination(
+internal fun UnknownScreenDestination(
   windowSizeClass: WindowSizeClass,
-  openChat: () -> Unit,
+  openPlayStore: () -> Unit,
   navigateBack: () -> Unit,
 ) {
-  UnknownScreenScreen(windowSizeClass, openChat, navigateBack)
+  UnknownScreenScreen(windowSizeClass, openPlayStore, navigateBack)
 }
 
 @Composable
 private fun UnknownScreenScreen(
-  // todo maybe show "Update your app" here instead.
   windowSizeClass: WindowSizeClass,
-  openChat: () -> Unit,
+  openPlayStore: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   ClaimFlowScaffold(
@@ -48,18 +47,18 @@ private fun UnknownScreenScreen(
     Spacer(Modifier.height(20.dp))
     AppStateInformation(
       type = AppStateInformationType.Failure,
-      title = stringResource(R.string.something_went_wrong),
-      description = stringResource(R.string.home_tab_error_body),
+      title = stringResource(R.string.EMBARK_UPDATE_APP_TITLE),
+      description = stringResource(R.string.EMBARK_UPDATE_APP_BODY),
       modifier = sideSpacingModifier,
     )
     Spacer(Modifier.height(40.dp))
     Spacer(Modifier.weight(1f))
-    LargeOutlinedButton(openChat, sideSpacingModifier) {
-      Text(stringResource(R.string.open_chat))
+    LargeOutlinedButton(openPlayStore, sideSpacingModifier) {
+      Text(stringResource(R.string.EMBARK_UPDATE_APP_BUTTON))
     }
     Spacer(Modifier.height(16.dp))
     LargeContainedButton(navigateBack, sideSpacingModifier) {
-      Text(text = stringResource(R.string.general_done_button))
+      Text(text = stringResource(R.string.general_close_button))
     }
     Spacer(Modifier.height(16.dp))
     Spacer(

--- a/feature-terminate-insurance/build.gradle.kts
+++ b/feature-terminate-insurance/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(projects.apollo.octopus)
   implementation(projects.auth.authAndroid)
   implementation(projects.coreCommon)
+  implementation(projects.coreCommonAndroid)
   implementation(projects.coreDesignSystem)
   implementation(projects.coreResources)
   implementation(projects.coreUi)

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/TerminateInsuranceActivity.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/TerminateInsuranceActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.hedvig.android.auth.android.AuthenticatedObserver
+import com.hedvig.android.core.common.android.tryOpenPlayStore
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceNavHost
 import com.hedvig.android.navigation.activity.Navigator
@@ -40,6 +41,7 @@ class TerminateInsuranceActivity : AppCompatActivity() {
               onSupportNavigateUp()
               activityNavigator.navigateToChat(this@TerminateInsuranceActivity)
             },
+            openPlayStore = { tryOpenPlayStore() },
             navigateUp = { onSupportNavigateUp() },
             finishTerminationFlow = { finish() },
           )

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
@@ -30,6 +30,7 @@ internal fun NavGraphBuilder.terminateInsuranceGraph(
   insuranceId: InsuranceId,
   navigateUp: () -> Boolean,
   openChat: () -> Unit,
+  openPlayStore: () -> Unit,
   finishTerminationFlow: () -> Unit,
 ) {
   animatedNavigation<Destinations.TerminateInsurance>(
@@ -97,7 +98,7 @@ internal fun NavGraphBuilder.terminateInsuranceGraph(
       BackHandler { finishTerminationFlow() }
       UnknownScreenDestination(
         windowSizeClass = windowSizeClass,
-        openChat = openChat,
+        openPlayStore = openPlayStore,
         navigateBack = finishTerminationFlow,
       )
     }

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceNavHost.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceNavHost.kt
@@ -14,6 +14,7 @@ internal fun TerminateInsuranceNavHost(
   navController: NavHostController,
   insuranceId: InsuranceId,
   openChat: () -> Unit,
+  openPlayStore: () -> Unit,
   navigateUp: () -> Boolean,
   finishTerminationFlow: () -> Unit,
 ) {
@@ -28,6 +29,7 @@ internal fun TerminateInsuranceNavHost(
       navController = navController,
       insuranceId = insuranceId,
       navigateUp = navigateUp,
+      openPlayStore = openPlayStore,
       openChat = openChat,
       finishTerminationFlow = finishTerminationFlow,
     )

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/unknown/UnknownScreenDestination.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/unknown/UnknownScreenDestination.kt
@@ -18,12 +18,12 @@ import hedvig.resources.R
 @Composable
 internal fun UnknownScreenDestination(
   windowSizeClass: WindowSizeClass,
-  openChat: () -> Unit,
+  openPlayStore: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   UnknownScreenScreen(
     windowSizeClass = windowSizeClass,
-    openChat = openChat,
+    openPlayStore = openPlayStore,
     navigateBack = navigateBack,
   )
 }
@@ -31,28 +31,28 @@ internal fun UnknownScreenDestination(
 @Composable
 private fun UnknownScreenScreen(
   windowSizeClass: WindowSizeClass,
-  openChat: () -> Unit,
+  openPlayStore: () -> Unit,
   navigateBack: () -> Unit,
 ) {
   TerminationInfoScreen(
     windowSizeClass = windowSizeClass,
-    navigateBack = navigateBack,
     title = "",
-    headerText = stringResource(R.string.TERMINATION_NOT_SUCCESSFUL_TITLE),
-    bodyText = "Could not find next step in flow. Please try again.",
+    headerText = stringResource(R.string.EMBARK_UPDATE_APP_TITLE),
+    bodyText = stringResource(R.string.EMBARK_UPDATE_APP_BODY),
+    icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
     bottomContent = {
       Column {
         LargeOutlinedTextButton(
-          text = stringResource(id = R.string.open_chat),
-          onClick = openChat,
+          text = stringResource(R.string.EMBARK_UPDATE_APP_BUTTON),
+          onClick = openPlayStore,
         )
         Spacer(Modifier.height(16.dp))
         LargeContainedTextButton(
-          text = stringResource(R.string.general_done_button),
+          text = stringResource(R.string.general_close_button),
           onClick = navigateBack,
         )
       }
     },
-    icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+    navigateBack = navigateBack,
   )
 }


### PR DESCRIPTION
Moves `tryOpenPlayStore()` to core-common-android to make it accessible in the feature module.
I didn't move the `makeToast()` function but just copied the code as I hope we won't be using this so much anyway in new features.

![image](https://user-images.githubusercontent.com/44558292/228281542-8690180c-ec53-46a2-a0d1-f7064693adaa.png)
