### PR TITLE
CLX-456: Claims flow small UI touches

### DIFF
--- a/apollo/octopus/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/claimflow/FragmentClaimFlowStepFragment.graphql
+++ b/apollo/octopus/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/claimflow/FragmentClaimFlowStepFragment.graphql
@@ -99,6 +99,7 @@ fragment FlowClaimSingleItemCheckoutStepFragment on FlowClaimSingleItemCheckoutS
 
 fragment FlowClaimSummaryStepFragment on FlowClaimSummaryStep {
   id
+  title
   locationStep {
     ...FlowClaimLocationStepFragment
   }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/ClaimFlowStep.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/ClaimFlowStep.kt
@@ -71,6 +71,7 @@ internal sealed interface ClaimFlowStep {
 
   data class ClaimSummaryStep(
     override val flowId: FlowId,
+    val claimTypeTitle: String,
     val location: String?,
     val options: List<FlowClaimLocationStepFragment.Option>,
     val dateOfOccurrence: LocalDate?,
@@ -146,6 +147,7 @@ internal fun ClaimFlowStepFragment.CurrentStep.toClaimFlowStep(flowId: FlowId): 
     is ClaimFlowStepFragment.FlowClaimSummaryStepCurrentStep -> {
       ClaimFlowStep.ClaimSummaryStep(
         flowId,
+        title,
         locationStep.location,
         locationStep.options,
         dateOfOccurrenceStep.dateOfOccurrence,
@@ -205,6 +207,7 @@ internal fun ClaimFlowStep.toClaimFlowDestination(): ClaimFlowDestination {
     }
     is ClaimFlowStep.ClaimSummaryStep -> {
       ClaimFlowDestination.Summary(
+        claimTypeTitle = claimTypeTitle,
         selectedLocation = location,
         locationOptions = options.map { it.toLocationOption() },
         dateOfOccurrence = dateOfOccurrence,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowDestination.kt
@@ -62,6 +62,7 @@ internal sealed interface ClaimFlowDestination : Destination {
 
   @Serializable
   data class Summary(
+    val claimTypeTitle: String,
     val selectedLocation: String?,
     val locationOptions: List<LocationOption>,
     val dateOfOccurrence: LocalDate?,

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/singleitem/SingleItemDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/singleitem/SingleItemDestination.kt
@@ -60,6 +60,7 @@ import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
 import com.hedvig.android.odyssey.ui.DatePickerRowCard
 import com.hedvig.android.odyssey.ui.DatePickerUiState
 import com.hedvig.android.odyssey.ui.MonetaryAmountInput
+import com.hedvig.android.odyssey.ui.MultiSelectDialog
 import com.hedvig.android.odyssey.ui.SingleSelectDialog
 import hedvig.resources.R
 import octopus.type.CurrencyCode
@@ -274,7 +275,7 @@ private fun PriceOfPurchase(
       keyboardController?.show()
     },
   ) {
-    Text("Price of purchase") // todo string resource
+    Text(stringResource(R.string.claims_item_screen_purchase_price_button))
     Spacer(Modifier.weight(1f))
     Spacer(Modifier.width(8.dp))
     CompositionLocalProvider(LocalContentColor provides LocalContentColor.current.copy(alpha = ContentAlpha.medium)) {
@@ -299,11 +300,12 @@ private fun ItemProblems(
 ) {
   var showDialog: Boolean by rememberSaveable { mutableStateOf(false) }
   if (showDialog) {
-    SingleSelectDialog(
+    MultiSelectDialog(
       title = stringResource(R.string.claims_item_screen_type_of_damage_button),
       optionsList = uiState.availableItemProblems,
       onSelected = selectProblem,
       getDisplayText = { it.displayName },
+      getIsSelected = { uiState.selectedItemProblems.contains(it) },
       getImageUrl = { null },
       getId = { it.itemProblemId },
       imageLoader = imageLoader,
@@ -317,7 +319,7 @@ private fun ItemProblems(
     enabled = enabled,
     modifier = modifier,
   ) {
-    Text("Damage") // todo string resource "Damage"
+    Text(stringResource(R.string.claims_item_screen_type_of_damage_button))
     Spacer(Modifier.weight(1f))
     Spacer(Modifier.width(8.dp))
     CompositionLocalProvider(LocalContentColor provides LocalContentColor.current.copy(alpha = ContentAlpha.medium)) {

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/singleitem/SingleItemDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/singleitem/SingleItemDestination.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import arrow.core.nonEmptyListOf
@@ -115,7 +117,7 @@ private fun SingleItemScreen(
     Spacer(Modifier.height(22.dp))
     uiState.itemBrandsUiState.asContent()?.let { itemBrandsUiState ->
       Spacer(Modifier.height(10.dp))
-      Brands(itemBrandsUiState, selectBrand, imageLoader, sideSpacingModifier)
+      Brands(itemBrandsUiState, uiState.canSubmit, selectBrand, imageLoader, sideSpacingModifier)
       Spacer(Modifier.height(10.dp))
     }
     val itemModelsUiStateContent = uiState.itemModelsUiState.asContent()
@@ -126,7 +128,7 @@ private fun SingleItemScreen(
     ) {
       Column {
         Spacer(Modifier.height(10.dp))
-        Models(itemModelsUiStateContent, selectModel, imageLoader, sideSpacingModifier)
+        Models(itemModelsUiStateContent, uiState.canSubmit, selectModel, imageLoader, sideSpacingModifier)
         Spacer(Modifier.height(10.dp))
       }
     }
@@ -141,7 +143,7 @@ private fun SingleItemScreen(
     Spacer(Modifier.height(10.dp))
     uiState.itemProblemsUiState.asContent()?.let { itemProblemsUiState ->
       Spacer(Modifier.height(10.dp))
-      ItemProblems(itemProblemsUiState, selectProblem, imageLoader, sideSpacingModifier)
+      ItemProblems(itemProblemsUiState, uiState.canSubmit, selectProblem, imageLoader, sideSpacingModifier)
       Spacer(Modifier.height(10.dp))
     }
     Spacer(Modifier.height(10.dp))
@@ -160,6 +162,7 @@ private fun SingleItemScreen(
 @Composable
 private fun Models(
   uiState: ItemModelsUiState.Content?,
+  enabled: Boolean,
   selectModel: (ItemModel) -> Unit,
   imageLoader: ImageLoader,
   modifier: Modifier = Modifier,
@@ -183,6 +186,7 @@ private fun Models(
 
   FormRowCard(
     onClick = { showDialog = true },
+    enabled = enabled,
     modifier = modifier,
   ) {
     Text(stringResource(R.string.claims_item_screen_model_button))
@@ -200,6 +204,7 @@ private fun Models(
 @Composable
 private fun Brands(
   uiState: ItemBrandsUiState.Content,
+  enabled: Boolean,
   selectBrand: (ItemBrand) -> Unit,
   imageLoader: ImageLoader,
   modifier: Modifier,
@@ -223,6 +228,7 @@ private fun Brands(
 
   FormRowCard(
     onClick = { showDialog = true },
+    enabled = enabled,
     modifier = modifier,
   ) {
     Text(stringResource(R.string.SINGLE_ITEM_INFO_BRAND))
@@ -286,6 +292,7 @@ private fun PriceOfPurchase(
 @Composable
 private fun ItemProblems(
   uiState: ItemProblemsUiState.Content,
+  enabled: Boolean,
   selectProblem: (ItemProblem) -> Unit,
   imageLoader: ImageLoader,
   modifier: Modifier,
@@ -307,6 +314,7 @@ private fun ItemProblems(
 
   FormRowCard(
     onClick = { showDialog = true },
+    enabled = enabled,
     modifier = modifier,
   ) {
     Text("Damage") // todo string resource "Damage"
@@ -329,7 +337,9 @@ private fun ItemProblems(
 
 @HedvigPreview
 @Composable
-private fun PreviewSingleItemScreen() {
+private fun PreviewSingleItemScreen(
+  @PreviewParameter(IsLoadingPreviewProvider::class) isLoading: Boolean,
+) {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       SingleItemScreen(
@@ -348,7 +358,7 @@ private fun PreviewSingleItemScreen() {
             nonEmptyListOf(ItemProblem("Item Problem", "")),
             listOf(ItemProblem("Item Problem", "")),
           ),
-          isLoading = false,
+          isLoading = isLoading,
           hasError = false,
           nextStep = null,
         ),
@@ -359,3 +369,5 @@ private fun PreviewSingleItemScreen() {
     }
   }
 }
+
+private class IsLoadingPreviewProvider : CollectionPreviewParameterProvider<Boolean>(listOf(false, true))

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryDestination.kt
@@ -112,9 +112,9 @@ private fun ClaimSummaryScreen(
     Spacer(Modifier.height(100.dp))
     ItemIcon(uiState.claimSummaryInfoUiState, imageLoader, sideSpacingModifier)
     Spacer(Modifier.height(20.dp))
-    uiState.claimSummaryInfoUiState.flowName?.let { flowName ->
+    uiState.claimSummaryInfoUiState.claimTypeTitle?.let { claimTypeTitle ->
       Text(
-        text = flowName,
+        text = claimTypeTitle,
         style = MaterialTheme.typography.titleLarge,
         modifier = sideSpacingModifier,
       )
@@ -276,7 +276,7 @@ private fun PreviewClaimSummaryScreen() {
         ClaimSummaryUiState(
           claimSummaryInfoUiState = ClaimSummaryInfoUiState(
             imageUrl = "https://fdn2.gsmarena.com/vv/bigpic/apple-iphone-14-pro.jpg",
-            flowName = "TODO Broken Phone",
+            claimTypeTitle = "Broken Phone",
             dateOfIncident = LocalDate.parse("2023-03-24"),
             locationOption = LocationOption(
               value = "IN_HOME_COUNTRY",

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryDestination.kt
@@ -59,10 +59,10 @@ import com.hedvig.android.odyssey.step.summary.resources.HedvigDeviceUnknown
 import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
 import com.hedvig.odyssey.compose.getLocale
 import hedvig.resources.R
+import java.time.format.DateTimeFormatter
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
 import octopus.type.CurrencyCode
-import java.time.format.DateTimeFormatter
 
 @Composable
 internal fun ClaimSummaryDestination(
@@ -222,10 +222,10 @@ private fun ItemDetailsText(
 
 @Composable
 private fun formatItemDetailsText(
-    itemType: ClaimSummaryInfoUiState.ItemType?,
-    dateOfPurchase: LocalDate?,
-    priceOfPurchase: UiNullableMoney?,
-    itemProblems: List<ItemProblem>,
+  itemType: ClaimSummaryInfoUiState.ItemType?,
+  dateOfPurchase: LocalDate?,
+  priceOfPurchase: UiNullableMoney?,
+  itemProblems: List<ItemProblem>,
 ): String? {
   val purchasedAndPaidText = run {
     if (dateOfPurchase == null) return@run null

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryViewModel.kt
@@ -11,6 +11,7 @@ import com.hedvig.android.odyssey.navigation.ItemModel
 import com.hedvig.android.odyssey.navigation.ItemProblem
 import com.hedvig.android.odyssey.navigation.LocationOption
 import com.hedvig.android.odyssey.navigation.UiNullableMoney
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -22,7 +23,6 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import octopus.type.FlowClaimItemBrandInput
 import octopus.type.FlowClaimItemModelInput
-import kotlin.time.Duration.Companion.seconds
 
 internal class ClaimSummaryViewModel(
   private val summary: ClaimFlowDestination.Summary,
@@ -118,14 +118,14 @@ internal data class ClaimSummaryStatusUiState(
 }
 
 internal data class ClaimSummaryInfoUiState(
-    val imageUrl: String?,
-    val flowName: String?, // e.g "Broken Phone"
-    val dateOfIncident: LocalDate?,
-    val locationOption: LocationOption?,
-    val itemType: ItemType?,
-    val dateOfPurchase: LocalDate?,
-    val priceOfPurchase: UiNullableMoney?,
-    val itemProblems: List<ItemProblem>,
+  val imageUrl: String?,
+  val flowName: String?, // e.g "Broken Phone"
+  val dateOfIncident: LocalDate?,
+  val locationOption: LocationOption?,
+  val itemType: ItemType?,
+  val dateOfPurchase: LocalDate?,
+  val priceOfPurchase: UiNullableMoney?,
+  val itemProblems: List<ItemProblem>,
 ) {
   sealed interface ItemType {
 

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryViewModel.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/summary/ClaimSummaryViewModel.kt
@@ -119,7 +119,7 @@ internal data class ClaimSummaryStatusUiState(
 
 internal data class ClaimSummaryInfoUiState(
   val imageUrl: String?,
-  val flowName: String?, // e.g "Broken Phone"
+  val claimTypeTitle: String?, // e.g "Broken Phone"
   val dateOfIncident: LocalDate?,
   val locationOption: LocationOption?,
   val itemType: ItemType?,
@@ -165,7 +165,7 @@ internal data class ClaimSummaryInfoUiState(
           ?.firstOrNull { it.asKnown()?.itemModelId == summary.selectedItemModel }
           ?.asKnown()
           ?.imageUrl,
-        flowName = "TODO Broken Phone", // Maybe backend should return this in the summary response?
+        claimTypeTitle = summary.claimTypeTitle,
         dateOfIncident = summary.dateOfOccurrence,
         locationOption = summary.locationOptions.firstOrNull { it.value == summary.selectedLocation },
         itemType = ItemType.fromSummary(summary),

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ui/SingleSelectDialog.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ui/SingleSelectDialog.kt
@@ -9,12 +9,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ListItem
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -22,10 +26,12 @@ import androidx.compose.ui.window.Dialog
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun <T> SingleSelectDialog(
+internal fun <T> SingleSelectDialog(
   title: String,
   optionsList: List<T>,
   onSelected: (T) -> Unit,
@@ -36,52 +42,126 @@ fun <T> SingleSelectDialog(
   onDismissRequest: () -> Unit,
 ) {
   Dialog(onDismissRequest = { onDismissRequest.invoke() }) {
-    Surface(shape = MaterialTheme.shapes.large) {
-      Column {
-        Spacer(modifier = Modifier.height(24.dp))
-        Text(
-          text = title,
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(horizontal = 24.dp),
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-        LazyColumn(
-          contentPadding = PaddingValues(bottom = 12.dp),
-        ) {
-          items(
-            items = optionsList,
-            key = { option: T -> getId(option) },
-            contentType = { "Option" },
-          ) { option: T ->
-            ListItem(
-              text = { Text(text = getDisplayText(option)) },
-              icon = if (getImageUrl(option) != null) {
-                {
-                  AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                      .data(getImageUrl(option))
-                      .crossfade(true)
-                      .build(),
-                    contentDescription = "Icon",
-                    imageLoader = imageLoader,
-                    modifier = Modifier
-                      .width(20.dp)
-                      .height(34.dp),
-                  )
-                }
-              } else {
-                null
-              },
-              modifier = Modifier
-                .clickable {
-                  onSelected(option)
-                  onDismissRequest()
-                }
-                .padding(horizontal = 12.dp),
-            )
-          }
+    SelectionContent(
+      title = title,
+      optionsList = optionsList,
+      getId = getId,
+      getDisplayText = getDisplayText,
+      getIsSelected = null,
+      getImageUrl = getImageUrl,
+      imageLoader = imageLoader,
+      onSelected = {
+        onDismissRequest()
+        onSelected(it)
+      },
+    )
+  }
+}
+
+@Composable
+internal fun <T> MultiSelectDialog(
+  title: String,
+  optionsList: List<T>,
+  onSelected: (T) -> Unit,
+  getDisplayText: (T) -> String,
+  getIsSelected: (T) -> Boolean,
+  getImageUrl: (T) -> String?,
+  getId: (T) -> String,
+  imageLoader: ImageLoader,
+  onDismissRequest: () -> Unit,
+) {
+  Dialog(onDismissRequest = { onDismissRequest.invoke() }) {
+    SelectionContent(
+      title = title,
+      optionsList = optionsList,
+      getId = getId,
+      getDisplayText = getDisplayText,
+      getIsSelected = getIsSelected,
+      getImageUrl = getImageUrl,
+      imageLoader = imageLoader,
+      onSelected = onSelected,
+    )
+  }
+}
+
+@Composable
+private fun <T> SelectionContent(
+  title: String,
+  optionsList: List<T>,
+  getId: (T) -> String,
+  getDisplayText: (T) -> String,
+  getIsSelected: ((T) -> Boolean)?,
+  getImageUrl: (T) -> String?,
+  imageLoader: ImageLoader,
+  onSelected: (T) -> Unit,
+) {
+  Surface(shape = MaterialTheme.shapes.large) {
+    Column {
+      Spacer(modifier = Modifier.height(24.dp))
+      Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.padding(horizontal = 24.dp),
+      )
+      Spacer(modifier = Modifier.height(12.dp))
+      LazyColumn(
+        contentPadding = PaddingValues(bottom = 12.dp),
+      ) {
+        items(
+          items = optionsList,
+          key = { option: T -> getId(option) },
+          contentType = { "Option" },
+        ) { option: T ->
+          ListItem(
+            headlineText = { Text(text = getDisplayText(option)) },
+            leadingContent = if (getImageUrl(option) != null) {
+              {
+                AsyncImage(
+                  model = ImageRequest.Builder(LocalContext.current)
+                    .data(getImageUrl(option))
+                    .crossfade(true)
+                    .build(),
+                  contentDescription = "Icon",
+                  imageLoader = imageLoader,
+                  modifier = Modifier
+                    .width(20.dp)
+                    .height(34.dp),
+                )
+              }
+            } else {
+              null
+            },
+            trailingContent = {
+              if (getIsSelected?.invoke(option) == true) {
+                Icon(Icons.Default.Check, null)
+              }
+            },
+            modifier = Modifier
+              .clickable { onSelected(option) }
+              .padding(horizontal = 12.dp),
+          )
         }
       }
+    }
+  }
+}
+
+@HedvigPreview
+@Composable
+private fun PreviewSelectionContent() {
+  val selectedOptions = remember { mutableStateListOf(0, 5) }
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      SelectionContent(
+        title = "Title",
+        optionsList = List(10) { it },
+        getId = Int::toString,
+        getDisplayText = Int::toString,
+        getIsSelected = { selectedOptions.contains(it) },
+        getImageUrl = { null },
+        imageLoader = rememberPreviewImageLoader(),
+        onSelected = { selectedOptions.add(it) },
+      )
     }
   }
 }


### PR DESCRIPTION
Had an issue with some items not looking disabled while loading

| Before | After |
| --- | --- |
| <img width="244" alt="image" src="https://user-images.githubusercontent.com/44558292/230110954-46255d70-7c8e-4d0b-a073-513dbfe9b5e2.png"> | <img width="244" alt="image" src="https://user-images.githubusercontent.com/44558292/230112065-6920014d-ffbe-4942-9360-22f9502d7366.png"> |

Now allows the user to select multiple items in the damage section, instead of instantly dismissing the dialog as soon as the first selection is done

<img width="352" alt="image" src="https://user-images.githubusercontent.com/44558292/230119411-edc18513-2fe9-4017-9030-e16315877111.png">

And replace the title in the summary step with the one coming from the backend as it now exists in the GQL schema

| Before | After |
| --- | --- |
| <img width="191" alt="image" src="https://user-images.githubusercontent.com/44558292/230128843-c72703b3-4d06-4eb9-8a60-4bf6bbc4f595.png"> | <img width="191" alt="image" src="https://user-images.githubusercontent.com/44558292/230128996-a5a08b34-2785-43f9-b4fb-b6b9d46462d1.png"> |


