### PR TITLE
Automatic android namespace

### DIFF
--- a/app/apollo/apollo-core/build.gradle.kts
+++ b/app/apollo/apollo-core/build.gradle.kts
@@ -15,7 +15,3 @@ dependencies {
   implementation(libs.apollo.normalizedCache)
   implementation(projects.coreCommonPublic)
 }
-
-android {
-  namespace = "com.hedvig.android.apollo.core"
-}

--- a/app/apollo/apollo-di/build.gradle.kts
+++ b/app/apollo/apollo-di/build.gradle.kts
@@ -9,7 +9,3 @@ dependencies {
   implementation(projects.apolloGiraffePublic)
   implementation(projects.apolloOctopusPublic)
 }
-
-android {
-  namespace = "com.hedvig.android.apollo.di"
-}

--- a/app/apollo/apollo-giraffe-public/build.gradle.kts
+++ b/app/apollo/apollo-giraffe-public/build.gradle.kts
@@ -15,10 +15,6 @@ dependencies {
   implementation(projects.coreCommonPublic)
 }
 
-android {
-  namespace = "com.hedvig.android.apollo.giraffe"
-}
-
 apollo {
   generateSourcesDuringGradleSync.set(false)
   service("giraffe") {

--- a/app/apollo/apollo-giraffe-test/build.gradle.kts
+++ b/app/apollo/apollo-giraffe-test/build.gradle.kts
@@ -10,7 +10,3 @@ dependencies {
 
   implementation(projects.apolloGiraffePublic)
 }
-
-android {
-  namespace = "com.hedvig.android.apollo.core"
-}

--- a/app/apollo/apollo-octopus-public/build.gradle.kts
+++ b/app/apollo/apollo-octopus-public/build.gradle.kts
@@ -15,10 +15,6 @@ dependencies {
   implementation(projects.coreCommonPublic)
 }
 
-android {
-  namespace = "com.hedvig.android.apollo.octopus"
-}
-
 apollo {
   generateSourcesDuringGradleSync.set(false)
   service("octopus") {

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/connectpayin/ConnectPaymentResultFragment.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/connectpayin/ConnectPaymentResultFragment.kt
@@ -38,7 +38,7 @@ class ConnectPaymentResultFragment : Fragment(R.layout.connect_payment_result_fr
 
       if (success) {
         connectPaymentViewModel.onPaymentSuccess()
-        icon.setImageResource(com.hedvig.android.core.designsystem.R.drawable.ic_checkmark_in_circle)
+        icon.setImageResource(com.hedvig.android.core.design.system.R.drawable.ic_checkmark_in_circle)
         title.setText(
           when (payinType) {
             ConnectPayinType.ADYEN -> hedvig.resources.R.string.pay_in_confirmation_headline
@@ -51,7 +51,7 @@ class ConnectPaymentResultFragment : Fragment(R.layout.connect_payment_result_fr
           connectPaymentViewModel.close()
         }
       } else {
-        icon.setImageResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle)
+        icon.setImageResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle)
         title.setText(hedvig.resources.R.string.pay_in_error_headline)
         body.setText(
           when (payinType) {

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/CrossSellingResultScreen.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/crossselling/ui/CrossSellingResultScreen.kt
@@ -78,7 +78,7 @@ private fun InformationSection(
 ) {
   val icon: Painter = when (crossSellingResult) {
     is CrossSellingResult.Success -> painterResource(
-      com.hedvig.android.core.designsystem.R.drawable.ic_checkmark_in_circle,
+      com.hedvig.android.core.design.system.R.drawable.ic_checkmark_in_circle,
     )
     CrossSellingResult.Error -> painterResource(R.drawable.ic_x_in_circle)
   }

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/FailedToRetrieveInfo.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/offer/ui/composable/insurely/FailedToRetrieveInfo.kt
@@ -33,7 +33,7 @@ fun FailedToRetrieveInfo(insuranceProviderDisplayName: String?) {
       bottom = 16.dp,
     ),
   ) {
-    Icon(painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle), null)
+    Icon(painterResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle), null)
     Column(
       verticalArrangement = Arrangement.spacedBy(4.dp),
       modifier = Modifier.fillMaxWidth(),

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/tab/ProfileDestination.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/profile/ui/tab/ProfileDestination.kt
@@ -209,10 +209,10 @@ private fun ColumnScope.ProfileItemRows(
       iconPainter = when {
         profileUiState.euroBonus == null -> ColorPainter(Color.Transparent)
         profileUiState.euroBonus.code != null -> {
-          painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_checkmark_in_circle)
+          painterResource(com.hedvig.android.core.design.system.R.drawable.ic_checkmark_in_circle)
         }
 
-        else -> painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_info)
+        else -> painterResource(com.hedvig.android.core.design.system.R.drawable.ic_info)
       },
       onClick = navigateToEurobonus,
     )

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeBottomSheet.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeBottomSheet.kt
@@ -86,7 +86,7 @@ abstract class RedeemCodeBottomSheet : BottomSheetDialogFragment() {
 
   private fun wrongPromotionCode(errorMessage: String) {
     binding.textField.errorIconDrawable =
-      requireContext().compatDrawable(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle)
+      requireContext().compatDrawable(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle)
     binding.textField.error = errorMessage
   }
 }

--- a/app/audio-player/build.gradle.kts
+++ b/app/audio-player/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.audio.player"
-}
-
 dependencies {
   implementation(libs.androidx.compose.animation)
   implementation(libs.androidx.compose.foundation)

--- a/app/audio-player/src/main/kotlin/com/hedvig/android/audio/player/internal/FailedAudioPlayerCard.kt
+++ b/app/audio-player/src/main/kotlin/com/hedvig/android/audio/player/internal/FailedAudioPlayerCard.kt
@@ -41,7 +41,7 @@ internal fun FailedAudioPlayerCard(
       modifier = Modifier.padding(horizontal = 16.dp),
     ) {
       Icon(
-        painter = painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+        painter = painterResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle),
         contentDescription = null,
       )
       Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/app/auth/auth-android/build.gradle.kts
+++ b/app/auth/auth-android/build.gradle.kts
@@ -10,7 +10,3 @@ dependencies {
   implementation(projects.authCore)
   implementation(projects.navigationActivity)
 }
-
-android {
-  namespace = "com.hedvig.android.auth.android"
-}

--- a/app/auth/auth-core/build.gradle.kts
+++ b/app/auth/auth-core/build.gradle.kts
@@ -30,7 +30,3 @@ dependencies {
   testImplementation(projects.coreCommonTest)
   testImplementation(projects.coreDatastoreTest)
 }
-
-android {
-  namespace = "com.hedvig.android.auth"
-}

--- a/app/core/core-common-android-public/build.gradle.kts
+++ b/app/core/core-common-android-public/build.gradle.kts
@@ -22,7 +22,3 @@ dependencies {
   testImplementation(libs.jsonTest)
   testImplementation(libs.junit)
 }
-
-android {
-  namespace = "com.hedvig.android.core.common.android"
-}

--- a/app/core/core-common-android-test/build.gradle.kts
+++ b/app/core/core-common-android-test/build.gradle.kts
@@ -7,7 +7,3 @@ plugins {
 dependencies {
   implementation(libs.slimber)
 }
-
-android {
-  namespace = "com.hedvig.android.core.common.android.test"
-}

--- a/app/core/core-design-system/build.gradle.kts
+++ b/app/core/core-design-system/build.gradle.kts
@@ -18,8 +18,6 @@ dependencies {
 }
 
 android {
-  namespace = "com.hedvig.android.core.designsystem"
-
   defaultConfig {
     vectorDrawables.useSupportLibrary = true
   }

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/information/AppStateInformation.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/information/AppStateInformation.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.R
+import com.hedvig.android.core.design.system.R
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 

--- a/app/core/core-icons/build.gradle.kts
+++ b/app/core/core-icons/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.core.icons"
-}
-
 dependencies {
   implementation(libs.androidx.compose.materialIconsCore)
   implementation(libs.androidx.compose.uiCore)

--- a/app/core/core-ui-data/build.gradle.kts
+++ b/app/core/core-ui-data/build.gradle.kts
@@ -7,10 +7,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.core.uidata"
-}
-
 dependencies {
   implementation(libs.androidx.compose.runtime)
   implementation(libs.kotlinx.serialization.core)

--- a/app/core/core-ui/build.gradle.kts
+++ b/app/core/core-ui/build.gradle.kts
@@ -9,8 +9,6 @@ plugins {
 }
 
 android {
-  namespace = "com.hedvig.android.core.ui"
-
   buildFeatures {
     viewBinding = true
   }

--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/infocard/InfoCard.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/infocard/InfoCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.R
+import com.hedvig.android.core.design.system.R
 import com.hedvig.android.core.designsystem.component.card.HedvigInfoCard
 import com.hedvig.android.core.designsystem.material3.infoContainer
 import com.hedvig.android.core.designsystem.material3.infoElement

--- a/app/data/data-claim-flow/build.gradle.kts
+++ b/app/data/data-claim-flow/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.data.claimflow"
-}
-
 dependencies {
   implementation(libs.androidx.compose.runtime)
   implementation(libs.apollo.runtime)

--- a/app/data/data-claim-triaging/build.gradle.kts
+++ b/app/data/data-claim-triaging/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.data.claimtriaging"
-}
-
 dependencies {
   implementation(libs.kotlinx.immutable.collections)
   implementation(libs.kotlinx.serialization.core)

--- a/app/data/data-travel-certificate/build.gradle.kts
+++ b/app/data/data-travel-certificate/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.data.travelcertificate"
-}
-
 dependencies {
   implementation(libs.apollo.runtime)
   implementation(libs.arrow.core)

--- a/app/datadog/build.gradle.kts
+++ b/app/datadog/build.gradle.kts
@@ -18,8 +18,6 @@ dependencies {
 }
 
 android {
-  namespace = "com.hedvig.android.datadog"
-
   lint {
     // Context: https://issuetracker.google.com/issues/265962219
     disable += "EnsureInitializerMetadata"

--- a/app/feature/feature-businessmodel/build.gradle.kts
+++ b/app/feature/feature-businessmodel/build.gradle.kts
@@ -18,7 +18,3 @@ dependencies {
   implementation(projects.navigationComposeTyped)
   implementation(projects.navigationCore)
 }
-
-android {
-  namespace = "com.hedvig.android.feature.businessmodel"
-}

--- a/app/feature/feature-changeaddress/build.gradle.kts
+++ b/app/feature/feature-changeaddress/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.feature.changeaddress"
-}
-
 dependencies {
   implementation(libs.accompanist.navigationAnimation)
   implementation(libs.androidx.compose.material3)

--- a/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/destination/ChangeAddressEnterNewAddressDestination.kt
+++ b/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/destination/ChangeAddressEnterNewAddressDestination.kt
@@ -334,7 +334,7 @@ private fun MovingDateButton(
         Spacer(Modifier.width(16.dp))
         Icon(
           painter = painterResource(
-            id = com.hedvig.android.core.designsystem.R.drawable.ic_drop_down_indicator,
+            id = com.hedvig.android.core.design.system.R.drawable.ic_drop_down_indicator,
           ),
           contentDescription = null,
           modifier = Modifier.size(16.dp),

--- a/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/ContractTermsOverView.kt
+++ b/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/ContractTermsOverView.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.R
+import com.hedvig.android.core.design.system.R
 import com.hedvig.android.core.designsystem.newtheme.SquircleShape
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 

--- a/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/QuoteCard.kt
+++ b/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/offer/QuoteCard.kt
@@ -95,7 +95,7 @@ private fun PillAndBasicInfo(movingDate: String?) {
           )
           Spacer(modifier = Modifier.width(4.dp))
           Icon(
-            painter = painterResource(id = com.hedvig.android.core.designsystem.R.drawable.ic_info),
+            painter = painterResource(id = com.hedvig.android.core.design.system.R.drawable.ic_info),
             contentDescription = null,
             modifier = Modifier.size(16.dp).padding(1.dp),
           )
@@ -127,7 +127,7 @@ private fun QuoteDetailsAndPrice(
           },
         )
         Icon(
-          painter = painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_drop_down_indicator),
+          painter = painterResource(com.hedvig.android.core.design.system.R.drawable.ic_drop_down_indicator),
           contentDescription = null,
           tint = MaterialTheme.colorScheme.outlineVariant,
           modifier = Modifier

--- a/app/feature/feature-claim-triaging/build.gradle.kts
+++ b/app/feature/feature-claim-triaging/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.feature.claimtriaging"
-}
-
 dependencies {
   implementation(libs.androidx.compose.material3)
   implementation(libs.androidx.lifecycle.compose)

--- a/app/feature/feature-home/build.gradle.kts
+++ b/app/feature/feature-home/build.gradle.kts
@@ -8,8 +8,6 @@ plugins {
 }
 
 android {
-  namespace = "com.hedvig.android.feature.home"
-
   buildFeatures {
     viewBinding = true
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ConnectPayinCard.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ConnectPayinCard.kt
@@ -51,7 +51,7 @@ internal fun ConnectPayinCard(
         modifier = Modifier.padding(horizontal = 16.dp),
       ) {
         Icon(
-          painter = painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+          painter = painterResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle),
           contentDescription = null,
         )
         Spacer(Modifier.width(16.dp))

--- a/app/feature/feature-insurances/build.gradle.kts
+++ b/app/feature/feature-insurances/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 android {
-  namespace = "com.hedvig.android.feature.insurances"
   testOptions.unitTests.isReturnDefaultValues = true
 }
 

--- a/app/feature/feature-odyssey/build.gradle.kts
+++ b/app/feature/feature-odyssey/build.gradle.kts
@@ -50,7 +50,3 @@ dependencies {
   testImplementation(libs.turbine)
   testImplementation(projects.coreCommonTest)
 }
-
-android {
-  namespace = "com.hedvig.android.feature.odyssey"
-}

--- a/app/feature/feature-terminate-insurance/build.gradle.kts
+++ b/app/feature/feature-terminate-insurance/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.feature.terminateinsurance"
-}
-
 dependencies {
   implementation(libs.accompanist.navigationAnimation)
   implementation(libs.androidx.compose.material3)

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deletion/InsuranceDeletionDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deletion/InsuranceDeletionDestination.kt
@@ -73,7 +73,7 @@ private fun InsuranceDeletionScreen(
         insuranceDisplayName,
       ),
       bodyText = uiState.disclaimer,
-      icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+      icon = ImageVector.vectorResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle),
       navigateUp = navigateBack,
     ) {
       Column {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationfailure/TerminationFailureDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationfailure/TerminationFailureDestination.kt
@@ -51,7 +51,7 @@ private fun TerminationFailureScreen(
     title = "",
     headerText = stringResource(R.string.TERMINATION_NOT_SUCCESSFUL_TITLE),
     bodyText = errorMessage.message ?: stringResource(R.string.something_went_wrong),
-    icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+    icon = ImageVector.vectorResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle),
     navigateUp = navigateUp,
   ) {
     Column {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/unknown/UnknownScreenDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/unknown/UnknownScreenDestination.kt
@@ -42,7 +42,7 @@ private fun UnknownScreenScreen(
     title = "",
     headerText = stringResource(R.string.EMBARK_UPDATE_APP_TITLE),
     bodyText = stringResource(R.string.EMBARK_UPDATE_APP_BODY),
-    icon = ImageVector.vectorResource(com.hedvig.android.core.designsystem.R.drawable.ic_warning_triangle),
+    icon = ImageVector.vectorResource(com.hedvig.android.core.design.system.R.drawable.ic_warning_triangle),
     navigateUp = navigateUp,
   ) {
     Column {

--- a/app/feature/feature-travel-certificate/build.gradle.kts
+++ b/app/feature/feature-travel-certificate/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.feature.travelcertificate"
-}
-
 dependencies {
   implementation(libs.androidx.compose.material3)
   implementation(libs.androidx.lifecycle.compose)

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/GenerateTravelCertificateInput.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/GenerateTravelCertificateInput.kt
@@ -154,7 +154,7 @@ internal fun GenerateTravelCertificateInput(
           Text(stringResource(id = R.string.travel_certificate_me))
           if (uiState.includeMember) {
             Icon(
-              painter = painterResource(id = com.hedvig.android.core.designsystem.R.drawable.ic_checkmark),
+              painter = painterResource(id = com.hedvig.android.core.design.system.R.drawable.ic_checkmark),
               tint = MaterialTheme.colorScheme.onSurface,
               contentDescription = "include me",
               modifier = Modifier.size(18.dp),
@@ -325,7 +325,7 @@ private fun MovingDateButton(
         Spacer(Modifier.width(16.dp))
         Icon(
           painter = painterResource(
-            id = com.hedvig.android.core.designsystem.R.drawable.ic_drop_down_indicator,
+            id = com.hedvig.android.core.design.system.R.drawable.ic_drop_down_indicator,
           ),
           tint = MaterialTheme.colorScheme.onInfoElement,
           contentDescription = null,

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/TravelCertificateInformation.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/TravelCertificateInformation.kt
@@ -68,7 +68,7 @@ internal fun TravelCertificateInformation(
         DrawableInfoCard(
           title = it.title,
           text = it.body,
-          icon = painterResource(com.hedvig.android.core.designsystem.R.drawable.ic_info_transparent),
+          icon = painterResource(com.hedvig.android.core.design.system.R.drawable.ic_info_transparent),
           iconColor = MaterialTheme.colorScheme.primary,
           colors = CardDefaults.outlinedCardColors(
             containerColor = MaterialTheme.colorScheme.surface,

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/TravelCertificateOverview.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/TravelCertificateOverview.kt
@@ -80,7 +80,7 @@ internal fun TravelCertificateOverview(
       DrawableInfoCard(
         title = stringResource(id = R.string.travel_certificate_travel_certificate_ready),
         text = stringResource(id = R.string.travel_certificate_travel_certificate_ready_description),
-        icon = painterResource(id = com.hedvig.android.core.designsystem.R.drawable.ic_checkmark_success),
+        icon = painterResource(id = com.hedvig.android.core.design.system.R.drawable.ic_checkmark_success),
         iconColor = MaterialTheme.colorScheme.primary,
         colors = CardDefaults.outlinedCardColors(
           containerColor = MaterialTheme.colorScheme.surface,

--- a/app/hanalytics/hanalytics-android/build.gradle.kts
+++ b/app/hanalytics/hanalytics-android/build.gradle.kts
@@ -21,10 +21,6 @@ dependencies {
   implementation(projects.hanalyticsCore)
 }
 
-android {
-  namespace = "com.hedvig.android.hanalytics.android"
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
   kotlinOptions {
     freeCompilerArgs = freeCompilerArgs + "-Xopt-in=com.hedvig.android.hanalytics.InternalHanalyticsApi"

--- a/app/hanalytics/hanalytics-feature-flags-public/build.gradle.kts
+++ b/app/hanalytics/hanalytics-feature-flags-public/build.gradle.kts
@@ -10,7 +10,3 @@ dependencies {
   implementation(projects.hanalyticsCore)
   implementation(projects.marketCore)
 }
-
-android {
-  namespace = "com.hedvig.android.hanalytics.featureflags"
-}

--- a/app/hanalytics/hanalytics-feature-flags-test/build.gradle.kts
+++ b/app/hanalytics/hanalytics-feature-flags-test/build.gradle.kts
@@ -10,7 +10,3 @@ dependencies {
   implementation(libs.turbine)
   implementation(projects.hanalyticsFeatureFlagsPublic)
 }
-
-android {
-  namespace = "com.hedvig.android.hanalytics.featureflags.test"
-}

--- a/app/language/language-core/build.gradle.kts
+++ b/app/language/language-core/build.gradle.kts
@@ -13,7 +13,3 @@ dependencies {
   implementation(libs.koin.core)
   implementation(projects.coreCommonPublic)
 }
-
-android {
-  namespace = "com.hedvig.android.language"
-}

--- a/app/language/language-test/build.gradle.kts
+++ b/app/language/language-test/build.gradle.kts
@@ -7,7 +7,3 @@ plugins {
 dependencies {
   implementation(projects.languageCore)
 }
-
-android {
-  namespace = "com.hedvig.android.language.test"
-}

--- a/app/market/market-core/build.gradle.kts
+++ b/app/market/market-core/build.gradle.kts
@@ -11,7 +11,3 @@ dependencies {
   implementation(projects.coreCommonPublic)
   implementation(projects.coreResources)
 }
-
-android {
-  namespace = "com.hedvig.android.market"
-}

--- a/app/market/market-test/build.gradle.kts
+++ b/app/market/market-test/build.gradle.kts
@@ -7,7 +7,3 @@ plugins {
 dependencies {
   implementation(projects.marketCore)
 }
-
-android {
-  namespace = "com.hedvig.android.market.test"
-}

--- a/app/molecule/molecule-android/build.gradle.kts
+++ b/app/molecule/molecule-android/build.gradle.kts
@@ -11,7 +11,3 @@ dependencies {
   implementation(libs.androidx.lifecycle.viewModel)
   implementation(libs.coroutines.core)
 }
-
-android {
-  namespace = "com.hedvig.android.molecule.android"
-}

--- a/app/navigation/navigation-activity/build.gradle.kts
+++ b/app/navigation/navigation-activity/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.navigation.activity"
-}
-
 dependencies {
   implementation(projects.coreCommonAndroidPublic)
 }

--- a/app/navigation/navigation-compose-typed/build.gradle.kts
+++ b/app/navigation/navigation-compose-typed/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.navigation.compose.typed"
-}
-
 dependencies {
   api(libs.androidx.navigation.common)
   api(libs.kiwi.navigationCompose)

--- a/app/navigation/navigation-core/build.gradle.kts
+++ b/app/navigation/navigation-core/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.navigation.core"
-}
-
 dependencies {
   implementation(libs.androidx.annotation)
   implementation(libs.androidx.navigation.common)

--- a/app/notification-badge-data/notification-badge-data-fake/build.gradle.kts
+++ b/app/notification-badge-data/notification-badge-data-fake/build.gradle.kts
@@ -8,7 +8,3 @@ dependencies {
   implementation(libs.turbine)
   implementation(projects.notificationBadgeDataPublic)
 }
-
-android {
-  namespace = "com.hedvig.android.notification.badge.data.test"
-}

--- a/app/notification-badge-data/notification-badge-data-public/build.gradle.kts
+++ b/app/notification-badge-data/notification-badge-data-public/build.gradle.kts
@@ -22,7 +22,3 @@ dependencies {
   testImplementation(libs.turbine)
   testImplementation(projects.hanalyticsFeatureFlagsTest)
 }
-
-android {
-  namespace = "com.hedvig.android.notification.badge.data"
-}

--- a/app/notification/notification-core/build.gradle.kts
+++ b/app/notification/notification-core/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.notification.core"
-}
-
 dependencies {
   implementation(platform(libs.firebase.bom))
 

--- a/app/notification/notification-firebase/build.gradle.kts
+++ b/app/notification/notification-firebase/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
   alias(libs.plugins.squareSortDependencies)
 }
 
-android {
-  namespace = "com.hedvig.android.notification.firebase"
-}
-
 dependencies {
   implementation(platform(libs.firebase.bom))
   implementation(libs.androidx.datastore.core)

--- a/app/testdata/build.gradle.kts
+++ b/app/testdata/build.gradle.kts
@@ -8,7 +8,3 @@ dependencies {
   implementation(libs.adyen)
   implementation(projects.apolloGiraffePublic)
 }
-
-android {
-  namespace = "com.hedvig.lib.testdata"
-}

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/KotlinAndroid.kt
@@ -34,6 +34,8 @@ internal fun Project.configureKotlinAndroid(
     kotlinOptions {
       configureKotlinOptions(this@configureKotlinAndroid)
     }
+
+    configureAutomaticNamespace(this)
   }
 
   dependencies {
@@ -47,6 +49,22 @@ internal fun Project.configureKotlinAndroid(
 internal fun Project.configureKotlin(kotlinCompile: KotlinCompile) {
   kotlinCompile.kotlinOptions {
     this.configureKotlinOptions(this@configureKotlin)
+  }
+}
+
+/**
+ * Takes the project name and creates an aptly named namespace definition for it. For example
+ * project name: :notification-badge-data-fake
+ * results in: com.hedvig.android.notification.badge.data.fake
+ */
+private fun Project.configureAutomaticNamespace(commonExtension: CommonExtension<*, *, *, *>) {
+  with(commonExtension) {
+    if (path.contains(".") || path.contains("_")) error("Module names should just contain `-` between words")
+    if (namespace == null) {
+      namespace = "com.hedvig.android" + path
+        .replace(":", ".")
+        .replace("-", ".")
+    }
   }
 }
 

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/KotlinAndroid.kt
@@ -62,8 +62,9 @@ private fun Project.configureAutomaticNamespace(commonExtension: CommonExtension
     if (path.contains(".") || path.contains("_")) error("Module names should just contain `-` between words")
     if (namespace == null) {
       namespace = "com.hedvig.android" + path
-        .replace(":", ".")
-        .replace("-", ".")
+        .replace(":", ".") // Change the ':' suffix into a `.` to go after com.hedvig.android
+        .replace("-", ".") // Change all '-' in the module name into '.'
+        .replace("public", "pub") // "public" breaks the generateRFile agp task, "pub" should suffice
     }
   }
 }

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 }
 
 android {
-  namespace = "com.hedvig.android.design.showcase"
-
   defaultConfig {
     applicationId = "com.hedvig.android.design.showcase"
 

--- a/sample-module/README.md
+++ b/sample-module/README.md
@@ -7,9 +7,8 @@ Example steps for a module called "sample".
 1. Rename the source folder to `sample`
 2. Go to [com.hedvig.android](src/main/kotlin/com/hedvig/android) and make a subpackage of `sample`.
 3. Add this new module as a `// implementation(projects.sample)` to whichever modules want to depend on this.
-4. If it's an android module, edit the namespace inside the `android{}` block from `namespace = "com.hedvig.android.todo"` to `namespace = "com.hedvig.android.sample"`.
-5. If it's not an android module, delete the AndroidManifest.xml file and change `id("hedvig.android.library")` to `id("hedvig.kotlin.library")`.
-6. Edit (or delete) this README of that new module to what's appropriate for it.
-7. Profit $$$
+4. If it's not an android module, delete the AndroidManifest.xml file and change `id("hedvig.android.library")` to `id("hedvig.kotlin.library")`.
+5. Edit (or delete) this README of that new module to what's appropriate for it.
+6. Profit $$$
 
 P.S. Remember to use the `internal` visibility modifier by default instead of public unless you specifically *know* it needs to be public 🙈

--- a/sample-module/build.gradle.kts
+++ b/sample-module/build.gradle.kts
@@ -3,7 +3,3 @@ plugins {
   id("hedvig.android.library")
   alias(libs.plugins.squareSortDependencies)
 }
-
-android {
-  namespace = "com.hedvig.android.todo"
-}


### PR DESCRIPTION
Doing the `configureAutomaticNamespace` function inside the convention plugin removes the need for us to define the namespace at all. This makes new modules even easier to create and use. Not to mention not having to make sure that the namespace name is correct, up to date and so on