### PR TITLE
GEN-717: Add composables for documents

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/documents/InsuranceDocumentsTab.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/documents/InsuranceDocumentsTab.kt
@@ -1,0 +1,65 @@
+package com.hedvig.app.feature.insurance.ui.detail.documents
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.R
+import com.hedvig.android.core.designsystem.newtheme.SquircleShape
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.insurance.DocumentRow
+import com.hedvig.app.feature.documents.DocumentItems
+
+@Composable
+fun InsuranceDocumentsTab(
+  documents: List<DocumentItems>,
+  onDocumentClicked: (DocumentItems.Document) -> Unit,
+) {
+  val context = LocalContext.current
+
+  Column {
+    documents.forEach { document ->
+      when (document) {
+        is DocumentItems.Document -> DocumentRow(
+          modifier = Modifier.padding(bottom = 4.dp),
+          title = document.getTitle(context) ?: "",
+          subTitle = document.getSubTitle(context) ?: "",
+          onClick = {
+            onDocumentClicked(document)
+          },
+        )
+        is DocumentItems.Header -> TODO("DocumentItems.Header type should be removed")
+      }
+    }
+  }
+}
+
+@HedvigPreview
+@Composable
+fun PreviewInsuranceDocumentsTab() {
+  HedvigTheme {
+    InsuranceDocumentsTab(
+      documents = listOf(
+        DocumentItems.Document(title = "Terms & Conditions", subtitle = "All details about your coverage", uri = Uri.EMPTY),
+        DocumentItems.Document(title = "Pre-purchase info", subtitle = "All pre-pruchase details", uri = Uri.EMPTY),
+        DocumentItems.Document(title = "Productinfo (IPID)", subtitle = "Compare your coverage", uri = Uri.EMPTY),
+      ),
+      onDocumentClicked = {},
+    )
+  }
+}

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/documents/InsuranceDocumentsTab.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/insurance/ui/detail/documents/InsuranceDocumentsTab.kt
@@ -1,25 +1,14 @@
 package com.hedvig.app.feature.insurance.ui.detail.documents
 
 import android.net.Uri
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.R
-import com.hedvig.android.core.designsystem.newtheme.SquircleShape
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.insurance.DocumentRow
@@ -52,14 +41,16 @@ fun InsuranceDocumentsTab(
 @HedvigPreview
 @Composable
 fun PreviewInsuranceDocumentsTab() {
-  HedvigTheme {
-    InsuranceDocumentsTab(
-      documents = listOf(
-        DocumentItems.Document(title = "Terms & Conditions", subtitle = "All details about your coverage", uri = Uri.EMPTY),
-        DocumentItems.Document(title = "Pre-purchase info", subtitle = "All pre-pruchase details", uri = Uri.EMPTY),
-        DocumentItems.Document(title = "Productinfo (IPID)", subtitle = "Compare your coverage", uri = Uri.EMPTY),
-      ),
-      onDocumentClicked = {},
-    )
+  HedvigTheme(useNewColorScheme = true) {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      InsuranceDocumentsTab(
+        documents = listOf(
+          DocumentItems.Document(title = "Terms & Conditions", subtitle = "All details about your coverage", uri = Uri.EMPTY),
+          DocumentItems.Document(title = "Pre-purchase info", subtitle = "All pre-pruchase details", uri = Uri.EMPTY),
+          DocumentItems.Document(title = "Productinfo (IPID)", subtitle = "Compare your coverage", uri = Uri.EMPTY),
+        ),
+        onDocumentClicked = {},
+      )
+    }
   }
 }

--- a/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/card/HedvigCard.kt
+++ b/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/card/HedvigCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardElevation
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -12,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.core.designsystem.material3.squircle
 
 /**
  * Our mapping of m3 style to our card is that we always want the outlined card colors, as they closely resemble how it
@@ -22,7 +24,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun HedvigCard(
   modifier: Modifier = Modifier,
-  shape: Shape = CardDefaults.shape,
+  shape: Shape = MaterialTheme.shapes.squircle,
   colors: CardColors = CardDefaults.outlinedCardColors(),
   elevation: HedvigCardElevation = HedvigCardElevation.NoElevation,
   border: BorderStroke? = null,
@@ -47,7 +49,7 @@ fun HedvigCard(
 fun HedvigCard(
   onClick: (() -> Unit)?,
   modifier: Modifier = Modifier,
-  shape: Shape = CardDefaults.shape,
+  shape: Shape = MaterialTheme.shapes.squircle,
   colors: CardColors = CardDefaults.outlinedCardColors(),
   elevation: HedvigCardElevation = HedvigCardElevation.NoElevation,
   border: BorderStroke? = null,

--- a/app/core/ui/build.gradle.kts
+++ b/app/core/ui/build.gradle.kts
@@ -17,6 +17,7 @@ android {
 dependencies {
   implementation(projects.app.core.designSystem)
   implementation(projects.app.core.resources)
+  implementation(projects.app.core.icons)
   implementation(projects.app.apollo.octopus)
 
   api(libs.androidx.compose.foundation)

--- a/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/DocumentRow.kt
+++ b/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/DocumentRow.kt
@@ -1,23 +1,25 @@
 package com.hedvig.android.core.ui.insurance
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.hedvig.android.core.designsystem.newtheme.SquircleShape
+import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.icons.Hedvig
@@ -30,42 +32,51 @@ fun DocumentRow(
   subTitle: String,
   onClick: () -> Unit,
 ) {
-  Row(
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.SpaceBetween,
-    modifier = modifier
-      .background(
-        shape = SquircleShape,
-        color = MaterialTheme.colorScheme.background
-      )
-      .fillMaxWidth()
-      .padding(horizontal = 16.dp, vertical = 12.dp)
-      .clickable { onClick() },
+  HedvigCard(
+    onClick = onClick,
+    modifier = modifier,
   ) {
-    Column {
-      Row {
-        Text(title)
-        Spacer(modifier = Modifier.padding(1.dp))
-        Text("PDF", fontSize = 11.sp)
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+      Column(Modifier.weight(1f, true)) {
+        Text(
+          text = buildAnnotatedString {
+            append(title)
+            withStyle(
+              SpanStyle(
+                baselineShift = BaselineShift(0.3f),
+                fontSize = 10.sp,
+              ),
+            ) {
+              append(" PDF")
+            }
+          },
+          fontSize = 18.sp,
+        )
+        CompositionLocalProvider(LocalContentColor.provides(MaterialTheme.colorScheme.onSurfaceVariant)) {
+          Text(subTitle, fontSize = 18.sp)
+        }
       }
-      Text(subTitle, color = MaterialTheme.colorScheme.secondary)
+      Icon(
+        imageVector = Icons.Hedvig.ArrowNorthEast,
+        contentDescription = null,
+      )
     }
-
-    Icon(
-      imageVector = Hedvig.ArrowNorthEast,
-      contentDescription = "link",
-    )
   }
 }
 
 @Composable
 @HedvigPreview
 fun PreviewDocumentRow() {
-  HedvigTheme {
-    DocumentRow(
-      title = "Document 1",
-      subTitle = "Subtitle 1",
-      onClick = {},
-    )
+  HedvigTheme(useNewColorScheme = true) {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      DocumentRow(
+        title = "Document 1",
+        subTitle = "Subtitle 1",
+        onClick = {},
+      )
+    }
   }
 }

--- a/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/DocumentRow.kt
+++ b/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/DocumentRow.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,7 +36,7 @@ fun DocumentRow(
     modifier = modifier
       .background(
         shape = SquircleShape,
-        color = Color(0xFFF0F0F0),
+        color = MaterialTheme.colorScheme.background
       )
       .fillMaxWidth()
       .padding(horizontal = 16.dp, vertical = 12.dp)
@@ -47,13 +48,12 @@ fun DocumentRow(
         Spacer(modifier = Modifier.padding(1.dp))
         Text("PDF", fontSize = 11.sp)
       }
-      Text(subTitle, color = Color(0xFF727272))
+      Text(subTitle, color = MaterialTheme.colorScheme.secondary)
     }
 
     Icon(
       imageVector = Hedvig.ArrowNorthEast,
       contentDescription = "link",
-      tint = Color(0xFF121212),
     )
   }
 }

--- a/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/DocumentRow.kt
+++ b/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/insurance/DocumentRow.kt
@@ -1,0 +1,71 @@
+package com.hedvig.android.core.ui.insurance
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hedvig.android.core.designsystem.newtheme.SquircleShape
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.icons.Hedvig
+import com.hedvig.android.core.icons.hedvig.small.hedvig.ArrowNorthEast
+
+@Composable
+fun DocumentRow(
+  modifier: Modifier = Modifier,
+  title: String,
+  subTitle: String,
+  onClick: () -> Unit,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.SpaceBetween,
+    modifier = modifier
+      .background(
+        shape = SquircleShape,
+        color = Color(0xFFF0F0F0),
+      )
+      .fillMaxWidth()
+      .padding(horizontal = 16.dp, vertical = 12.dp)
+      .clickable { onClick() },
+  ) {
+    Column {
+      Row {
+        Text(title)
+        Spacer(modifier = Modifier.padding(1.dp))
+        Text("PDF", fontSize = 11.sp)
+      }
+      Text(subTitle, color = Color(0xFF727272))
+    }
+
+    Icon(
+      imageVector = Hedvig.ArrowNorthEast,
+      contentDescription = "link",
+      tint = Color(0xFF121212),
+    )
+  }
+}
+
+@Composable
+@HedvigPreview
+fun PreviewDocumentRow() {
+  HedvigTheme {
+    DocumentRow(
+      title = "Document 1",
+      subTitle = "Subtitle 1",
+      onClick = {},
+    )
+  }
+}


### PR DESCRIPTION
<img width="438" alt="image" src="https://github.com/HedvigInsurance/android/assets/5929732/843869c4-cc3f-4347-98cf-d8f30a64b7ed">

Not sure about the colors from the theme here. Should we change those later?