### PR TITLE
Remove accompanist web view dependency

### DIFF
--- a/app/feature/feature-payments/build.gradle.kts
+++ b/app/feature/feature-payments/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
   apolloMetadata(projects.apolloOctopusPublic)
 
   implementation(libs.accompanist.permissions)
-  implementation(libs.accompanist.webview)
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.runtime)

--- a/app/feature/feature-profile/build.gradle.kts
+++ b/app/feature/feature-profile/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   apolloMetadata(projects.apolloOctopusPublic)
 
   implementation(libs.accompanist.permissions)
-  implementation(libs.accompanist.webview)
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.compose.material3.windowSizeClass)
   implementation(libs.androidx.compose.runtime)
@@ -30,6 +29,7 @@ dependencies {
   implementation(projects.apolloCore)
   implementation(projects.apolloOctopusPublic)
   implementation(projects.authCorePublic)
+  implementation(projects.composeWebview)
   implementation(projects.coreBuildConstants)
   implementation(projects.coreCommonAndroidPublic)
   implementation(projects.coreCommonPublic)

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/LicensesDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/LicensesDestination.kt
@@ -1,7 +1,12 @@
 package com.hedvig.android.feature.profile.aboutapp
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
@@ -9,8 +14,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.google.accompanist.web.WebView
-import com.google.accompanist.web.rememberWebViewState
+import com.hedvig.android.composewebview.WebView
+import com.hedvig.android.composewebview.rememberWebViewState
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBack
 import hedvig.resources.R
 
@@ -22,17 +27,26 @@ internal fun LicensesDestination(onBackPressed: () -> Unit) {
     color = MaterialTheme.colorScheme.background,
     modifier = Modifier.fillMaxSize(),
   ) {
-    Column(
-      Modifier
-        .fillMaxSize()
-        .verticalScroll(rememberScrollState()),
-    ) {
+    Column {
       TopAppBarWithBack(
         onClick = onBackPressed,
         title = stringResource(R.string.PROFILE_ABOUT_APP_LICENSE_ATTRIBUTIONS),
       )
-      val state = rememberWebViewState(licensesUrl)
-      WebView(state = state)
+      Column(
+          Modifier
+              .fillMaxSize()
+              .verticalScroll(rememberScrollState()),
+      ) {
+        val webViewState = rememberWebViewState(licensesUrl)
+        WebView(
+          state = webViewState,
+          modifier = Modifier
+              .fillMaxSize()
+              .windowInsetsPadding(
+                  WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+              ),
+        )
+      }
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,6 @@ zoomable = "1.5.3"
 
 accompanist-pagerIndicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
-accompanist-webview = { module = "com.google.accompanist:accompanist-webview", version.ref = "accompanist" }
 androidx-activity-core = { module = "androidx.activity:activity", version.ref = "androidx-activity-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }


### PR DESCRIPTION
Just saw that we still have this in the dependency bump PR and I realized we do not need to anymore. That library is deprecated https://google.github.io/accompanist/web/ and they encourage people to just copy it and adjust as needed.