### PR TITLE
Bump to latest material3 dependency

### DIFF
--- a/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/datepicker/HedvigDatePicker.kt
+++ b/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/datepicker/HedvigDatePicker.kt
@@ -1,18 +1,19 @@
 package com.hedvig.android.core.designsystem.component.datepicker
 
-import androidx.compose.foundation.layout.height
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerColors
 import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.DatePickerFormatter
 import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.layout
-import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 
 /**
  * Renders the M3 DatePicker but after cutting a bit from the top and the bottom to match our design. Particularly, we
@@ -28,56 +29,40 @@ fun HedvigDatePicker(
   modifier: Modifier = Modifier,
   dateFormatter: DatePickerFormatter = remember { DatePickerFormatter() },
   dateValidator: (Long) -> Boolean = { true },
-  headline: @Composable () -> Unit = {
-    DatePickerDefaults.DatePickerHeadline(
-      datePickerState,
-      dateFormatter,
-    )
-  },
   colors: DatePickerColors = DatePickerDefaults.colors(
     selectedDayContainerColor = MaterialTheme.colorScheme.tertiary,
     selectedDayContentColor = MaterialTheme.colorScheme.onTertiary,
   ),
 ) {
   DatePicker(
-    datePickerState = datePickerState,
+    state = datePickerState,
     dateFormatter = dateFormatter,
     dateValidator = dateValidator,
-    title = {
-      // Explicitly set no text here, as we don't want it to render the default title but passing null is not
-      // supported from the current implementation of m3 DatePicker
-      Text("")
-    },
-    headline = headline,
     colors = colors,
-    modifier = modifier
-      .height(requiredDatePickerHeight)
-      .layout { measurable, constraints ->
-        val requiredHeight = datePickerRealHeight.roundToPx()
-        val placeable = measurable.measure(
-          constraints.copy(minHeight = requiredHeight, maxHeight = requiredHeight),
-        )
-        // If the layout size is bigger than incoming constraints, it will be centered in the parent. This finds
-        // the real parent's top y position
-        val actualZeroYPositionOfParent = (requiredHeight - constraints.maxHeight) / 2
-        layout(placeable.width, placeable.height) {
-          placeable.place(0, actualZeroYPositionOfParent - titleHeight.roundToPx())
-        }
-      },
+    modifier = modifier,
   )
 }
 
-// Specs below taken from https://m3.material.io/components/date-pickers/specs#2a458311-c7a0-42c3-a517-495fe0e1f75e
+@HedvigPreview
+@Composable
+private fun PreviewHedvigDatePickerSimple() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      HedvigDatePicker(
+        rememberDatePickerState(),
+      )
+    }
+  }
+}
 
-// We do not want to render the "Select date" title so we can cut this much above. Still allows for room to render when
-// on font scale x1.5
-private val titleHeight = 36.dp
-
-// We do not render the "Cancel" and "OK" buttons, so hide these too. Buttons + their padding
-private val buttonsHeight = (36 + 8).dp
-
-// https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/tokens/DatePickerModalTokens.kt;l=26
-private val datePickerRealHeight = 568.dp
-
-// The actual size of how much we want to render. The date picker, without the title and the buttons
-private val requiredDatePickerHeight = datePickerRealHeight - titleHeight - buttonsHeight
+@HedvigPreview
+@Composable
+private fun PreviewHedvigDatePickerInput() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      HedvigDatePicker(
+        rememberDatePickerState(initialDisplayMode = DisplayMode.Input),
+      )
+    }
+  }
+}

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ui/DatePickerRowCard.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ui/DatePickerRowCard.kt
@@ -1,14 +1,12 @@
 package com.hedvig.android.odyssey.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -22,10 +20,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import com.hedvig.android.core.designsystem.component.button.FormRowCard
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.datepicker.HedvigDatePicker
@@ -50,39 +46,32 @@ internal fun DatePickerRowCard(
 ) {
   var showDatePicker by rememberSaveable { mutableStateOf(false) }
   if (showDatePicker) {
-    Dialog(onDismissRequest = { showDatePicker = false }) {
-      Surface(
-        Modifier.clip(MaterialTheme.shapes.extraLarge),
-      ) {
-        Column {
-          HedvigDatePicker(
-            datePickerState = uiState.datePickerState,
-            dateValidator = uiState::validateDate,
-          )
-          Row(
-            modifier = Modifier
-              .fillMaxWidth()
-              .padding(12.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-          ) {
-            TextButton(
-              onClick = {
-                uiState.clearDateSelection()
-                showDatePicker = false
-              },
-              shape = MaterialTheme.shapes.medium,
-            ) {
-              Text(stringResource(R.string.GENERAL_NOT_SURE))
-            }
-            TextButton(
-              onClick = { showDatePicker = false },
-              shape = MaterialTheme.shapes.medium,
-            ) {
-              Text(stringResource(R.string.ALERT_OK))
-            }
-          }
+    DatePickerDialog(
+      onDismissRequest = { showDatePicker = false },
+      confirmButton = {
+        TextButton(
+          onClick = { showDatePicker = false },
+          shape = MaterialTheme.shapes.medium,
+        ) {
+          Text(stringResource(R.string.ALERT_OK))
         }
-      }
+      },
+      dismissButton = {
+        TextButton(
+          onClick = {
+            uiState.clearDateSelection()
+            showDatePicker = false
+          },
+          shape = MaterialTheme.shapes.medium,
+        ) {
+          Text(stringResource(R.string.GENERAL_NOT_SURE))
+        }
+      },
+    ) {
+      HedvigDatePicker(
+        datePickerState = uiState.datePickerState,
+        dateValidator = uiState::validateDate,
+      )
     }
   }
 
@@ -132,12 +121,12 @@ internal class DatePickerUiState(
   val datePickerState = DatePickerState(
     initialSelectedDateMillis = initiallySelectedDate?.atStartOfDayIn(TimeZone.UTC)?.toEpochMilliseconds(),
     initialDisplayedMonthMillis = null,
-    yearsRange = minDate.year..maxDate.year,
+    yearRange = minDate.year..maxDate.year,
+    initialDisplayMode = DisplayMode.Picker,
   )
 
   fun clearDateSelection() {
-    @Suppress("INVISIBLE_MEMBER") // Resetting the date exists in material3 1.1.0-alpha08, for now access internal code
-    datePickerState.selectedDate = null
+    datePickerState.setSelection(null)
   }
 
   fun validateDate(selectedDateEpochMillis: Long): Boolean {

--- a/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ui/SingleSelectDialog.kt
+++ b/feature-odyssey/src/main/kotlin/com/hedvig/android/odyssey/ui/SingleSelectDialog.kt
@@ -113,7 +113,7 @@ private fun <T> SelectionContent(
           contentType = { "Option" },
         ) { option: T ->
           ListItem(
-            headlineText = { Text(text = getDisplayText(option)) },
+            headlineContent = { Text(text = getDisplayText(option)) },
             leadingContent = if (getImageUrl(option) != null) {
               {
                 AsyncImage(

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/TerminateInsuranceActivity.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/TerminateInsuranceActivity.kt
@@ -6,14 +6,16 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.common.android.tryOpenPlayStore
+import com.hedvig.android.core.designsystem.theme.ConfigureTransparentSystemBars
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceNavHost
 import com.hedvig.android.navigation.activity.Navigator
@@ -35,7 +37,8 @@ class TerminateInsuranceActivity : AppCompatActivity() {
 
     setContent {
       HedvigTheme {
-        Box(Modifier.fillMaxSize(), propagateMinConstraints = true) {
+        ConfigureTransparentSystemBars()
+        Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
           TerminateInsuranceNavHost(
             windowSizeClass = calculateWindowSizeClass(this@TerminateInsuranceActivity),
             navController = rememberAnimatedNavController(),

--- a/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationdate/TerminationDateViewModel.kt
+++ b/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationdate/TerminationDateViewModel.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.terminateinsurance.step.terminationdate
 
 import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.DisplayMode
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
@@ -81,9 +82,14 @@ internal class TerminationDateViewModel(
 private class DatePickerConfiguration(minDate: LocalDate, maxDate: LocalDate) {
   private val minDateInMillis = minDate.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
   private val maxDateInMillis = maxDate.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
-  private val yearsRange = minDate.year..maxDate.year
+  private val yearRange = minDate.year..maxDate.year
 
-  val datePickerState = DatePickerState(null, null, yearsRange)
+  val datePickerState = DatePickerState(
+    initialSelectedDateMillis = null,
+    initialDisplayedMonthMillis = null,
+    yearRange = yearRange,
+    initialDisplayMode = DisplayMode.Picker,
+  )
   val dateValidator: (Long) -> Boolean = { selectedDateEpochMillis ->
     selectedDateEpochMillis in minDateInMillis..maxDateInMillis
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,8 +25,7 @@ accompanist = "0.30.1"
 adyen = "4.11.0"
 androidx-arch-testing = "2.2.0"
 androidx-composeBom = "2023.04.01"
-#noinspection GradleDependency // alpha05 and alpha06 crash https://issuetracker.google.com/issues/269487074
-androidx-composeMaterial3 = { strictly = "1.1.0-alpha04" }
+androidx-composeMaterial3 = { strictly = "1.1.0-rc01" }
 androidx-composeCompiler = "1.4.6"
 androidx-datastore = "1.0.0"
 androidx-espresso = "3.5.1"


### PR DESCRIPTION
This now removes the workaround we were doing on DatePicker which didn't
 fit out needs.
Also removes calling some internal code which is now properly public, to
 set the date manually
And now we get a proper DatePickerDialog from the library so we don't have to make our own Dialog to wrap it.