### PR TITLE
Fix chat scrolling to top bug

### DIFF
--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/compose/LogCompositions.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/compose/LogCompositions.kt
@@ -1,10 +1,9 @@
-package com.hedvig.app.util.compose
+package com.hedvig.android.core.ui.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import com.hedvig.android.logger.logcat
-import com.hedvig.app.BuildConfig
 
 /**
  * Only for use with [LogCompositions], not defined as private because inline [LogCompositions] doesn't allow it.
@@ -19,9 +18,7 @@ class Ref(var value: Int)
 @Suppress("NOTHING_TO_INLINE")
 @Composable
 inline fun LogCompositions(message: String) {
-  if (BuildConfig.DEBUG) {
-    val ref = remember { Ref(0) }
-    SideEffect { ref.value++ }
-    logcat { "Debug Log Compositions: $message ${ref.value}" }
-  }
+  val ref = remember { Ref(0) }
+  SideEffect { ref.value++ }
+  logcat { "Debug Log Compositions: $message ${ref.value}" }
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
@@ -101,7 +101,9 @@ private fun ChatScreen(
       ChatTopAppBar(
         onNavigateUp = onNavigateUp,
         topAppBarScrollBehavior = topAppBarScrollBehavior,
-        onHeightChanged = { height -> with(density) { topAppBarHeight = height.toDp() } },
+        modifier = Modifier.onSizeChanged {
+          with(density) { topAppBarHeight = it.height.toDp() }
+        },
       )
       Box(
         modifier = Modifier
@@ -139,18 +141,14 @@ private fun ChatScreen(
 private fun ChatTopAppBar(
   onNavigateUp: () -> Unit,
   topAppBarScrollBehavior: TopAppBarScrollBehavior,
-  onHeightChanged: (Int) -> Unit,
+  modifier: Modifier = Modifier,
 ) {
   TopAppBarWithBack(
     title = stringResource(R.string.CHAT_TITLE),
     onClick = onNavigateUp,
     scrollBehavior = topAppBarScrollBehavior,
     windowInsets = chatTopAppBarWindowInsets(TopAppBarDefaults.windowInsets, topAppBarScrollBehavior),
-    modifier = Modifier
-      .fillMaxWidth()
-      .onSizeChanged {
-        onHeightChanged(it.height)
-      },
+    modifier = modifier.fillMaxWidth(),
   )
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -112,9 +113,10 @@ private fun ChatScreen(
           .consumeWindowInsets(PaddingValues(top = topAppBarHeight)),
         propagateMinConstraints = true,
       ) {
+        val loadingIndicator = remember { movableContentOf { HedvigFullScreenCenterAlignedProgress() } }
         when (uiState) {
           ChatUiState.Initializing -> {
-            HedvigFullScreenCenterAlignedProgress()
+            loadingIndicator()
           }
 
           is ChatUiState.Loaded -> {
@@ -130,6 +132,12 @@ private fun ChatScreen(
               onSendMedia = onSendMedia,
               onFetchMoreMessages = onFetchMoreMessages,
             )
+            val stillLoadingInitialMessages = uiState.messages.isEmpty() &&
+              (uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.StillInitializing ||
+                uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore)
+            if (stillLoadingInitialMessages) {
+              loadingIndicator()
+            }
           }
         }
       }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
@@ -267,37 +267,41 @@ private fun ChatLazyColumn(
           .padding(bottom = 8.dp),
       )
     }
-    item(
-      key = "Space",
-      contentType = "Space",
-    ) {
-      Spacer(modifier = Modifier.height(8.dp))
-    }
-    if (
-      uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FailedToFetch ||
-      uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore
-    ) {
+    // We want to show other items only when there are already some chat messages, to have first messages appear at the
+    // bottom of the UI when the screen is first opened
+    if (uiState.messages.isNotEmpty()) {
       item(
-        key = "FetchingState",
-        contentType = "FetchingState",
+        key = "Space",
+        contentType = "Space",
       ) {
-        LaunchedEffect(Unit) {
-          onFetchMoreMessages()
-        }
-        if (uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FailedToFetch) {
+        Spacer(modifier = Modifier.height(8.dp))
+      }
+      if (
+        uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FailedToFetch ||
+        uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore
+      ) {
+        item(
+          key = "FetchingState",
+          contentType = "FetchingState",
+        ) {
           LaunchedEffect(Unit) {
-            while (isActive) {
-              delay(5.seconds)
-              onFetchMoreMessages()
+            onFetchMoreMessages()
+          }
+          if (uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FailedToFetch) {
+            LaunchedEffect(Unit) {
+              while (isActive) {
+                delay(5.seconds)
+                onFetchMoreMessages()
+              }
             }
           }
+          ThreeDotsLoading(
+            Modifier
+              .padding(24.dp)
+              .fillParentMaxWidth()
+              .wrapContentWidth(Alignment.CenterHorizontally),
+          )
         }
-        ThreeDotsLoading(
-          Modifier
-            .padding(24.dp)
-            .fillParentMaxWidth()
-            .wrapContentWidth(Alignment.CenterHorizontally),
-        )
       }
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
@@ -575,7 +575,9 @@ internal fun ChatMessageWithTimeAndDeliveryStatus(
     Spacer(modifier = Modifier.height(4.dp))
     Row(
       verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier.align(uiChatMessage.chatMessage.messageHorizontalAlignment()).padding(horizontal = 2.dp),
+      modifier = Modifier
+        .align(uiChatMessage.chatMessage.messageHorizontalAlignment())
+        .padding(horizontal = 2.dp),
     ) {
       Text(
         text = buildString {


### PR DESCRIPTION
Initially, when there is nothing in the lazy list, the messages are
empty, and what shows in the lazy list is the loading indicator and a
spacer here.
https://github.com/HedvigInsurance/android/blob/c1d80d089e9cf7af184e94503fddcc09c70f67f5/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt#L277-L308

Then after the messages show, what LazyList tries to do when new items
come into the list is to see the unique ID of each of the items that
were showing before, and still keep those items in view, because
otherwise it looks super odd to have new items come in and suddenly what
you were looking at just disappears.

Now what that means is that all the chat messages come first in the
list, but it tries to keep the loading indicator in the screen too, so
despite the fact that we have reverseScrolling set to true and it should
scroll from bottom-up, it just scrolls all the way to the top in order
to keep those two items at the top.

Not adding any items to the list before the first messages show up fixes
this issue.

To still show a loading state, we show the same loading indication as we
did when the chat is still initializing until the first messages come in
since we can not rely on the loading indicator to show the loading state