### PR TITLE
Remove jira ticket updating CI task

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -159,33 +159,3 @@ jobs:
         with:
           name: Pull Request-Build
           path: ${{ steps.sign_app.outputs.signedReleaseFile }}
-      - uses: atlassian/gajira-login@v3.0.1
-        env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      - uses: atlassian/gajira-cli@v3.0.1
-      - uses: atlassian/gajira-find-issue-key@v3.0.1
-        id: find_issue
-        with:
-          string: ${{ github.event.pull_request.title }}
-        continue-on-error: true
-      - name: Update Jira issue with artifact URL
-        continue-on-error: true
-        if: ${{ steps.find_issue.outputs.issue != null }}
-        env:
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-        run: |
-          mkdir -p ~/.jira.d/templates
-          cat << EOF > ~/.jira.d/templates/edit
-          {{/* edit template */ -}}
-          # issue: {{ .key }} - created: {{ .fields.created | age}} ago
-          fields:
-          {{- if .meta.fields.customfield_10066 }}
-            customfield_10066: {{.overrides.artifact_url}}
-          {{- end }}
-          EOF
-          sudo apt-get install -y jq curl
-
-          jira edit ${{ steps.find_issue.outputs.issue }} --noedit --override artifact_url=$(curl -s https://api.github.com/repos/hedviginsurance/android/actions/runs/${{ github.run_id }} | jq ".html_url" -r)
-  


### PR DESCRIPTION
Inspired by this https://hedviginsurance.slack.com/archives/C02FSPVUUA1/p1685107022721769 since we don't have our tickets in Jira anymore