### PR TITLE
Fix not using Java 17 on the gradle plugins too

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 plugins {
   `kotlin-dsl`
 }
@@ -7,6 +9,10 @@ group = "com.hedvig.android.buildlogic"
 java {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
 }
 
 dependencies {

--- a/lokalise-gradle-plugin/lokalise/build.gradle.kts
+++ b/lokalise-gradle-plugin/lokalise/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 plugins {
   `embedded-kotlin`
   `java-gradle-plugin`
@@ -12,6 +14,10 @@ dependencies {
 java {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
 }
 
 gradlePlugin {


### PR DESCRIPTION
The app and all modules have this configured through the convention plugins. But the custom gradle plugins we got don't also get it for free. So this was a mistake that I forgot to fix as I was bumping up all java versions.