### PR TITLE
Bump to AGP 8.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,6 @@ android {
   buildFeatures {
     buildConfig = true
     viewBinding = true
-    aidl = false
-    renderScript = false
   }
 
   defaultConfig {
@@ -47,7 +45,7 @@ android {
     abortOnError = false
   }
 
-  packagingOptions {
+  packaging {
     resources {
       excludes += "javamoney.properties"
       excludes += "README.txt"

--- a/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
@@ -24,9 +24,6 @@ class LibraryConventionPlugin : Plugin<Project> {
         defaultConfig.targetSdk = libs.versions.targetSdkVersion.get().toInt()
         @Suppress("UnstableApiUsage")
         buildFeatures {
-          buildConfig = false
-          aidl = false
-          renderScript = false
           resValues = false
           shaders = false
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,3 @@ systemProp.org.gradle.android.cache-fix.ignoreVersionCheck=true
 android.useAndroidX=true
 android.experimental.cacheCompileLibResources=true
 android.experimental.enableSourceSetPathsMap=true
-
-# Context: https://blog.blundellapps.co.uk/speed-up-your-build-non-transitive-r-files/
-android.nonTransitiveRClass=true
-# Context: https://issuetracker.google.com/issues/244063664#comment5
-# Remove when bumping to AGP 8.x.x
-android.disableResourceValidation=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdkVersion = "33"
 minSdkVersion = "23"
 
 # gradlePlugin versions
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0"
 apollo = "3.7.4"
 buildTimeTracker = "0.11.0"
 cacheFix = "2.7.0"

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -4,16 +4,8 @@ plugins {
   id("hedvig.android.ktlint")
 }
 
-@Suppress("UnstableApiUsage")
 android {
   namespace = "com.hedvig.android.design.showcase"
-
-  buildFeatures {
-    buildConfig = false
-    viewBinding = false
-    aidl = false
-    renderScript = false
-  }
 
   defaultConfig {
     applicationId = "com.hedvig.android.design.showcase"


### PR DESCRIPTION
buildconfig is now false by default.
Same for renderScript and aidl.

This allows us to use the new capabilities of Android Studio Flamingo which is the current latest stable and remove some workarounds we've had for a couple of little things.

Also, this requires for you to use JDK 17. There's this section which helps with that https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp