### PR TITLE
Home layout

### DIFF
--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/animation/AnimatePlacement.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/animation/AnimatePlacement.kt
@@ -1,0 +1,53 @@
+package com.hedvig.android.core.ui.animation
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.AnimationVector2D
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.round
+import kotlinx.coroutines.launch
+
+/**
+ * If the composable was laid out somewhere before and they get a new position, it keeps the old position initially and
+ * starts an animation towards the new position with [animationSpec].
+ */
+fun Modifier.animatePlacement(
+  animationSpec: AnimationSpec<IntOffset> = spring(stiffness = Spring.StiffnessMediumLow),
+): Modifier = composed {
+  val scope = rememberCoroutineScope()
+  var targetOffset by remember { mutableStateOf(IntOffset.Zero) }
+  var animatable by remember {
+    mutableStateOf<Animatable<IntOffset, AnimationVector2D>?>(null)
+  }
+  this
+    .onPlaced {
+      // Calculate the position in the parent layout
+      targetOffset = it.positionInParent().round()
+    }
+    .offset {
+      // Animate to the new target offset when alignment changes.
+      val anim = animatable ?: Animatable(targetOffset, IntOffset.VectorConverter)
+        .also { animatable = it }
+      if (anim.targetValue != targetOffset) {
+        scope.launch {
+          anim.animateTo(targetOffset, animationSpec)
+        }
+      }
+      // Offset the child in the opposite direction to the targetOffset, and slowly catch
+      // up to zero offset via an animation to achieve an overall animated movement.
+      animatable?.let { it.value - targetOffset } ?: IntOffset.Zero
+    }
+}

--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/layout/FixedSizePlaceable.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/layout/FixedSizePlaceable.kt
@@ -1,0 +1,19 @@
+package com.hedvig.android.core.ui.layout
+
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.layout.AlignmentLine
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * A [Placeable] to be used inside custom [androidx.compose.ui.layout.Layout] if we need to add some spacing manually.
+ */
+class FixedSizePlaceable(width: Int, height: Int) : Placeable() {
+  init {
+    measuredSize = IntSize(width, height)
+  }
+
+  override fun get(alignmentLine: AlignmentLine): Int = AlignmentLine.Unspecified
+  override fun placeAt(position: IntOffset, zIndex: Float, layerBlock: (GraphicsLayerScope.() -> Unit)?) = Unit
+}

--- a/app/feature/feature-home/build.gradle.kts
+++ b/app/feature/feature-home/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   implementation(libs.accompanist.permissions)
   implementation(libs.androidx.compose.foundation)
   implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.uiUtil)
   implementation(libs.androidx.compose.uiViewBinding)
   implementation(libs.androidx.lifecycle.compose)
   implementation(libs.androidx.lifecycle.runtime)

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCards.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCards.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.systemGestureExclusion
@@ -59,7 +60,7 @@ internal fun ClaimStatusCards(
       HorizontalPagerIndicator(
         pagerState = pagerState,
         pageCount = claimStatusCardsUiState.size,
-        modifier = Modifier.align(Alignment.CenterHorizontally),
+        modifier = Modifier.padding(contentPadding).align(Alignment.CenterHorizontally),
       )
     }
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCards.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/claimstatus/ClaimStatusCards.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.systemGestureExclusion
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -60,6 +61,7 @@ internal fun ClaimStatusCards(
       HorizontalPagerIndicator(
         pagerState = pagerState,
         pageCount = claimStatusCardsUiState.size,
+        activeColor = LocalContentColor.current,
         modifier = Modifier.padding(contentPadding).align(Alignment.CenterHorizontally),
       )
     }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -3,6 +3,7 @@ package com.hedvig.android.feature.home.home.ui
 import android.content.Context
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -317,6 +318,19 @@ private fun HomeScreenSuccess(
           )
         }
       },
+      veryImportantMessages = {
+        Column(
+          modifier = modifier,
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          for ((index, veryImportantMessage) in uiState.veryImportantMessages.withIndex()) {
+            VeryImportantMessageBanner(openUrl, veryImportantMessage)
+            if (index == uiState.veryImportantMessages.lastIndex) {
+              Spacer(Modifier.height(16.dp))
+            }
+          }
+        }
+      },
       memberReminderCards = {
         val memberReminders =
           uiState.memberReminders.onlyApplicableReminders(notificationPermissionState.status.isGranted)
@@ -356,14 +370,6 @@ private fun HomeScreenSuccess(
       bottomSpacer = {
         Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)).height(16.dp))
       },
-//      veryImportantMessages = {
-//        for ((index, veryImportantMessage) in uiState.veryImportantMessages.withIndex()) {
-//          VeryImportantMessageBanner(openUrl, veryImportantMessage)
-//          if (index == uiState.veryImportantMessages.lastIndex) {
-//            Spacer(Modifier.height(16.dp))
-//          }
-//        }
-//      }
       fullScreenSize = fullScreenSize,
     )
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -20,18 +19,16 @@ import androidx.compose.foundation.layout.onConsumedWindowInsetsChanged
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material3.Icon
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -55,17 +52,20 @@ import arrow.core.nonEmptyListOf
 import com.google.accompanist.permissions.isGranted
 import com.hedvig.android.core.common.android.SHARED_PREFERENCE_NAME
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
+import com.hedvig.android.core.designsystem.component.button.HedvigContainedSmallButton
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.component.error.HedvigErrorSection
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.core.designsystem.material3.onWarningContainer
 import com.hedvig.android.core.designsystem.material3.warningContainer
+import com.hedvig.android.core.designsystem.material3.warningElement
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.icons.Hedvig
-import com.hedvig.android.core.icons.hedvig.normal.ArrowForward
+import com.hedvig.android.core.icons.hedvig.normal.WarningFilled
 import com.hedvig.android.core.ui.appbar.m3.ToolbarChatIcon
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarLayoutForActions
+import com.hedvig.android.core.ui.infocard.VectorInfoCard
 import com.hedvig.android.core.ui.plus
 import com.hedvig.android.feature.home.claimdetail.ui.previewList
 import com.hedvig.android.feature.home.claims.commonclaim.CommonClaimsData
@@ -320,14 +320,14 @@ private fun HomeScreenSuccess(
       },
       veryImportantMessages = {
         Column(
-          modifier = modifier,
           verticalArrangement = Arrangement.spacedBy(8.dp),
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
         ) {
-          for ((index, veryImportantMessage) in uiState.veryImportantMessages.withIndex()) {
-            VeryImportantMessageBanner(openUrl, veryImportantMessage)
-            if (index == uiState.veryImportantMessages.lastIndex) {
-              Spacer(Modifier.height(16.dp))
-            }
+          for (veryImportantMessage in uiState.veryImportantMessages) {
+            VeryImportantMessageCard(openUrl, veryImportantMessage)
           }
         }
       },
@@ -357,7 +357,7 @@ private fun HomeScreenSuccess(
       },
       otherServicesButton = {
         HedvigTextButton(
-          text = stringResource(id = R.string.home_tab_other_services),
+          text = stringResource(R.string.home_tab_other_services),
           onClick = { showEditYourInfoBottomSheet = true },
           modifier = Modifier
             .padding(horizontal = 16.dp)
@@ -376,33 +376,31 @@ private fun HomeScreenSuccess(
 }
 
 @Composable
-private fun VeryImportantMessageBanner(
+private fun VeryImportantMessageCard(
   openUrl: (String) -> Unit,
   veryImportantMessage: HomeData.VeryImportantMessage,
+  modifier: Modifier = Modifier,
 ) {
-  Surface(
-    onClick = { openUrl(veryImportantMessage.link) },
-    color = MaterialTheme.colorScheme.warningContainer,
-    contentColor = MaterialTheme.colorScheme.onWarningContainer,
+  VectorInfoCard(
+    text = veryImportantMessage.message,
+    icon = Icons.Hedvig.WarningFilled,
+    iconColor = MaterialTheme.colorScheme.warningElement,
+    colors = CardDefaults.outlinedCardColors(
+      containerColor = MaterialTheme.colorScheme.warningContainer,
+      contentColor = MaterialTheme.colorScheme.onWarningContainer,
+    ),
+    modifier = modifier,
   ) {
-    Row(
-      verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier
-        .minimumInteractiveComponentSize()
-        .fillMaxWidth()
-        .padding(horizontal = 32.dp, vertical = 8.dp),
-    ) {
-      Text(
-        text = veryImportantMessage.message,
-        modifier = Modifier.weight(1f),
-      )
-      Spacer(Modifier.width(16.dp))
-      Icon(
-        imageVector = Icons.Hedvig.ArrowForward,
-        contentDescription = null,
-        modifier = Modifier.size(16.dp),
-      )
-    }
+    HedvigContainedSmallButton(
+      text = stringResource(R.string.important_message_read_more),
+      onClick = { openUrl(veryImportantMessage.link) },
+      colors = ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+      ),
+      textStyle = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.fillMaxWidth(),
+    )
   }
 }
 

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeLayout.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeLayout.kt
@@ -44,6 +44,7 @@ internal fun HomeLayout(
   fullScreenSize: IntSize,
   welcomeMessage: @Composable @UiComposable () -> Unit,
   claimStatusCards: @Composable @UiComposable () -> Unit,
+  veryImportantMessages: @Composable @UiComposable () -> Unit,
   memberReminderCards: @Composable @UiComposable () -> Unit,
   startClaimButton: @Composable @UiComposable () -> Unit,
   otherServicesButton: @Composable @UiComposable () -> Unit,
@@ -55,6 +56,7 @@ internal fun HomeLayout(
     content = {
       Box(Modifier.layoutId(HomeLayoutContent.WelcomeMessage).animatePlacement()) { welcomeMessage() }
       Box(Modifier.layoutId(HomeLayoutContent.ClaimStatusCards).animatePlacement()) { claimStatusCards() }
+      Box(Modifier.layoutId(HomeLayoutContent.VeryImportantMessages)) { veryImportantMessages() }
       Box(Modifier.layoutId(HomeLayoutContent.MemberReminderCards)) { memberReminderCards() }
       Box(Modifier.layoutId(HomeLayoutContent.StartClaimButton)) { startClaimButton() }
       Box(Modifier.layoutId(HomeLayoutContent.OtherServicesButton)) { otherServicesButton() }
@@ -72,6 +74,8 @@ internal fun HomeLayout(
       measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.WelcomeMessage }!!.measure(constraints)
     val claimStatusCardsPlaceable: Placeable =
       measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.ClaimStatusCards }!!.measure(constraints)
+    val veryImportantMessagesPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.VeryImportantMessages }!!.measure(constraints)
     val memberReminderCardsPlaceable: Placeable =
       measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.MemberReminderCards }!!.measure(constraints)
     val startClaimButtonPlaceable: Placeable =
@@ -89,6 +93,10 @@ internal fun HomeLayout(
 
     val bottomAttachedPlaceables = buildList {
       add(FixedSizePlaceable(0, 16.dp.roundToPx()))
+      if (veryImportantMessagesPlaceable.height > 0) {
+        add(veryImportantMessagesPlaceable)
+        add(FixedSizePlaceable(0, 8.dp.roundToPx()))
+      }
       if (memberReminderCardsPlaceable.height > 0) {
         add(memberReminderCardsPlaceable)
         add(FixedSizePlaceable(0, 16.dp.roundToPx()))
@@ -157,7 +165,8 @@ private fun Placeable.PlacementScope.placeAsColumn(
 }
 
 private enum class HomeLayoutContent {
-  WelcomeMessage, ClaimStatusCards, MemberReminderCards, StartClaimButton, OtherServicesButton, TopSpacer, BottomSpacer
+  WelcomeMessage, ClaimStatusCards, MemberReminderCards, StartClaimButton, OtherServicesButton, VeryImportantMessages,
+  TopSpacer, BottomSpacer
 }
 
 // region previews
@@ -212,9 +221,14 @@ private fun PreviewHomeLayoutNonCenteredNonScrollableContent() {
         PreviewHomeLayout(
           maxWidth = constraints.maxWidth,
           maxHeight = constraints.maxHeight,
+          veryImportantMessages = {
+            Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
+              PreviewBox(0) { Text("Important message") }
+            }
+          },
           memberReminderCards = {
             Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
-              repeat(5) { index ->
+              repeat(3) { index ->
                 PreviewBox(index)
               }
             }
@@ -258,12 +272,14 @@ private fun PreviewHomeLayout(
   maxHeight: Int,
   modifier: Modifier = Modifier,
   claimStatusCards: @Composable @UiComposable () -> Unit = {},
+  veryImportantMessages: @Composable @UiComposable () -> Unit = {},
   memberReminderCards: @Composable @UiComposable () -> Unit = {},
 ) {
   HomeLayout(
     fullScreenSize = IntSize(maxWidth, maxHeight),
     welcomeMessage = { Text("Welcome!", Modifier.fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally)) },
     claimStatusCards = claimStatusCards,
+    veryImportantMessages = veryImportantMessages,
     memberReminderCards = memberReminderCards,
     startClaimButton = {
       HedvigContainedButton(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeLayout.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeLayout.kt
@@ -1,0 +1,298 @@
+package com.hedvig.android.feature.home.home.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsTopHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.UiComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastFirstOrNull
+import androidx.compose.ui.util.fastForEachIndexed
+import androidx.compose.ui.util.fastSumBy
+import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
+import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.ui.animation.animatePlacement
+import com.hedvig.android.core.ui.layout.FixedSizePlaceable
+import kotlin.math.max
+
+@Composable
+internal fun HomeLayout(
+  fullScreenSize: IntSize,
+  welcomeMessage: @Composable @UiComposable () -> Unit,
+  claimStatusCards: @Composable @UiComposable () -> Unit,
+  memberReminderCards: @Composable @UiComposable () -> Unit,
+  startClaimButton: @Composable @UiComposable () -> Unit,
+  otherServicesButton: @Composable @UiComposable () -> Unit,
+  topSpacer: @Composable @UiComposable () -> Unit,
+  bottomSpacer: @Composable @UiComposable () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Layout(
+    content = {
+      Box(Modifier.layoutId(HomeLayoutContent.WelcomeMessage).animatePlacement()) { welcomeMessage() }
+      Box(Modifier.layoutId(HomeLayoutContent.ClaimStatusCards).animatePlacement()) { claimStatusCards() }
+      Box(Modifier.layoutId(HomeLayoutContent.MemberReminderCards)) { memberReminderCards() }
+      Box(Modifier.layoutId(HomeLayoutContent.StartClaimButton)) { startClaimButton() }
+      Box(Modifier.layoutId(HomeLayoutContent.OtherServicesButton)) { otherServicesButton() }
+      Box(Modifier.layoutId(HomeLayoutContent.TopSpacer)) { topSpacer() }
+      Box(Modifier.layoutId(HomeLayoutContent.BottomSpacer)) { bottomSpacer() }
+    },
+    modifier = modifier,
+  ) { measurables, constraints ->
+    val topSpacerPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.TopSpacer }!!.measure(constraints)
+    val bottomSpacerPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.BottomSpacer }!!.measure(constraints)
+
+    val welcomeMessagePlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.WelcomeMessage }!!.measure(constraints)
+    val claimStatusCardsPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.ClaimStatusCards }!!.measure(constraints)
+    val memberReminderCardsPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.MemberReminderCards }!!.measure(constraints)
+    val startClaimButtonPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.StartClaimButton }!!.measure(constraints)
+    val otherServicesButtonPlaceable: Placeable =
+      measurables.fastFirstOrNull { it.layoutId == HomeLayoutContent.OtherServicesButton }!!.measure(constraints)
+
+    val centerPlaceables = buildList {
+      add(welcomeMessagePlaceable)
+      if (claimStatusCardsPlaceable.height > 0) {
+        add(FixedSizePlaceable(0, 24.dp.roundToPx()))
+        add(claimStatusCardsPlaceable)
+      }
+    }
+
+    val bottomAttachedPlaceables = buildList {
+      add(FixedSizePlaceable(0, 16.dp.roundToPx()))
+      if (memberReminderCardsPlaceable.height > 0) {
+        add(memberReminderCardsPlaceable)
+        add(FixedSizePlaceable(0, 16.dp.roundToPx()))
+      }
+      add(startClaimButtonPlaceable)
+      add(FixedSizePlaceable(0, 8.dp.roundToPx()))
+      add(otherServicesButtonPlaceable)
+      add(bottomSpacerPlaceable)
+    }
+
+    val topSpacerHeight = topSpacerPlaceable.height
+    val centerPlaceablesSumHeight = centerPlaceables.fastSumBy { it.height }
+    val bottomAttachedPlaceablesSumHeight = bottomAttachedPlaceables.fastSumBy { it.height }
+
+    val contentHeight: Int = topSpacerHeight + centerPlaceablesSumHeight + bottomAttachedPlaceablesSumHeight
+
+    val layoutHeight = max(contentHeight, fullScreenSize.height)
+    layout(constraints.maxWidth, layoutHeight) {
+      topSpacerPlaceable.place(0, 0)
+      if (contentHeight >= fullScreenSize.height) {
+        // If we're exceeding the available space, simply lay everything out as a column would
+        placeAsColumn(
+          placeables = centerPlaceables + bottomAttachedPlaceables,
+          startYPosition = topSpacerHeight,
+        )
+      } else {
+        // Here we got enough space to not need to scroll
+        val layoutCenterYPoint = fullScreenSize.height / 2
+        // The end Y position if the center items were to be centered properly, aka where they end
+        val centeredPlacablesPreferredBottomYPosition = layoutCenterYPoint + (centerPlaceablesSumHeight / 2)
+        // The top Y position for thebottom attached items, aka where they start
+        val bottomAttachedPlaceablesTopYPosition = fullScreenSize.height - bottomAttachedPlaceablesSumHeight
+        if (centeredPlacablesPreferredBottomYPosition < bottomAttachedPlaceablesTopYPosition) {
+          // Happy path, we can center the content and have space for bottom attached too
+          placeAsColumn(bottomAttachedPlaceables, bottomAttachedPlaceablesTopYPosition)
+          placeAsColumn(centerPlaceables, centeredPlacablesPreferredBottomYPosition - centerPlaceablesSumHeight, true)
+        } else {
+          // Here we need to move the "centered" content up as much as the bottom attached content needs to push it
+          placeAsColumn(
+            placeables = centerPlaceables + bottomAttachedPlaceables,
+            startYPosition = bottomAttachedPlaceablesTopYPosition - centerPlaceablesSumHeight,
+            reverseOrderOfZIndex = true,
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * [reverseOrderOfZIndex] lays out items from top to bottom, so if they overlap the top ones show above the bottom ones
+ * This is useful for the centered content, so that the text stays above the card content when they are overlapping
+ * during an animation
+ */
+private fun Placeable.PlacementScope.placeAsColumn(
+  placeables: List<Placeable>,
+  startYPosition: Int,
+  reverseOrderOfZIndex: Boolean = false,
+) {
+  var yPosition = startYPosition
+  placeables.fastForEachIndexed { index, placeable ->
+    val zIndex = if (reverseOrderOfZIndex) 1000 - index.toFloat() else 0f
+    placeable.place(0, yPosition, zIndex)
+    yPosition += placeable.height
+  }
+}
+
+private enum class HomeLayoutContent {
+  WelcomeMessage, ClaimStatusCards, MemberReminderCards, StartClaimButton, OtherServicesButton, TopSpacer, BottomSpacer
+}
+
+// region previews
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewHomeLayoutCenteredContent() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.fillMaxSize()) {
+      BoxWithConstraints {
+        PreviewHomeLayout(
+          maxWidth = constraints.maxWidth,
+          maxHeight = constraints.maxHeight,
+          claimStatusCards = {
+            Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
+              PreviewBox() { Text("claim status card") }
+            }
+          },
+        )
+      }
+    }
+  }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewHomeLayoutCenteredContentWithSomeBottomAttachedContent() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.fillMaxSize()) {
+      BoxWithConstraints {
+        PreviewHomeLayout(
+          maxWidth = constraints.maxWidth,
+          maxHeight = constraints.maxHeight,
+          memberReminderCards = {
+            Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
+              repeat(1) { index ->
+                PreviewBox(index)
+              }
+            }
+          },
+        )
+      }
+    }
+  }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewHomeLayoutNonCenteredNonScrollableContent() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.fillMaxSize()) {
+      BoxWithConstraints {
+        PreviewHomeLayout(
+          maxWidth = constraints.maxWidth,
+          maxHeight = constraints.maxHeight,
+          memberReminderCards = {
+            Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
+              repeat(5) { index ->
+                PreviewBox(index)
+              }
+            }
+          },
+        )
+      }
+    }
+  }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewHomeLayoutScrollingContent() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.fillMaxSize()) {
+      BoxWithConstraints {
+        PreviewHomeLayout(
+          maxWidth = constraints.maxWidth,
+          maxHeight = constraints.maxHeight,
+          claimStatusCards = {
+            Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
+              PreviewBox() { Text("claim status card") }
+            }
+          },
+          memberReminderCards = {
+            Column(Modifier.padding(horizontal = 16.dp), Arrangement.spacedBy(8.dp)) {
+              repeat(3) { index ->
+                PreviewBox(index)
+              }
+            }
+          },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun PreviewHomeLayout(
+  maxWidth: Int,
+  maxHeight: Int,
+  modifier: Modifier = Modifier,
+  claimStatusCards: @Composable @UiComposable () -> Unit = {},
+  memberReminderCards: @Composable @UiComposable () -> Unit = {},
+) {
+  HomeLayout(
+    fullScreenSize = IntSize(maxWidth, maxHeight),
+    welcomeMessage = { Text("Welcome!", Modifier.fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally)) },
+    claimStatusCards = claimStatusCards,
+    memberReminderCards = memberReminderCards,
+    startClaimButton = {
+      HedvigContainedButton(
+        text = "Start claim",
+        onClick = {},
+        modifier = Modifier.padding(horizontal = 16.dp),
+      )
+    },
+    otherServicesButton = {
+      HedvigTextButton(
+        text = "Other services",
+        onClick = {},
+        modifier = Modifier.padding(horizontal = 16.dp),
+      )
+    },
+    topSpacer = {
+      Spacer(Modifier.height(64.dp).windowInsetsTopHeight(WindowInsets.safeDrawing))
+    },
+    bottomSpacer = {
+      Spacer(Modifier.height(16.dp).windowInsetsBottomHeight(WindowInsets.safeDrawing))
+    },
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun PreviewBox(index: Int = 0, content: @Composable () -> Unit = {}) {
+  Box(Modifier.fillMaxWidth().height(80.dp).background(Color(0xFF0066FF + (index * 0xFF001100)))) {
+    content()
+  }
+}
+// endregion


### PR DESCRIPTION
This kinda shows what happens when there is: only a text, a text with claim cards and some reminder cards, and a text without the claim cards and more reminder cards
https://github.com/HedvigInsurance/android/assets/44558292/584203dc-3bb6-49f3-8cc2-913e75df4726

More states here
| Enough content where it's scrollable | Centered content with cards | Just name | Name + reminder cards |
| --- | --- | --- | --- |
| ![image](https://github.com/HedvigInsurance/android/assets/44558292/765ab89b-e2e3-424c-b49b-9cfc7393d96e) | <img width="317" alt="image" src="https://github.com/HedvigInsurance/android/assets/44558292/fbf38eec-dd7e-4224-8355-9064fec51c45"> | <img width="317" alt="image" src="https://github.com/HedvigInsurance/android/assets/44558292/accdce92-f0f1-4b79-8183-c7f5eeff99cd"> | <img width="317" alt="image" src="https://github.com/HedvigInsurance/android/assets/44558292/f3044824-a4f4-460e-b837-bfc520d8f85f"> |

| Horizontal | With PSA item |
| --- | --- |
| ![Screenshot_20230831_131830](https://github.com/HedvigInsurance/android/assets/44558292/cb320ffb-92f5-4ce1-9adf-4cb08751938b) | ![Screenshot_20230831_145521](https://github.com/HedvigInsurance/android/assets/44558292/9cddcf95-7e00-46cc-bca7-58941650b9df) |
