### PR TITLE
Fix crash when no peril items exist

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageFragment.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/CoverageFragment.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -42,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import arrow.core.toNonEmptyListOrNull
 import coil.ImageLoader
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
@@ -118,7 +120,9 @@ private fun CoverageFragmentScreen(
     CoverageUiState.Error -> {
       GenericErrorScreen(
         onRetryButtonClick = retryLoading,
-        modifier = Modifier.padding(16.dp).windowInsetsPadding(WindowInsets.safeDrawing),
+        modifier = Modifier
+          .padding(16.dp)
+          .windowInsetsPadding(WindowInsets.safeDrawing),
       )
     }
     CoverageUiState.Loading -> {}
@@ -164,26 +168,32 @@ private fun ColumnScope.PerilSection(
   imageLoader: ImageLoader,
   onPerilClick: (Peril) -> Unit,
 ) {
-  Text(
-    text = stringResource(hedvig.resources.R.string.CONTRACT_COVERAGE_CONTRACT_TYPE, contractDisplayName),
-    style = MaterialTheme.typography.titleLarge,
-    modifier = Modifier
-      .padding(horizontal = 16.dp)
-      .heightIn(min = 40.dp)
-      .wrapContentSize(Alignment.BottomStart),
-  )
-  Spacer(Modifier.height(16.dp))
-  PerilGrid(
-    perils = perilItems.map { peril: Peril ->
+  val isSystemInDarkTheme = isSystemInDarkTheme()
+  val perilGridData = remember(perilItems, isSystemInDarkTheme) {
+    perilItems.map { peril: Peril ->
       PerilGridData(
         text = peril.title,
-        iconUrl = if (isSystemInDarkTheme()) peril.darkUrl else peril.lightUrl,
+        iconUrl = if (isSystemInDarkTheme) peril.darkUrl else peril.lightUrl,
         onClick = { onPerilClick(peril) },
       )
-    },
-    imageLoader = imageLoader,
-    contentPadding = PaddingValues(horizontal = 16.dp),
-  )
+    }.toNonEmptyListOrNull()
+  }
+  if (perilGridData != null) {
+    Text(
+      text = stringResource(hedvig.resources.R.string.CONTRACT_COVERAGE_CONTRACT_TYPE, contractDisplayName),
+      style = MaterialTheme.typography.titleLarge,
+      modifier = Modifier
+        .padding(horizontal = 16.dp)
+        .heightIn(min = 40.dp)
+        .wrapContentSize(Alignment.BottomStart),
+    )
+    Spacer(Modifier.height(16.dp))
+    PerilGrid(
+      perils = perilGridData,
+      imageLoader = imageLoader,
+      contentPadding = PaddingValues(horizontal = 16.dp),
+    )
+  }
 }
 
 @Suppress("UnusedReceiverParameter")

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(libs.androidx.compose.foundation)
   api(libs.androidx.compose.material)
   api(libs.androidx.compose.material3)
+  api(libs.arrow.core)
 
   implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.uiUtil)

--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/PerilGrid.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/PerilGrid.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import arrow.core.NonEmptyList
+import arrow.core.toNonEmptyListOrNull
 import coil.ImageLoader
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
@@ -17,7 +19,7 @@ import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 
 @Composable
 fun PerilGrid(
-  perils: List<PerilGridData>,
+  perils: NonEmptyList<PerilGridData>,
   imageLoader: ImageLoader,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(0.dp),
@@ -51,7 +53,7 @@ private fun PreviewPerilGrid() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       PerilGrid(
-        List(9) { PerilGridData("Peril#$it", "", {}) },
+        List(9) { PerilGridData("Peril#$it", "", {}) }.toNonEmptyListOrNull()!!,
         rememberPreviewImageLoader(),
         contentPadding = PaddingValues(16.dp),
       )


### PR DESCRIPTION
Crash:
https://console.firebase.google.com/u/0/project/hedvig-app/crashlytics/app/android:com.hedvig.app/issues/e98ea7e8fd8195f23e69ca44c5bd1590?time=last-thirty-days&versions=10.3.0%20(1679681923)&sessionEventKey=642349D10118000179DE3299BA90214A_1794138022370128837

Fixes the crash by making sure we never send no items inside the grid, and instead do not render the grid nor the title above it at all when the list is empty