### PR TITLE
Invalidate hanalytics flags on login/logout events

### DIFF
--- a/app/app/src/debug/kotlin/com/hedvig/app/debug/impersonation/ImpersonationReceiverActivity.kt
+++ b/app/app/src/debug/kotlin/com/hedvig/app/debug/impersonation/ImpersonationReceiverActivity.kt
@@ -18,7 +18,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.app.feature.loggedin.ui.LoggedInActivity
 import com.hedvig.authlib.AuthRepository
 import com.hedvig.authlib.AuthTokenResult
@@ -88,7 +87,7 @@ class ImpersonationReceiverActivity : AppCompatActivity() {
   companion object {
     val module = module {
       viewModel { params ->
-        ImpersonationReceiverViewModel(params.get(), get(), get(), get())
+        ImpersonationReceiverViewModel(params.get(), get(), get())
       }
     }
   }
@@ -98,7 +97,6 @@ class ImpersonationReceiverViewModel(
   exchangeToken: String,
   authTokenService: AuthTokenService,
   authRepository: AuthRepository,
-  featureManager: FeatureManager,
 ) : ViewModel() {
   sealed class ViewState {
     object Loading : ViewState()
@@ -120,7 +118,6 @@ class ImpersonationReceiverViewModel(
         is AuthTokenResult.Error -> _state.update { ViewState.Error(result.message) }
         is AuthTokenResult.Success -> {
           authTokenService.loginWithTokens(result.accessToken, result.refreshToken)
-          featureManager.invalidateExperiments()
           _state.update { ViewState.Success }
           delay(500.milliseconds)
           _events.send(GoToLoggedInActivityEvent)

--- a/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -279,10 +279,10 @@ fun makeUserAgent(locale: Locale): String = buildString {
 private val viewModelModule = module {
   viewModel { ChatViewModel(get(), get(), get(), get()) }
   viewModel { (quoteCartId: QuoteCartId?) -> RedeemCodeViewModel(quoteCartId, get(), get()) }
-  viewModel { BankIdLoginViewModel(get(), get(), get(), get(), get()) }
+  viewModel { BankIdLoginViewModel(get(), get(), get(), get()) }
   viewModel { DatePickerViewModel() }
   viewModel { params ->
-    SimpleSignAuthenticationViewModel(params.get(), get(), get(), get(), get(), get())
+    SimpleSignAuthenticationViewModel(params.get(), get(), get(), get(), get())
   }
   viewModel { (data: MultiActionParams) -> MultiActionViewModel(data) }
   viewModel { (componentState: MultiActionItem.Component?, multiActionParams: MultiActionParams) ->
@@ -490,7 +490,7 @@ private val clockModule = module {
 private val useCaseModule = module {
   single { StartCheckoutUseCase(get<ApolloClient>(giraffeClient), get(), get()) }
   single<LogoutUseCase> {
-    LogoutUseCaseImpl(get<ApolloClient>(giraffeClient), get(), get(), get(), get(), get(), get())
+    LogoutUseCaseImpl(get<ApolloClient>(giraffeClient), get(), get(), get(), get(), get())
   }
   single { GraphQLQueryUseCase(get()) }
   single<GetInsuranceProvidersUseCase> {

--- a/app/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModel.kt
@@ -3,7 +3,6 @@ package com.hedvig.app.authenticate
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hedvig.android.auth.AuthTokenService
-import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.market.Market
@@ -30,7 +29,6 @@ import kotlin.time.Duration.Companion.seconds
 
 class BankIdLoginViewModel(
   private val hAnalytics: HAnalytics,
-  private val featureManager: FeatureManager,
   private val uploadMarketAndLanguagePreferencesUseCase: UploadMarketAndLanguagePreferencesUseCase,
   private val authTokenService: AuthTokenService,
   private val authRepository: AuthRepository,
@@ -135,7 +133,6 @@ class BankIdLoginViewModel(
       authTokenResult.accessToken,
       authTokenResult.refreshToken,
     )
-    featureManager.invalidateExperiments()
     uploadMarketAndLanguagePreferencesUseCase.invoke()
     hAnalytics.loggedIn()
     logcat(LogPriority.INFO) { "Logged in!" }

--- a/app/app/src/main/kotlin/com/hedvig/app/authenticate/LogoutUseCase.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/authenticate/LogoutUseCase.kt
@@ -5,7 +5,6 @@ import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.auth.LogoutUseCase
 import com.hedvig.android.core.common.ApplicationScope
-import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.logger.logcat
 import com.hedvig.app.feature.chat.data.ChatEventStore
 import com.hedvig.app.feature.chat.data.UserRepository
@@ -18,7 +17,6 @@ internal class LogoutUseCaseImpl(
   private val userRepository: UserRepository,
   private val authTokenService: AuthTokenService,
   private val chatEventStore: ChatEventStore,
-  private val featureManager: FeatureManager,
   private val hAnalytics: HAnalytics,
   private val applicationScope: ApplicationScope,
 ) : LogoutUseCase {
@@ -27,7 +25,6 @@ internal class LogoutUseCaseImpl(
     applicationScope.launch { hAnalytics.loggedOut() }
     applicationScope.launch { userRepository.logout() }
     applicationScope.launch { authTokenService.logoutAndInvalidateTokens() }
-    applicationScope.launch { featureManager.invalidateExperiments() }
     applicationScope.launch { apolloClient.apolloStore.clearAll() }
     applicationScope.launch { chatEventStore.resetChatClosedCounter() }
     applicationScope.launch { apolloClient.reconnectSubscriptions() }

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/zignsec/SimpleSignAuthenticationViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.asFlow
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.hedvig.android.auth.AuthTokenService
-import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.market.Market
@@ -28,7 +27,6 @@ import kotlinx.coroutines.launch
 class SimpleSignAuthenticationViewModel(
   private val data: SimpleSignAuthenticationData,
   private val hAnalytics: HAnalytics,
-  private val featureManager: FeatureManager,
   private val uploadMarketAndLanguagePreferencesUseCase: UploadMarketAndLanguagePreferencesUseCase,
   private val authRepository: AuthRepository,
   private val authTokenService: AuthTokenService,
@@ -136,7 +134,6 @@ class SimpleSignAuthenticationViewModel(
       is AuthTokenResult.Success -> {
         logcat { "Login exchange success:$result" }
         hAnalytics.loggedIn()
-        featureManager.invalidateExperiments()
         authTokenService.loginWithTokens(result.accessToken, result.refreshToken)
         uploadMarketAndLanguagePreferencesUseCase.invoke()
       }

--- a/app/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/app/authenticate/BankIdLoginViewModelTest.kt
@@ -15,7 +15,6 @@ import com.hedvig.android.auth.storage.AuthTokenStorage
 import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.common.test.MainCoroutineRule
 import com.hedvig.android.core.datastore.TestPreferencesDataStore
-import com.hedvig.android.hanalytics.featureflags.test.FakeFeatureManager
 import com.hedvig.android.hanalytics.test.FakeHAnalytics
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.app.feature.marketing.data.UploadMarketAndLanguagePreferencesUseCase
@@ -27,7 +26,6 @@ import com.hedvig.authlib.AuthorizationCodeGrant
 import com.hedvig.authlib.LoginStatusResult
 import com.hedvig.authlib.RefreshToken
 import com.hedvig.authlib.StatusUrl
-import com.hedvig.hanalytics.LoginMethod
 import io.mockk.mockk
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -186,7 +184,6 @@ class BankIdLoginViewModelTest {
     @Suppress("RemoveExplicitTypeArguments")
     return BankIdLoginViewModel(
       FakeHAnalytics(),
-      FakeFeatureManager(loginMethod = { LoginMethod.BANK_ID_SWEDEN }),
       mockk<UploadMarketAndLanguagePreferencesUseCase>(relaxed = true),
       authTokenService,
       authRepository,

--- a/app/datadog/src/main/kotlin/com/hedvig/android/datadog/memberid/DatadogMemberIdUpdatingAuthEventListener.kt
+++ b/app/datadog/src/main/kotlin/com/hedvig/android/datadog/memberid/DatadogMemberIdUpdatingAuthEventListener.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-class DatadogMemberIdUpdatingAuthEventListener : AuthEventListener {
+internal class DatadogMemberIdUpdatingAuthEventListener : AuthEventListener {
   override suspend fun loggedOut() {
     logcat(LogPriority.INFO) { "Removing from global RUM attribute:$MEMBER_ID_TRACKING_KEY" }
     Datadog.addUserExtraInfo(mapOf(MEMBER_ID_TRACKING_KEY to null))

--- a/app/hanalytics/hanalytics-feature-flags-public/build.gradle.kts
+++ b/app/hanalytics/hanalytics-feature-flags-public/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
   implementation(libs.coroutines.core)
   implementation(libs.koin.core)
+  implementation(projects.authEventCore)
   implementation(projects.coreBuildConstants)
   implementation(projects.coreCommonPublic)
   implementation(projects.hanalyticsCore)

--- a/app/hanalytics/hanalytics-feature-flags-public/src/main/kotlin/com/hedvig/android/hanalytics/featureflags/di/featureManagerModule.kt
+++ b/app/hanalytics/hanalytics-feature-flags-public/src/main/kotlin/com/hedvig/android/hanalytics/featureflags/di/featureManagerModule.kt
@@ -1,15 +1,18 @@
 package com.hedvig.android.hanalytics.featureflags.di
 
+import com.hedvig.android.auth.event.AuthEventListener
 import com.hedvig.android.code.buildoconstants.HedvigBuildConstants
 import com.hedvig.android.hanalytics.featureflags.ClearHAnalyticsExperimentsCacheUseCase
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.hanalytics.featureflags.FeatureManagerImpl
 import com.hedvig.android.hanalytics.featureflags.flags.DevFeatureFlagProvider
+import com.hedvig.android.hanalytics.featureflags.flags.FeatureFlagAuthEventListener
 import com.hedvig.android.hanalytics.featureflags.flags.HAnalyticsFeatureFlagProvider
 import com.hedvig.android.hanalytics.featureflags.loginmethod.DevLoginMethodProvider
 import com.hedvig.android.hanalytics.featureflags.loginmethod.HAnalyticsLoginMethodProvider
 import com.hedvig.android.hanalytics.featureflags.paymenttype.DevPaymentTypeProvider
 import com.hedvig.android.hanalytics.featureflags.paymenttype.HAnalyticsPaymentTypeProvider
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 @Suppress("RemoveExplicitTypeArguments")
@@ -32,4 +35,7 @@ val featureManagerModule = module {
       )
     }
   }
+  single<FeatureFlagAuthEventListener> {
+    FeatureFlagAuthEventListener(get<FeatureManager>())
+  } bind AuthEventListener::class
 }

--- a/app/hanalytics/hanalytics-feature-flags-public/src/main/kotlin/com/hedvig/android/hanalytics/featureflags/flags/FeatureFlagAuthEventListener.kt
+++ b/app/hanalytics/hanalytics-feature-flags-public/src/main/kotlin/com/hedvig/android/hanalytics/featureflags/flags/FeatureFlagAuthEventListener.kt
@@ -1,0 +1,16 @@
+package com.hedvig.android.hanalytics.featureflags.flags
+
+import com.hedvig.android.auth.event.AuthEventListener
+import com.hedvig.android.hanalytics.featureflags.FeatureManager
+
+internal class FeatureFlagAuthEventListener(
+  private val featureManager: FeatureManager,
+) : AuthEventListener {
+  override suspend fun loggedIn(accessToken: String) {
+    featureManager.invalidateExperiments()
+  }
+
+  override suspend fun loggedOut() {
+    featureManager.invalidateExperiments()
+  }
+}


### PR DESCRIPTION
Instead of having to manually do it on each place in the app which might perform a login/logout action.
FeatureFlagAuthEventListener catches all these events in a centralized spot.