### PR TITLE
Claim flow audio permission

### DIFF
--- a/core-common-android/src/main/kotlin/com/hedvig/android/core/common/android/JSONObject.kt
+++ b/core-common-android/src/main/kotlin/com/hedvig/android/core/common/android/JSONObject.kt
@@ -13,7 +13,7 @@ fun jsonObjectOf(vararg properties: Pair<String, Any?>) = JSONObject().apply {
 fun Map<*, *>.toJsonObject(): JSONObject = entries.fold(JSONObject()) { acc, entry ->
   val entryKey = entry.key
   if (entryKey !is String) {
-    error("Only `Map<String, Any?>` may be converted to `JSONObject`")
+    throw IllegalArgumentException("Only `Map<String, Any?>` may be converted to `JSONObject`")
   }
   val entryValue = entry.value
   acc.put(entryKey, convertValueToJson(entryValue))

--- a/core-ui/src/main/kotlin/com/hedvig/android/core/ui/permission/PermissionDialog.kt
+++ b/core-ui/src/main/kotlin/com/hedvig/android/core/ui/permission/PermissionDialog.kt
@@ -1,0 +1,89 @@
+package com.hedvig.android.core.ui.permission
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+
+/**
+ * [permissionDescription] The text which will be used as the description of why we want this permission
+ * [isPermanentlyDeclined] Fetched by querying [android.app.Activity.shouldShowRequestPermissionRationale]. We can rely
+ *   on this only when we've already received a negative response from the rememberNotificationPermissionState callback
+ * [onDismiss] Used to dismiss the dialog itself
+ * [okClick] The callback when we know we can ask for the permission. Should be permissionState::launchPermissionRequest
+ * [openAppSettings] This gets triggered when we know we've been declined the permission, to open the app settings
+ *
+ *  Sample usage:
+ *  ```
+ *  var showDialog by remember { mutableStateOf(false) }
+ *  val permissionState: PermissionState = rememberPermissionState(Manifest.permission.FOO) { isGranted ->
+ *    if (isGranted) {
+ *      doActionWithPermissionGranted()
+ *    } else {
+ *      showDialog = true
+ *    }
+ *  }
+ *  if (showDialog) {
+ *    PermissionDialog(
+ *      permissionDescription = stringResource(R.string.PERMISSION_DIALOG_RECORD_AUDIO_MESSAGE),
+ *      isPermanentlyDeclined = !shouldShowRequestPermissionRationale(Manifest.permission.FOO),
+ *      onDismiss = { showDialog = false },
+ *      okClick = permissionState::launchPermissionRequest,
+ *      openAppSettings = openAppSettings,
+ *    )
+ *  }
+ *  // and then to use it
+ *  SomeComposable(
+ *    // This will ask for permission and then do the action or do the action directly when the permission is already given
+ *    onClick = permissionState.launchPermissionRequest()
+ *  )
+ *  ```
+ */
+@Composable
+fun PermissionDialog(
+  permissionDescription: String,
+  isPermanentlyDeclined: Boolean,
+  onDismiss: () -> Unit,
+  okClick: () -> Unit,
+  openAppSettings: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    dismissButton = {
+      TextButton(
+        onClick = onDismiss,
+        shape = MaterialTheme.shapes.medium,
+      ) {
+        Text(stringResource(android.R.string.cancel))
+      }
+    },
+    confirmButton = {
+      TextButton(
+        onClick = {
+          onDismiss()
+          if (isPermanentlyDeclined) {
+            openAppSettings()
+          } else {
+            okClick()
+          }
+        },
+        shape = MaterialTheme.shapes.medium,
+      ) {
+        Text(
+          if (isPermanentlyDeclined) {
+            stringResource(hedvig.resources.R.string.profile_appSettingsSection_title)
+          } else {
+            stringResource(android.R.string.ok)
+          },
+        )
+      }
+    },
+    title = { Text(stringResource(hedvig.resources.R.string.PERMISSION_DIALOG_TITLE)) },
+    text = { Text(permissionDescription) },
+    modifier = modifier,
+  )
+}

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
@@ -95,6 +95,7 @@ internal fun NavGraphBuilder.claimFlowGraph(
         viewModel = viewModel,
         windowSizeClass = windowSizeClass,
         questions = questions,
+        shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale,
         openAppSettings = openAppSettings,
         navigateToNextStep = { claimFlowStep ->
           viewModel.handledNextStepNavigation()

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/navigation/ClaimFlowGraph.kt
@@ -100,7 +100,7 @@ internal fun NavGraphBuilder.claimFlowGraph(
           viewModel.handledNextStepNavigation()
           navController.navigate(claimFlowStep.toClaimFlowDestination())
         },
-        navigateBack = { navController.navigateUp() || navigateUp() },
+        navigateUp = { navController.navigateUp() || navigateUp() },
       )
     }
     animatedComposable<ClaimFlowDestination.DateOfOccurrence> {

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/audiorecording/AudioRecordingDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/audiorecording/AudioRecordingDestination.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
@@ -15,19 +14,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -36,7 +30,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -49,16 +42,15 @@ import com.hedvig.android.core.designsystem.component.button.LargeContainedTextB
 import com.hedvig.android.core.designsystem.component.button.LargeTextButton
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.card.HedvigCardElevation
-import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
-import com.hedvig.android.core.ui.progress.FullScreenHedvigProgress
-import com.hedvig.android.core.ui.snackbar.ErrorSnackbar
+import com.hedvig.android.core.ui.snackbar.ErrorSnackbarState
 import com.hedvig.android.odyssey.data.ClaimFlowStep
+import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
 import com.hedvig.odyssey.renderers.audiorecorder.PlaybackWaveForm
 import com.hedvig.odyssey.renderers.audiorecorder.RecordingAmplitudeIndicator
 import com.hedvig.odyssey.renderers.utils.ScreenOnFlag
 import hedvig.resources.R
-import kotlinx.datetime.Clock
 import java.io.File
+import kotlinx.datetime.Clock
 
 @Composable
 internal fun AudioRecordingDestination(
@@ -67,7 +59,7 @@ internal fun AudioRecordingDestination(
   questions: List<String>,
   openAppSettings: () -> Unit,
   navigateToNextStep: (ClaimFlowStep) -> Unit,
-  navigateBack: () -> Unit,
+  navigateUp: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   val claimFlowStep = (uiState as? AudioRecordingUiState.Playback)?.nextStep
@@ -89,7 +81,7 @@ internal fun AudioRecordingDestination(
     pause = viewModel::pause,
     showedError = viewModel::showedError,
     openAppSettings = openAppSettings,
-    navigateBack = navigateBack,
+    navigateUp = navigateUp,
   )
 }
 
@@ -107,75 +99,49 @@ private fun AudioRecordingScreen(
   pause: () -> Unit,
   showedError: () -> Unit,
   openAppSettings: () -> Unit,
-  navigateBack: () -> Unit,
+  navigateUp: () -> Unit,
 ) {
-  Box(Modifier.fillMaxSize()) {
-    Column {
-      val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-      TopAppBarWithBack(
-        onClick = navigateBack,
-        title = stringResource(R.string.claims_incident_screen_header),
-        scrollBehavior = topAppBarScrollBehavior,
-      )
-      Column(
-        Modifier
-          .fillMaxSize()
-          .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-          .verticalScroll(rememberScrollState())
-          .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
+  ClaimFlowScaffold(
+    windowSizeClass = windowSizeClass,
+    navigateUp = navigateUp,
+    topAppBarText = stringResource(R.string.claims_incident_screen_header),
+    isLoading = false,
+    errorSnackbarState = ErrorSnackbarState(uiState.hasAudioSubmissionError, showedError),
+  ) { sideSpacingModifier ->
+    Spacer(Modifier.height(20.dp))
+    for (question in questions) {
+      HedvigCard(
+        shape = RoundedCornerShape(12.dp),
+        elevation = HedvigCardElevation.Elevated(),
+        modifier = sideSpacingModifier.padding(end = 16.dp),
       ) {
-        val sideSpacingModifier = if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
-          Modifier
-            .fillMaxWidth(0.8f)
-            .wrapContentWidth(Alignment.Start)
-            .align(Alignment.CenterHorizontally)
-        } else {
-          Modifier.padding(horizontal = 16.dp)
-        }
-        Spacer(Modifier.height(20.dp))
-        for (question in questions) {
-          HedvigCard(
-            shape = RoundedCornerShape(12.dp),
-            elevation = HedvigCardElevation.Elevated(),
-            modifier = sideSpacingModifier.padding(end = 16.dp),
-          ) {
-            Text(
-              text = question,
-              modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
-              style = MaterialTheme.typography.bodyLarge,
-            )
-          }
-          Spacer(Modifier.height(8.dp))
-        }
-        Spacer(Modifier.weight(1f))
-        Spacer(Modifier.height(16.dp))
-        AudioRecordingSection(
-          uiState = uiState,
-          clock = clock,
-          startRecording = startRecording,
-          stopRecording = stopRecording,
-          submitAudioFile = submitAudioFile,
-          redo = redo,
-          play = play,
-          pause = pause,
-          openAppSettings = openAppSettings,
-          modifier = sideSpacingModifier,
-        )
-        Spacer(Modifier.height(16.dp))
-        Spacer(
-          Modifier.windowInsetsPadding(
-            WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
-          ),
+        Text(
+          text = question,
+          modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
+          style = MaterialTheme.typography.bodyLarge,
         )
       }
+      Spacer(Modifier.height(8.dp))
     }
-    FullScreenHedvigProgress(show = (uiState as? AudioRecordingUiState.Playback)?.isLoading == true)
-    ErrorSnackbar(
-      hasError = uiState.hasAudioSubmissionError,
-      showedError = showedError,
-      modifier = Modifier
-        .align(Alignment.BottomCenter)
-        .windowInsetsPadding(WindowInsets.safeDrawing),
+    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(16.dp))
+    AudioRecordingSection(
+      uiState = uiState,
+      clock = clock,
+      startRecording = startRecording,
+      stopRecording = stopRecording,
+      submitAudioFile = submitAudioFile,
+      redo = redo,
+      play = play,
+      pause = pause,
+      openAppSettings = openAppSettings,
+      modifier = sideSpacingModifier,
+    )
+    Spacer(Modifier.height(16.dp))
+    Spacer(
+      Modifier.windowInsetsPadding(
+        WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
+      ),
     )
   }
 }
@@ -219,10 +185,6 @@ private fun AudioRecordingSection(
     redo = redo,
     play = play,
     pause = pause,
-    startRecordingText = stringResource(R.string.EMBARK_START_RECORDING),
-    stopRecordingText = stringResource(R.string.EMBARK_STOP_RECORDING),
-    recordAgainText = stringResource(R.string.EMBARK_RECORD_AGAIN),
-    submitClaimText = stringResource(R.string.general_continue_button),
     openAppSettings = openAppSettings,
     modifier = modifier,
   )
@@ -240,10 +202,6 @@ private fun AudioRecorder(
   redo: () -> Unit,
   play: () -> Unit,
   pause: () -> Unit,
-  startRecordingText: String,
-  stopRecordingText: String,
-  recordAgainText: String,
-  submitClaimText: String,
   openAppSettings: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -255,13 +213,11 @@ private fun AudioRecorder(
       when (uiState) {
         AudioRecordingUiState.NotRecording -> NotRecording(
           startRecording = startRecording,
-          startRecordingText = startRecordingText,
           modifier = modifier,
         )
         is AudioRecordingUiState.Recording -> Recording(
           uiState = uiState,
           stopRecording = stopRecording,
-          stopRecordingText = stopRecordingText,
           clock = clock,
           modifier = modifier,
         )
@@ -272,8 +228,6 @@ private fun AudioRecorder(
             val audioFile = File(filePath)
             submitAudioFile(audioFile)
           },
-          submitClaimText = submitClaimText,
-          recordAgainText = recordAgainText,
           redo = redo,
           play = play,
           pause = pause,
@@ -305,7 +259,6 @@ private fun DeniedMicrophonePermission(
 @Composable
 private fun NotRecording(
   startRecording: () -> Unit,
-  startRecordingText: String,
   modifier: Modifier = Modifier,
 ) {
   Column(
@@ -320,11 +273,11 @@ private fun NotRecording(
     ) {
       Image(
         painter = painterResource(com.hedvig.android.odyssey.R.drawable.ic_record),
-        contentDescription = startRecordingText,
+        contentDescription = stringResource(R.string.EMBARK_START_RECORDING),
       )
     }
     Text(
-      text = startRecordingText,
+      text = stringResource(R.string.EMBARK_START_RECORDING),
       style = MaterialTheme.typography.bodySmall,
       modifier = Modifier.padding(bottom = 16.dp),
     )
@@ -335,7 +288,6 @@ private fun NotRecording(
 private fun Recording(
   uiState: AudioRecordingUiState.Recording,
   stopRecording: () -> Unit,
-  stopRecordingText: String,
   clock: Clock,
   modifier: Modifier = Modifier,
 ) {
@@ -360,7 +312,7 @@ private fun Recording(
           painter = painterResource(
             com.hedvig.android.odyssey.R.drawable.ic_record_stop,
           ),
-          contentDescription = stopRecordingText,
+          contentDescription = stringResource(R.string.EMBARK_STOP_RECORDING),
         )
       }
     }
@@ -378,8 +330,6 @@ private fun Recording(
 private fun Playback(
   uiState: AudioRecordingUiState.Playback,
   submit: () -> Unit,
-  submitClaimText: String,
-  recordAgainText: String,
   redo: () -> Unit,
   play: () -> Unit,
   pause: () -> Unit,
@@ -403,7 +353,7 @@ private fun Playback(
 
     LargeContainedTextButton(
       onClick = submit,
-      text = submitClaimText,
+      text = stringResource(R.string.general_continue_button),
       enabled = uiState.canSubmit,
       modifier = Modifier.padding(top = 16.dp),
     )
@@ -413,7 +363,7 @@ private fun Playback(
       enabled = uiState.canSubmit,
       modifier = Modifier.padding(top = 8.dp),
     ) {
-      Text(recordAgainText)
+      Text(stringResource(R.string.EMBARK_RECORD_AGAIN))
     }
   }
 }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/notificationpermission/NotificationPermissionDestination.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/step/notificationpermission/NotificationPermissionDestination.kt
@@ -13,12 +13,10 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +38,7 @@ import com.hedvig.android.core.designsystem.component.button.LargeContainedTextB
 import com.hedvig.android.core.designsystem.component.button.LargeOutlinedTextButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.permission.PermissionDialog
 import com.hedvig.android.core.ui.preview.calculateForPreview
 import com.hedvig.android.odyssey.data.ClaimFlowStep
 import com.hedvig.android.odyssey.ui.ClaimFlowScaffold
@@ -95,7 +94,8 @@ private fun NotificationPermissionScreen(
       }
     }
     if (showDialog) {
-      NotificationPermissionDialog(
+      PermissionDialog(
+        permissionDescription = stringResource(R.string.CLAIMS_ACTIVATE_NOTIFICATIONS_BODY),
         isPermanentlyDeclined = !shouldShowNotificationPermissionRationale(shouldShowRequestPermissionRationale),
         onDismiss = { showDialog = false },
         okClick = notificationPermissionState::launchPermissionRequest,
@@ -173,51 +173,6 @@ private fun NotificationPermissionScreen(
     Spacer(Modifier.height(16.dp))
     Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)))
   }
-}
-
-@Composable
-private fun NotificationPermissionDialog(
-  isPermanentlyDeclined: Boolean,
-  onDismiss: () -> Unit,
-  okClick: () -> Unit,
-  openAppSettings: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  AlertDialog(
-    onDismissRequest = onDismiss,
-    dismissButton = {
-      TextButton(
-        onClick = onDismiss,
-        shape = MaterialTheme.shapes.medium,
-      ) {
-        Text(stringResource(android.R.string.cancel))
-      }
-    },
-    confirmButton = {
-      TextButton(
-        onClick = {
-          onDismiss()
-          if (isPermanentlyDeclined) {
-            openAppSettings()
-          } else {
-            okClick()
-          }
-        },
-        shape = MaterialTheme.shapes.medium,
-      ) {
-        Text(
-          if (isPermanentlyDeclined) {
-            stringResource(R.string.profile_appSettingsSection_title)
-          } else {
-            stringResource(android.R.string.ok)
-          },
-        )
-      }
-    },
-    title = { Text(stringResource(R.string.PERMISSION_DIALOG_TITLE)) },
-    text = { Text(stringResource(R.string.CLAIMS_ACTIVATE_NOTIFICATIONS_BODY)) },
-    modifier = modifier,
-  )
 }
 
 @OptIn(ExperimentalPermissionsApi::class)


### PR DESCRIPTION
Now uses the proper flow of asking for the permission on first action
click, then asking again if we are allowed to give them the rationale,
and allow them to go directly to settings if we are not allowed to show
them a rationale and we've been denied at least once.