### PR TITLE
Error day

### DIFF
--- a/app/data/data-travel-certificate/data-travel-certificate-public/src/main/kotlin/com/hedvig/android/data/travelcertificate/GetTravelCertificateSpecificationsUseCase.kt
+++ b/app/data/data-travel-certificate/data-travel-certificate-public/src/main/kotlin/com/hedvig/android/data/travelcertificate/GetTravelCertificateSpecificationsUseCase.kt
@@ -36,7 +36,7 @@ internal class GetTravelCertificateSpecificationsUseCaseImpl(
         .safeExecute()
         .toEither(::ErrorMessage)
         .mapLeft(TravelCertificateError::Error)
-        .onLeft { logcat(LogPriority.ERROR, it.throwable) { it.message ?: "Could not fetch travel certificate" } }
+        .onLeft { logcat(LogPriority.INFO, it.throwable) { "Could not fetch travel certificate:${it.message}" } }
         .bind()
         .currentMember
 


### PR DESCRIPTION
I think this way we can log all errors as we should.
If this results in a spike of error logs, we should try and assess if those logs are noise of if they are showing real problems.
`NetworkError` being an `INFO` level log is very deliberate, as those errors are the ones that come from network connection problems or when we ourselves cancel a request (from leaving a screen for example). So for those we do want them to be INFO just for tracing capabilities, while the rest are probably real errors that require our attention. That's at least my assumption now, we will change this as we see fit.

The TODO is there because currently we do get errors for being unauthenticated that have no way to differentiate from a real backend issue. What could be done in the near future is that backend returns inside the `extensions` field in the GQL response information about this. But until they do, we will simply continue logging it as we would any other error.