### PR TITLE
Remove language sharedpref migration

### DIFF
--- a/app/core/core-common-public/src/main/kotlin/com/hedvig/android/core/common/preferences/PreferenceKey.kt
+++ b/app/core/core-common-public/src/main/kotlin/com/hedvig/android/core/common/preferences/PreferenceKey.kt
@@ -1,5 +1,0 @@
-package com.hedvig.android.core.common.preferences
-
-object PreferenceKey {
-  const val SETTING_LANGUAGE = "language"
-}

--- a/app/language/language-core/src/main/kotlin/com/hedvig/android/language/LanguageService.kt
+++ b/app/language/language-core/src/main/kotlin/com/hedvig/android/language/LanguageService.kt
@@ -1,32 +1,21 @@
 package com.hedvig.android.language
 
-import android.content.Context
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
-import androidx.preference.PreferenceManager
-import com.hedvig.android.core.common.preferences.PreferenceKey
 import com.hedvig.android.market.Language
-import com.hedvig.android.market.Market
-import com.hedvig.android.market.MarketManager
 import java.util.Locale
 
 interface LanguageService {
   @MainThread
   fun setLanguage(language: Language)
   fun getLanguage(): Language
-  fun getLocale(): Locale
+  fun getLocale(): java.util.Locale
   fun getGraphQLLocale(): giraffe.type.Locale
   fun performOnLaunchLanguageCheck()
 }
 
-class AndroidLanguageService(
-  private val context: Context,
-  private val marketManager: MarketManager,
-) : LanguageService {
-  private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-
+class AndroidLanguageService() : LanguageService {
   /**
    * Sets the language, and as a side effect, restarts all running activities.
    * Only safe to call from the Main Thread.
@@ -61,46 +50,10 @@ class AndroidLanguageService(
   }
 
   override fun performOnLaunchLanguageCheck() {
-    performOneTimeLanguageMigration()
     val currentLanguage = AppCompatDelegate.getApplicationLocales()
     // Always default to English, Sweden, if nothing else is set
     if (currentLanguage.isEmpty) {
       setLanguage(Language.EN_SE)
-    }
-  }
-
-  private fun performOneTimeLanguageMigration() {
-    // We're already migrated, and hence we don't need to do anything
-    if (preferences.contains(PreferenceKey.SETTING_LANGUAGE).not()) {
-      return
-    }
-    // Retrieve the language from settings
-    val storedLanguage = languageFromSettings(context, marketManager.market)
-    // Set it using official APIs
-    setLanguage(storedLanguage)
-    // Clear it out from storage
-    preferences.edit {
-      remove(PreferenceKey.SETTING_LANGUAGE)
-    }
-  }
-
-  private fun languageFromSettings(context: Context, market: Market?): Language = when (market) {
-    null -> Language.from(Language.SETTING_EN_SE)
-    else -> getLanguageFromSharedPreferences(context, market)
-  }
-
-  private fun getLanguageFromSharedPreferences(context: Context, market: Market): Language {
-    val sharedPref = PreferenceManager.getDefaultSharedPreferences(context)
-    val firstAvailableLanguage = Language.getAvailableLanguages(market).first().toString()
-    val selectedLanguage = sharedPref.getString(
-      PreferenceKey.SETTING_LANGUAGE,
-      firstAvailableLanguage,
-    ) ?: firstAvailableLanguage
-
-    return if (selectedLanguage == Language.SETTING_SYSTEM_DEFAULT) {
-      Language.from(firstAvailableLanguage)
-    } else {
-      Language.from(selectedLanguage)
     }
   }
 }

--- a/app/language/language-core/src/main/kotlin/com/hedvig/android/language/di/LanguageModule.kt
+++ b/app/language/language-core/src/main/kotlin/com/hedvig/android/language/di/LanguageModule.kt
@@ -6,10 +6,5 @@ import org.koin.dsl.module
 
 @Suppress("RemoveExplicitTypeArguments")
 val languageModule = module {
-  single<LanguageService> {
-    AndroidLanguageService(
-      context = get(),
-      marketManager = get(),
-    )
-  }
+  single<LanguageService> { AndroidLanguageService() }
 }

--- a/app/market/market-core/src/main/kotlin/com/hedvig/android/market/Language.kt
+++ b/app/market/market-core/src/main/kotlin/com/hedvig/android/market/Language.kt
@@ -48,7 +48,6 @@ enum class Language {
   }
 
   companion object {
-    const val SETTING_SYSTEM_DEFAULT = "system_default"
     const val SETTING_SV_SE = "sv-SE"
     const val SETTING_EN_SE = "en-SE"
     const val SETTING_NB_NO = "nb-NO"


### PR DESCRIPTION
We've had this migration since 2022-09-19. By now everyone must've run this code to migrate their specified language. And if not, what will happen for them is that the sharedprefs will store the old choice but it will not be used in any way, and en-SE will be automatically chosen for them.

Should simplify some code a bit as I am touching these classes