### PR TITLE
Feature/chat feature flag

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -277,7 +277,7 @@ fun makeUserAgent(locale: Locale): String = buildString {
 }
 
 private val viewModelModule = module {
-  viewModel { ChatViewModel(get(), get(), get()) }
+  viewModel { ChatViewModel(get(), get(), get(), get()) }
   viewModel { (quoteCartId: QuoteCartId?) -> RedeemCodeViewModel(quoteCartId, get(), get()) }
   viewModel { BankIdLoginViewModel(get(), get(), get(), get(), get()) }
   viewModel { DatePickerViewModel() }

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/chat/ui/ChatActivity.kt
@@ -5,8 +5,16 @@ import android.os.Bundle
 import android.os.Environment
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.core.content.FileProvider
+import androidx.core.view.isGone
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -16,6 +24,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.hedvig.android.auth.LogoutUseCase
 import com.hedvig.android.auth.android.AuthenticatedObserver
 import com.hedvig.android.core.common.android.show
+import com.hedvig.android.core.designsystem.component.error.HedvigErrorSection
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.app.BuildConfig
@@ -141,6 +151,31 @@ class ChatActivity : AppCompatActivity(R.layout.activity_chat) {
     initializeInput()
     initializeKeyboardVisibilityHandler()
     observeData()
+
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        chatViewModel.isChatDisabled.collect { isChatDisabled ->
+          if (isChatDisabled == false) {
+            binding.disabledChatView.isGone = true
+          }
+        }
+      }
+    }
+    binding.disabledChatView.setContent {
+      val isChatDisabled by chatViewModel.isChatDisabled.collectAsStateWithLifecycle()
+      HedvigTheme {
+        Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+          if (isChatDisabled == true) {
+            HedvigErrorSection(
+              title = stringResource(hedvig.resources.R.string.CHAT_DISABLED_MESSAGE),
+              subTitle = null,
+              buttonText = stringResource(hedvig.resources.R.string.general_close_button),
+              retry = { finish() },
+            )
+          }
+        }
+      }
+    }
   }
 
   override fun onResume() {

--- a/app/app/src/main/res/layout/activity_chat.xml
+++ b/app/app/src/main/res/layout/activity_chat.xml
@@ -52,14 +52,14 @@
         </LinearLayout>
 
         <TextView
+            style="@style/TextAppearance.AppCompat.Body1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:contentDescription="@string/HEDVIG_LOGO_ACCESSIBILITY"
-            style="@style/TextAppearance.AppCompat.Body1"
-            android:textSize="18sp"
+            android:text="@string/CHAT_TITLE"
             android:textColor="?colorPrimary"
-            android:text="@string/CHAT_TITLE" />
+            android:textSize="18sp" />
 
     </FrameLayout>
 
@@ -68,5 +68,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/disabled_chat_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/error/HedvigErrorSection.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/error/HedvigErrorSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -21,6 +22,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedSmallButton
@@ -60,6 +62,9 @@ fun HedvigErrorSection(
     Text(
       text = title,
       textAlign = TextAlign.Center,
+      style = LocalTextStyle.current.copy(
+        lineBreak = LineBreak.Heading,
+      ),
       modifier = Modifier.fillMaxWidth(),
     )
     Spacer(Modifier.height(2.dp))

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeModule.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeModule.kt
@@ -15,6 +15,7 @@ import com.hedvig.android.feature.home.legacychangeaddress.CreateQuoteCartUseCas
 import com.hedvig.android.feature.home.legacychangeaddress.GetAddressChangeStoryIdUseCase
 import com.hedvig.android.feature.home.legacychangeaddress.GetUpcomingAgreementUseCase
 import com.hedvig.android.feature.home.legacychangeaddress.LegacyChangeAddressViewModel
+import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.memberreminders.GetMemberRemindersUseCase
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -39,6 +40,6 @@ val homeModule = module {
   viewModel<LegacyChangeAddressViewModel> { LegacyChangeAddressViewModel(get(), get(), get()) }
   viewModel<ClaimDetailViewModel> { (claimId: String) -> ClaimDetailViewModel(claimId, get(), get()) }
   viewModel<CommonClaimViewModel> { CommonClaimViewModel(get()) }
-  viewModel<HomeViewModel> { HomeViewModel(get<GetHomeDataUseCase>()) }
+  viewModel<HomeViewModel> { HomeViewModel(get<GetHomeDataUseCase>(), get<FeatureManager>()) }
   viewModel<HonestyPledgeViewModel> { HonestyPledgeViewModel(get()) }
 }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -205,23 +205,25 @@ private fun HomeScreen(
         }
       }
     }
-    Column {
-      TopAppBarLayoutForActions {
-        ToolbarChatIcon(
-          onClick = onStartChat,
+    if (uiState.showChatIcon) {
+      Column {
+        TopAppBarLayoutForActions {
+          ToolbarChatIcon(
+            onClick = onStartChat,
+          )
+        }
+        val shouldShowTooltip by produceState(false) {
+          val daysSinceLastTooltipShown = daysSinceLastTooltipShown(context)
+          value = daysSinceLastTooltipShown
+        }
+        ChatTooltip(
+          showTooltip = shouldShowTooltip,
+          tooltipShown = {
+            context.setLastEpochDayWhenChatTooltipWasShown(java.time.LocalDate.now().toEpochDay())
+          },
+          modifier = Modifier.align(Alignment.End).padding(horizontal = 16.dp),
         )
       }
-      val shouldShowTooltip by produceState(false) {
-        val daysSinceLastTooltipShown = daysSinceLastTooltipShown(context)
-        value = daysSinceLastTooltipShown
-      }
-      ChatTooltip(
-        showTooltip = shouldShowTooltip,
-        tooltipShown = {
-          context.setLastEpochDayWhenChatTooltipWasShown(java.time.LocalDate.now().toEpochDay())
-        },
-        modifier = Modifier.align(Alignment.End).padding(horizontal = 16.dp),
-      )
     }
     PullRefreshIndicator(
       refreshing = uiState.isReloading,
@@ -485,6 +487,7 @@ private fun PreviewHomeScreen() {
           allowGeneratingTravelCertificate = true,
           emergencyData = null,
           commonClaimsData = persistentListOf(),
+          showChatIcon = true,
         ),
         notificationPermissionState = rememberPreviewNotificationPermissionState(),
         reload = {},

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeViewModel.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeViewModel.kt
@@ -1,11 +1,13 @@
 package com.hedvig.android.feature.home.home.ui
 
 import com.hedvig.android.feature.home.data.GetHomeDataUseCase
+import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.molecule.android.MoleculeViewModel
 
 internal class HomeViewModel(
   getHomeDataUseCase: GetHomeDataUseCase,
+  featureManager: FeatureManager,
 ) : MoleculeViewModel<HomeEvent, HomeUiState>(
   HomeUiState.Loading,
-  HomePresenter(getHomeDataUseCase),
+  HomePresenter(getHomeDataUseCase, featureManager),
 )


### PR DESCRIPTION
We show the compose view on top of everything to hide the chat behind it completely. The `Surface` with the background color ensures that this is the case.
As soon as we have evaluated the flag, if it disables the chat, we show the error section. If it does not disable the chat, we completely hide the composable by making it `gone`.

The first commit hides the chat icon from the Home Screen too. This is basically removing the main entry point to the chat. People can still enter the chat through among other places:
* The claim status detail screen
* A notification coming from chat
* Some error screens which redirect to the chat

I figured this set of changes are the best balance of effort to what we get out of it with this. Disabling the chat button in all possible places in the app would be a basically impossible task. Disabling the chat itself is the most important and mandatory part, hiding the chat icon too is just a little extra touch.

![image](https://github.com/HedvigInsurance/android/assets/44558292/e19a95fe-c84a-4a7c-a3d8-d4ac10920ff8)
