### PR TITLE
Try to show review dialog more than just once

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/ReviewDialogViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/ReviewDialogViewModel.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import slimber.log.d
 
 class ReviewDialogViewModel(
   private val chatEventStore: ChatEventStore,
@@ -17,13 +19,17 @@ class ReviewDialogViewModel(
   private val _shouldOpenReviewDialog = MutableSharedFlow<Boolean>(
     extraBufferCapacity = 1,
     onBufferOverflow = BufferOverflow.DROP_OLDEST,
-  )
+  ).also {
+    it.onEach {
+      d { "Will try to show the review dialog" }
+    }
+  }
   val shouldOpenReviewDialog: SharedFlow<Boolean> = _shouldOpenReviewDialog.asSharedFlow()
 
   init {
     viewModelScope.launch {
       chatEventStore.observeChatClosedCounter()
-        .map { it == 3 }
+        .map { it % 3 == 0 }
         .collect(_shouldOpenReviewDialog::tryEmit)
     }
   }


### PR DESCRIPTION
Before we would try to show the review dialog just once and absolutely never again.
This probably means that most of our members who've had this show at least once will never see it again, even if they never responded. This change should make it so that as the users use the app more, this dialog will trigger again eventually.
We should not be concerned regarding showing this too much, as the review APIs by themselves rate limit when this is shown. In reality they will see it less often than every month for example, as explained here https://developer.android.com/guide/playcore/in-app-review#quotas