### PR TITLE
Log compose destinations to datadog

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppState.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppState.kt
@@ -17,6 +17,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navOptions
+import com.datadog.android.rum.GlobalRum
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.flags.Feature
@@ -208,6 +209,10 @@ private fun NavigationTrackingSideEffect(navController: NavController) {
           }
         }
       }
+      GlobalRum.get().startView(
+        key = destination,
+        name = destination.route ?: destination.displayName,
+      )
     }
     navController.addOnDestinationChangedListener(listener)
     onDispose {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppState.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppState.kt
@@ -76,8 +76,8 @@ internal fun rememberHedvigAppState(
 internal class HedvigAppState(
   val navController: NavHostController,
   val windowSizeClass: WindowSizeClass,
-  private val coroutineScope: CoroutineScope,
-  private val tabNotificationBadgeService: TabNotificationBadgeService,
+  coroutineScope: CoroutineScope,
+  tabNotificationBadgeService: TabNotificationBadgeService,
   private val featureManager: FeatureManager,
 ) {
   val currentDestination: NavDestination?
@@ -211,7 +211,7 @@ private fun NavigationTrackingSideEffect(navController: NavController) {
       }
       GlobalRum.get().startView(
         key = destination,
-        name = destination.route ?: destination.displayName,
+        name = destination.route ?: "Unknown route",
       )
     }
     navController.addOnDestinationChangedListener(listener)


### PR DESCRIPTION
With this we can create metrics for errors in claims flow, as well as number of successful claims

Example:  https://app.datadoghq.eu/rum/sessions?query=%40application.id%3A4d7b8355-396d-406e-b543-30a073050e8f%20env%3Adev%20%40type%3Aview&cols=&event=AgAAAYlAK9tYrpuf6QAAAAAAAAAYAAAAAEFZbEFLOXRZQUFBelRkeFFBWHpjNE9lbwAAACQAAAAAMDE4OTQwMmUtYzYwYi00NzJkLTljZTQtZDMwNTg3Y2E0ZmUz&viz=stream&from_ts=1688998380133&to_ts=1688999280133&live=true