### PR TITLE
Remove Upload scalar mapping since it's no longer in the schema

### DIFF
--- a/app/apollo/apollo-octopus-public/build.gradle.kts
+++ b/app/apollo/apollo-octopus-public/build.gradle.kts
@@ -39,7 +39,6 @@ apollo { // Octopus client
     mapScalar("Date", "kotlinx.datetime.LocalDate", "com.apollographql.apollo3.adapter.KotlinxLocalDateAdapter")
     mapScalar("DateTime", "kotlinx.datetime.LocalDate", "com.apollographql.apollo3.adapter.KotlinxLocalDateTimeAdapter")
     mapScalar("Instant", "kotlinx.datetime.Instant", "com.apollographql.apollo3.adapter.KotlinxInstantAdapter")
-    mapScalarToUpload("Upload")
     mapScalarToKotlinString("UUID")
     mapScalarToKotlinString("Url")
     mapScalarToKotlinString("FlowContext")


### PR DESCRIPTION
This fixes CI which always fails too since apollo crashes when it realizes the latest schema simply does not have the `Upload` scalar in it at all