### PR TITLE
Fix app resetting when opening it from home screen

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.hedvig.app
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -38,10 +37,20 @@ class MainActivity : AppCompatActivity() {
     installSplashScreen().setKeepOnScreenCondition { true }
     super.onCreate(savedInstanceState)
     languageService.performOnLaunchLanguageCheck()
-    getLoginStatusAndNavigate(intent)
+    val isBringingToFront = intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0
+    val resetTaskIfNeeded = intent.flags and Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED != 0
+    if (isBringingToFront && resetTaskIfNeeded) {
+      // We've started the app from the home screen after it was put there by pressing the home button, and not going
+      // back from the start destination. In this case, do not override the existing backstack.
+      // And since `MainActivity` is added at the top of the backstack, we need to simply pop it out and we're good.
+      // This fixes the bug in DK where exiting the app, entering the auth info, and clicking on the app in the home
+      // screen to come back to the app fails by navigating to the marketing screen again, and failing authentication.
+      onBackPressedDispatcher.onBackPressed()
+    } else {
+      getLoginStatusAndNavigate(intent)
+    }
   }
 
-  @SuppressLint("MissingSuperCall")
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     getLoginStatusAndNavigate(intent)


### PR DESCRIPTION
The combination of FLAG_ACTIVITY_BROUGHT_TO_FRONT and FLAG_ACTIVITY_RESET_TASK_IF_NEEDED is true when specifically, the app is opened by clicking the home screen icon, while the app was already running and was present in the "recents" view.

All this due to our multi-activity setup, so if we ever manage to use a single activity setup, or at least handle the login screen along with the loggedIn screen in one activity, we can remove this workaround.

We figured this out by testing this together with Anna here https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1681739007104209?thread_ts=1680765598.502819&cid=CPCUHMMJQ
After this is released we will be able to test this again with her, but for now I've tested the exact same scenario which failed for us and it now worked!

It is a workaround, that's for sure, and the code itself is cryptic, but I try to explain all of it with my comment in there.