### PR TITLE
Fix proguard rules to new okhttp release

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,19 +1,4 @@
-# region okhttp - https://square.github.io/okhttp/features/r8_proguard/
-# JSR 305 annotations are for embedding nullability information.
--dontwarn javax.annotation.**
-
-# A resource is loaded with a relative path so the package of this class must be preserved.
--adaptresourcefilenames okhttp3/internal/publicsuffix/PublicSuffixDatabase.gz
-
-# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
--dontwarn org.codehaus.mojo.animal_sniffer.*
-
-# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
--dontwarn okhttp3.internal.platform.**
--dontwarn org.conscrypt.**
--dontwarn org.bouncycastle.**
--dontwarn org.openjsse.**
-
+# region Retrofit
 # https://github.com/square/retrofit/issues/3751#issuecomment-1192043644
 # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
 -keep,allowobfuscation,allowshrinking interface retrofit2.Call
@@ -22,11 +7,6 @@
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
-# endregion
-
-# region okio - https://square.github.io/okio/#r8-proguard
-# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
--dontwarn org.codehaus.mojo.animal_sniffer.*
 # endregion
 
 # arrow-integrations-retrofit-adapter - https://github.com/arrow-kt/arrow-integrations/issues/121


### PR DESCRIPTION
OkHttp 4.11.0 now has all these rules built-in
https://github.com/square/okhttp/compare/parent-4.10.0...parent-4.11.0#diff-2c8b9c303079dd83e7937b68b4074e19bbdcb65a72ed8fb43b4057ab6d8629acR10-R14 We now only need the ones for Retrofit which aren't merged into the main library yet.