### PR TITLE
Fix bottom and navigation rail to new designs

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigBottomBar.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigBottomBar.kt
@@ -9,6 +9,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -51,7 +53,19 @@ private fun HedvigBottomBar(
   getIsCurrentlySelected: (TopLevelGraph) -> Boolean,
   modifier: Modifier = Modifier,
 ) {
-  NavigationBar(modifier = modifier) {
+  val outlineVariant = MaterialTheme.colorScheme.outlineVariant
+  NavigationBar(
+    containerColor = MaterialTheme.colorScheme.background,
+    contentColor = MaterialTheme.colorScheme.onBackground,
+    modifier = modifier.drawWithContent {
+      drawContent()
+      drawLine(
+        color = outlineVariant,
+        start = Offset.Zero,
+        end = Offset(size.width, 0f),
+      )
+    },
+  ) {
     for (destination in destinations) {
       val hasNotification = destinationsWithNotifications.contains(destination)
       val selected = getIsCurrentlySelected(destination)
@@ -75,7 +89,7 @@ private fun HedvigBottomBar(
         },
         label = { Text(stringResource(destination.titleTextId)) },
         colors = NavigationBarItemDefaults.colors(
-          indicatorColor = MaterialTheme.colorScheme.background,
+          indicatorColor = MaterialTheme.colorScheme.surface,
           selectedIconColor = MaterialTheme.colorScheme.onSurface,
           unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
         ),

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigNavRail.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigNavRail.kt
@@ -1,5 +1,11 @@
 package com.hedvig.android.app.ui
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRail
@@ -9,6 +15,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -51,9 +59,20 @@ private fun HedvigNavRail(
   getIsCurrentlySelected: (TopLevelGraph) -> Boolean,
   modifier: Modifier = Modifier,
 ) {
+  val outlineVariant = MaterialTheme.colorScheme.outlineVariant
   NavigationRail(
-    containerColor = Color.Transparent,
-    modifier = modifier,
+    containerColor = MaterialTheme.colorScheme.background,
+    contentColor = MaterialTheme.colorScheme.onBackground,
+    windowInsets = WindowInsets.systemBars.union(WindowInsets.displayCutout)
+      .only(WindowInsetsSides.Vertical + WindowInsetsSides.Left),
+    modifier = modifier.drawWithContent {
+      drawContent()
+      drawLine(
+        color = outlineVariant,
+        start = Offset(size.width, 0f),
+        end = Offset(size.width, size.height),
+      )
+    },
   ) {
     for (destination in destinations) {
       val hasNotification = destinationsWithNotifications.contains(destination)

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -23,11 +23,13 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -360,7 +362,7 @@ private fun Modifier.animatedNavigationBarInsetsConsumption(
   val insetsToConsume = if (hedvigAppState.shouldShowBottomBar) {
     WindowInsets.systemBars.only(WindowInsetsSides.Bottom).asPaddingValues(density)
   } else if (hedvigAppState.shouldShowNavRail) {
-    WindowInsets.systemBars.only(WindowInsetsSides.Left).asPaddingValues(density)
+    WindowInsets.systemBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Left).asPaddingValues(density)
   } else {
     PaddingValues(0.dp)
   }
@@ -393,5 +395,5 @@ private fun Modifier.animatedNavigationBarInsetsConsumption(
     animationSpec = tween(MotionTokens.DurationMedium1.toInt()),
     label = "Padding values inset animation",
   )
-  Modifier.consumeWindowInsets(animatedInsetsToConsume)
+  consumeWindowInsets(animatedInsetsToConsume)
 }

--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/m3/TopAppBar.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/m3/TopAppBar.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -43,7 +45,10 @@ fun TopAppBarLayoutForActions(
     horizontalArrangement = Arrangement.End,
     verticalAlignment = Alignment.CenterVertically,
     modifier = modifier
-      .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top))
+      .windowInsetsPadding(
+        WindowInsets.systemBars.union(WindowInsets.displayCutout)
+          .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+      )
       .height(64.dp)
       .fillMaxWidth()
       .padding(horizontal = 16.dp),


### PR DESCRIPTION
Make them both use the surface color, with a hairline width divider-like line where the split is between them and the content. Also fix a bit how the insets were consumed in the navigation rail scenario, where the display cutout inset was not consumed. https://issuetracker.google.com/issues/296990873

Also fix cutout insets for the top app bar icons

<img width="627" alt="image" src="https://github.com/HedvigInsurance/android/assets/44558292/3e603179-9027-49fe-a042-d8620ae88186">
<img width="290" alt="image" src="https://github.com/HedvigInsurance/android/assets/44558292/ad7eafe2-9113-4e48-9a6f-3fd8136f4761">