### PR TITLE
Demo mode extra in demo features

### DIFF
--- a/app/apollo/apollo-auth-listeners/build.gradle.kts
+++ b/app/apollo/apollo-auth-listeners/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  id("hedvig.android.ktlint")
+  id("hedvig.android.library")
+  alias(libs.plugins.squareSortDependencies)
+}
+
+dependencies {
+  implementation(libs.apollo.api)
+  implementation(libs.apollo.normalizedCache)
+  implementation(libs.apollo.runtime)
+  implementation(libs.koin.core)
+  implementation(projects.apolloGiraffePublic)
+  implementation(projects.apolloOctopusPublic)
+  implementation(projects.authEventCore)
+}

--- a/app/apollo/apollo-auth-listeners/src/main/AndroidManifest.xml
+++ b/app/apollo/apollo-auth-listeners/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/di/ApolloAuthListenersModule.kt
+++ b/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/di/ApolloAuthListenersModule.kt
@@ -1,0 +1,24 @@
+package com.hedvig.android.apollo.auth.listeners.di
+
+import com.apollographql.apollo3.ApolloClient
+import com.hedvig.android.apollo.auth.listeners.normalizedcache.ApolloNormalizedCacheAuthEventListener
+import com.hedvig.android.apollo.auth.listeners.subscription.ApolloSubscriptionReconnectingAuthEventListener
+import com.hedvig.android.apollo.giraffe.di.giraffeClient
+import com.hedvig.android.apollo.octopus.di.octopusClient
+import com.hedvig.android.auth.event.AuthEventListener
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val apolloAuthListenersModule = module {
+  single<ApolloNormalizedCacheAuthEventListener> {
+    ApolloNormalizedCacheAuthEventListener(
+      get<ApolloClient>(giraffeClient),
+      get<ApolloClient>(octopusClient),
+    )
+  } bind AuthEventListener::class
+  single<ApolloSubscriptionReconnectingAuthEventListener> {
+    ApolloSubscriptionReconnectingAuthEventListener(
+      get<ApolloClient>(giraffeClient),
+    )
+  } bind AuthEventListener::class
+}

--- a/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/normalizedcache/ApolloNormalizedCacheAuthEventListener.kt
+++ b/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/normalizedcache/ApolloNormalizedCacheAuthEventListener.kt
@@ -1,0 +1,20 @@
+package com.hedvig.android.apollo.auth.listeners.normalizedcache
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.apolloStore
+import com.hedvig.android.auth.event.AuthEventListener
+
+internal class ApolloNormalizedCacheAuthEventListener(
+  private val giraffeApolloClient: ApolloClient,
+  private val octopusApolloClient: ApolloClient,
+) : AuthEventListener {
+  override suspend fun loggedIn(accessToken: String) {
+    giraffeApolloClient.apolloStore.clearAll()
+    octopusApolloClient.apolloStore.clearAll()
+  }
+
+  override suspend fun loggedOut() {
+    giraffeApolloClient.apolloStore.clearAll()
+    octopusApolloClient.apolloStore.clearAll()
+  }
+}

--- a/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/subscription/ApolloSubscriptionReconnectingAuthEventListener.kt
+++ b/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/subscription/ApolloSubscriptionReconnectingAuthEventListener.kt
@@ -1,0 +1,16 @@
+package com.hedvig.android.apollo.auth.listeners.subscription
+
+import com.apollographql.apollo3.ApolloClient
+import com.hedvig.android.auth.event.AuthEventListener
+
+internal class ApolloSubscriptionReconnectingAuthEventListener(
+  private val giraffeApolloClient: ApolloClient,
+) : AuthEventListener {
+  override suspend fun loggedIn(accessToken: String) {
+    giraffeApolloClient.reconnectSubscriptions()
+  }
+
+  override suspend fun loggedOut() {
+    giraffeApolloClient.reconnectSubscriptions()
+  }
+}

--- a/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/subscription/ReopenSubscriptionException.kt
+++ b/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/subscription/ReopenSubscriptionException.kt
@@ -1,9 +1,11 @@
-package com.hedvig.app.util.apollo
+package com.hedvig.android.apollo.auth.listeners.subscription
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.network.ws.closeConnection
 
-object ReopenSubscriptionException : Exception("ReopenSubscriptionException")
+object ReopenSubscriptionException : Exception("ReopenSubscriptionException") {
+  private fun readResolve(): Any = ReopenSubscriptionException
+}
 
 /**
  * The name "reconnect" depends on the apolloClient being configured to re-open the subscription when specifically
@@ -19,6 +21,6 @@ object ReopenSubscriptionException : Exception("ReopenSubscriptionException")
  * }
  * ```
  */
-fun ApolloClient.reconnectSubscriptions() {
+internal fun ApolloClient.reconnectSubscriptions() {
   subscriptionNetworkTransport.closeConnection(ReopenSubscriptionException)
 }

--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -184,6 +184,7 @@ dependencies {
   implementation(libs.reactiveX.kotlin)
   implementation(libs.shimmer)
   implementation(libs.timber)
+  implementation(projects.apolloAuthListeners)
   implementation(projects.apolloCore)
   implementation(projects.apolloDi)
   implementation(projects.apolloGiraffePublic)

--- a/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -275,7 +275,7 @@ fun makeUserAgent(locale: Locale): String = buildString {
 }
 
 private val viewModelModule = module {
-  viewModel { ChatViewModel(get(), get(), get(), get()) }
+  viewModel { ChatViewModel(get(), get(), get(), get(), get()) }
   viewModel { (quoteCartId: QuoteCartId?) -> RedeemCodeViewModel(quoteCartId, get(), get()) }
   viewModel { DatePickerViewModel() }
   viewModel { params ->

--- a/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/ApplicationModule.kt
@@ -19,6 +19,8 @@ import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.network.okHttpClient
 import com.apollographql.apollo3.network.ws.SubscriptionWsProtocol
 import com.hedvig.android.apollo.NetworkCacheManager
+import com.hedvig.android.apollo.auth.listeners.di.apolloAuthListenersModule
+import com.hedvig.android.apollo.auth.listeners.subscription.ReopenSubscriptionException
 import com.hedvig.android.apollo.di.apolloClientModule
 import com.hedvig.android.apollo.giraffe.di.giraffeClient
 import com.hedvig.android.app.di.appModule
@@ -146,7 +148,6 @@ import com.hedvig.app.service.push.senders.ReferralsNotificationSender
 import com.hedvig.app.util.apollo.DeviceIdInterceptor
 import com.hedvig.app.util.apollo.GraphQLQueryHandler
 import com.hedvig.app.util.apollo.NetworkCacheManagerImpl
-import com.hedvig.app.util.apollo.ReopenSubscriptionException
 import com.hedvig.app.util.apollo.SunsettingInterceptor
 import com.hedvig.app.util.extensions.startChat
 import com.hedvig.authlib.AuthEnvironment
@@ -491,7 +492,7 @@ private val clockModule = module {
 private val useCaseModule = module {
   single { StartCheckoutUseCase(get<ApolloClient>(giraffeClient), get(), get()) }
   single<LogoutUseCase> {
-    LogoutUseCaseImpl(get<ApolloClient>(giraffeClient), get(), get(), get(), get(), get(), get())
+    LogoutUseCaseImpl(get(), get(), get(), get(), get(), get())
   }
   single { GraphQLQueryUseCase(get()) }
   single<GetInsuranceProvidersUseCase> {
@@ -610,6 +611,7 @@ val applicationModule = module {
     listOf(
       activityNavigatorModule,
       adyenModule,
+      apolloAuthListenersModule,
       apolloClientModule,
       appModule,
       authModule,

--- a/app/app/src/main/kotlin/com/hedvig/app/authenticate/LogoutUseCase.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/authenticate/LogoutUseCase.kt
@@ -1,7 +1,5 @@
 package com.hedvig.app.authenticate
 
-import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.auth.LogoutUseCase
 import com.hedvig.android.core.common.ApplicationScope
@@ -9,12 +7,10 @@ import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.logger.logcat
 import com.hedvig.app.feature.chat.data.ChatEventStore
 import com.hedvig.app.feature.chat.data.UserRepository
-import com.hedvig.app.util.apollo.reconnectSubscriptions
 import com.hedvig.hanalytics.HAnalytics
 import kotlinx.coroutines.launch
 
 internal class LogoutUseCaseImpl(
-  private val apolloClient: ApolloClient,
   private val userRepository: UserRepository,
   private val authTokenService: AuthTokenService,
   private val chatEventStore: ChatEventStore,
@@ -27,9 +23,7 @@ internal class LogoutUseCaseImpl(
     applicationScope.launch { hAnalytics.loggedOut() }
     applicationScope.launch { userRepository.logout() }
     applicationScope.launch { authTokenService.logoutAndInvalidateTokens() }
-    applicationScope.launch { apolloClient.apolloStore.clearAll() }
     applicationScope.launch { chatEventStore.resetChatClosedCounter() }
-    applicationScope.launch { apolloClient.reconnectSubscriptions() }
     applicationScope.launch { demoManager.setDemoMode(false) }
   }
 }

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeViewModel.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/referrals/ui/redeemcode/RedeemCodeViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hedvig.android.core.common.android.QuoteCartId
 import com.hedvig.android.data.forever.CampaignCode
-import com.hedvig.android.data.forever.ForeverRepositoryImpl
+import com.hedvig.android.data.forever.ForeverRepository
 import com.hedvig.app.feature.offer.usecase.EditCampaignUseCase
 import giraffe.RedeemReferralCodeMutation
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 
 class RedeemCodeViewModel(
   private val quoteCartId: QuoteCartId?,
-  private val referralsRepository: ForeverRepositoryImpl,
+  private val referralsRepository: ForeverRepository,
   private val editCampaignUseCase: EditCampaignUseCase,
 ) : ViewModel() {
 

--- a/app/app/src/test/kotlin/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/app/feature/genericauth/OtpInputViewModelTest.kt
@@ -8,9 +8,8 @@ import assertk.assertions.isNull
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.auth.AuthTokenServiceImpl
 import com.hedvig.android.auth.FakeAuthRepository
-import com.hedvig.android.auth.event.AuthEventBroadcaster
+import com.hedvig.android.auth.event.AuthEventStorage
 import com.hedvig.android.auth.storage.AuthTokenStorage
-import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.common.test.MainCoroutineRule
 import com.hedvig.android.core.datastore.TestPreferencesDataStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
@@ -30,7 +29,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import kotlin.coroutines.EmptyCoroutineContext
 
 class OtpInputViewModelTest {
 
@@ -224,11 +222,7 @@ class OtpInputViewModelTest {
     return AuthTokenServiceImpl(
       authTokenStorage = authTokenStorage,
       authRepository = authRepository,
-      authEventBroadcaster = AuthEventBroadcaster(
-        emptySet(),
-        ApplicationScope(backgroundScope),
-        EmptyCoroutineContext,
-      ),
+      authEventStorage = AuthEventStorage(),
       coroutineScope = backgroundScope,
     )
   }

--- a/app/auth/auth-core/build.gradle.kts
+++ b/app/auth/auth-core/build.gradle.kts
@@ -19,8 +19,10 @@ dependencies {
   implementation(projects.coreCommonAndroidPublic)
   implementation(projects.coreCommonPublic)
   implementation(projects.coreDatastorePublic)
-  implementation(projects.testClock)
   implementation(projects.coreDemoMode)
+  implementation(projects.initializable)
+  implementation(projects.testClock)
+
   testImplementation(libs.assertK)
   testImplementation(libs.coroutines.test)
   testImplementation(libs.okhttp.mockWebServer)

--- a/app/auth/auth-core/src/main/kotlin/com/hedvig/android/auth/AuthTokenServiceImpl.kt
+++ b/app/auth/auth-core/src/main/kotlin/com/hedvig/android/auth/AuthTokenServiceImpl.kt
@@ -1,6 +1,6 @@
 package com.hedvig.android.auth
 
-import com.hedvig.android.auth.event.AuthEventBroadcaster
+import com.hedvig.android.auth.event.AuthEventStorage
 import com.hedvig.android.auth.storage.AuthTokenStorage
 import com.hedvig.android.auth.token.AuthTokens
 import com.hedvig.android.auth.token.LocalRefreshToken
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.stateIn
 class AuthTokenServiceImpl(
   private val authTokenStorage: AuthTokenStorage,
   private val authRepository: AuthRepository,
-  private val authEventBroadcaster: AuthEventBroadcaster,
+  private val authEventStorage: AuthEventStorage,
   coroutineScope: CoroutineScope,
 ) : AuthTokenService {
 
@@ -58,12 +58,12 @@ class AuthTokenServiceImpl(
 
   override suspend fun loginWithTokens(accessToken: AccessToken, refreshToken: RefreshToken) {
     authTokenStorage.updateTokens(accessToken, refreshToken)
-    authEventBroadcaster.loggedIn(accessToken.token)
+    authEventStorage.loggedIn(accessToken.token)
   }
 
   override suspend fun logoutAndInvalidateTokens() {
     authTokenStorage.clearTokens()
-    authEventBroadcaster.loggedOut()
+    authEventStorage.loggedOut()
   }
 
   private suspend fun getRefreshToken(): LocalRefreshToken? {

--- a/app/auth/auth-core/src/main/kotlin/com/hedvig/android/auth/event/AuthEvent.kt
+++ b/app/auth/auth-core/src/main/kotlin/com/hedvig/android/auth/event/AuthEvent.kt
@@ -1,0 +1,6 @@
+package com.hedvig.android.auth.event
+
+sealed interface AuthEvent {
+  data class LoggedIn(val accessToken: String) : AuthEvent
+  data object LoggedOut : AuthEvent
+}

--- a/app/auth/auth-core/src/main/kotlin/com/hedvig/android/auth/event/AuthEventStorage.kt
+++ b/app/auth/auth-core/src/main/kotlin/com/hedvig/android/auth/event/AuthEventStorage.kt
@@ -1,0 +1,15 @@
+package com.hedvig.android.auth.event
+
+import kotlinx.coroutines.channels.Channel
+
+class AuthEventStorage() {
+  val authEvents = Channel<AuthEvent>(Channel.UNLIMITED)
+
+  fun loggedIn(accessToken: String) {
+    authEvents.trySend(AuthEvent.LoggedIn(accessToken))
+  }
+
+  fun loggedOut() {
+    authEvents.trySend(AuthEvent.LoggedOut)
+  }
+}

--- a/app/auth/auth-core/src/test/kotlin/com/hedvig/android/auth/interceptor/AuthTokenRefreshingInterceptorTest.kt
+++ b/app/auth/auth-core/src/test/kotlin/com/hedvig/android/auth/interceptor/AuthTokenRefreshingInterceptorTest.kt
@@ -8,9 +8,8 @@ import com.hedvig.android.auth.AndroidAccessTokenProvider
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.auth.AuthTokenServiceImpl
 import com.hedvig.android.auth.FakeAuthRepository
-import com.hedvig.android.auth.event.AuthEventBroadcaster
+import com.hedvig.android.auth.event.AuthEventStorage
 import com.hedvig.android.auth.storage.AuthTokenStorage
-import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.datastore.TestPreferencesDataStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.test.clock.TestClock
@@ -31,7 +30,6 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
@@ -222,7 +220,7 @@ class AuthTokenRefreshingInterceptorTest {
     return AuthTokenServiceImpl(
       authTokenStorage,
       fakeAuthRepository,
-      AuthEventBroadcaster(emptySet(), ApplicationScope(backgroundScope), EmptyCoroutineContext),
+      AuthEventStorage(),
       backgroundScope,
     )
   }

--- a/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepository.kt
+++ b/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepository.kt
@@ -7,6 +7,27 @@ import giraffe.ReferralsQuery
 
 interface ForeverRepository {
   suspend fun getReferralsData(): Either<ErrorMessage, ReferralsQuery.Data>
-  suspend fun updateCode(newCode: String): Either<ForeverRepositoryImpl.ReferralError, String>
+  suspend fun updateCode(newCode: String): Either<ForeverRepository.ReferralError, String>
   suspend fun redeemReferralCode(campaignCode: CampaignCode): Either<ErrorMessage, RedeemReferralCodeMutation.Data?>
+
+  sealed interface ReferralError {
+    data class GeneralError(
+      val message: String?,
+    ) : ReferralError
+
+    data class CodeTooLong(
+      val maxCharacters: Int,
+    ) : ReferralError
+
+    data class CodeTooShort(
+      val minCharacters: Int,
+    ) : ReferralError
+
+    data class MaxUpdates(
+      val maxUpdates: Int,
+    ) : ReferralError
+
+    data object CodeIsEmpty : ReferralError
+    data object CodeExists : ReferralError
+  }
 }

--- a/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryDemo.kt
+++ b/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryDemo.kt
@@ -11,7 +11,7 @@ internal class ForeverRepositoryDemo : ForeverRepository {
     ReferralsQuery.Data()
   }
 
-  override suspend fun updateCode(newCode: String): Either<ForeverRepositoryImpl.ReferralError, String> = either {
+  override suspend fun updateCode(newCode: String): Either<ForeverRepository.ReferralError, String> = either {
     newCode
   }
 

--- a/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryDemo.kt
+++ b/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryDemo.kt
@@ -2,22 +2,112 @@ package com.hedvig.android.data.forever
 
 import arrow.core.Either
 import arrow.core.raise.either
+import arrow.core.right
 import com.hedvig.android.core.common.ErrorMessage
 import giraffe.RedeemReferralCodeMutation
 import giraffe.ReferralsQuery
+import giraffe.fragment.CostFragment
+import giraffe.fragment.MonetaryAmountFragment
+import giraffe.fragment.ReferralFragment
 
 internal class ForeverRepositoryDemo : ForeverRepository {
+  private var code: String = "code"
+
   override suspend fun getReferralsData(): Either<ErrorMessage, ReferralsQuery.Data> = either {
-    ReferralsQuery.Data()
+    ReferralsQuery.Data(
+      ReferralsQuery.ReferralInformation(
+        ReferralsQuery.Campaign(
+          code,
+          ReferralsQuery.Incentive(
+            "",
+            ReferralsQuery.AsMonthlyCostDeduction(
+              "",
+              ReferralsQuery.Amount(
+                "",
+                ReferralsQuery.Amount.Fragments(
+                  MonetaryAmountFragment("10", "SEK"),
+                ),
+              ),
+            ),
+          ),
+        ),
+        costReducedIndefiniteDiscount = ReferralsQuery.CostReducedIndefiniteDiscount(
+          "",
+          ReferralsQuery.CostReducedIndefiniteDiscount.Fragments(
+            CostFragment(
+              CostFragment.MonthlyDiscount(
+                "",
+                CostFragment.MonthlyDiscount.Fragments(MonetaryAmountFragment("20", "SEK")),
+              ),
+              CostFragment.MonthlyNet(
+                "",
+                CostFragment.MonthlyNet.Fragments(MonetaryAmountFragment("40", "SEK")),
+              ),
+              CostFragment.MonthlyGross(
+                "",
+                CostFragment.MonthlyGross.Fragments(MonetaryAmountFragment("60", "SEK")),
+              ),
+            ),
+          ),
+        ),
+        referredBy = ReferralsQuery.ReferredBy(
+          "",
+          ReferralsQuery.ReferredBy.Fragments(
+            ReferralFragment(
+              "",
+              ReferralFragment.AsActiveReferral(
+                "",
+                "Adam",
+                ReferralFragment.Discount(
+                  "",
+                  ReferralFragment.Discount.Fragments(
+                    MonetaryAmountFragment(
+                      "10",
+                      "SEK",
+                    ),
+                  ),
+                ),
+              ),
+              null,
+              null,
+            ),
+          ),
+        ),
+        invitations = List(2) { index ->
+          ReferralsQuery.Invitation(
+            "",
+            ReferralsQuery.Invitation.Fragments(
+              ReferralFragment(
+                "",
+                ReferralFragment.AsActiveReferral(
+                  "",
+                  if (index % 2 == 0) "Adam" else "Claire",
+                  ReferralFragment.Discount(
+                    "",
+                    ReferralFragment.Discount.Fragments(
+                      MonetaryAmountFragment(
+                        "10",
+                        "SEK",
+                      ),
+                    ),
+                  ),
+                ),
+                null,
+                null,
+              ),
+            ),
+          )
+        },
+      ),
+    )
   }
 
-  override suspend fun updateCode(newCode: String): Either<ForeverRepository.ReferralError, String> = either {
-    newCode
+  override suspend fun updateCode(newCode: String): Either<ForeverRepository.ReferralError, String> {
+    code = newCode
+    return newCode.right()
   }
 
   override suspend fun redeemReferralCode(
     campaignCode: CampaignCode,
-  ): Either<ErrorMessage, RedeemReferralCodeMutation.Data?> = either {
-    null
-  }
+  ): Either<ErrorMessage, RedeemReferralCodeMutation.Data?> = either { null }
 }

--- a/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryDemo.kt
+++ b/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryDemo.kt
@@ -6,7 +6,7 @@ import com.hedvig.android.core.common.ErrorMessage
 import giraffe.RedeemReferralCodeMutation
 import giraffe.ReferralsQuery
 
-class ForeverRepositoryDemo : ForeverRepository {
+internal class ForeverRepositoryDemo : ForeverRepository {
   override suspend fun getReferralsData(): Either<ErrorMessage, ReferralsQuery.Data> = either {
     ReferralsQuery.Data()
   }

--- a/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryImpl.kt
+++ b/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryImpl.kt
@@ -16,7 +16,7 @@ import giraffe.UpdateReferralCampaignCodeMutation
 @JvmInline
 value class CampaignCode(val code: String)
 
-class ForeverRepositoryImpl(
+internal class ForeverRepositoryImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
 ) : ForeverRepository {

--- a/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryImpl.kt
+++ b/app/data/data-forever/src/main/kotlin/com/hedvig/android/data/forever/ForeverRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.data.forever.ForeverRepository.ReferralError
 import com.hedvig.android.language.LanguageService
 import giraffe.RedeemReferralCodeMutation
 import giraffe.ReferralsQuery
@@ -82,25 +83,4 @@ internal class ForeverRepositoryImpl(
   }
 
   private fun toReferralError(message: String?) = ReferralError.GeneralError(message)
-
-  sealed interface ReferralError {
-    data class GeneralError(
-      val message: String?,
-    ) : ReferralError
-
-    data class CodeTooLong(
-      val maxCharacters: Int,
-    ) : ReferralError
-
-    data class CodeTooShort(
-      val minCharacters: Int,
-    ) : ReferralError
-
-    data class MaxUpdates(
-      val maxUpdates: Int,
-    ) : ReferralError
-
-    data object CodeIsEmpty : ReferralError
-    data object CodeExists : ReferralError
-  }
 }

--- a/app/datadog/datadog-demo-tracking/src/main/kotlin/com/hedvig/android/datadog/demo/tracking/DatadogDemoModeTracking.kt
+++ b/app/datadog/datadog-demo-tracking/src/main/kotlin/com/hedvig/android/datadog/demo/tracking/DatadogDemoModeTracking.kt
@@ -6,10 +6,8 @@ import com.hedvig.android.datadog.core.attributestracking.DatadogAttributesManag
 import com.hedvig.android.initializable.Initializable
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.launch
 
-@OptIn(InternalCoroutinesApi::class)
 class DatadogDemoModeTracking(
   private val applicationScope: ApplicationScope,
   private val demoManager: DemoManager,

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ForeverViewModel.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ForeverViewModel.kt
@@ -3,6 +3,7 @@ package com.hedvig.android.feature.forever
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -12,7 +13,6 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.data.forever.ForeverRepository
-import com.hedvig.android.data.forever.ForeverRepositoryImpl
 import com.hedvig.android.feature.forever.data.GetReferralsInformationUseCase
 import com.hedvig.android.molecule.android.MoleculeViewModel
 import com.hedvig.android.molecule.public.MoleculePresenter
@@ -39,12 +39,12 @@ internal class ForeverPresenter(
   @Composable
   override fun MoleculePresenterScope<ForeverEvent>.present(lastState: ForeverUiState): ForeverUiState {
     var isLoadingForeverData by remember { mutableStateOf(lastState.isLoadingForeverData) }
-    var foreverDataLoadIteration by remember { mutableStateOf(0) }
+    var foreverDataLoadIteration by remember { mutableIntStateOf(0) }
     var foreverDataErrorMessage by remember { mutableStateOf(lastState.foreverDataErrorMessage) }
     var foreverData by remember { mutableStateOf(lastState.foreverData) }
 
     var referralCodeToSubmit by remember { mutableStateOf<String?>(null) }
-    var referralCodeToSubmitErrorMessage by remember { mutableStateOf<ForeverRepositoryImpl.ReferralError?>(null) }
+    var referralCodeToSubmitErrorMessage by remember { mutableStateOf<ForeverRepository.ReferralError?>(null) }
     var showReferralCodeToSubmitSuccess by remember { mutableStateOf<Boolean>(false) }
 
     CollectEvents { event ->
@@ -114,7 +114,7 @@ internal data class ForeverUiState(
   val isLoadingForeverData: Boolean,
   val foreverDataErrorMessage: ErrorMessage?,
   val referralCodeLoading: Boolean,
-  val referralCodeErrorMessage: ForeverRepositoryImpl.ReferralError?,
+  val referralCodeErrorMessage: ForeverRepository.ReferralError?,
   val showReferralCodeSuccessfullyChangedMessage: Boolean,
 ) {
 

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ForeverViewModel.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ForeverViewModel.kt
@@ -62,11 +62,11 @@ internal class ForeverPresenter(
       either {
         parZip(
           { foreverRepositoryProvider.provide().getReferralsData().bind() },
-          { getReferralsInformationUseCaseProvider.provide().invoke().bind() },
+          { getReferralsInformationUseCaseProvider.provide().invoke() },
         ) { referralsData, terms ->
           ForeverUiState.ForeverData(
             referralsData = referralsData,
-            referralTerms = terms,
+            referralTerms = terms.getOrNull(),
           )
         }
       }.fold(

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/data/GetReferralsInformationUseCaseDemo.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/data/GetReferralsInformationUseCaseDemo.kt
@@ -7,6 +7,6 @@ import giraffe.ReferralTermsQuery
 
 class GetReferralsInformationUseCaseDemo : GetReferralsInformationUseCase {
   override suspend fun invoke(): Either<ErrorMessage, ReferralTermsQuery.ReferralTerms> = either {
-    ReferralTermsQuery.ReferralTerms("test")
+    raise(ErrorMessage("Demo"))
   }
 }

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/DiscountPieChart.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/DiscountPieChart.kt
@@ -35,23 +35,23 @@ fun DiscountPieChart(
   incentiveColor: Color = MaterialTheme.colorScheme.typeContainer,
 ) {
   val transition = rememberInfiniteTransition(label = "transition")
+  val targetForeverIncentiveValue = calculateAngleDegrees(totalPrice, incentive)
   val foreverIncentiveSweep by transition.animateFloat(
     initialValue = 0f,
-    targetValue = calculateAngleDegrees(totalPrice, incentive),
+    targetValue = targetForeverIncentiveValue,
     animationSpec = InfiniteRepeatableSpec(
       animation = keyframes {
         durationMillis = 4100
         0f at 0
         0f at 1800 with FastOutSlowInEasing
-        30f at 2300
-        30f at 3600 with FastOutSlowInEasing
+        targetForeverIncentiveValue at 2300
+        targetForeverIncentiveValue at 3600 with FastOutSlowInEasing
         0f at 4100
       },
       repeatMode = RepeatMode.Restart,
     ),
-    label = "animation",
+    label = "incentive sweep animation",
   )
-
   Canvas(
     modifier = modifier.size(215.dp),
     onDraw = {

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/EditCodeBottomSheet.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/EditCodeBottomSheet.kt
@@ -29,7 +29,7 @@ import com.hedvig.android.core.designsystem.component.button.HedvigContainedButt
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.component.textfield.HedvigTextField
 import com.hedvig.android.core.designsystem.material3.squircleLargeTop
-import com.hedvig.android.data.forever.ForeverRepositoryImpl
+import com.hedvig.android.data.forever.ForeverRepository
 import hedvig.resources.R
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.filter
 internal fun EditCodeBottomSheet(
   sheetState: SheetState,
   code: TextFieldValue,
-  referralCodeUpdateError: ForeverRepositoryImpl.ReferralError?,
+  referralCodeUpdateError: ForeverRepository.ReferralError?,
   showedReferralCodeSubmissionError: () -> Unit,
   onCodeChanged: (TextFieldValue) -> Unit,
   onDismiss: () -> Unit,
@@ -110,24 +110,24 @@ internal fun EditCodeBottomSheet(
 }
 
 @Composable
-private fun ForeverRepositoryImpl.ReferralError.toErrorMessage(): String {
+private fun ForeverRepository.ReferralError.toErrorMessage(): String {
   return when (this) {
-    ForeverRepositoryImpl.ReferralError.CodeExists -> {
+    ForeverRepository.ReferralError.CodeExists -> {
       stringResource(R.string.referrals_change_code_sheet_error_claimed_code)
     }
-    is ForeverRepositoryImpl.ReferralError.CodeTooLong -> {
+    is ForeverRepository.ReferralError.CodeTooLong -> {
       stringResource(R.string.referrals_change_code_sheet_error_max_length)
     }
-    is ForeverRepositoryImpl.ReferralError.CodeIsEmpty -> {
+    is ForeverRepository.ReferralError.CodeIsEmpty -> {
       stringResource(R.string.referrals_change_code_sheet_error_empty_code)
     }
-    is ForeverRepositoryImpl.ReferralError.CodeTooShort -> {
+    is ForeverRepository.ReferralError.CodeTooShort -> {
       stringResource(R.string.referrals_change_code_sheet_general_error)
     }
-    is ForeverRepositoryImpl.ReferralError.GeneralError -> {
+    is ForeverRepository.ReferralError.GeneralError -> {
       stringResource(R.string.referrals_change_code_sheet_general_error)
     }
-    is ForeverRepositoryImpl.ReferralError.MaxUpdates -> {
+    is ForeverRepository.ReferralError.MaxUpdates -> {
       stringResource(R.string.referrals_change_code_sheet_error_change_limit_reached, this.maxUpdates)
     }
   }

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/ForeverDestination.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/ForeverDestination.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -178,6 +179,7 @@ private fun ForeverScreen(
   }
 }
 
+@ExperimentalMaterial3Api
 @Composable
 internal fun ForeverContent(
   uiState: ForeverUiState,

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetCrossSellsUseCaseDemo.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetCrossSellsUseCaseDemo.kt
@@ -4,11 +4,41 @@ import arrow.core.Either
 import arrow.core.raise.either
 import com.hedvig.android.core.common.ErrorMessage
 import octopus.CrossSalesQuery
+import octopus.type.CrossSellType
 
 internal class GetCrossSellsUseCaseDemo : GetCrossSellsUseCase {
   override suspend fun invoke(): Either<ErrorMessage, List<CrossSalesQuery.Data.CurrentMember.CrossSell>> {
     return either {
-      listOf()
+      listOf(
+        CrossSalesQuery.Data.CurrentMember.CrossSell(
+          "1",
+          "Home Insurance",
+          "For you, your family and your home",
+          "",
+          CrossSellType.HOME,
+        ),
+        CrossSalesQuery.Data.CurrentMember.CrossSell(
+          "2",
+          "Pet Insurance",
+          "For your dog or cat",
+          "",
+          CrossSellType.PET,
+        ),
+        CrossSalesQuery.Data.CurrentMember.CrossSell(
+          "3",
+          "Car Insurance",
+          "For your and your car",
+          "",
+          CrossSellType.CAR,
+        ),
+        CrossSalesQuery.Data.CurrentMember.CrossSell(
+          "4",
+          "Accident Insurance",
+          "No loopholes on our part. No worries on your part.",
+          "",
+          CrossSellType.ACCIDENT,
+        ),
+      )
     }
   }
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCaseDemo.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCaseDemo.kt
@@ -17,14 +17,6 @@ internal class GetInsuranceContractsUseCaseDemo : GetInsuranceContractsUseCase {
           isTerminated = false,
           typeOfContract = TypeOfContract.SE_HOUSE,
         ),
-        InsuranceContract(
-          id = "2",
-          displayName = "Pet Insurance",
-          statusPills = listOf("Active"),
-          detailPills = listOf("Douglas"),
-          isTerminated = false,
-          typeOfContract = TypeOfContract.SE_DOG_PREMIUM,
-        ),
       )
     }
   }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCaseDemo.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCaseDemo.kt
@@ -13,7 +13,7 @@ internal class GetInsuranceContractsUseCaseDemo : GetInsuranceContractsUseCase {
           id = "1",
           displayName = "Home Insurance",
           statusPills = listOf("Active"),
-          detailPills = listOf("Testway 10"),
+          detailPills = listOf("Road 10"),
           isTerminated = false,
           typeOfContract = TypeOfContract.SE_HOUSE,
         ),

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
@@ -11,14 +11,17 @@ import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseDe
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseImpl
 import com.hedvig.android.feature.insurances.insurance.presentation.InsuranceViewModel
 import com.hedvig.android.feature.insurances.insurancedetail.ContractDetailViewModel
-import com.hedvig.android.feature.insurances.insurancedetail.GetContractDetailsUseCase
 import com.hedvig.android.feature.insurances.insurancedetail.coverage.GetContractCoverageUseCase
 import com.hedvig.android.feature.insurances.insurancedetail.coverage.GetContractCoverageUseCaseImpl
+import com.hedvig.android.feature.insurances.insurancedetail.data.GetContractDetailsUseCaseDemo
+import com.hedvig.android.feature.insurances.insurancedetail.data.GetContractDetailsUseCaseImpl
+import com.hedvig.android.feature.insurances.insurancedetail.data.GetContractDetailsUseCaseProvider
 import com.hedvig.android.feature.insurances.terminatedcontracts.TerminatedContractsViewModel
 import com.hedvig.android.hanalytics.featureflags.FeatureManager
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.notification.badge.data.crosssell.card.CrossSellCardNotificationBadgeService
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val insurancesModule = module {
@@ -33,24 +36,18 @@ val insurancesModule = module {
     TerminatedContractsViewModel(get<GetInsuranceContractsUseCase>())
   }
   viewModel<ContractDetailViewModel> { (contractId: String) ->
-    ContractDetailViewModel(contractId, get(), get())
+    ContractDetailViewModel(contractId, get<GetContractDetailsUseCaseProvider>())
   }
 
   single<GetContractCoverageUseCase> {
     GetContractCoverageUseCaseImpl(get<ApolloClient>(octopusClient))
   }
-  single<GetContractDetailsUseCase> {
-    GetContractDetailsUseCase(
+  single<GetContractDetailsUseCaseImpl> {
+    GetContractDetailsUseCaseImpl(
       get<ApolloClient>(giraffeClient),
       get<GetContractCoverageUseCase>(),
       get<LanguageService>(),
       get<FeatureManager>(),
-    )
-  }
-  single<GetInsuranceContractsUseCaseImpl> {
-    GetInsuranceContractsUseCaseImpl(
-      get<ApolloClient>(giraffeClient),
-      get<LanguageService>(),
     )
   }
   single<GetInsuranceContractsUseCaseDemo> {
@@ -71,12 +68,31 @@ val insurancesModule = module {
   single<GetCrossSellsUseCaseDemo> {
     GetCrossSellsUseCaseDemo()
   }
-
   single {
     GetCrossSellsUseCaseProvider(
       demoManager = get<DemoManager>(),
       prodImpl = get<GetCrossSellsUseCaseImpl>(),
       demoImpl = get<GetCrossSellsUseCaseDemo>(),
+    )
+  }
+  provideGetContractDetailsUseCase()
+}
+
+private fun Module.provideGetContractDetailsUseCase() {
+  single<GetContractDetailsUseCaseDemo> {
+    GetContractDetailsUseCaseDemo()
+  }
+  single<GetInsuranceContractsUseCaseImpl> {
+    GetInsuranceContractsUseCaseImpl(
+      get<ApolloClient>(giraffeClient),
+      get<LanguageService>(),
+    )
+  }
+  single<GetContractDetailsUseCaseProvider> {
+    GetContractDetailsUseCaseProvider(
+      demoManager = get<DemoManager>(),
+      demoImpl = get<GetContractDetailsUseCaseDemo>(),
+      prodImpl = get<GetContractDetailsUseCaseImpl>(),
     )
   }
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceGraph.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceGraph.kt
@@ -9,7 +9,7 @@ import com.hedvig.android.core.designsystem.material3.motion.MotionDefaults
 import com.hedvig.android.feature.insurances.insurance.presentation.InsuranceViewModel
 import com.hedvig.android.feature.insurances.insurancedetail.ContractDetailDestination
 import com.hedvig.android.feature.insurances.insurancedetail.ContractDetailViewModel
-import com.hedvig.android.feature.insurances.insurancedetail.ContractDetails
+import com.hedvig.android.feature.insurances.insurancedetail.data.ContractDetails
 import com.hedvig.android.feature.insurances.navigation.InsurancesDestination
 import com.hedvig.android.feature.insurances.terminatedcontracts.TerminatedContractsDestination
 import com.hedvig.android.feature.insurances.terminatedcontracts.TerminatedContractsViewModel

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -52,6 +52,7 @@ import com.hedvig.android.core.ui.insurance.toDrawableRes
 import com.hedvig.android.core.ui.plus
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.feature.insurances.insurancedetail.coverage.CoverageTab
+import com.hedvig.android.feature.insurances.insurancedetail.data.ContractDetails
 import com.hedvig.android.feature.insurances.insurancedetail.documents.DocumentsTab
 import com.hedvig.android.feature.insurances.insurancedetail.yourinfo.YourInfoTab
 import hedvig.resources.R

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -159,6 +159,7 @@ private fun ContractDetailScreen(
                   0 -> {
                     YourInfoTab(
                       coverageItems = state.contractDetails.overviewItems,
+                      allowChangeAddress = state.contractDetails.allowChangeAddress,
                       allowEditCoInsured = state.contractDetails.allowEditCoInsured,
                       onEditCoInsuredClick = onEditCoInsuredClick,
                       onChangeAddressClick = onChangeAddressClick,
@@ -249,6 +250,7 @@ private fun PreviewContractDetailScreen() {
             ),
             overviewItems = persistentListOf(),
             cancelInsuranceData = ContractDetails.CancelInsuranceData("", ""),
+            allowChangeAddress = true,
             allowEditCoInsured = true,
             insurableLimits = persistentListOf(),
             perils = persistentListOf(),

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailViewModel.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailViewModel.kt
@@ -4,8 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import arrow.core.raise.either
 import com.hedvig.android.core.common.RetryChannel
-import com.hedvig.hanalytics.AppScreen
-import com.hedvig.hanalytics.HAnalytics
+import com.hedvig.android.core.demomode.Provider
+import com.hedvig.android.feature.insurances.insurancedetail.data.ContractDetails
+import com.hedvig.android.feature.insurances.insurancedetail.data.GetContractDetailsUseCase
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
@@ -14,18 +15,13 @@ import kotlin.time.Duration.Companion.seconds
 
 internal class ContractDetailViewModel(
   contractId: String,
-  private val getContractDetailsUseCase: GetContractDetailsUseCase,
-  hAnalytics: HAnalytics,
+  private val getContractDetailsUseCase: Provider<GetContractDetailsUseCase>,
 ) : ViewModel() {
-  init {
-    hAnalytics.screenView(AppScreen.INSURANCE_DETAIL)
-  }
-
   private val retryChannel = RetryChannel()
   val uiState: StateFlow<ContractDetailsUiState> = retryChannel.transformLatest {
     emit(ContractDetailsUiState.Loading)
     val uiState = either {
-      getContractDetailsUseCase.invoke(contractId).bind()
+      getContractDetailsUseCase.provide().invoke(contractId).bind()
     }.fold(
       ifLeft = { ContractDetailsUiState.Error },
       ifRight = { ContractDetailsUiState.Success(it) },

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -56,6 +57,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 
+@ExperimentalMaterial3Api
 @Composable
 internal fun CoverageTab(
   insurableLimits: ImmutableList<ContractCoverage.InsurableLimit>,
@@ -239,7 +241,7 @@ private fun ColumnScope.InsurableLimitSection(
           Text(
             text = insurableLimitItem.limit,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.align(Alignment.Top),
+            modifier = Modifier.align(Alignment.CenterVertically),
           )
           Spacer(Modifier.width(8.dp))
           Icon(

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/GetContractCoverageUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/GetContractCoverageUseCase.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.feature.insurances.insurancedetail.ContractDetails
+import com.hedvig.android.feature.insurances.insurancedetail.data.ContractDetails
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import octopus.ContractCoverageQuery

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCase.kt
@@ -102,6 +102,7 @@ internal class GetContractDetailsUseCaseImpl(
             null
           },
           cancelInsuranceData = cancelInsuranceData,
+          allowChangeAddress = true,
           allowEditCoInsured = contract.typeOfContract.canChangeCoInsured(),
           insurableLimits = contractCoverage.insurableLimits,
           perils = contractCoverage.contractPerils,
@@ -122,6 +123,7 @@ internal data class ContractDetails(
   val overviewItems: ImmutableList<Pair<String, String>>,
   val upcomingChanges: UpcomingChanges?,
   val cancelInsuranceData: CancelInsuranceData?,
+  val allowChangeAddress: Boolean,
   val allowEditCoInsured: Boolean,
   val insurableLimits: ImmutableList<ContractCoverage.InsurableLimit>,
   val perils: ImmutableList<ContractCoverage.Peril>,

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCase.kt
@@ -1,4 +1,4 @@
-package com.hedvig.android.feature.insurances.insurancedetail
+package com.hedvig.android.feature.insurances.insurancedetail.data
 
 import arrow.core.Either
 import arrow.core.raise.either
@@ -20,13 +20,17 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 
-internal class GetContractDetailsUseCase(
+internal interface GetContractDetailsUseCase {
+  suspend fun invoke(contractId: String): Either<ContractDetailError, ContractDetails>
+}
+
+internal class GetContractDetailsUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val getContractCoverageUseCase: GetContractCoverageUseCase,
   private val languageService: LanguageService,
   private val featureManager: FeatureManager,
-) {
-  suspend fun invoke(contractId: String): Either<ContractDetailError, ContractDetails> {
+) : GetContractDetailsUseCase {
+  override suspend fun invoke(contractId: String): Either<ContractDetailError, ContractDetails> {
     return either {
       parZip(
         {

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCaseDemo.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCaseDemo.kt
@@ -1,0 +1,60 @@
+package com.hedvig.android.feature.insurances.insurancedetail.data
+
+import arrow.core.Either
+import arrow.core.raise.either
+import com.hedvig.android.core.ui.insurance.ContractType
+import com.hedvig.android.feature.insurances.insurancedetail.coverage.ContractCoverage
+import kotlinx.collections.immutable.persistentListOf
+
+internal class GetContractDetailsUseCaseDemo : GetContractDetailsUseCase {
+  override suspend fun invoke(contractId: String): Either<ContractDetailError, ContractDetails> {
+    return either {
+      ContractDetails(
+        contractCardData = ContractDetails.ContractCardData(
+          contractId = "1",
+          backgroundImageUrl = null,
+          chips = persistentListOf("Active"),
+          title = "Home Insurance",
+          subtitle = "Road 10",
+          contractType = ContractType.HOUSE,
+        ),
+        overviewItems = persistentListOf(
+          "Street" to "Road 10",
+          "Postal code" to "12345",
+          "Insured people" to "You + 2",
+        ),
+        upcomingChanges = null,
+        cancelInsuranceData = null,
+        allowEditCoInsured = false,
+        insurableLimits = persistentListOf(
+          ContractCoverage.InsurableLimit(
+            "Your things are insured at",
+            "1 000 000 SEK",
+            "All your posessions are together insured up to 1 million SEK",
+          ),
+          ContractCoverage.InsurableLimit(
+            "The deductible is",
+            "1 500 SEK",
+            "Deductible is the amount you have to pay yourself in the event of a damage",
+          ),
+          ContractCoverage.InsurableLimit(
+            "Travel insurance",
+            "45 days",
+            "Travel insurance covers you on your trip",
+          ),
+        ),
+        perils = persistentListOf(
+          ContractCoverage.Peril("1", "Fire", "We will cover fire damage", persistentListOf(), 0xFFFF0000),
+          ContractCoverage.Peril(
+            "2",
+            "Water leaks",
+            "We cover different types of water damages",
+            persistentListOf(),
+            0xFF4040FF,
+          ),
+        ),
+        documents = persistentListOf(ContractDetails.Document.TermsAndConditions("")),
+      )
+    }
+  }
+}

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCaseDemo.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCaseDemo.kt
@@ -25,6 +25,7 @@ internal class GetContractDetailsUseCaseDemo : GetContractDetailsUseCase {
         ),
         upcomingChanges = null,
         cancelInsuranceData = null,
+        allowChangeAddress = false,
         allowEditCoInsured = false,
         insurableLimits = persistentListOf(
           ContractCoverage.InsurableLimit(
@@ -53,7 +54,7 @@ internal class GetContractDetailsUseCaseDemo : GetContractDetailsUseCase {
             0xFF4040FF,
           ),
         ),
-        documents = persistentListOf(ContractDetails.Document.TermsAndConditions("")),
+        documents = persistentListOf(ContractDetails.Document.TermsAndConditions("", "Insurance Certificate")),
       )
     }
   }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCaseProvider.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/data/GetContractDetailsUseCaseProvider.kt
@@ -1,0 +1,10 @@
+package com.hedvig.android.feature.insurances.insurancedetail.data
+
+import com.hedvig.android.core.demomode.DemoManager
+import com.hedvig.android.core.demomode.ProdOrDemoProvider
+
+internal class GetContractDetailsUseCaseProvider(
+  override val demoManager: DemoManager,
+  override val demoImpl: GetContractDetailsUseCaseDemo,
+  override val prodImpl: GetContractDetailsUseCaseImpl,
+) : ProdOrDemoProvider<GetContractDetailsUseCase>

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
@@ -35,7 +35,7 @@ import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.icons.Hedvig
 import com.hedvig.android.core.icons.hedvig.small.hedvig.ArrowNorthEast
-import com.hedvig.android.feature.insurances.insurancedetail.ContractDetails
+import com.hedvig.android.feature.insurances.insurancedetail.data.ContractDetails
 import hedvig.resources.R
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.insurances.insurancedetail.yourinfo
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,7 +16,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -34,13 +35,14 @@ import hedvig.resources.R
 
 @Composable
 internal fun EditInsuranceBottomSheetContent(
+  allowChangeAddress: Boolean,
   allowEditCoInsured: Boolean,
   onEditCoInsuredClick: () -> Unit,
   onChangeAddressClick: () -> Unit,
   onDismiss: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  var selectedItemIndex by rememberSaveable { mutableStateOf(-1) }
+  var selectedItemIndex by rememberSaveable { mutableIntStateOf(-1) }
   Column(
     modifier = modifier,
   ) {
@@ -53,30 +55,35 @@ internal fun EditInsuranceBottomSheetContent(
         .padding(horizontal = 24.dp),
     )
     Spacer(modifier = Modifier.height(32.dp))
-    SelectableItem(
-      text = stringResource(R.string.insurance_details_change_address_button),
-      isSelected = selectedItemIndex == 0,
-      onClick = {
-        selectedItemIndex = if (selectedItemIndex == 0) {
-          -1
-        } else {
-          0
-        }
-      },
-    )
-    if (allowEditCoInsured) {
-      Spacer(modifier = Modifier.height(4.dp))
-      SelectableItem(
-        text = stringResource(R.string.CONTRACT_EDIT_COINSURED),
-        isSelected = selectedItemIndex == 1,
-        onClick = {
-          selectedItemIndex = if (selectedItemIndex == 1) {
-            -1
-          } else {
-            1
-          }
-        },
-      )
+    Column(
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      if (allowChangeAddress) {
+        SelectableItem(
+          text = stringResource(R.string.insurance_details_change_address_button),
+          isSelected = selectedItemIndex == 0,
+          onClick = {
+            selectedItemIndex = if (selectedItemIndex == 0) {
+              -1
+            } else {
+              0
+            }
+          },
+        )
+      }
+      if (allowEditCoInsured) {
+        SelectableItem(
+          text = stringResource(R.string.CONTRACT_EDIT_COINSURED),
+          isSelected = selectedItemIndex == 1,
+          onClick = {
+            selectedItemIndex = if (selectedItemIndex == 1) {
+              -1
+            } else {
+              1
+            }
+          },
+        )
+      }
     }
     Spacer(modifier = Modifier.height(16.dp))
     AnimatedVisibility(visible = selectedItemIndex == 1) {
@@ -138,6 +145,7 @@ private fun PreviewEditInsuranceBottomSheetContent() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       EditInsuranceBottomSheetContent(
+        allowChangeAddress = true,
         allowEditCoInsured = true,
         onEditCoInsuredClick = {},
         onChangeAddressClick = {},

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun YourInfoTab(
   coverageItems: ImmutableList<Pair<String, String>>,
+  allowChangeAddress: Boolean,
   allowEditCoInsured: Boolean,
   upcomingChanges: ContractDetails.UpcomingChanges?,
   onEditCoInsuredClick: () -> Unit,
@@ -73,6 +74,7 @@ internal fun YourInfoTab(
       windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
     ) {
       EditInsuranceBottomSheetContent(
+        allowChangeAddress = allowChangeAddress,
         allowEditCoInsured = allowEditCoInsured,
         onEditCoInsuredClick = {
           coroutineScope.launch {
@@ -162,16 +164,18 @@ internal fun YourInfoTab(
       Spacer(Modifier.height(8.dp))
     }
     CoverageRows(coverageItems, Modifier.padding(horizontal = 16.dp))
-    Spacer(Modifier.height(16.dp))
-    HedvigContainedButton(
-      text = stringResource(R.string.CONTRACT_EDIT_INFO_LABEL),
-      onClick = { showEditYourInfoBottomSheet = true },
-      colors = ButtonDefaults.buttonColors(
-        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = MaterialTheme.colorScheme.onSurface,
-      ),
-      modifier = Modifier.padding(horizontal = 16.dp),
-    )
+    if (allowChangeAddress || allowEditCoInsured) {
+      Spacer(Modifier.height(16.dp))
+      HedvigContainedButton(
+        text = stringResource(R.string.CONTRACT_EDIT_INFO_LABEL),
+        onClick = { showEditYourInfoBottomSheet = true },
+        colors = ButtonDefaults.buttonColors(
+          containerColor = MaterialTheme.colorScheme.surfaceVariant,
+          contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        modifier = Modifier.padding(horizontal = 16.dp),
+      )
+    }
     if (cancelInsuranceData != null) {
       Spacer(Modifier.height(8.dp))
       HedvigTextButton(
@@ -238,6 +242,7 @@ private fun PreviewYourInfoTab() {
           "Size" to "56 m2",
           "Co-insured".repeat(4) to "You +1".repeat(5),
         ),
+        allowChangeAddress = true,
         allowEditCoInsured = true,
         upcomingChanges = ContractDetails.UpcomingChanges(
           "Your insurance will update on 2023.08.17",

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
@@ -39,12 +40,13 @@ import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.infocard.VectorInfoCard
 import com.hedvig.android.core.ui.text.HorizontalItemsWithMaximumSpaceTaken
-import com.hedvig.android.feature.insurances.insurancedetail.ContractDetails
+import com.hedvig.android.feature.insurances.insurancedetail.data.ContractDetails
 import hedvig.resources.R
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
+@ExperimentalMaterial3Api
 @Composable
 internal fun YourInfoTab(
   coverageItems: ImmutableList<Pair<String, String>>,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ProfileRepositoryDemo.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ProfileRepositoryDemo.kt
@@ -7,13 +7,17 @@ import org.javamoney.moneta.Money
 import java.math.BigDecimal
 
 internal class ProfileRepositoryDemo : ProfileRepository {
-  private val demoMember = Member(
-    id = "test",
-    firstName = "Google",
-    lastName = "Tester",
-    phoneNumber = null,
-    email = "google@gmail.com",
-  )
+  private var email = "google@gmail.com"
+  private var phoneNumber = "072102103"
+
+  private val demoMember: Member
+    get() = Member(
+      id = "test",
+      firstName = "Google",
+      lastName = "Tester",
+      phoneNumber = phoneNumber,
+      email = email,
+    )
 
   override suspend fun profile(): Either<OperationResult.Error, ProfileData> = either {
     ProfileData(
@@ -29,10 +33,12 @@ internal class ProfileRepositoryDemo : ProfileRepository {
   }
 
   override suspend fun updateEmail(input: String): Either<OperationResult.Error, Member> = either {
+    email = input
     demoMember
   }
 
   override suspend fun updatePhoneNumber(input: String): Either<OperationResult.Error, Member> = either {
+    phoneNumber = input
     demoMember
   }
 }

--- a/app/navigation/navigation-activity/src/main/kotlin/com/hedvig/android/navigation/activity/ActivityNavigator.kt
+++ b/app/navigation/navigation-activity/src/main/kotlin/com/hedvig/android/navigation/activity/ActivityNavigator.kt
@@ -70,7 +70,7 @@ class ActivityNavigator(
     if (browserIntent.resolveActivity(context.packageManager) != null) {
       context.startActivity(browserIntent)
     } else {
-      logcat(LogPriority.ERROR) { "Tried to launch $uri but the phone has nothing to support such an intent." }
+      logcat(LogPriority.WARN) { "Tried to launch $uri but the phone has nothing to support such an intent." }
     }
   }
 }

--- a/app/notification-badge-data/notification-badge-data-public/src/main/kotlin/com/hedvig/android/notification/badge/data/crosssell/GetCrossSellsContractTypesUseCase.kt
+++ b/app/notification-badge-data/notification-badge-data-public/src/main/kotlin/com/hedvig/android/notification/badge/data/crosssell/GetCrossSellsContractTypesUseCase.kt
@@ -5,7 +5,6 @@ import com.hedvig.android.apollo.OperationResult
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.toEither
 import com.hedvig.android.language.LanguageService
-import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import giraffe.CrossSellsQuery
 import giraffe.type.TypeOfContract
@@ -25,7 +24,7 @@ internal class GetCrossSellsContractTypesUseCaseImpl(
       .toEither()
       .fold(
         { operationResultError: OperationResult.Error ->
-          logcat(LogPriority.DEBUG, operationResultError.throwable) {
+          logcat(throwable = operationResultError.throwable) {
             "Error when loading potential cross-sells: $operationResultError"
           }
           emptySet()

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-auth-listeners.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-auth-listeners.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.1)" variant="all" version="8.1.1">
+
+</issues>


### PR DESCRIPTION
* Make logging in and out both clear the apollo cache for both our apollo clients, and to also make sure that the subscriptions are reconnecting (to get the new token)

* Some cleanup on some Impl classes leaking to callers

* Split AuthEventStorage out of AuthEventBroadcaster

This way, the ones emitting the events can just emit to
AuthEventStorage which gets initialized without any dependencies.
Then we have the AuthEventBroadcaster simply consume those events, and
we make it initializable, and let it do its own thing for the entire
lifetime of the application.

This breaks the ever-repeating problem of AuthEventListeners needing
access to classes like ApolloClient OkHttp but in turn those need all
the listeners to already be initialized.