### PR TITLE
Hedvig theme always use new color scheme

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigBottomBar.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigBottomBar.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.app.ui
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -76,11 +75,7 @@ private fun HedvigBottomBar(
         },
         label = { Text(stringResource(destination.titleTextId)) },
         colors = NavigationBarItemDefaults.colors(
-          indicatorColor = if (isSystemInDarkTheme()) {
-            MaterialTheme.colorScheme.background
-          } else {
-            MaterialTheme.colorScheme.surfaceVariant
-          },
+          indicatorColor = MaterialTheme.colorScheme.background,
           selectedIconColor = MaterialTheme.colorScheme.onSurface,
           unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
         ),

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/myinfo/MyInfoDestination.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/myinfo/MyInfoDestination.kt
@@ -145,7 +145,7 @@ private fun MyInfoScreen(
 @HedvigPreview
 @Composable
 private fun PreviewMyInfoScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface {
       MyInfoScreen(
         uiState = MyInfoUiState(

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/PaymentDestination.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/PaymentDestination.kt
@@ -425,7 +425,7 @@ fun PaymentHistory(onClick: () -> Unit) {
 @Composable
 @HedvigPreview
 private fun PreviewPaymentScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface {
       PaymentScreen(
         uiState = PaymentUiState(

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/history/PaymentHistoryDestination.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/payment/history/PaymentHistoryDestination.kt
@@ -37,10 +37,9 @@ import com.hedvig.android.core.ui.appbar.m3.TopAppBar
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarActionType
 import com.hedvig.android.core.ui.hedvigSecondaryDateTimeFormatter
 import com.hedvig.android.core.ui.plus
-import com.hedvig.app.feature.profile.ui.payment.history.PaymentHistoryViewModel.*
 import hedvig.resources.R
 import java.time.LocalDate
-import java.util.*
+import java.util.Locale
 
 @Composable
 internal fun PaymentHistoryDestination(
@@ -63,7 +62,7 @@ internal fun PaymentHistoryDestination(
 
 @Composable
 private fun PaymentHistoryScreen(
-  uiState: PaymentHistoryUiState,
+  uiState: PaymentHistoryViewModel.PaymentHistoryUiState,
   locale: Locale,
   navigateUp: () -> Unit,
 ) {
@@ -94,7 +93,7 @@ private fun PaymentHistoryScreen(
           itemsIndexed(
             items = uiState.charges,
             contentType = { _, _ -> "Charge" },
-          ) { index: Int, charge: PaymentHistoryUiState.Payment ->
+          ) { index: Int, charge: PaymentHistoryViewModel.PaymentHistoryUiState.Payment ->
             Row(
               modifier = Modifier
                 .fillMaxWidth()
@@ -129,20 +128,20 @@ private fun PaymentHistoryScreen(
 @Composable
 @HedvigPreview
 private fun PreviewPaymentHistoryScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface {
       PaymentHistoryScreen(
-        uiState = PaymentHistoryUiState(
+        uiState = PaymentHistoryViewModel.PaymentHistoryUiState(
           charges = listOf(
-            PaymentHistoryUiState.Payment(
+            PaymentHistoryViewModel.PaymentHistoryUiState.Payment(
               amount = "350kr",
               date = LocalDate.now(),
             ),
-            PaymentHistoryUiState.Payment(
+            PaymentHistoryViewModel.PaymentHistoryUiState.Payment(
               amount = "250kr",
               date = LocalDate.now().minusDays(1),
             ),
-            PaymentHistoryUiState.Payment(
+            PaymentHistoryViewModel.PaymentHistoryUiState.Payment(
               amount = "300kr",
               date = LocalDate.now().minusDays(2),
             ),

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/settings/SettingsDestination.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/settings/SettingsDestination.kt
@@ -189,7 +189,7 @@ fun SettingsScreen(
 @Composable
 @HedvigPreview
 fun PreviewSettingsScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface {
       SettingsScreen(
         onBackPressed = {},

--- a/app/audio-player/src/main/kotlin/com/hedvig/android/audio/player/internal/FakeAudioWaves.kt
+++ b/app/audio-player/src/main/kotlin/com/hedvig/android/audio/player/internal/FakeAudioWaves.kt
@@ -134,7 +134,7 @@ private fun FakeAudioWavePill(
 @HedvigPreview
 @Composable
 private fun PreviewFakeAudioWaves() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(
       color = MaterialTheme.colorScheme.surface,
       modifier = Modifier.height(150.dp),

--- a/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/card/HedvigBigCard.kt
+++ b/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/card/HedvigBigCard.kt
@@ -97,7 +97,7 @@ fun HedvigBigCard(
 @HedvigPreview
 @Composable
 private fun PreviewHedvigCardButtonWithInput() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Box(Modifier.padding(16.dp)) {
         HedvigBigCard(
@@ -113,7 +113,7 @@ private fun PreviewHedvigCardButtonWithInput() {
 @HedvigPreview
 @Composable
 private fun PreviewHedvigCardButton() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Box(Modifier.padding(16.dp)) {
         HedvigBigCard(

--- a/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigMaterialColors.kt
+++ b/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigMaterialColors.kt
@@ -8,9 +8,9 @@ import com.hedvig.android.core.designsystem.newtheme.hedvigTonalPalette
 internal val light_primary = hedvigTonalPalette.neutral0
 internal val light_onPrimary = hedvigTonalPalette.neutral100
 internal val light_primaryVariant = hedvigTonalPalette.neutral20
-internal val light_background = hedvigTonalPalette.neutral95
+internal val light_background = hedvigTonalPalette.neutral100
 internal val light_onBackground = hedvigTonalPalette.neutral0
-internal val light_surface = hedvigTonalPalette.neutral100
+internal val light_surface = hedvigTonalPalette.neutral95
 internal val light_onSurface = hedvigTonalPalette.neutral0
 internal val light_surfaceVariant = hedvigTonalPalette.neutral90
 internal val light_onSurfaceVariant = hedvigTonalPalette.neutral30

--- a/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigTheme.kt
+++ b/app/core/design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigTheme.kt
@@ -37,28 +37,3 @@ fun HedvigTheme(
     }
   }
 }
-
-@Composable
-fun HedvigTheme(
-  darkTheme: Boolean = isSystemInDarkTheme(),
-  useNewColorScheme: Boolean,
-  content: @Composable () -> Unit,
-) {
-  HedvigTheme(
-    darkTheme = darkTheme,
-    m3ColorOverrides = if (useNewColorScheme && !darkTheme) {
-      { oldColorScheme ->
-        oldColorScheme.copy(
-          background = oldColorScheme.surface,
-          onBackground = oldColorScheme.onSurface,
-          surface = oldColorScheme.background,
-          onSurface = oldColorScheme.onBackground,
-        )
-      }
-    } else {
-      { it }
-    },
-  ) {
-    content()
-  }
-}

--- a/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/SelectIndicationCircle.kt
+++ b/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/SelectIndicationCircle.kt
@@ -38,7 +38,7 @@ fun SelectIndicationCircle(selected: Boolean, modifier: Modifier = Modifier) {
 private fun PreviewSelectIndicationCircle(
   @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) selected: Boolean,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       SelectIndicationCircle(selected, Modifier.padding(16.dp))
     }

--- a/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/card/InsuranceCard.kt
+++ b/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/card/InsuranceCard.kt
@@ -62,10 +62,7 @@ fun InsuranceCard(
       contentScale = ContentScale.Crop,
       modifier = Modifier.matchParentSize(),
     )
-    HedvigTheme(
-      darkTheme = true,
-      useNewColorScheme = true,
-    ) {
+    HedvigTheme(darkTheme = true) {
       Column(Modifier.padding(16.dp)) {
         Row(Modifier.heightIn(86.dp)) {
           FlowRow(

--- a/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/dialog/SingleSelectDialog.kt
+++ b/app/core/ui/src/main/kotlin/com/hedvig/android/core/ui/dialog/SingleSelectDialog.kt
@@ -177,7 +177,7 @@ private fun PreviewSelectionContent(
   val (isScrolled, smallSelectionItems) = input
   val selectedOptions = remember { mutableStateListOf("Front", "Water") }
   val density = LocalDensity.current
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       SelectionContent(
         title = "Type of damage",

--- a/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/destination/ChangeAddressOfferDestination.kt
+++ b/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/destination/ChangeAddressOfferDestination.kt
@@ -426,7 +426,7 @@ private fun Pdfs(quote: MoveQuote) {
 )
 @Composable
 private fun PreviewChangeAddressOfferScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       ChangeAddressOfferScreen(
         ChangeAddressUiState(

--- a/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/AddressInfoCard.kt
+++ b/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/AddressInfoCard.kt
@@ -46,7 +46,7 @@ internal fun AddressInfoCard(
 @HedvigPreview
 @Composable
 private fun PreviewAddressInfoCard() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Box(modifier = Modifier.padding(8.dp)) {
         AddressInfoCard(

--- a/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/Faqs.kt
+++ b/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/Faqs.kt
@@ -80,7 +80,7 @@ private fun FaqItem(
 @HedvigPreview
 @Composable
 private fun PreviewFaqItem() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       var isExpanded by remember { mutableStateOf(false) }
       FaqItem(
@@ -95,7 +95,7 @@ private fun PreviewFaqItem() {
 @HedvigPreview
 @Composable
 private fun PreviewFaqs() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Faqs()
     }

--- a/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/QuoteCard.kt
+++ b/app/feature/changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/QuoteCard.kt
@@ -188,7 +188,7 @@ private fun ExpandedInformation(
 @HedvigPreview
 @Composable
 fun PreviewQuoteCard() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       QuoteCard(
         movingDate = "2021-01-02",

--- a/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/OptionChipsFlowRow.kt
+++ b/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/OptionChipsFlowRow.kt
@@ -154,7 +154,7 @@ internal fun <T> OptionChipsFlowRow(
 @HedvigPreview
 @Composable
 private fun PreviewOptionChipsFlowRow() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Box(modifier = Modifier.padding(16.dp)) {
         val items = remember {

--- a/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimentrypointoptions/ClaimEntryPointOptionsDestination.kt
+++ b/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimentrypointoptions/ClaimEntryPointOptionsDestination.kt
@@ -84,7 +84,7 @@ private fun ClaimEntryPointOptionsScreen(
       onDismiss = showedStartClaimError,
     )
   }
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     HedvigScaffold(
       navigateUp = navigateUp,
       topAppBarActions = {
@@ -144,7 +144,7 @@ private fun ClaimEntryPointOptionsScreen(
 @HedvigPreview
 @Composable
 private fun PreviewClaimEntryPointOptionsScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       val entryPointOptions = remember {
         List(12) {

--- a/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimentrypoints/ClaimEntryPointsDestination.kt
+++ b/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimentrypoints/ClaimEntryPointsDestination.kt
@@ -93,7 +93,7 @@ private fun ClaimEntryPointsScreen(
       onDismiss = showedStartClaimError,
     )
   }
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     HedvigScaffold(
       navigateUp = navigateUp,
       topAppBarActions = {
@@ -153,7 +153,7 @@ private fun ClaimEntryPointsScreen(
 @HedvigPreview
 @Composable
 private fun PreviewClaimEntryPointsScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       val entryPoints = remember {
         List(12) {

--- a/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimgroups/ClaimGroupsDestination.kt
+++ b/app/feature/claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimgroups/ClaimGroupsDestination.kt
@@ -94,7 +94,7 @@ private fun ClaimGroupsScreen(
       onDismiss = showedStartClaimError,
     )
   }
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     HedvigScaffold(
       navigateUp = navigateUp,
       topAppBarActions = {
@@ -182,7 +182,7 @@ private fun ClaimGroupsScreen(
 private fun PreviewClaimGroupsScreen(
   @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) hasError: Boolean,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       val claimGroups = remember {
         List(12) {

--- a/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
+++ b/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
@@ -390,7 +390,7 @@ private fun TerminatedContractsButton(
 @HedvigPreview
 @Composable
 private fun PreviewInsuranceScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       InsuranceScreen(
         InsuranceUiState(

--- a/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
+++ b/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
@@ -270,7 +270,7 @@ private fun ColumnScope.InsurableLimitSection(
 @HedvigPreview
 @Composable
 private fun PreviewCoverageTab() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       CoverageTab(
         previewInsurableLimits,
@@ -283,7 +283,7 @@ private fun PreviewCoverageTab() {
 @HedvigPreview
 @Composable
 private fun PreviewInsurableLimitSection() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Column {
         InsurableLimitSection(
@@ -298,7 +298,7 @@ private fun PreviewInsurableLimitSection() {
 @HedvigPreview
 @Composable
 private fun PreviewPerilSection() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       Column {
         PerilSection(previewPerils)

--- a/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
+++ b/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
@@ -126,7 +126,7 @@ private fun DocumentCard(
 @HedvigPreview
 @Composable
 private fun PreviewDocumentsScreen() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       DocumentsTab(
         documents = persistentListOf(

--- a/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
+++ b/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
@@ -125,7 +125,7 @@ private fun SelectableItem(text: String, isSelected: Boolean, onClick: () -> Uni
 @Composable
 @HedvigPreview
 private fun PreviewEditInsuranceBottomSheetContent() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       EditInsuranceBottomSheetContent(
         allowEditCoInsured = true,

--- a/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -166,7 +166,7 @@ private fun CoverageRows(
 @Composable
 @HedvigPreview
 private fun PreviewYourInfoTab() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       YourInfoTab(
         coverageItems = persistentListOf(

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/audiorecording/ui/AudioRecorder.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/audiorecording/ui/AudioRecorder.kt
@@ -284,7 +284,7 @@ private fun PrerecordedPlayback(
 @HedvigPreview
 @Composable
 private fun PreviewNotRecording() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       AudioRecorder(
         uiState = AudioRecordingUiState.NotRecording,
@@ -302,7 +302,7 @@ private fun PreviewNotRecording() {
 @HedvigPreview
 @Composable
 private fun PreviewRecording() {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       AudioRecorder(
         uiState = AudioRecordingUiState.Recording(listOf(70), Clock.System.now(), ""),

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/singleitempayout/SingleItemPayoutDestination.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/singleitempayout/SingleItemPayoutDestination.kt
@@ -74,7 +74,7 @@ private fun SingleItemPayoutScreen(
   openChat: () -> Unit,
   closePayoutScreen: () -> Unit,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(
       color = MaterialTheme.colorScheme.background,
       modifier = Modifier.fillMaxSize().safeDrawingPadding(),
@@ -265,7 +265,7 @@ private val OvershootEasing: Easing = Easing { fraction ->
 private fun PreviewPayoutScreenLoading(
   @PreviewParameter(PayoutUiStatePreviewProvider::class) payoutUiState: PayoutUiState,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       SingleItemPayoutScreen(
         payoutUiState,
@@ -305,7 +305,7 @@ private fun PreviewPayoutScreenAnimations() {
       value = value.copy(status = PayoutUiState.Status.Loading)
     }
   }
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       SingleItemPayoutScreen(uiState, {}, {}, {}, {})
     }

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/success/ClaimSuccessDestination.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/success/ClaimSuccessDestination.kt
@@ -47,7 +47,7 @@ private fun ClaimSuccessScreen(
   openChat: () -> Unit,
   closeSuccessScreen: () -> Unit,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(
       color = MaterialTheme.colorScheme.background,
       modifier = Modifier.fillMaxSize(),

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/unknownerror/UnknownErrorDestination.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/unknownerror/UnknownErrorDestination.kt
@@ -47,7 +47,7 @@ private fun UnknownErrorScreen(
   openChat: () -> Unit,
   closeFailureScreenDestination: () -> Unit,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(
       color = MaterialTheme.colorScheme.background,
       modifier = Modifier.fillMaxSize(),

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/unknownscreen/UnknownScreenDestination.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/unknownscreen/UnknownScreenDestination.kt
@@ -44,7 +44,7 @@ private fun UnknownScreenScreen(
   openPlayStore: () -> Unit,
   closeUnknownScreenDestination: () -> Unit,
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     Surface(
       color = MaterialTheme.colorScheme.background,
       modifier = Modifier.fillMaxSize(),

--- a/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/ClaimFlowScaffold.kt
+++ b/app/feature/odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/ClaimFlowScaffold.kt
@@ -51,7 +51,7 @@ internal fun ClaimFlowScaffold(
   itemsColumnHorizontalAlignment: Alignment.Horizontal = Alignment.Start,
   content: @Composable (ColumnScope.(sideSpacingModifier: Modifier) -> Unit),
 ) {
-  HedvigTheme(useNewColorScheme = true) {
+  HedvigTheme {
     var showCloseClaimsFlowDialog by rememberSaveable { mutableStateOf(false) }
     if (showCloseClaimsFlowDialog) {
       HedvigAlertDialog(


### PR DESCRIPTION
The new theme colors option basically was simply flipping background with surface, so this is now done in the color definition itself, and the extra HedvigTheme overload is no longer necessary.