### PR TITLE
Fix: Remove decimal handling in monetary input

### DIFF
--- a/app/data/claim-flow/src/main/kotlin/com/hedvig/android/data/claimflow/ClaimFlowRepository.kt
+++ b/app/data/claim-flow/src/main/kotlin/com/hedvig/android/data/claimflow/ClaimFlowRepository.kt
@@ -195,7 +195,7 @@ internal class ClaimFlowRepositoryImpl(
               itemModelInput = Optional.presentIfNotNull(itemModelInput),
               itemProblemIds = Optional.presentIfNotNull(itemProblemIds),
               purchaseDate = Optional.presentIfNotNull(purchaseDate),
-              purchasePrice = Optional.presentIfNotNull(purchasePrice),
+              purchasePrice = Optional.presentIfNotNull(purchasePrice.takeIf { it: Double? -> it != 0.0 }),
             ),
             claimFlowContextStorage.getContext(),
           ),

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/singleitem/SingleItemDestination.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/singleitem/SingleItemDestination.kt
@@ -267,7 +267,6 @@ private fun PriceOfPurchase(
     canInteract = canInteract,
     onInput = { uiState.updateAmount(it) },
     currency = uiState.uiMoney.currencyCode.rawValue,
-    maximumFractionDigits = 0,
     focusRequester = focusRequester,
     modifier = modifier,
   )

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/MonetaryAmountOffsetMapping.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/MonetaryAmountOffsetMapping.kt
@@ -3,51 +3,33 @@ package com.hedvig.android.feature.odyssey.ui
 import androidx.compose.ui.text.input.OffsetMapping
 
 /**
- * [OffsetMapping] for the visual transformation of number 1_000_000.01 into string "1 000 000.01 kr"
+ * [OffsetMapping] for the visual transformation of number 1_000_000 into string "1 000 000 kr"
  * Handles the spacings between the numbers, while also ignoring any potential currency at the end of the string.
  *
- * [text] is the original number, in string format. For example "1000000.01" for number 1_000_000.01.
+ * [text] is the original number, in string format. For example "1000000" for number 1_000_000.
  */
 class MonetaryAmountOffsetMapping(
   private val text: String,
-  private val decimalSeparator: Char,
 ) : OffsetMapping {
   override fun originalToTransformed(offset: Int): Int {
     if (text.length <= 3) return offset
-    val numberOfCharsBeforeFirstSpace = text.withoutDecimal.length % 3
-    val spaceIndices = text.withoutDecimal.spaceIndices(numberOfCharsBeforeFirstSpace)
+    val numberOfCharsBeforeFirstSpace = text.length % 3
+    val spaceIndices = text.spaceIndices(numberOfCharsBeforeFirstSpace)
     return spaceIndices.count { it < offset } + offset
   }
 
   override fun transformedToOriginal(offset: Int): Int {
-    if (text.withoutDecimal.length <= 3) return offset.coerceAtMost(text.length)
-    val numberOfCharsBeforeFirstSpace = text.withoutDecimal.length % 3
-    val integralLength = text.withoutDecimal.length
-    val numberOfSpaces = text.withoutDecimal.spaceIndices(numberOfCharsBeforeFirstSpace).count()
+    if (text.length <= 3) return offset.coerceAtMost(text.length)
+    val numberOfCharsBeforeFirstSpace = text.length % 3
     return when {
       numberOfCharsBeforeFirstSpace == 0 -> offset - (offset / 4)
       offset <= numberOfCharsBeforeFirstSpace -> offset
       else -> {
         val indexOfAfterFirstSpace = numberOfCharsBeforeFirstSpace + 1
-        if (text.contains(decimalSeparator)) {
-          val charactersBeforeDecimal = integralLength + numberOfSpaces
-          if (offset <= charactersBeforeDecimal) {
-            offset - 1 - ((offset - indexOfAfterFirstSpace) / 4)
-          } else {
-            val extraOffset = offset - charactersBeforeDecimal
-            val tempOffset = offset - extraOffset
-            val tmp = tempOffset - 1 - ((tempOffset - indexOfAfterFirstSpace) / 4)
-            tmp + extraOffset
-          }
-        } else {
-          offset - 1 - ((offset - indexOfAfterFirstSpace) / 4)
-        }
+        offset - 1 - ((offset - indexOfAfterFirstSpace) / 4)
       }
     }.coerceAtMost(text.length)
   }
-
-  private val String.withoutDecimal: String
-    get() = this.substringBefore(decimalSeparator)
 
   private fun String.spaceIndices(numberOfCharsBeforeFirstSpace: Int): List<Int> {
     return (this.indices step 3)

--- a/app/feature/odyssey/src/test/kotlin/com/hedvig/android/feature/odyssey/ui/MonetaryAmountOffsetMappingTest.kt
+++ b/app/feature/odyssey/src/test/kotlin/com/hedvig/android/feature/odyssey/ui/MonetaryAmountOffsetMappingTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class MonetaryAmountOffsetMappingTest {
   @Test
   fun `originalToTransformed, normal mapping`() {
-    val mapping = MonetaryAmountOffsetMapping("100", '.')
+    val mapping = MonetaryAmountOffsetMapping("100")
 
     assertEquals(0, mapping.originalToTransformed(0))
     assertEquals(1, mapping.originalToTransformed(1))
@@ -15,7 +15,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `transformedToOriginal, normal mapping`() {
-    val mapping = MonetaryAmountOffsetMapping("100", '.')
+    val mapping = MonetaryAmountOffsetMapping("100")
 
     assertEquals(0, mapping.transformedToOriginal(0))
     assertEquals(1, mapping.transformedToOriginal(1))
@@ -24,7 +24,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `originalToTransformed, with one extra leading number mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(1_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(1_000.toString())
     // transformed = "1 000 kr"
 
     assertEquals(0, mapping.originalToTransformed(0))
@@ -36,7 +36,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `transformedToOriginal, with one extra leading number mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(1_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(1_000.toString())
     // transformed = "1 000 kr"
 
     assertEquals(0, mapping.transformedToOriginal(0))
@@ -53,7 +53,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `originalToTransformed, with two extra leading numbers mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(10_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(10_000.toString())
     // transformed = "10 000 kr"
 
     assertEquals(0, mapping.originalToTransformed(0))
@@ -66,7 +66,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `transformedToOriginal, with two extra leading numbers mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(10_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(10_000.toString())
     // transformed = "10 000 kr"
 
     assertEquals(0, mapping.transformedToOriginal(0))
@@ -84,7 +84,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `originalToTransformed, with three extra leading numbers mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(100_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(100_000.toString())
     // transformed = "100 000 kr"
 
     assertEquals(0, mapping.originalToTransformed(0))
@@ -98,7 +98,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `transformedToOriginal, with three extra leading numbers mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(100_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(100_000.toString())
     // transformed = "100 000 kr"
 
     assertEquals(0, mapping.transformedToOriginal(0))
@@ -117,7 +117,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `originalToTransformed, with one extra leading number and over a million mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(1_000_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(1_000_000.toString())
     // transformed = "1 000 000 kr"
 
     assertEquals(0, mapping.originalToTransformed(0))
@@ -132,7 +132,7 @@ class MonetaryAmountOffsetMappingTest {
 
   @Test
   fun `transformedToOriginal, with one extra leading number and over a million mapping`() {
-    val mapping = MonetaryAmountOffsetMapping(1_000_000.toString(), '.')
+    val mapping = MonetaryAmountOffsetMapping(1_000_000.toString())
     // transformed = "1 000 000 kr"
 
     assertEquals(0, mapping.transformedToOriginal(0))
@@ -149,130 +149,5 @@ class MonetaryAmountOffsetMappingTest {
     assertEquals(7, mapping.transformedToOriginal(10))
     assertEquals(7, mapping.transformedToOriginal(11))
     assertEquals(7, mapping.transformedToOriginal(12))
-  }
-
-  @Test
-  fun `originalToTransformed, with decimals`() {
-    val mapping = MonetaryAmountOffsetMapping(1_000_000.11.toString(), '.')
-    // transformed = "1 000 000.00 kr"
-
-    assertEquals(0, mapping.originalToTransformed(0))
-    assertEquals(1, mapping.originalToTransformed(1))
-    assertEquals(3, mapping.originalToTransformed(2))
-    assertEquals(4, mapping.originalToTransformed(3))
-    assertEquals(5, mapping.originalToTransformed(4))
-    assertEquals(7, mapping.originalToTransformed(5))
-    assertEquals(8, mapping.originalToTransformed(6))
-    assertEquals(9, mapping.originalToTransformed(7))
-    assertEquals(10, mapping.originalToTransformed(8))
-    assertEquals(11, mapping.originalToTransformed(9))
-    assertEquals(12, mapping.originalToTransformed(10))
-  }
-
-  @Test
-  fun `transformedToOriginal, with decimals`() {
-    val mapping = MonetaryAmountOffsetMapping(1_000_000.11.toString(), '.')
-    // transformed = "1 000 000.00 kr"
-
-    assertEquals(0, mapping.transformedToOriginal(0))
-    assertEquals(1, mapping.transformedToOriginal(1))
-    assertEquals(1, mapping.transformedToOriginal(2))
-    assertEquals(2, mapping.transformedToOriginal(3))
-    assertEquals(3, mapping.transformedToOriginal(4))
-    assertEquals(4, mapping.transformedToOriginal(5))
-    assertEquals(4, mapping.transformedToOriginal(6))
-    assertEquals(5, mapping.transformedToOriginal(7))
-    assertEquals(6, mapping.transformedToOriginal(8))
-    assertEquals(7, mapping.transformedToOriginal(9))
-    assertEquals(8, mapping.transformedToOriginal(10))
-    assertEquals(9, mapping.transformedToOriginal(11))
-    assertEquals(10, mapping.transformedToOriginal(12))
-
-    assertEquals(10, mapping.transformedToOriginal(13))
-    assertEquals(10, mapping.transformedToOriginal(14))
-    assertEquals(10, mapping.transformedToOriginal(15))
-  }
-
-  @Test
-  fun `originalToTransformed, only with decimal separator`() {
-    val mapping = MonetaryAmountOffsetMapping("1000.", '.')
-    // transformed = "1 000. kr"
-
-    assertEquals(0, mapping.originalToTransformed(0))
-    assertEquals(1, mapping.originalToTransformed(1))
-    assertEquals(3, mapping.originalToTransformed(2))
-    assertEquals(4, mapping.originalToTransformed(3))
-    assertEquals(5, mapping.originalToTransformed(4))
-    assertEquals(6, mapping.originalToTransformed(5))
-  }
-
-  @Test
-  fun `transformedToOriginal, only with decimal separator`() {
-    val mapping = MonetaryAmountOffsetMapping("1000.", '.')
-    // transformed = "1 000. kr"
-
-    assertEquals(0, mapping.transformedToOriginal(0))
-    assertEquals(1, mapping.transformedToOriginal(1))
-    assertEquals(1, mapping.transformedToOriginal(2))
-    assertEquals(2, mapping.transformedToOriginal(3))
-    assertEquals(3, mapping.transformedToOriginal(4))
-    assertEquals(4, mapping.transformedToOriginal(5))
-    assertEquals(5, mapping.transformedToOriginal(6))
-
-    assertEquals(5, mapping.transformedToOriginal(7))
-    assertEquals(5, mapping.transformedToOriginal(8))
-    assertEquals(5, mapping.transformedToOriginal(9))
-  }
-
-  @Test
-  fun `originalToTransformed, with decimal and single digit`() {
-    val mapping = MonetaryAmountOffsetMapping("1.00", '.')
-    // transformed = "1.00 kr"
-
-    assertEquals(0, mapping.originalToTransformed(0))
-    assertEquals(1, mapping.originalToTransformed(1))
-    assertEquals(2, mapping.originalToTransformed(2))
-    assertEquals(3, mapping.originalToTransformed(3))
-    assertEquals(4, mapping.originalToTransformed(4))
-  }
-
-  @Test
-  fun `transformedToOriginal, with decimal and single digit`() {
-    val mapping = MonetaryAmountOffsetMapping("1.00", '.')
-    // transformed = "1.00 kr"
-
-    assertEquals(0, mapping.transformedToOriginal(0))
-    assertEquals(1, mapping.transformedToOriginal(1))
-    assertEquals(2, mapping.transformedToOriginal(2))
-    assertEquals(3, mapping.transformedToOriginal(3))
-    assertEquals(4, mapping.transformedToOriginal(4))
-
-    assertEquals(4, mapping.transformedToOriginal(5))
-    assertEquals(4, mapping.transformedToOriginal(6))
-    assertEquals(4, mapping.transformedToOriginal(7))
-  }
-
-  @Test
-  fun `originalToTransformed, with empty decimal and single digit`() {
-    val mapping = MonetaryAmountOffsetMapping("1.", '.')
-    // transformed = "1. kr"
-
-    assertEquals(0, mapping.originalToTransformed(0))
-    assertEquals(1, mapping.originalToTransformed(1))
-    assertEquals(2, mapping.originalToTransformed(2))
-  }
-
-  @Test
-  fun `transformedToOriginal, with empty decimal and single digit`() {
-    val mapping = MonetaryAmountOffsetMapping("1.", '.')
-    // transformed = "1. kr"
-
-    assertEquals(0, mapping.transformedToOriginal(0))
-    assertEquals(1, mapping.transformedToOriginal(1))
-    assertEquals(2, mapping.transformedToOriginal(2))
-
-    assertEquals(2, mapping.transformedToOriginal(3))
-    assertEquals(2, mapping.transformedToOriginal(4))
-    assertEquals(2, mapping.transformedToOriginal(5))
   }
 }


### PR DESCRIPTION
There was a crash with an edge case on the monetary amount, but we are not interested in handling decimal amounts anyway. So remove the entire handling code for it instead, the tests still pass for the non-decimal situation 😊