### PR TITLE
Bump to arrow 1.2.0

### DIFF
--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/data/ChatRepository.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/data/ChatRepository.kt
@@ -4,7 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.toUpload

--- a/app/src/main/kotlin/com/hedvig/app/feature/checkout/CheckoutViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/checkout/CheckoutViewModel.kt
@@ -3,7 +3,7 @@ package com.hedvig.app.feature.checkout
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.android.validation.ValidationResult
 import com.hedvig.android.core.common.android.validation.validateEmail

--- a/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/data/GetClaimDetailUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/claimdetail/data/GetClaimDetailUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.claimdetail.data
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.firstOrNone
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
@@ -29,7 +29,8 @@ class GetClaimDetailUseCase(
   suspend operator fun invoke(claimId: String): Either<Error, ClaimDetailsQuery.ClaimDetail> {
     return either {
       val data = queryCall.safeExecute().toEither { Error.NetworkError }.bind()
-      data.claimDetails.firstOrNone { it.id == claimId }.bind { Error.NoClaimFound }
+      val claimDetail = data.claimDetails.firstOrNull { it.id == claimId }
+      ensureNotNull(claimDetail) { Error.NoClaimFound }
     }
   }
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/crossselling/usecase/GetCrossSellsUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/crossselling/usecase/GetCrossSellsUseCase.kt
@@ -1,7 +1,7 @@
 package com.hedvig.app.feature.crossselling.usecase
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/data/GetContractsUseCase.kt
@@ -1,7 +1,7 @@
 package com.hedvig.app.feature.insurance.data
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.fetchPolicy

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/GetContractDetailsUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.insurance.ui.detail
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.fetchPolicy

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/GetContractCoverageUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/coverage/GetContractCoverageUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.insurance.ui.detail.coverage
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither

--- a/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/tab/InsuranceViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/tab/InsuranceViewModel.kt
@@ -3,7 +3,7 @@ package com.hedvig.app.feature.insurance.ui.tab
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.hedvig.android.notification.badge.data.crosssell.card.CrossSellCardNotificationBadgeService
 import com.hedvig.app.feature.crossselling.ui.CrossSellData
 import com.hedvig.app.feature.crossselling.usecase.GetCrossSellsUseCase

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferRepository.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferRepository.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.offer
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.fetchPolicy

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferViewModel.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/OfferViewModel.kt
@@ -3,8 +3,8 @@ package com.hedvig.app.feature.offer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.hanalytics.featureflags.FeatureManager

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/changestartdate/QuoteCartEditStartDateUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/changestartdate/QuoteCartEditStartDateUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.offer.ui.changestartdate
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/EditCampaignUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/EditCampaignUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.offer.usecase
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/GetQuoteCartCheckoutUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/GetQuoteCartCheckoutUseCase.kt
@@ -1,7 +1,7 @@
 package com.hedvig.app.feature.offer.usecase
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.fetchPolicy

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/ObserveOfferStateUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/ObserveOfferStateUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.offer.usecase
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.app.feature.embark.util.SelectedContractType
 import com.hedvig.app.feature.offer.OfferRepository

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/ObserveQuoteCartCheckoutUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/ObserveQuoteCartCheckoutUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.app.feature.offer.usecase
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.hedvig.android.apollo.OperationResult
 import com.hedvig.app.feature.offer.model.Checkout
 import com.hedvig.app.feature.offer.model.QuoteCartId

--- a/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/StartCheckoutUseCase.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/offer/usecase/StartCheckoutUseCase.kt
@@ -1,8 +1,9 @@
 package com.hedvig.app.feature.offer.usecase
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
@@ -40,6 +41,5 @@ class StartCheckoutUseCase(
   ): Either<ErrorMessage, QuoteCartStartCheckoutMutation.Data> = apolloClient
     .mutation(QuoteCartStartCheckoutMutation(quoteCartId.id, quoteIds))
     .safeExecute()
-    .toEither()
-    .mapLeft { ErrorMessage(it.message) }
+    .toEither(::ErrorMessage)
 }

--- a/app/src/main/kotlin/com/hedvig/app/feature/referrals/data/RedeemReferralCodeRepository.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/referrals/data/RedeemReferralCodeRepository.kt
@@ -19,7 +19,6 @@ class RedeemReferralCodeRepository(
     return apolloClient
       .mutation(RedeemReferralCodeMutation(campaignCode.code, languageService.getGraphQLLocale()))
       .safeExecute()
-      .toEither()
-      .mapLeft { ErrorMessage(it.message) }
+      .toEither(::ErrorMessage)
   }
 }

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/ClaimFlowRepository.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/data/ClaimFlowRepository.kt
@@ -1,8 +1,8 @@
 package com.hedvig.android.odyssey.data
 
 import arrow.core.Either
-import arrow.core.continuations.EffectScope
-import arrow.core.continuations.either
+import arrow.core.raise.Raise
+import arrow.core.raise.either
 import arrow.retrofit.adapter.either.networkhandling.CallError
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.Optional
@@ -253,7 +253,7 @@ internal class ClaimFlowRepositoryImpl(
     }
   }
 
-  private suspend fun EffectScope<ErrorMessage>.uploadAudioFile(flowId: String, file: File): AudioUrl {
+  private suspend fun Raise<ErrorMessage>.uploadAudioFile(flowId: String, file: File): AudioUrl {
     val result = odysseyService
       .uploadAudioRecordingFile(
         flowId = flowId,
@@ -272,7 +272,7 @@ internal class ClaimFlowRepositoryImpl(
     return AudioUrl(result.audioUrl)
   }
 
-  private suspend fun EffectScope<ErrorMessage>.nextClaimFlowStepWithAudioUrl(audioUrl: AudioUrl): ClaimFlowStep {
+  private suspend fun Raise<ErrorMessage>.nextClaimFlowStepWithAudioUrl(audioUrl: AudioUrl): ClaimFlowStep {
     val result = apolloClient
       .mutation(FlowClaimAudioRecordingNextMutation(audioUrl.value, claimFlowContext!!))
       .safeExecute()

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetNetworkClaimEntryPointsUseCase.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/search/GetNetworkClaimEntryPointsUseCase.kt
@@ -1,7 +1,7 @@
 package com.hedvig.android.odyssey.search
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
@@ -1,7 +1,7 @@
 package com.hedvig.android.feature.terminateinsurance.data
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither


### PR DESCRIPTION
Use the new 1.2.0 Arrow APIs.
This is the last arrow bump which changes the imports and so on, in preparation for Arrow 2.0 which will contain all these APIs, and remove all the deprecated ones.

Main changes are in the imports, and this PR changes all of them. Along with a couple of functions that we may have been using which are deprecated and will be removed shortly.