### PR TITLE
Feature/claim card fixes

### DIFF
--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/HedvigContainedSmallButton.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/button/HedvigContainedSmallButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.material3.squircleMedium
 
@@ -18,6 +19,7 @@ fun HedvigContainedSmallButton(
   text: String,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  textStyle: TextStyle = MaterialTheme.typography.bodyLarge,
   enabled: Boolean = true,
   colors: ButtonColors = ButtonDefaults.buttonColors(
     containerColor = MaterialTheme.colorScheme.primary,
@@ -36,7 +38,7 @@ fun HedvigContainedSmallButton(
     contentPadding = contentPadding,
     colors = colors,
   ) {
-    ButtonText(text)
+    ButtonText(text = text, textStyle = textStyle)
   }
 }
 
@@ -64,10 +66,14 @@ private fun HedvigContainedSmallButton(
 }
 
 @Composable
-private fun ButtonText(text: String, modifier: Modifier = Modifier) {
+private fun ButtonText(
+  text: String,
+  modifier: Modifier = Modifier,
+  textStyle: TextStyle = MaterialTheme.typography.bodyLarge,
+) {
   Text(
     text = text,
-    style = MaterialTheme.typography.bodyLarge,
+    style = textStyle,
     modifier = modifier,
   )
 }

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigMaterialColors.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/theme/HedvigMaterialColors.kt
@@ -18,7 +18,7 @@ internal val light_secondary = lavender_300
 internal val light_onSecondary = hedvigTonalPalette.neutral0
 internal val light_error = Color(0xFFDD2727)
 internal val light_onError = hedvigTonalPalette.neutral100
-internal val light_outlineVariant = hedvigTonalPalette.neutral60
+internal val light_outlineVariant = hedvigTonalPalette.neutral70
 
 // Dark from xml | https://github.com/HedvigInsurance/android/blob/e86158084061de59a9f1b6d71dda3b234057883d/app/src/main/res/values-night/colors_dark.xml#L2
 internal val dark_primary = hedvigTonalPalette.neutral100
@@ -34,4 +34,4 @@ internal val dark_secondary = lavender_400
 internal val dark_onSecondary = hedvigTonalPalette.neutral0
 internal val dark_error = Color(0xFFE24646)
 internal val dark_onError = hedvigTonalPalette.neutral100
-internal val dark_outlineVariant = hedvigTonalPalette.neutral40
+internal val dark_outlineVariant = hedvigTonalPalette.neutral30

--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/infocard/InfoCard.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/infocard/InfoCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,6 +27,8 @@ import com.hedvig.android.core.designsystem.component.card.HedvigInfoCard
 import com.hedvig.android.core.designsystem.material3.infoContainer
 import com.hedvig.android.core.designsystem.material3.infoElement
 import com.hedvig.android.core.designsystem.material3.onInfoContainer
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.icons.Hedvig
 import com.hedvig.android.core.icons.hedvig.normal.InfoFilled
 
@@ -130,6 +133,16 @@ fun DrawableInfoCard(
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.secondary,
       )
+    }
+  }
+}
+
+@HedvigPreview
+@Composable
+private fun PreviewVectorInfoCard() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      VectorInfoCard("Lorem ipsum")
     }
   }
 }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimdetail/ui/ClaimDetailScreen.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimdetail/ui/ClaimDetailScreen.kt
@@ -91,7 +91,6 @@ private fun ClaimDetailScreen(
           pillsUiState = uiState.pillsUiState,
           title = uiState.claimType,
           subtitle = uiState.insuranceType,
-          isClickable = false,
           modifier = Modifier.padding(16.dp),
         )
         Divider()

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimPillsAndForwardArrow.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimPillsAndForwardArrow.kt
@@ -3,14 +3,10 @@ package com.hedvig.android.feature.home.claimstatus
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -26,28 +22,15 @@ import com.hedvig.android.feature.home.claimstatus.data.PillUiState
 internal fun ClaimPillsAndForwardArrow(
   pillsUiState: List<PillUiState>,
   modifier: Modifier = Modifier,
-  isClickable: Boolean = false,
 ) {
   Row(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
     modifier = modifier.fillMaxWidth(),
-    verticalAlignment = Alignment.Top,
   ) {
-    Row(
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-      modifier = Modifier.weight(1f),
-    ) {
-      pillsUiState.forEach { pillUiState: PillUiState ->
-        ClaimPill(
-          text = pillUiState.text,
-          pillType = pillUiState.type,
-        )
-      }
-    }
-    if (isClickable) {
-      Icon(
-        painter = painterResource(hedvig.resources.R.drawable.ic_arrow_forward),
-        contentDescription = null,
-        modifier = Modifier.size(16.dp),
+    pillsUiState.forEach { pillUiState: PillUiState ->
+      ClaimPill(
+        text = pillUiState.text,
+        pillType = pillUiState.type,
       )
     }
   }
@@ -74,7 +57,7 @@ private fun PreviewPills(
 ) {
   HedvigTheme {
     Surface(color = MaterialTheme.colors.background) {
-      ClaimPillsAndForwardArrow(pillsUiState, isClickable = true)
+      ClaimPillsAndForwardArrow(pillsUiState)
     }
   }
 }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCard.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCard.kt
@@ -2,7 +2,6 @@ package com.hedvig.android.feature.home.claimstatus
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -10,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
-import com.hedvig.android.core.designsystem.component.card.HedvigCardElevation
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.feature.home.claimdetail.ui.previewList
@@ -33,8 +31,6 @@ internal fun ClaimStatusCard(
   }
   HedvigCard(
     onClick = onClick,
-    colors = CardDefaults.elevatedCardColors(),
-    elevation = HedvigCardElevation.Elevated(4.dp),
     modifier = modifier,
   ) {
     Column {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCard.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCard.kt
@@ -38,7 +38,6 @@ internal fun ClaimStatusCard(
         pillsUiState = uiState.pillsUiState,
         title = uiState.title,
         subtitle = uiState.subtitle,
-        isClickable = goToDetailScreen != null,
         modifier = Modifier.padding(16.dp),
       )
       Divider()

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCards.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCards.kt
@@ -42,7 +42,7 @@ internal fun ClaimStatusCards(
       state = pagerState,
       contentPadding = contentPadding,
       beyondBoundsPageCount = 1,
-      pageSpacing = 12.dp,
+      pageSpacing = 8.dp,
       key = { index -> claimStatusCardsUiState[index].id },
       modifier = Modifier.fillMaxWidth().systemGestureExclusion(),
     ) { page: Int ->

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/TopInfo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/TopInfo.kt
@@ -23,10 +23,9 @@ internal fun TopInfo(
   title: String,
   subtitle: String,
   modifier: Modifier = Modifier,
-  isClickable: Boolean = false,
 ) {
   Column(modifier = modifier) {
-    ClaimPillsAndForwardArrow(pillsUiState, isClickable = isClickable)
+    ClaimPillsAndForwardArrow(pillsUiState)
     Spacer(modifier = Modifier.height(20.dp))
     Text(title)
     CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/claimprogress/ClaimProgressRow.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/claimprogress/ClaimProgressRow.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -14,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -85,7 +87,8 @@ private fun ClaimProgress(
       Canvas(
         modifier = Modifier
           .fillMaxWidth()
-          .height(4.dp),
+          .height(4.dp)
+          .clip(CircleShape),
       ) {
         drawRect(progressColor)
       }

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
@@ -196,6 +196,7 @@ private fun InfoCardTextButton(
       containerColor = MaterialTheme.colorScheme.background,
       contentColor = MaterialTheme.colorScheme.onBackground,
     ),
+    textStyle = MaterialTheme.typography.bodyMedium,
     modifier = modifier,
   )
 }


### PR DESCRIPTION
Remove the arrow, remove elevation and move the cards closer, make the progress bars circular, make the divider match the design color more closely

<img width="486" alt="image" src="https://github.com/HedvigInsurance/android/assets/44558292/e4acd38a-8971-4c0d-b5fc-730e885a2acf">

