### PR TITLE
Remove all unused permissions, most importantly, the camera one

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ run `./gradlew ktlintFormat` to make ktlint to format all files according to the
 
 ![Module graph](misc/images/modularization-graph.png "Image showing the module dependencies graph")
 
-Generated from `./gradlew :generateProjectDependencyGraph`*\
+Generated from `./gradlew :generateProjectDependencyGraph --no-configuration-cache`*\
 *Note that this requires `dot` from graphviz to be on your path. Run `brew install graphviz`
 
 ## Renovate

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -11,6 +11,5 @@
     <string name="BASE_URL" translatable="false">https://graphql.dev.hedvigit.com</string>
     <string name="WEB_BASE_URL" translatable="false">https://www.dev.hedvigit.com</string>
     <string name="HANALYTICS_URL" translatable="false">https://hanalytics.dev.hedvigit.com</string>
-    <string name="file_provider_authority" translatable="false">com.hedvig.android.dev.file.provider</string>
     <string name="ODYSSEY_URL" translatable="false">https://odyssey.dev.hedvigit.com</string>
 </resources>

--- a/app/src/debug/res/xml/file_paths.xml
+++ b/app/src/debug/res/xml/file_paths.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <external-path name="my_images" path="Android/data/com.hedvig.dev.app/files/Pictures" />
-</paths>

--- a/app/src/debug/res/xml/provider_paths.xml
+++ b/app/src/debug/res/xml/provider_paths.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!---
+    This is used by a file provider defined in `AndroidManifest.xml` and is used by the chat.
+    The `name` value "chat_pictures" does not hold any significance in how we call this.
+    This is called from a `androidx.core.content.FileProvider` provider which also sets the
+    AUTHORITY string.
+    Then in the code, create a file targeting this place, through
+    `val file = File(getExternalFilesDir(Environment.DIRECTORY_PICTURES), "someNewFileName.jpg")`
+    Then grabbing the URI for that file using the authority
+    `val photoUri = FileProvider.getUriForFile(context, AUTHORITY, file)`
+    That directory often looks something like this
+    `/storage/emulated/0/Android/data/com.hedvig.dev.app/files/Pictures/someNewFileName.jpg.`
+    The `Pictures/` directory comes from the Environment.DIRECTORY_PICTURES just as a directory to
+    better indicate that it's a directory of pictures.
+
+    Sample code
+    ```kotlin
+    val newPhotoFile: File = File(getExternalFilesDir(Environment.DIRECTORY_PICTURES), "JPEG_${System.currentTimeMillis()}.jpg")
+    val newPhotoUri: Uri = FileProvider.getUriForFile(this@Context, "${BuildConfig.APPLICATION_ID}.provider", newPhotoFile)
+    ```
+
+    More context in all this: https://commonsware.com/Jetpack/pages/chap-files-005.html
+    -->
+    <external-path
+        name="chat_pictures"
+        path="/" />
+</paths>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,11 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -272,16 +268,15 @@
             android:name="firebase_messaging_auto_init_enabled"
             android:value="false" />
 
+        <!-- Context for this: https://commonsware.com/Jetpack/pages/chap-files-005.html -->
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="@string/file_provider_authority"
+            android:authorities="${applicationId}.provider"
             android:exported="false"
-            android:grantUriPermissions="true"
-            tools:replace="android:authorities">
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths"
-                tools:replace="android:resource" />
+                android:resource="@xml/provider_paths" />
         </provider>
 
         <service

--- a/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
+++ b/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
@@ -1,12 +1,8 @@
 package com.hedvig.app.feature.chat.ui
 
-import android.Manifest
-import android.app.Activity
-import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
-import android.provider.MediaStore
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
@@ -15,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import coil.ImageLoader
 import com.hedvig.android.auth.android.AuthenticatedObserver
+import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import com.hedvig.app.authenticate.LogoutUseCase
 import com.hedvig.app.databinding.ActivityChatBinding
@@ -26,9 +23,7 @@ import com.hedvig.app.util.extensions.calculateNonFullscreenHeightDiff
 import com.hedvig.app.util.extensions.compatSetDecorFitsSystemWindows
 import com.hedvig.app.util.extensions.composeContactSupportEmail
 import com.hedvig.app.util.extensions.handleSingleSelectLink
-import com.hedvig.app.util.extensions.hasPermissions
 import com.hedvig.app.util.extensions.showAlert
-import com.hedvig.app.util.extensions.showPermissionExplanationDialog
 import com.hedvig.app.util.extensions.storeBoolean
 import com.hedvig.app.util.extensions.triggerRestartActivity
 import com.hedvig.app.util.extensions.view.applyStatusBarInsets
@@ -41,9 +36,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import slimber.log.d
 import slimber.log.e
 import java.io.File
-import java.io.IOException
 
 class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
   private val chatViewModel: ChatViewModel by viewModel()
@@ -61,25 +56,30 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
   private var preventOpenAttachFile = false
 
   private var attachPickerDialog: AttachPickerDialog? = null
+  private var forceScrollToBottom = true
 
   private var currentPhotoPath: String? = null
 
-  private var forceScrollToBottom = true
-
-  private val cameraPermission = Manifest.permission.CAMERA
-
-  private val cameraPermissionResultLauncher = registerForActivityResult(
-    ActivityResultContracts.RequestPermission(),
-  ) { permissionGranted ->
-    if (permissionGranted) {
-      startTakePicture()
-    } else {
-      showPermissionExplanationDialog(cameraPermission)
+  val takePictureLauncher = registerForActivityResult(ActivityResultContracts.TakePicture()) { didSucceed ->
+    d { "Take piture launcher result, didSucceed:$didSucceed, currentPhotoPath:$currentPhotoPath" }
+    if (didSucceed) {
+      currentPhotoPath?.let { tempFile ->
+        attachPickerDialog?.uploadingTakenPicture(true)
+        chatViewModel.uploadTakenPicture(Uri.fromFile(File(tempFile)))
+      }
     }
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putString("photo", currentPhotoPath)
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    if (savedInstanceState != null) {
+      currentPhotoPath = savedInstanceState.getString("photo")
+    }
     lifecycle.addObserver(AuthenticatedObserver())
 
     keyboardHeight = resources.getDimensionPixelSize(R.dimen.default_attach_file_height)
@@ -135,6 +135,12 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
   override fun onPause() {
     storeBoolean(ACTIVITY_IS_IN_FOREGROUND, false)
     super.onPause()
+  }
+
+  override fun finish() {
+    super.finish()
+    chatViewModel.onChatClosed()
+    overridePendingTransition(R.anim.stay_in_place, R.anim.chat_slide_down_out)
   }
 
   private fun initializeInput() {
@@ -227,6 +233,7 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
     chatViewModel.takePictureUploadFinished.observe(this) {
       attachPickerDialog?.uploadingTakenPicture(false)
       currentPhotoPath?.let { File(it).delete() }
+      currentPhotoPath = null
     }
 
     chatViewModel.networkError.observe(this) { networkError ->
@@ -287,11 +294,7 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
     val attachPickerDialog = AttachPickerDialog(this)
     attachPickerDialog.initialize(
       takePhotoCallback = {
-        if (hasPermissions(cameraPermission)) {
-          startTakePicture()
-        } else {
-          cameraPermissionResultLauncher.launch(cameraPermission)
-        }
+        startTakePicture()
       },
       showUploadBottomSheetCallback = {
         ChatFileUploadBottomSheet
@@ -330,63 +333,31 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
   }
 
   private fun startTakePicture() {
-    val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-    val storageDir: File = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-      ?: run {
-        e { "Could not getExternalFilesDir" }
-        return
-      }
-
-    val tempTakenPhotoFile = try {
-      File.createTempFile(
-        "JPEG_${System.currentTimeMillis()}_",
-        ".jpg",
-        storageDir,
-      ).apply {
-        currentPhotoPath = absolutePath
-      }
-    } catch (ex: IOException) {
-      e(ex) { "Error occurred while creating the photo file" }
-      null
-    }
-
-    tempTakenPhotoFile?.also { file ->
-      val photoURI: Uri = FileProvider.getUriForFile(
-        this,
-        getString(R.string.file_provider_authority),
-        file,
+    val externalPhotosDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES) ?: run {
+      e { "Could not getExternalFilesDir(Environment.DIRECTORY_PICTURES)" }
+      showAlert(
+        title = hedvig.resources.R.string.something_went_wrong,
+        positiveLabel = hedvig.resources.R.string.GENERAL_EMAIL_US,
+        positiveAction = { composeContactSupportEmail() },
       )
-      takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI)
-      startActivityForResult(
-        takePictureIntent,
-        TAKE_PICTURE_REQUEST_CODE,
-      )
+      return
     }
-  }
-
-  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-    super.onActivityResult(requestCode, resultCode, data)
-    when (requestCode) {
-      TAKE_PICTURE_REQUEST_CODE -> if (resultCode == Activity.RESULT_OK) {
-        currentPhotoPath?.let { tempFile ->
-          attachPickerDialog?.uploadingTakenPicture(true)
-
-          chatViewModel.uploadTakenPicture(Uri.fromFile(File(tempFile)))
-        }
-      }
+    val newPhotoFile: File = File(
+      externalPhotosDir,
+      "JPEG_${System.currentTimeMillis()}.jpg",
+    ).apply {
+      currentPhotoPath = absolutePath
     }
-  }
 
-  override fun finish() {
-    super.finish()
-    chatViewModel.onChatClosed()
-    overridePendingTransition(R.anim.stay_in_place, R.anim.chat_slide_down_out)
+    val newPhotoUri: Uri = FileProvider.getUriForFile(
+      this,
+      "${BuildConfig.APPLICATION_ID}.provider",
+      newPhotoFile,
+    )
+    takePictureLauncher.launch(newPhotoUri)
   }
 
   companion object {
-
-    private const val TAKE_PICTURE_REQUEST_CODE = 2371
-
     const val ACTIVITY_IS_IN_FOREGROUND = "chat_activity_is_in_foreground"
   }
 }

--- a/app/src/release/res/values/strings.xml
+++ b/app/src/release/res/values/strings.xml
@@ -11,7 +11,6 @@
     <string name="BASE_URL" translatable="false">https://giraffe.hedvig.com</string>
     <string name="WEB_BASE_URL" translatable="false">https://www.hedvig.com</string>
     <string name="HANALYTICS_URL" translatable="false">https://hanalytics.prod.hedvigit.com</string>
-    <string name="file_provider_authority" translatable="false">com.hedvig.android.file.provider</string>
     <string name="ODYSSEY_URL" translatable="false">https://odyssey.prod.hedvigit.com</string>
     <string name="AUTH_URL" translatable="false">"https://auth.prod.hedvigit.com"</string>
 </resources>

--- a/app/src/staging/res/values/strings.xml
+++ b/app/src/staging/res/values/strings.xml
@@ -11,7 +11,6 @@
     <string name="BASE_URL" translatable="false">https://graphql.dev.hedvigit.com</string>
     <string name="WEB_BASE_URL" translatable="false">https://www.dev.hedvigit.com</string>
     <string name="HANALYTICS_URL" translatable="false">https://hanalytics.dev.hedvigit.com</string>
-    <string name="file_provider_authority" translatable="false">com.hedvig.android.test.file.provider</string>
     <string name="ODYSSEY_URL" translatable="false">https://odyssey.dev.hedvigit.com</string>
     <string name="AUTH_URL" translatable="false">"https://auth.dev.hedvigit.com"</string>
 </resources>


### PR DESCRIPTION
This was part of what we wanted to do when we used the contract for fetching a file from the phone without using the permission. This was a tiny bit more involved, but still the same concept applies. No longer have to ask for a permission to see their camera, since we are not accessing anything, just letting their own camera app do the work, and we only get to see the resulting picture if they want to send it to us, we are not allowing ourselves to see anything more than that.

Use the camera activity result contracts instead to fetch a picture.
Rewrite a bit of the logic of where it's saved as a consequence of this change.
All this is explained in a comment inside provider_paths.xml

This change also fixes compared to before that in case we start the picture taking, while we're there our application is killed by the system, and then the user picks a picture and they come back, this flow still works, as we are saving the URI string through process death.