### PR TITLE
Chat dialog on send error

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/FileUploadOutcome.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/FileUploadOutcome.kt
@@ -1,8 +1,0 @@
-package com.hedvig.app.feature.chat
-
-import android.net.Uri
-
-data class FileUploadOutcome(
-  val uri: Uri,
-  val wasSuccessful: Boolean,
-)

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/data/ChatRepository.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/data/ChatRepository.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.watch
+import com.hedvig.android.apollo.OperationResult
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.app.service.FileService
@@ -66,14 +67,19 @@ class ChatRepository(
   suspend fun sendChatMessage(
     id: String,
     message: String,
-  ) = apolloClient.mutation(
-    SendChatTextResponseMutation(
-      ChatResponseTextInput(
-        id,
-        ChatResponseBodyTextInput(message),
-      ),
-    ),
-  ).execute()
+  ): Either<OperationResult.Error, SendChatTextResponseMutation.Data> {
+    return apolloClient
+      .mutation(
+        SendChatTextResponseMutation(
+          ChatResponseTextInput(
+            id,
+            ChatResponseBodyTextInput(message),
+          ),
+        ),
+      )
+      .safeExecute()
+      .toEither()
+  }
 
   suspend fun sendSingleSelect(
     id: String,
@@ -112,7 +118,7 @@ class ChatRepository(
   }
 
   @SuppressLint("Recycle")
-  suspend fun uploadFileFromProvider(uri: Uri): ApolloResponse<UploadFileMutation.Data> {
+  suspend fun uploadFileFromProvider(uri: Uri): Either<OperationResult.Error, UploadFileMutation.Data> {
     val mimeType = fileService.getMimeType(uri)
     val file = File(
       context.cacheDir,
@@ -125,14 +131,14 @@ class ChatRepository(
     }
   }
 
-  suspend fun uploadFile(uri: Uri): ApolloResponse<UploadFileMutation.Data> =
+  suspend fun uploadFile(uri: Uri): Either<OperationResult.Error, UploadFileMutation.Data> =
     uploadFile(File(uri.path!!), fileService.getMimeType(uri))
 
   private suspend fun uploadFile(
     file: File,
     mimeType: String,
-  ): ApolloResponse<UploadFileMutation.Data> {
-    return apolloClient.mutation(UploadFileMutation(file.toUpload(mimeType))).execute()
+  ): Either<OperationResult.Error, UploadFileMutation.Data> {
+    return apolloClient.mutation(UploadFileMutation(file.toUpload(mimeType))).safeExecute().toEither()
   }
 
   suspend fun sendFileResponse(

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
@@ -24,6 +24,7 @@ import com.hedvig.app.feature.chat.viewmodel.ChatViewModel
 import com.hedvig.app.feature.settings.SettingsActivity
 import com.hedvig.app.util.extensions.calculateNonFullscreenHeightDiff
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
+import com.hedvig.app.util.extensions.composeContactSupportEmail
 import com.hedvig.app.util.extensions.handleSingleSelectLink
 import com.hedvig.app.util.extensions.hasPermissions
 import com.hedvig.app.util.extensions.showAlert
@@ -93,12 +94,14 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
           ChatViewModel.Event.Restart -> {
             triggerRestartActivity(ChatActivity::class.java)
           }
-
           is ChatViewModel.Event.Error -> showAlert(
-            title = com.adyen.checkout.dropin.R.string.error_dialog_title,
-            message = com.adyen.checkout.dropin.R.string.component_error,
-            positiveAction = {},
-            negativeLabel = null,
+            title = hedvig.resources.R.string.something_went_wrong,
+            message = hedvig.resources.R.string.NETWORK_ERROR_ALERT_MESSAGE,
+            positiveAction = {
+              composeContactSupportEmail()
+            },
+            positiveLabel = hedvig.resources.R.string.GENERAL_EMAIL_US,
+            negativeLabel = hedvig.resources.R.string.general_cancel_button,
           )
         }
       }

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
@@ -221,7 +221,7 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
         binding.input.clearInput()
       }
     }
-    chatViewModel.takePictureUploadOutcome.observe(this) {
+    chatViewModel.takePictureUploadFinished.observe(this) {
       attachPickerDialog?.uploadingTakenPicture(false)
       currentPhotoPath?.let { File(it).delete() }
     }

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.apollographql.apollo3.api.ApolloResponse
-import com.hedvig.app.feature.chat.FileUploadOutcome
 import com.hedvig.app.feature.chat.data.ChatEventStore
 import com.hedvig.app.feature.chat.data.ChatRepository
 import com.hedvig.app.util.LiveEvent
@@ -44,7 +43,7 @@ class ChatViewModel(
   val sendMessageResponse = MutableLiveData<Boolean>()
   val isUploading = LiveEvent<Boolean>()
   val uploadBottomSheetResponse = LiveEvent<UploadFileMutation.Data>()
-  val takePictureUploadOutcome = LiveEvent<FileUploadOutcome>()
+  val takePictureUploadFinished = LiveEvent<Unit>() // Reports that the picture upload was done, even if it failed
   val networkError = LiveEvent<Boolean>()
   val gifs = MutableLiveData<GifQuery.Data>()
 
@@ -160,8 +159,8 @@ class ChatViewModel(
   fun uploadTakenPicture(uri: Uri) {
     hAnalytics.chatRichMessageSent()
     viewModelScope.launch {
-      val data = uploadFileInner(uri) ?: return@launch
-      takePictureUploadOutcome.postValue(FileUploadOutcome(uri, !data.hasErrors()))
+      uploadFileInner(uri)
+      takePictureUploadFinished.postValue(Unit)
     }
   }
 

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
@@ -164,16 +164,26 @@ class ChatViewModel(
     }
   }
 
-  private suspend fun uploadFileInner(uri: Uri): ApolloResponse<UploadFileMutation.Data>? {
+  private suspend fun uploadFileInner(uri: Uri): UploadFileMutation.Data? {
     isSubscriptionAllowedToWrite = false
     isUploading.value = true
-    val response = runCatching { chatRepository.uploadFile(uri) }
-    if (response.isFailure) {
-      response.exceptionOrNull()?.let { e(it) }
-      return null
-    }
-    response.getOrNull()?.data?.uploadFile?.key?.let { respondWithFile(it, uri) }
-    return response.getOrNull()
+    val response = chatRepository.uploadFile(uri)
+    return response.fold(
+      ifLeft = { error ->
+        val throwable = error.throwable
+        if (throwable != null) {
+          e(throwable) { "Chat: uploadFileInner failed" }
+        } else {
+          e { "Chat: uploadFileInner failed. Message:${error.message}" }
+        }
+        _events.send(Event.Error)
+        null
+      },
+      ifRight = { data ->
+        respondWithFile(data.uploadFile.key, uri)
+        return data
+      },
+    )
   }
 
   fun uploadFileFromProvider(uri: Uri) {
@@ -181,18 +191,25 @@ class ChatViewModel(
     isSubscriptionAllowedToWrite = false
     isUploading.value = true
     viewModelScope.launch {
-      val response = runCatching { chatRepository.uploadFileFromProvider(uri) }
-      if (response.isFailure) {
-        response.exceptionOrNull()?.let { e(it) }
-        return@launch
-      }
-      response.getOrNull()?.data?.uploadFile?.key?.let { key ->
-        respondWithFile(
-          key,
-          uri,
-        )
-      }
-      response.getOrNull()?.data?.let(uploadBottomSheetResponse::postValue)
+      val response = chatRepository.uploadFileFromProvider(uri)
+      response.fold(
+        ifLeft = { error ->
+          val throwable = error.throwable
+          if (throwable != null) {
+            e(throwable) { "Chat: uploadFileFromProvider failed" }
+          } else {
+            e { "Chat: uploadFileFromProvider failed. Message:${error.message}" }
+          }
+          _events.send(Event.Error)
+        },
+        ifRight = { data ->
+          respondWithFile(
+            key = data.uploadFile.key,
+            uri = uri,
+          )
+          uploadBottomSheetResponse.postValue(data)
+        },
+      )
     }
   }
 
@@ -217,19 +234,25 @@ class ChatViewModel(
     isSendingMessage = true
     isSubscriptionAllowedToWrite = false
     viewModelScope.launch {
-      val response = runCatching {
-        chatRepository.sendChatMessage(getLastId(), message)
-      }
-      if (response.isFailure) {
-        isSendingMessage = false
-        response.exceptionOrNull()?.let { e(it) }
-        return@launch
-      }
+      val response = chatRepository.sendChatMessage(getLastId(), message)
       isSendingMessage = false
-      if (response.getOrNull()?.data?.sendChatTextResponse == true) {
-        load()
-      }
-      sendMessageResponse.postValue(response.getOrNull()?.data?.sendChatTextResponse)
+      response.fold(
+        ifLeft = { error ->
+          val throwable = error.throwable
+          if (throwable != null) {
+            e(throwable) { "Chat: Replying through ChatViewModel failed" }
+          } else {
+            e { "Chat: Replying through ChatViewModel failed. Message:${error.message}" }
+          }
+          _events.send(Event.Error)
+        },
+        ifRight = { data ->
+          if (data.sendChatTextResponse) {
+            load()
+          }
+          sendMessageResponse.postValue(data.sendChatTextResponse)
+        },
+      )
     }
   }
 

--- a/app/src/main/kotlin/com/hedvig/app/util/extensions/ActivityExtensions.kt
+++ b/app/src/main/kotlin/com/hedvig/app/util/extensions/ActivityExtensions.kt
@@ -2,6 +2,7 @@ package com.hedvig.app.util.extensions
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.content.Context
 import android.content.Intent
 import android.content.pm.LabeledIntent
 import android.content.pm.PackageManager
@@ -106,6 +107,23 @@ fun Activity.openEmail(title: String) {
     startActivity(openInChooser)
   } else {
     e { "No email app found" }
+  }
+}
+
+fun Context.composeContactSupportEmail(
+  emailAddresses: List<String> = listOf(getString(hedvig.resources.R.string.GENERAL_EMAIL)),
+  subject: String? = null,
+) {
+  val intent = Intent(Intent.ACTION_SENDTO).apply {
+    data = Uri.parse("mailto:") // only email apps should handle this
+    putExtra(Intent.EXTRA_EMAIL, emailAddresses.toTypedArray())
+    putExtra(Intent.EXTRA_SUBJECT, subject)
+  }
+  if (intent.resolveActivity(packageManager) != null) {
+    startActivity(intent)
+  } else {
+    e { "Failed to open email app through `composeEmail`" }
+    makeToast(hedvig.resources.R.string.login_open_email_app_button)
   }
 }
 


### PR DESCRIPTION
By the way, as I see from the code here, we did not clear the text itself even before my changes here (I didn't touch that part), if the network request failed. So that means that for the folks that were having issues, the network request seemed to work fine, and then the text was cleared. The problem was that even though the network request was OK, the message never arrived, which means it was for sure on the backend, and it also means that this change won't necessarily catch this issue again. Since from our perspective, sending the value worked fine.
Just some context on what I see here, but regardless, this is a good change.

* Add email opening function with hedvig support email prefilled

This does not open a bottom sheet to pick a mail, just opens it directly
 
* Remove unused FileUploadOutcome

Was only used to get a report that it's done, without using the result
in any way other than informing the UI that the operation is done. So
changed the model to reflect that fact.

Before, if it failed,
`attachPickerDialog?.uploadingTakenPicture(false)` would never be
called, and it'd be stuck on a loading state forever.
 
* Use safeExecute instead of runCatching

RunCatching is problematic as it catches even CancellationExceptions and
then reports them as slimber.e errors which is definitely not what we
want to do.
 
* Make the error dialog prompt to open an email app

The dialog now says that something went wrong and to check their
internet connection, and gives an option to contact us through opening
an email with the hedvig support email prefilled.

| When the error happens | After you click "Contact us" and you get the email prefilled |
| --- | --- |
| <img width="356" alt="image" src="https://user-images.githubusercontent.com/44558292/234838385-05406710-c0ee-48a3-962c-13ea7cbc8af3.png"> | <img width="356" alt="image" src="https://user-images.githubusercontent.com/44558292/234839394-a1d9ad64-e893-4fc3-961f-ca537dc069dc.png"> |