### PR TITLE
Hotfix/11.5.0

### DIFF
--- a/app/apollo/giraffe/build.gradle.kts
+++ b/app/apollo/giraffe/build.gradle.kts
@@ -25,7 +25,10 @@ apollo {
       endpointUrl.set("https://graphql.dev.hedvigit.com/graphql")
       schemaFile.set(file("src/main/graphql/com/hedvig/android/apollo/giraffe/schema.graphqls"))
     }
-    schemaFile.set(file("src/main/graphql/com/hedvig/android/apollo/giraffe/schema.graphqls"))
+    schemaFiles.setFrom(
+      file("src/main/graphql/com/hedvig/android/apollo/giraffe/schema.graphqls"),
+      file("src/main/graphql/com/hedvig/android/apollo/giraffe/extra.graphqls"),
+    )
     srcDir(file("src/main/graphql/com/hedvig/android/apollo/giraffe/graphql"))
 
     packageName.set("giraffe")

--- a/app/apollo/giraffe/src/main/graphql/com/hedvig/android/apollo/giraffe/extra.graphqls
+++ b/app/apollo/giraffe/src/main/graphql/com/hedvig/android/apollo/giraffe/extra.graphqls
@@ -1,0 +1,13 @@
+extend type Message @typePolicy(keyFields: "globalId")
+
+extend type MessageHeader @typePolicy(keyFields: "messageId")
+
+extend type MessageBodySingleSelect @typePolicy(keyFields: "id")
+extend type MessageBodyMultipleSelect @typePolicy(keyFields: "id")
+extend type MessageBodyText @typePolicy(keyFields: "id")
+extend type MessageBodyNumber @typePolicy(keyFields: "id")
+extend type MessageBodyAudio @typePolicy(keyFields: "id")
+extend type MessageBodyBankIdCollect @typePolicy(keyFields: "id")
+extend type MessageBodyFile @typePolicy(keyFields: "id")
+extend type MessageBodyParagraph @typePolicy(keyFields: "id")
+extend type MessageBodyUndefined @typePolicy(keyFields: "id")

--- a/app/apollo/giraffe/src/main/graphql/com/hedvig/android/apollo/giraffe/graphql/chatMessages.graphql
+++ b/app/apollo/giraffe/src/main/graphql/com/hedvig/android/apollo/giraffe/graphql/chatMessages.graphql
@@ -21,6 +21,7 @@ fragment ChatMessageFragment on Message {
   }
   body {
     ... on MessageBodySingleSelect {
+      id
       type
       choices {
         ... on MessageBodyChoicesSelection {
@@ -48,19 +49,23 @@ fragment ChatMessageFragment on Message {
       }
     }
     ... on MessageBodyCore {
+      id
       type
       text
     }
     ... on MessageBodyFile {
+      id
       file {
         signedUrl
       }
     }
     ... on MessageBodyText {
+      id
       keyboard
       placeholder
     }
     ... on MessageBodyNumber {
+      id
       keyboard
       placeholder
     }

--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
     applicationId = "com.hedvig"
 
     versionCode = 43
-    versionName = "11.4.4"
+    versionName = "11.5.0"
 
     vectorDrawables.useSupportLibrary = true
 

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/chat/data/ChatRepository.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/chat/data/ChatRepository.kt
@@ -8,6 +8,11 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.toUpload
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
+import com.apollographql.apollo3.cache.normalized.api.CacheKey
+import com.apollographql.apollo3.cache.normalized.api.Record
+import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.api.normalize
 import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.watch
@@ -39,27 +44,26 @@ import java.io.File
 import java.util.UUID
 
 class ChatRepository(
-  private val apolloClient: ApolloClient,
+  val apolloClient: ApolloClient,
   private val fileService: FileService,
   private val context: Context,
 ) {
-  private lateinit var messagesQuery: ChatMessagesQuery
+  private val messagesQuery: ChatMessagesQuery = ChatMessagesQuery()
 
   fun fetchChatMessages(): Flow<ApolloResponse<ChatMessagesQuery.Data>> {
-    messagesQuery = ChatMessagesQuery()
     return apolloClient
       .query(messagesQuery)
       .fetchPolicy(FetchPolicy.NetworkOnly)
-      .watch()
+      .watch(fetchThrows = true)
   }
 
-  suspend fun messageIds() =
+  suspend fun messageIds(): ApolloResponse<ChatMessageIdQuery.Data> =
     apolloClient
       .query(ChatMessageIdQuery())
       .fetchPolicy(FetchPolicy.NetworkOnly)
       .execute()
 
-  fun subscribeToChatMessages() =
+  fun subscribeToChatMessages(): Flow<ApolloResponse<ChatMessageSubscription.Data>> =
     apolloClient.subscription(ChatMessageSubscription()).toFlow()
 
   suspend fun sendChatMessage(
@@ -90,33 +94,6 @@ class ChatRepository(
       ChatResponseSingleSelectInput(id, ChatResponseBodySingleSelectInput(value)),
     ),
   ).execute()
-
-  suspend fun writeNewMessage(message: ChatMessageFragment) {
-    val cachedData = apolloClient
-      .apolloStore
-      .readOperation(messagesQuery)
-
-    val chatMessagesFragment =
-      ChatMessagesQuery
-        .Message
-        .Fragments(chatMessageFragment = message)
-
-    val newMessages = cachedData.messages.toMutableList()
-    newMessages.add(
-      0,
-      ChatMessagesQuery.Message(
-        message.body.__typename,
-        fragments = chatMessagesFragment,
-      ),
-    )
-
-    val newData = cachedData
-      .copy(messages = newMessages)
-
-    apolloClient
-      .apolloStore
-      .writeOperation(messagesQuery, newData)
-  }
 
   @SuppressLint("Recycle")
   suspend fun uploadFileFromProvider(uri: Uri): Either<OperationResult.Error, UploadFileMutation.Data> {
@@ -173,4 +150,124 @@ class ChatRepository(
 
   suspend fun searchGifs(query: String): ApolloResponse<GifQuery.Data> =
     apolloClient.query(GifQuery(query)).execute()
+
+  suspend fun writeNewMessageToApolloCache(message: ChatMessageFragment) {
+    /**
+     * Using [com.apollographql.apollo3.cache.normalized.ApolloStore.accessCache] here to use the
+     * [java.util.concurrent.locks.ReentrantReadWriteLock] which resides inside the
+     * [com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore] to respect in the read/write lock as we
+     * want to touch the cache internals. This should make it so that we can't make a modification which would override
+     * a cache entry which was written in-between us fetching the previous cache and appending our new message to it.
+     */
+    val changedKeys = apolloClient.apolloStore.accessCache { cache ->
+      /**
+       * [nomalize] here acts as a way to go from a query response into the map of key to records that we would've
+       * gotten back. We construct our own fake `ChatMessagesQuery.Data` object with the [message] fragment to get the
+       * exact record we would've gotten if the query came in normally from the backend.
+       */
+      val records: Map<String, Record> = messagesQuery.normalize(
+        data = ChatMessagesQuery.Data(
+          listOf(
+            ChatMessagesQuery.Message(
+              __typename = message.__typename,
+              globalId = message.globalId,
+              fragments = ChatMessagesQuery.Message.Fragments(message),
+            ),
+          ),
+        ),
+        customScalarAdapters = apolloClient.customScalarAdapters,
+        cacheKeyGenerator = TypePolicyCacheKeyGenerator,
+      )
+      // These were the old cache entries for the MESSAGES_QUERY_NAME query.
+      val oldCachedMessageCacheKeys: Set<CacheKey> = cache
+        .loadRecord(CacheKey.rootKey().key, CacheHeaders.NONE)
+        ?.get(MESSAGES_QUERY_NAME)
+        ?.cast<List<CacheKey>>()
+        ?.toSet() ?: emptySet()
+      // This inlcudes the one new message which we want to write to the cache
+      val newCachedMessageCacheKeys: Set<CacheKey> = records
+        .get(CacheKey.rootKey().key)
+        ?.get(MESSAGES_QUERY_NAME)
+        ?.cast<List<CacheKey>>()
+        ?.toSet() ?: emptySet()
+
+      // This includes all the existing messages + the new one. In needs to be *first* to show as the last message in
+      // the chat which is inverted, goes from bottom to top.
+      val newMessageKeys: Set<CacheKey> = newCachedMessageCacheKeys + oldCachedMessageCacheKeys
+
+      /**
+       * We create a new Record for the "QUERY_ROOT" entry in the cache. This will look something like:
+       * ```
+       * "QUERY_ROOT" : {
+       *   "messages" : [
+       *     CacheKey(Message:123123123)
+       *     CacheKey(Message:234234234)
+       *     CacheKey(Message:345345345)
+       *   ]
+       * }
+       * ```
+       */
+      val queryRootRecordWithAllMessages: Record = Record(
+        key = CacheKey.rootKey().key,
+        fields = mapOf(MESSAGES_QUERY_NAME to newMessageKeys.toList()),
+        mutationId = null,
+      )
+
+      // We take the original [records] which was going to be written to the cache, and we change what was going to be
+      // written to the "QUERY_ROOT" entry by entering our own Record which we've enriched to include all the chat
+      // messages.
+      // We keep the original [records] since in there it also includes information about where the message itself will
+      // be stored, along with the message body and the message header which have their own key. This will mean that
+      // the final [alteredRecords] map will look something like:
+      // ```
+      // mapOf(
+      //   "QUERY_ROOT" : {
+      //     "messages" : [
+      //       CacheKey(Message:123123123) // This is the new entry which we're now wring
+      //       CacheKey(Message:234234234) // This and the one below were already in the cache
+      //       CacheKey(Message:345345345) // Already was in the cache
+      //     ]
+      //   },
+      //   "Message:123123123" : { // The new message we're storing
+      //     "__typename" : Message
+      //     "globalId" : 123123123
+      //     "id" : free.chat.message
+      //     "header" : CacheKey(Message:123123123.header) // reference to the header entry below
+      //     "body" : CacheKey(Message:123123123.body) // reference to the body entry below
+      //   },
+      //   "Message:123123123.header" : { // The header of the new message we're storing
+      //     "fromMyself" : true
+      //     "statusMessage" : Tack för ditt meddelande. Vi svarar så snart som möjligt.
+      //     "pollingInterval" : 1000
+      //     "richTextChatCompatible" : true
+      //   },
+      //   "Message:123123123.body" : { // The body of the new message we're storing
+      //     "__typename" : MessageBodyText
+      //     "type" : text
+      //     "text" : Hello, I would like some help with this.
+      //     "keyboard" : DEFAULT
+      //     "placeholder" : Aa
+      //   }
+      // )
+      // ```
+      val alteredRecords: Map<String, Record> = records.toMutableMap().apply {
+        put(CacheKey.rootKey().key, queryRootRecordWithAllMessages)
+      }
+
+      // This should merge everything together nicely. The new message entries will get stored, and the entries for
+      // QUERY_ROOT will be retained, and the "messages" one will be updated with the old messages + the new one.
+      cache.merge(alteredRecords.values.toList(), CacheHeaders.NONE)
+    }
+    apolloClient.apolloStore.publish(changedKeys)
+  }
+
+  companion object {
+    /**
+     * The name of the query in the schema is "messages" so it's used as the key for the record saved inside QUERY_ROOT
+     * for caching purposes.
+     */
+    const val MESSAGES_QUERY_NAME = "messages"
+  }
 }
+
+private inline fun <reified T> Any?.cast() = this as T

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
@@ -19,7 +19,6 @@ import com.hedvig.app.R
 import com.hedvig.app.authenticate.LogoutUseCase
 import com.hedvig.app.databinding.ActivityChatBinding
 import com.hedvig.app.feature.chat.ChatInputType
-import com.hedvig.app.feature.chat.ParagraphInput
 import com.hedvig.app.feature.chat.viewmodel.ChatViewModel
 import com.hedvig.app.feature.settings.SettingsActivity
 import com.hedvig.app.util.extensions.calculateNonFullscreenHeightDiff
@@ -60,7 +59,6 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
   private var preventOpenAttachFile = false
 
   private var attachPickerDialog: AttachPickerDialog? = null
-  private var forceScrollToBottom = true
 
   private var currentPhotoPath: String? = null
 
@@ -130,7 +128,6 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
   override fun onResume() {
     super.onResume()
     storeBoolean(ACTIVITY_IS_IN_FOREGROUND, true)
-    forceScrollToBottom = true
   }
 
   override fun onPause() {
@@ -212,7 +209,7 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
 
   private fun observeData() {
     chatViewModel.messages.observe(this) { data ->
-      data?.let { bindData(it, forceScrollToBottom) }
+      data?.let { bindData(it) }
     }
     // Maybe we should move the loading into the chatViewModel instead
     lifecycleScope.launch {
@@ -258,28 +255,17 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
     }
   }
 
-  private fun bindData(data: ChatMessagesQuery.Data, forceScrollToBottom: Boolean) {
-    var triggerScrollToBottom = false
+  private fun bindData(data: ChatMessagesQuery.Data) {
     val firstMessage = data.messages.firstOrNull()?.let {
       ChatInputType.from(
         it,
       )
     }
     binding.input.message = firstMessage
-    if (firstMessage is ParagraphInput) {
-      triggerScrollToBottom = true
-    }
     (binding.messages.adapter as? ChatAdapter)?.let {
       it.messages = data.messages.filterNotNull()
-      val layoutManager = binding.messages.layoutManager as LinearLayoutManager
-      val pos = layoutManager.findFirstCompletelyVisibleItemPosition()
-      if (pos == 0) {
-        triggerScrollToBottom = true
-      }
     }
-    if (triggerScrollToBottom || forceScrollToBottom) {
-      scrollToBottom(false)
-    }
+    scrollToBottom(true)
   }
 
   private fun openAttachPicker() {

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
@@ -13,7 +13,6 @@ import com.hedvig.hanalytics.HAnalytics
 import giraffe.ChatMessagesQuery
 import giraffe.GifQuery
 import giraffe.UploadFileMutation
-import io.reactivex.disposables.CompositeDisposable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -82,15 +81,13 @@ class ChatViewModel(
   val takePictureUploadFinished = LiveEvent<Unit>() // Reports that the picture upload was done, even if it failed
   val gifs = MutableLiveData<GifQuery.Data>()
 
-  private val disposables = CompositeDisposable()
-
   private var isSendingMessage = false
 
   private val _events = Channel<ChatEvent>(Channel.UNLIMITED)
   val events = _events.receiveAsFlow()
 
   fun retry() {
-    v { "Chat: retrying" }
+    d { "Chat: retrying" }
     retryChannel.retry()
   }
 
@@ -210,11 +207,6 @@ class ChatViewModel(
   private fun getLastId(): String =
     _messages.value?.messages?.firstOrNull()?.fragments?.chatMessageFragment?.globalId
       ?: error("Messages is not initialized!")
-
-  override fun onCleared() {
-    super.onCleared()
-    disposables.clear()
-  }
 
   fun searchGifs(query: String) {
     viewModelScope.launch {

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
@@ -42,7 +42,12 @@ class ChatViewModel(
   }
 
   val messages = MutableLiveData<ChatMessagesQuery.Data>()
-  val sendMessageResponse = MutableLiveData<Boolean>()
+
+  /**
+   * When there is an event thrown into this channel, the UI clears the existing input in the chat box
+   * Used to clear the text after a message was successfully sent
+   */
+  val clearTextFieldInputSignal = Channel<Unit>(Channel.UNLIMITED)
   val isUploading = LiveEvent<Boolean>()
   val uploadBottomSheetResponse = LiveEvent<UploadFileMutation.Data>()
   val takePictureUploadFinished = LiveEvent<Unit>() // Reports that the picture upload was done, even if it failed
@@ -231,9 +236,9 @@ class ChatViewModel(
         },
         ifRight = { data ->
           if (data.sendChatTextResponse) {
+            clearTextFieldInputSignal.send(Unit)
             load()
           }
-          sendMessageResponse.postValue(data.sendChatTextResponse)
         },
       )
     }

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/chat/viewmodel/ChatViewModel.kt
@@ -4,8 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.apollographql.apollo3.api.ApolloResponse
-import com.hedvig.android.core.common.android.e
+import com.hedvig.android.core.common.RetryChannel
 import com.hedvig.app.feature.chat.data.ChatEventStore
 import com.hedvig.app.feature.chat.data.ChatRepository
 import com.hedvig.app.util.LiveEvent
@@ -14,22 +13,18 @@ import com.hedvig.hanalytics.HAnalytics
 import giraffe.ChatMessagesQuery
 import giraffe.GifQuery
 import giraffe.UploadFileMutation
-import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import slimber.log.d
 import slimber.log.e
-import slimber.log.i
-import java.util.concurrent.TimeUnit
+import slimber.log.v
 
 class ChatViewModel(
   private val chatRepository: ChatRepository,
@@ -37,17 +32,42 @@ class ChatViewModel(
   private val hAnalytics: HAnalytics,
 ) : ViewModel() {
 
+  private val retryChannel = RetryChannel()
+
+  private val _messages = MutableStateFlow<ChatMessagesQuery.Data?>(null)
+  val messages = _messages.asStateFlow()
+
   init {
     hAnalytics.screenView(AppScreen.CHAT)
+    viewModelScope.launch {
+      d { "Chat: fetchChatMessages starting" }
+      retryChannel
+        .flatMapLatest { chatRepository.fetchChatMessages() }
+        .catch {
+          e(it) { "chatRepository.fetchChatMessages threw an exception" }
+          _events.send(ChatEvent.Error)
+        }
+        .collect { response ->
+          v { "Chat: new response from chat query with #${response.data?.messages?.count() ?: 0} messages" }
+          response.data?.let { responseData -> _messages.update { responseData } }
+        }
+      d { "Chat: fetchChatMessages finished" }
+    }
+    viewModelScope.launch {
+      retryChannel
+        .flatMapLatest { chatRepository.subscribeToChatMessages() }
+        .onStart { d { "Chat: start subscription" } }
+        .catch { e(it) { "Chat: Error on chat subscription" } }
+        .collect { response ->
+          d { "Chat: subscription response null?:${response.data == null}" }
+          // Write to cache
+          response.data?.message?.fragments?.chatMessageFragment?.let {
+            chatRepository.writeNewMessageToApolloCache(it)
+          }
+        }
+    }
   }
 
-  val messages = MutableLiveData<ChatMessagesQuery.Data>()
-
-  /**
-   * When there is an event thrown into this channel, the UI clears the existing input in the chat box
-   * Used to clear the text after a message was successfully sent
-   */
-  val clearTextFieldInputSignal = Channel<Unit>(Channel.UNLIMITED)
   val isUploading = LiveEvent<Boolean>()
   val uploadBottomSheetResponse = LiveEvent<UploadFileMutation.Data>()
   val takePictureUploadFinished = LiveEvent<Unit>() // Reports that the picture upload was done, even if it failed
@@ -56,110 +76,13 @@ class ChatViewModel(
 
   private val disposables = CompositeDisposable()
 
-  private var isSubscriptionAllowedToWrite = true
-  private var isWaitingForParagraph = false
   private var isSendingMessage = false
-  private var loadRetries = 0L
 
-  private val _events = Channel<Event>(Channel.UNLIMITED)
+  private val _events = Channel<ChatEvent>(Channel.UNLIMITED)
   val events = _events.receiveAsFlow()
 
-  sealed class Event {
-    object Error : Event()
-  }
-
-  fun subscribe() {
-    viewModelScope.launch {
-      chatRepository
-        .subscribeToChatMessages()
-        .onStart {
-          d { "Chat: start subscription" }
-        }
-        .onEach { response ->
-          d { "Chat: subscription response null?:${response.data == null}" }
-          response.data?.message?.let { message ->
-            if (isSubscriptionAllowedToWrite) {
-              chatRepository
-                .writeNewMessage(
-                  message.fragments.chatMessageFragment,
-                )
-            } else {
-              i { "Chat: subscription was not allowed to write" }
-            }
-          }
-        }
-        .catch { e(it) { "Chat: Error on chat subscription" } }
-        .launchIn(this)
-    }
-  }
-
-  fun load() {
-    isSubscriptionAllowedToWrite = false
-    viewModelScope.launch {
-      chatRepository
-        .fetchChatMessages()
-        .onEach { response ->
-          postResponseValue(response)
-          if (isFirstParagraph(response)) {
-            waitForParagraph(getFirstParagraphDelay(response))
-          }
-          isSubscriptionAllowedToWrite = true
-        }.catch {
-          retryLoad()
-          isSubscriptionAllowedToWrite = true
-          e(it)
-        }
-        .launchIn(this)
-    }
-  }
-
-  private fun retryLoad() {
-    if (loadRetries < 5) {
-      loadRetries += 1
-      disposables += Observable
-        .timer(loadRetries, TimeUnit.SECONDS, Schedulers.io())
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(
-          {
-            load()
-          },
-          { e(it) },
-        )
-    } else {
-      networkError.postValue(true)
-    }
-  }
-
-  private fun isFirstParagraph(response: ApolloResponse<ChatMessagesQuery.Data>) = response
-    .data
-    ?.messages
-    ?.firstOrNull()
-    ?.fragments
-    ?.chatMessageFragment
-    ?.body
-    ?.asMessageBodyCore
-    ?.type == "paragraph"
-
-  private fun getFirstParagraphDelay(response: ApolloResponse<ChatMessagesQuery.Data>) =
-    response.data?.messages?.firstOrNull()?.fragments?.chatMessageFragment?.header?.pollingInterval?.toLong()
-      ?: 0L
-
-  private fun waitForParagraph(delay: Long) {
-    if (isWaitingForParagraph) {
-      return
-    }
-
-    isWaitingForParagraph = true
-    disposables += Observable
-      .timer(delay, TimeUnit.MILLISECONDS, Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(
-        {
-          load()
-          isWaitingForParagraph = false
-        },
-        {},
-      )
+  fun retry() {
+    retryChannel.retry()
   }
 
   fun uploadTakenPicture(uri: Uri) {
@@ -171,12 +94,11 @@ class ChatViewModel(
   }
 
   private suspend fun uploadFileInner(uri: Uri): UploadFileMutation.Data? {
-    isSubscriptionAllowedToWrite = false
     isUploading.value = true
     val response = chatRepository.uploadFile(uri)
     return response.fold(
       ifLeft = {
-        _events.send(Event.Error)
+        _events.send(ChatEvent.Error)
         null
       },
       ifRight = { data ->
@@ -188,13 +110,12 @@ class ChatViewModel(
 
   fun uploadFileFromProvider(uri: Uri) {
     hAnalytics.chatRichMessageSent()
-    isSubscriptionAllowedToWrite = false
     isUploading.value = true
     viewModelScope.launch {
       val response = chatRepository.uploadFileFromProvider(uri)
       response.fold(
         ifLeft = {
-          _events.send(Event.Error)
+          _events.send(ChatEvent.Error)
         },
         ifRight = { data ->
           respondWithFile(
@@ -205,10 +126,6 @@ class ChatViewModel(
         },
       )
     }
-  }
-
-  private fun postResponseValue(response: ApolloResponse<ChatMessagesQuery.Data>) {
-    response.data?.let { messages.postValue(it) }
   }
 
   fun respondWithGif(url: String) {
@@ -226,19 +143,15 @@ class ChatViewModel(
       return
     }
     isSendingMessage = true
-    isSubscriptionAllowedToWrite = false
     viewModelScope.launch {
       val response = chatRepository.sendChatMessage(getLastId(), message)
       isSendingMessage = false
       response.fold(
         ifLeft = {
-          _events.send(Event.Error)
+          _events.send(ChatEvent.Error)
         },
-        ifRight = { data ->
-          if (data.sendChatTextResponse) {
-            clearTextFieldInputSignal.send(Unit)
-            load()
-          }
+        ifRight = {
+          _events.send(ChatEvent.ClearTextFieldInput)
         },
       )
     }
@@ -249,21 +162,18 @@ class ChatViewModel(
       return
     }
     isSendingMessage = true
-    isSubscriptionAllowedToWrite = false
     viewModelScope.launch {
       val response = runCatching {
-        chatRepository
-          .sendFileResponse(getLastId(), key, uri)
+        chatRepository.sendFileResponse(getLastId(), key, uri)
       }
+      isSendingMessage = false
       if (response.isFailure) {
-        isSendingMessage = false
         response.exceptionOrNull()?.let { e(it) }
         return@launch
       }
-      isSendingMessage = false
-      if (response.getOrNull()?.data?.sendChatFileResponse == true) {
-        load()
-      }
+//      if (response.getOrNull()?.data?.sendChatFileResponse == true) {
+//        load()
+//      }
     }
   }
 
@@ -272,26 +182,24 @@ class ChatViewModel(
       return
     }
     isSendingMessage = true
-    isSubscriptionAllowedToWrite = false
     viewModelScope.launch {
       val response = runCatching {
         chatRepository
           .sendSingleSelect(getLastId(), value)
       }
+      isSendingMessage = false
       if (response.isFailure) {
-        isSendingMessage = false
         response.exceptionOrNull()?.let { e(it) }
         return@launch
       }
-      isSendingMessage = false
-      if (response.getOrNull()?.data?.sendChatSingleSelectResponse == true) {
-        load()
-      }
+//      if (response.getOrNull()?.data?.sendChatSingleSelectResponse == true) {
+//        load()
+//      }
     }
   }
 
   private fun getLastId(): String =
-    messages.value?.messages?.firstOrNull()?.fragments?.chatMessageFragment?.globalId
+    _messages.value?.messages?.firstOrNull()?.fragments?.chatMessageFragment?.globalId
       ?: error("Messages is not initialized!")
 
   override fun onCleared() {
@@ -315,4 +223,11 @@ class ChatViewModel(
       chatClosedTracker.increaseChatClosedCounter()
     }
   }
+}
+
+sealed class ChatEvent {
+  object Error : ChatEvent()
+
+  // An event to inform the UI that the current input field can be cleared. Used after a message was successfully sent
+  object ClearTextFieldInput : ChatEvent()
 }


### PR DESCRIPTION
**Add proper IDs to chat messages**

Used to properly cache message entries in the apollo cache.

**Improve writeNewMessage to use apollo's lock to read/write**

This gets rid of our own `isSubscriptionAllowedToWrite` boolean which
was really hard to reason about, while also bringing issues with
dropping new messages under normal operation right after we've sent a
new message.

The new way we're storing the message in the cache is explained inside
the ChatRepository in the writeNewMessageToApolloCache function, which
takes care of this by using `accessCache` and doing everything within
the lambda, which is properly locked with a ReentrantReadWriteLock.

This removes the ability for us to simply drop new messages and log a
warning which we were doing before if the subscription was receiving a
new message at the same time that our "mutex" was already acquired.

**Make network errors retryable and exit chat on cancellation**

For the RetryChannel to still continue working after an exception is
thrown, it needs to not see the exception itself, such is the way flows
handle exceptions. If an exception is in fact thrown, then that flow is
closed forever (if there's no retry operator). This change makes it so
that the inner flow catches the exception itself, and acts accordingly
(sends the error event) and lets the retry channel continue working,
ready to receive the rety event to restart the inner flow.

On the UI side, a dialog is shown in these scenarios, which is
non-dismissable, and on positive button restarts the two messaging
flows, and on cancel simply exits the chat.

This also deletes the unused `networkError` which was never sent a value
 in the first place.