### PR TITLE
Fix/killswitch feature flag

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -46,7 +46,6 @@ import com.hedvig.android.navigation.core.TopLevelGraph
 import com.hedvig.android.notification.badge.data.tab.TabNotificationBadgeService
 import com.hedvig.android.theme.Theme
 import com.hedvig.app.feature.sunsetting.ForceUpgradeActivity
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -57,7 +56,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -109,13 +107,12 @@ class LoggedInActivity : AppCompatActivity() {
     val intent: Intent = intent
     lifecycleScope.launch {
       launch {
-        while (isActive) {
-          if (featureManager.isFeatureEnabled(Feature.UPDATE_NECESSARY)) {
+        featureManager.isFeatureEnabled(Feature.UPDATE_NECESSARY).collectLatest {
+          if (it) {
             applicationContext.startActivity(ForceUpgradeActivity.newInstance(applicationContext))
             finish()
             cancel()
           }
-          delay(5.seconds)
         }
       }
       launch {

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/marketing/MarketingActivity.kt
@@ -36,11 +36,9 @@ import com.hedvig.app.feature.sunsetting.ForceUpgradeActivity
 import com.kiwi.navigationcompose.typed.Destination
 import com.kiwi.navigationcompose.typed.createRoutePattern
 import com.kiwi.navigationcompose.typed.navigate
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
@@ -56,13 +54,12 @@ class MarketingActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     lifecycleScope.launch {
       launch {
-        while (isActive) {
-          if (featureManager.isFeatureEnabled(Feature.UPDATE_NECESSARY)) {
+        featureManager.isFeatureEnabled(Feature.UPDATE_NECESSARY).collectLatest {
+          if (it) {
             applicationContext.startActivity(ForceUpgradeActivity.newInstance(applicationContext))
             finish()
             cancel()
           }
-          delay(5.seconds)
         }
       }
       lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
@@ -133,8 +133,10 @@ private fun ChatScreen(
               onFetchMoreMessages = onFetchMoreMessages,
             )
             val stillLoadingInitialMessages = uiState.messages.isEmpty() &&
-              (uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.StillInitializing ||
-                uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore)
+              (
+                uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.StillInitializing ||
+                  uiState.fetchMoreMessagesUiState is ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore
+              )
             if (stillLoadingInitialMessages) {
               loadingIndicator()
             }

--- a/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/data/GetQuickLinksUseCase.kt
+++ b/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/data/GetQuickLinksUseCase.kt
@@ -17,6 +17,7 @@ import com.hedvig.android.navigation.core.AppDestination
 import hedvig.resources.R
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.first
 import octopus.AvailableSelfServiceOnContractsQuery
 
 internal class GetQuickLinksUseCase(
@@ -35,7 +36,7 @@ internal class GetQuickLinksUseCase(
     buildList {
       contracts
         .filter { it.supportsCoInsured }
-        .takeIf { featureManager.isFeatureEnabled(Feature.EDIT_COINSURED) }
+        .takeIf { featureManager.isFeatureEnabled(Feature.EDIT_COINSURED).first() }
         ?.let {
           if (it.size > 1) {
             val links = it.map { contract ->
@@ -85,7 +86,7 @@ internal class GetQuickLinksUseCase(
 
       contracts
         .firstOrNull { it.supportsMoving }
-        .takeIf { featureManager.isFeatureEnabled(Feature.MOVING_FLOW) }
+        .takeIf { featureManager.isFeatureEnabled(Feature.MOVING_FLOW).first() }
         ?.let {
           add(
             QuickAction.QuickLink(
@@ -109,7 +110,7 @@ internal class GetQuickLinksUseCase(
           )
         }
 
-      if (featureManager.isFeatureEnabled(Feature.PAYMENT_SCREEN)) {
+      if (featureManager.isFeatureEnabled(Feature.PAYMENT_SCREEN).first()) {
         add(
           QuickAction.QuickLink(
             destination = AppDestination.ConnectPayment,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.feature.home.home.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -38,13 +39,12 @@ internal class HomePresenter(
     var successData: SuccessData? by remember { mutableStateOf(SuccessData.fromLastState(lastState)) }
     var loadIteration by remember { mutableIntStateOf(0) }
     val showChatIcon by produceState(lastState.showChatIcon) {
-      val showChatIcon = !featureManager.isFeatureEnabled(Feature.DISABLE_CHAT)
-      value = showChatIcon
+      featureManager.isFeatureEnabled(Feature.DISABLE_CHAT).collectLatest { isChatDisabled ->
+        value = !isChatDisabled
+      }
     }
-    val isHelpCenterEnabled by produceState(lastState.isHelpCenterEnabled) {
-      val isHelpCenterEnabled = featureManager.isFeatureEnabled(Feature.HELP_CENTER)
-      value = isHelpCenterEnabled
-    }
+    val isHelpCenterEnabled by
+      featureManager.isFeatureEnabled(Feature.HELP_CENTER).collectAsState(lastState.isHelpCenterEnabled)
     val hasUnseenChatMessages by produceState(
       lastState.safeCast<HomeUiState.Success>()?.hasUnseenChatMessages ?: false,
     ) {

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCase.kt
@@ -15,6 +15,7 @@ import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.first
 import octopus.InsuranceContractsQuery
 import octopus.fragment.ContractFragment
 import octopus.type.AgreementCreationCause
@@ -36,8 +37,8 @@ internal class GetInsuranceContractsUseCaseImpl(
         .toEither(::ErrorMessage)
         .bind()
 
-      val isEditCoInsuredEnabled = featureManager.isFeatureEnabled(Feature.EDIT_COINSURED)
-      val isMovingFlowEnabled = featureManager.isFeatureEnabled(Feature.MOVING_FLOW)
+      val isEditCoInsuredEnabled = featureManager.isFeatureEnabled(Feature.EDIT_COINSURED).first()
+      val isMovingFlowEnabled = featureManager.isFeatureEnabled(Feature.MOVING_FLOW).first()
 
       val contractHolderDisplayName = insuranceQueryData.getContractHolderDisplayName()
       val contractHolderSSN = insuranceQueryData.currentMember.ssn?.let { formatSsn(it) }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/LicensesDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/LicensesDestination.kt
@@ -33,18 +33,18 @@ internal fun LicensesDestination(onBackPressed: () -> Unit) {
         title = stringResource(R.string.PROFILE_ABOUT_APP_LICENSE_ATTRIBUTIONS),
       )
       Column(
-          Modifier
-              .fillMaxSize()
-              .verticalScroll(rememberScrollState()),
+        Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState()),
       ) {
         val webViewState = rememberWebViewState(licensesUrl)
         WebView(
           state = webViewState,
           modifier = Modifier
-              .fillMaxSize()
-              .windowInsetsPadding(
-                  WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
-              ),
+            .fillMaxSize()
+            .windowInsetsPadding(
+              WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+            ),
         )
       }
     }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModel.kt
@@ -30,7 +30,7 @@ internal class ProfileViewModel(
   val data: StateFlow<ProfileUiState> = retryChannel.flatMapLatest {
     combine(
       getMemberRemindersUseCase.invoke(),
-      flow { emit(featureManager.isFeatureEnabled(Feature.PAYMENT_SCREEN)) },
+      featureManager.isFeatureEnabled(Feature.PAYMENT_SCREEN),
       flow { emit(getEuroBonusStatusUseCase.invoke()) },
     ) { memberReminders, isPaymentScreenFeatureEnabled, eurobonusResponse ->
       ProfileUiState(

--- a/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/FeatureManager.kt
+++ b/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/FeatureManager.kt
@@ -1,7 +1,8 @@
 package com.hedvig.android.featureflags
 
 import com.hedvig.android.featureflags.flags.Feature
+import kotlinx.coroutines.flow.Flow
 
 interface FeatureManager {
-  suspend fun isFeatureEnabled(feature: Feature): Boolean
+  fun isFeatureEnabled(feature: Feature): Flow<Boolean>
 }

--- a/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
+++ b/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
@@ -1,48 +1,55 @@
 package com.hedvig.android.featureflags
 
-import com.hedvig.android.market.Market
 import com.hedvig.android.market.MarketManager
 import io.getunleash.UnleashClient
 import io.getunleash.UnleashConfig
 import io.getunleash.UnleashContext
 import io.getunleash.polling.AutoPollingMode
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 private const val PRODUCTION_CLIENT_KEY = "*:production.21d6af57ae16320fde3a3caf024162db19cc33bf600ab7439c865c20"
 private const val DEVELOPMENT_CLIENT_KEY = "*:development.f2455340ac9d599b5816fa879d079f21dd0eb03e4315130deb5377b6"
 private const val UNLEASH_URL = "https://eu.app.unleash-hosted.com/eubb1047/api/frontend"
 private const val APP_NAME = "android"
 
-class UnleashClientProvider(
+class HedvigUnleashClient(
   private val isProduction: Boolean,
   private val appVersionName: String,
   marketManager: MarketManager,
   coroutineScope: CoroutineScope,
 ) {
-  private var client = createClient(marketManager.market.value)
-
-  init {
-    marketManager.market.map {
-      client = createClient(it)
-    }.stateIn(
-      scope = coroutineScope,
-      started = SharingStarted.Eagerly,
-      initialValue = null,
-    )
-  }
-
-  fun provideUnleashClient() = client
-
-  private fun createClient(market: Market) = UnleashClient(
+  val client = UnleashClient(
     unleashConfig = createConfig(),
     unleashContext = createContext(
-      market = market.name,
+      market = marketManager.market.value.name,
       appVersion = appVersionName,
     ),
   )
+  val featureUpdatedFlow: Flow<Unit> = callbackFlow {
+    trySend(Unit)
+    client.addTogglesUpdatedListener {
+      trySend(Unit)
+    }
+    awaitClose {}
+  }
+
+  init {
+    coroutineScope.launch {
+      marketManager.market.collectLatest { market ->
+        client.updateContext(
+          createContext(
+            market = market.name,
+            appVersion = appVersionName,
+          ),
+        )
+      }
+    }
+  }
 
   private fun createConfig(): UnleashConfig {
     val clientKey = if (isProduction) {

--- a/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/di/featureManagerModule.kt
+++ b/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/di/featureManagerModule.kt
@@ -3,14 +3,14 @@ package com.hedvig.android.featureflags.di
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
 import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.featureflags.FeatureManager
-import com.hedvig.android.featureflags.UnleashClientProvider
+import com.hedvig.android.featureflags.HedvigUnleashClient
 import com.hedvig.android.featureflags.flags.UnleashFeatureFlagProvider
 import com.hedvig.android.market.MarketManager
 import org.koin.dsl.module
 
 val featureManagerModule = module {
-  single<UnleashClientProvider> {
-    UnleashClientProvider(
+  single<HedvigUnleashClient> {
+    HedvigUnleashClient(
       isProduction = get<HedvigBuildConstants>().isProduction,
       appVersionName = get<HedvigBuildConstants>().appVersionName,
       marketManager = get<MarketManager>(),
@@ -20,9 +20,9 @@ val featureManagerModule = module {
 
   single<FeatureManager> {
     if (get<HedvigBuildConstants>().isProduction) {
-      UnleashFeatureFlagProvider(get<UnleashClientProvider>())
+      UnleashFeatureFlagProvider(get<HedvigUnleashClient>())
     } else {
-      UnleashFeatureFlagProvider(get<UnleashClientProvider>())
+      UnleashFeatureFlagProvider(get<HedvigUnleashClient>())
     }
   }
 }

--- a/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -1,18 +1,25 @@
 package com.hedvig.android.featureflags.flags
 
 import com.hedvig.android.featureflags.FeatureManager
-import com.hedvig.android.featureflags.UnleashClientProvider
+import com.hedvig.android.featureflags.HedvigUnleashClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 
 internal class UnleashFeatureFlagProvider(
-  private val unleashClientProvider: UnleashClientProvider,
+  private val hedvigUnleashClient: HedvigUnleashClient,
 ) : FeatureManager {
-  override suspend fun isFeatureEnabled(feature: Feature): Boolean = when (feature) {
-    Feature.DISABLE_CHAT -> unleashClientProvider.provideUnleashClient().isEnabled("disable_chat", false)
-    Feature.MOVING_FLOW -> unleashClientProvider.provideUnleashClient().isEnabled("moving_flow", false)
-    Feature.PAYMENT_SCREEN -> unleashClientProvider.provideUnleashClient().isEnabled("payment_screen", false)
-    Feature.TERMINATION_FLOW -> unleashClientProvider.provideUnleashClient().isEnabled("termination_flow", false)
-    Feature.UPDATE_NECESSARY -> unleashClientProvider.provideUnleashClient().isEnabled("update_necessary", false)
-    Feature.EDIT_COINSURED -> unleashClientProvider.provideUnleashClient().isEnabled("edit_coinsured", false)
-    Feature.HELP_CENTER -> unleashClientProvider.provideUnleashClient().isEnabled("help_center", false)
+  override fun isFeatureEnabled(feature: Feature): Flow<Boolean> {
+    return hedvigUnleashClient.featureUpdatedFlow.map {
+      when (feature) {
+        Feature.DISABLE_CHAT -> hedvigUnleashClient.client.isEnabled("disable_chat", false)
+        Feature.MOVING_FLOW -> hedvigUnleashClient.client.isEnabled("moving_flow", false)
+        Feature.PAYMENT_SCREEN -> hedvigUnleashClient.client.isEnabled("payment_screen", false)
+        Feature.TERMINATION_FLOW -> hedvigUnleashClient.client.isEnabled("termination_flow", false)
+        Feature.UPDATE_NECESSARY -> hedvigUnleashClient.client.isEnabled("update_necessary", false)
+        Feature.EDIT_COINSURED -> hedvigUnleashClient.client.isEnabled("edit_coinsured", false)
+        Feature.HELP_CENTER -> hedvigUnleashClient.client.isEnabled("help_center", false)
+      }
+    }.distinctUntilChanged()
   }
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
@@ -11,6 +11,7 @@ import com.hedvig.android.apollo.toEither
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
+import kotlinx.coroutines.flow.first
 import octopus.NeedsCoInsuredInfoReminderQuery
 
 internal interface GetNeedsCoInsuredInfoRemindersUseCase {
@@ -23,7 +24,7 @@ internal class GetNeedsCoInsuredInfoRemindersUseCaseImpl(
 ) : GetNeedsCoInsuredInfoRemindersUseCase {
   override suspend fun invoke(): Either<CoInsuredInfoReminderError, NonEmptyList<MemberReminder.CoInsuredInfo>> {
     return either {
-      if (!featureManager.isFeatureEnabled(Feature.EDIT_COINSURED)) {
+      if (!featureManager.isFeatureEnabled(Feature.EDIT_COINSURED).first()) {
         raise(CoInsuredInfoReminderError.CoInsuredReminderNotEnabled)
       }
 


### PR DESCRIPTION
Use the reactive APIs from unleash to listen to feature flag changes: Update the FeatureManager API to return a Flow instead of it exposing a suspend function, so that we can get the new values too if they change after we first query for them

add continuous fetching for feature flag UPDATE_NECESSARY