### PR TITLE
Make file provider authority unique across all app variants

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -23,6 +23,7 @@ import com.hedvig.android.language.LanguageService
 import com.hedvig.android.market.MarketManager
 import com.hedvig.android.navigation.core.AppDestination
 import com.hedvig.android.navigation.core.TopLevelGraph
+import com.hedvig.app.BuildConfig
 import com.hedvig.app.feature.dismissiblepager.DismissiblePagerModel
 import com.hedvig.app.feature.home.ui.HowClaimsWorkDialog
 import com.hedvig.app.feature.insurance.ui.tab.insuranceGraph
@@ -77,6 +78,7 @@ internal fun HedvigNavHost(
         generateTravelCertificateGraph(
           density = density,
           navController = navController,
+          applicationId = BuildConfig.APPLICATION_ID,
         )
       },
       onStartChat = { context.startChat() },

--- a/app/data/travel-certificate/src/main/kotlin/com/hedvig/android/data/travelcertificate/GetTravelCertificateSpecificationsUseCase.kt
+++ b/app/data/travel-certificate/src/main/kotlin/com/hedvig/android/data/travelcertificate/GetTravelCertificateSpecificationsUseCase.kt
@@ -24,7 +24,7 @@ class GetTravelCertificateSpecificationsUseCase(
 
   suspend fun invoke(): Either<TravelCertificateError, TravelCertificateData> {
     return either {
-      ensure(featureManager.isFeatureEnabled(Feature.TRAVEL_CERTIFICATE) == false) {
+      ensure(featureManager.isFeatureEnabled(Feature.TRAVEL_CERTIFICATE)) {
         TravelCertificateError.NotEligible
       }
       val member = apolloClient

--- a/app/feature/travel-certificate/src/main/AndroidManifest.xml
+++ b/app/feature/travel-certificate/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <application>
         <provider
             android:name="com.hedvig.android.feature.travelcertificate.data.MyFileProvider"
-            android:authorities="com.hedvig.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/feature/travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/navigation/GenerateTravelCertificateGraph.kt
+++ b/app/feature/travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/navigation/GenerateTravelCertificateGraph.kt
@@ -27,6 +27,7 @@ import com.kiwi.navigationcompose.typed.popBackStack
 fun NavGraphBuilder.generateTravelCertificateGraph(
   density: Density,
   navController: NavHostController,
+  applicationId: String,
   finish: () -> Unit = {
     navController.popBackStack<AppDestination.GenerateTravelCertificate>(true)
   },
@@ -132,7 +133,7 @@ fun NavGraphBuilder.generateTravelCertificateGraph(
         onErrorDialogDismissed = viewModel::onErrorDialogDismissed,
         navigateBack = finish,
         onShareTravelCertificate = {
-          val contentUri = getUriForFile(context, "com.hedvig.fileprovider", it.uri)
+          val contentUri = getUriForFile(context, "$applicationId.fileprovider", it.uri)
 
           val sendIntent: Intent = Intent().apply {
             action = Intent.ACTION_VIEW


### PR DESCRIPTION
Also check for the feature flag properly for travel certificate. It was inverted before by accident.

Turns out we didn't need to do something special to get buildConfig inside the feature module, :app can just give it through the `generateTravelCertificateGraph` function.