### PR TITLE
Contain HAnalytics to some specific modules

### DIFF
--- a/app/hanalytics/hanalytics-android/build.gradle.kts
+++ b/app/hanalytics/hanalytics-android/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
 }
 
 dependencies {
-  api(libs.hAnalytics)
-
   implementation(libs.androidx.lifecycle.common)
   implementation(libs.coroutines.core)
+  implementation(libs.hAnalytics)
   implementation(libs.koin.core)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.okhttp.core)

--- a/app/hanalytics/hanalytics-core/build.gradle.kts
+++ b/app/hanalytics/hanalytics-core/build.gradle.kts
@@ -6,9 +6,8 @@ plugins {
 }
 
 dependencies {
-  api(libs.hAnalytics)
-
   implementation(libs.coroutines.core)
+  implementation(libs.hAnalytics)
   implementation(libs.koin.core)
   implementation(libs.kotlinx.serialization.core)
   implementation(projects.coreCommonPublic)

--- a/app/hanalytics/hanalytics-feature-flags-public/build.gradle.kts
+++ b/app/hanalytics/hanalytics-feature-flags-public/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
   implementation(libs.coroutines.core)
+  implementation(libs.hAnalytics)
   implementation(libs.koin.core)
   implementation(projects.authEventCore)
   implementation(projects.coreBuildConstants)

--- a/app/hanalytics/hanalytics-feature-flags-test/build.gradle.kts
+++ b/app/hanalytics/hanalytics-feature-flags-test/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 }
 
 dependencies {
-  api(libs.hAnalytics)
-
   implementation(libs.turbine)
   implementation(projects.hanalyticsFeatureFlagsPublic)
 }


### PR DESCRIPTION
Since we no longer need access to HAnalytics in various screens in order to log some events, we can avoid using `api` which previously let other modules know about the HAnalytics type