### PR TITLE
Hotfix/12.1.1

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     applicationId = "com.hedvig"
 
     versionCode = 43
-    versionName = "12.1.0"
+    versionName = "12.1.1"
 
     vectorDrawables.useSupportLibrary = true
 

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
@@ -6,7 +6,6 @@ import com.hedvig.android.apollo.octopus.di.octopusClient
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.feature.insurances.data.GetCrossSellsUseCaseDemo
 import com.hedvig.android.feature.insurances.data.GetCrossSellsUseCaseImpl
-import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseDemo
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseImpl
 import com.hedvig.android.feature.insurances.insurance.presentation.InsuranceViewModel
@@ -33,7 +32,7 @@ val insurancesModule = module {
     )
   }
   viewModel<TerminatedContractsViewModel> {
-    TerminatedContractsViewModel(get<GetInsuranceContractsUseCase>())
+    TerminatedContractsViewModel(get<GetInsuranceContractsUseCaseProvider>())
   }
   viewModel<ContractDetailViewModel> { (contractId: String) ->
     ContractDetailViewModel(contractId, get<GetContractDetailsUseCaseProvider>())

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsViewModel.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsViewModel.kt
@@ -6,6 +6,7 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.RetryChannel
+import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
 import com.hedvig.android.feature.insurances.data.InsuranceContract
 import com.hedvig.android.logger.LogPriority
@@ -20,14 +21,15 @@ import kotlinx.coroutines.flow.stateIn
 import kotlin.time.Duration.Companion.seconds
 
 internal class TerminatedContractsViewModel(
-  private val getInsuranceContractsUseCase: GetInsuranceContractsUseCase,
+  private val getInsuranceContractsUseCaseProvider: Provider<GetInsuranceContractsUseCase>,
 ) : ViewModel() {
   private val retryChannel = RetryChannel()
 
   val uiState: StateFlow<TerminatedContractsUiState> = flow {
     emit(TerminatedContractsUiState.Loading)
     either {
-      val terminatedContracts = getInsuranceContractsUseCase
+      val terminatedContracts = getInsuranceContractsUseCaseProvider
+        .provide()
         .invoke()
         .bind()
         .filter(InsuranceContract::isTerminated)

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
@@ -86,7 +86,6 @@ fun NavGraphBuilder.terminateInsuranceGraph(
         navigateToNextStep = { terminationStep ->
           viewModel.handledNextStepNavigation()
           navigator.navigateToTerminateFlowDestination(
-            backStackEntry = backStackEntry,
             destination = terminationStep.toTerminateInsuranceDestination(),
           )
         },
@@ -107,7 +106,6 @@ fun NavGraphBuilder.terminateInsuranceGraph(
         navigateToNextStep = { terminationStep ->
           viewModel.handledNextStepNavigation()
           navigator.navigateToTerminateFlowDestination(
-            backStackEntry = backStackEntry,
             destination = terminationStep.toTerminateInsuranceDestination(),
           )
         },
@@ -136,7 +134,6 @@ fun NavGraphBuilder.terminateInsuranceGraph(
         navigateToNextStep = { terminationStep ->
           viewModel.handledNextStepNavigation()
           navigator.navigateToTerminateFlowDestination(
-            backStackEntry = backStackEntry,
             destination = terminationStep.toTerminateInsuranceDestination(),
           )
         },
@@ -168,10 +165,7 @@ private fun getTerminateInsuranceDataFromParentBackstack(
 /**
  * If we're going to a terminal destination, pop the termination flow backstack completely before going there.
  */
-private fun <T : TerminateInsuranceDestination> Navigator.navigateToTerminateFlowDestination(
-  backStackEntry: NavBackStackEntry,
-  destination: T,
-) {
+private fun <T : TerminateInsuranceDestination> Navigator.navigateToTerminateFlowDestination(destination: T) {
   val navOptions = navOptions {
     when {
       destination is TerminateInsuranceDestination.TerminationSuccess ||
@@ -184,7 +178,7 @@ private fun <T : TerminateInsuranceDestination> Navigator.navigateToTerminateFlo
       else -> {}
     }
   }
-  backStackEntry.navigate(destination, navOptions)
+  navigateUnsafe(destination, navOptions)
 }
 
 private fun finishTerminationFlow(navController: NavController) {


### PR DESCRIPTION
* Force navigation for navigation events

When we use navigate with the backstackentry lifecycle in mind, we do it
so that we do not have navigation events overlapping and going to the
same navigation destination twice.
This works great when we do navigation events due to some click action.
However, this does *not* work great for situations where the navigation
event comes once already anyway due to some state change and so on. That
is because this navigation may get swallowed if a previous navigation
event was happening already.

Particularly in the cancel insurance case, what was going on is that as
we are going into the termination flow, we immediately do a network
request to know where to go next. This event comes in, but we are still
navigating from the previous screen, so this nav event *sometimes* just
gets swallowed. This change fixes this, and we must consider other
situations where navigation happens due to a state change, and not due
to a user interaction, that we use the unsafe variant of the Navigator

* Use the provider for GetInsuranceContractsUseCase

Now with the Provider<> being present in some places, there is the risk
that we forget to provide the right dependency through DI to it.
In this case, the class was still expecting just T instead of
Provider<T> which was crashing the app. That is because we no longer
provide an instance of type T to the DI graph. We provide TImpl, TDemo
and the Provider<T> through the ProdOrDemoProvider<T>.

An easy mistake to do, and we are not really guarded by any type-safety
here, besides actually running the app and getting the runtime crash.