### PR TITLE
Chat banner from backend

### DIFF
--- a/app/apollo/apollo-octopus-public/build.gradle.kts
+++ b/app/apollo/apollo-octopus-public/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(libs.koin.core)
   implementation(projects.coreBuildConstants)
   implementation(projects.coreCommonPublic)
+  implementation(projects.coreMarkdown)
 }
 
 apollo { // Octopus client
@@ -39,6 +40,7 @@ apollo { // Octopus client
     mapScalar("Date", "kotlinx.datetime.LocalDate", "com.apollographql.apollo3.adapter.KotlinxLocalDateAdapter")
     mapScalar("DateTime", "kotlinx.datetime.LocalDate", "com.apollographql.apollo3.adapter.KotlinxLocalDateTimeAdapter")
     mapScalar("Instant", "kotlinx.datetime.Instant", "com.apollographql.apollo3.adapter.KotlinxInstantAdapter")
+    mapScalar("Markdown", "com.hedvig.android.core.markdown.MarkdownString", "com.hedvig.android.apollo.octopus.MarkdownStringAdapter")
     mapScalarToKotlinString("UUID")
     mapScalarToKotlinString("Url")
     mapScalarToKotlinString("FlowContext")

--- a/app/apollo/apollo-octopus-public/src/main/kotlin/com/hedvig/android/apollo/octopus/MarkdownAdapter.kt
+++ b/app/apollo/apollo-octopus-public/src/main/kotlin/com/hedvig/android/apollo/octopus/MarkdownAdapter.kt
@@ -1,0 +1,18 @@
+
+package com.hedvig.android.apollo.octopus
+
+import com.apollographql.apollo3.api.Adapter
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.json.JsonReader
+import com.apollographql.apollo3.api.json.JsonWriter
+import com.hedvig.android.core.markdown.MarkdownString
+
+object MarkdownStringAdapter : Adapter<MarkdownString> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): MarkdownString {
+    return MarkdownString(reader.nextString()!!)
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: MarkdownString) {
+    writer.value(value.string)
+  }
+}

--- a/app/core/core-markdown/build.gradle.kts
+++ b/app/core/core-markdown/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+  id("hedvig.android.ktlint")
+  id("hedvig.kotlin.library")
+}

--- a/app/core/core-markdown/src/main/AndroidManifest.xml
+++ b/app/core/core-markdown/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/app/core/core-markdown/src/main/kotlin/com/hedvig/android/core/markdown/MarkdownString.kt
+++ b/app/core/core-markdown/src/main/kotlin/com/hedvig/android/core/markdown/MarkdownString.kt
@@ -1,0 +1,4 @@
+package com.hedvig.android.core.markdown
+
+@JvmInline
+value class MarkdownString(val string: String)

--- a/app/feature/feature-chat/build.gradle.kts
+++ b/app/feature/feature-chat/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
   implementation(projects.coreDesignSystem)
   implementation(projects.coreFileUpload)
   implementation(projects.coreIcons)
+  implementation(projects.coreMarkdown)
   implementation(projects.coreResources)
   implementation(projects.coreRetrofit)
   implementation(projects.coreUi)

--- a/app/feature/feature-chat/src/main/graphql/QueryChatMessages.graphql
+++ b/app/feature/feature-chat/src/main/graphql/QueryChatMessages.graphql
@@ -6,5 +6,6 @@ query ChatMessages($until: Instant) {
     messages {
       ...MessageFragment
     }
+    bannerText
   }
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatPresenter.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatPresenter.kt
@@ -58,8 +58,8 @@ internal sealed interface ChatUiState {
   data class Loaded(
     // The list of messages, ordered from the newest one to the oldest one
     val messages: ImmutableList<UiChatMessage>,
-    val bannerText: String?,
     val fetchMoreMessagesUiState: FetchMoreMessagesUiState,
+    val bannerText: String?,
   ) : ChatUiState {
     data class UiChatMessage(
       val chatMessage: ChatMessage,
@@ -239,8 +239,8 @@ internal class ChatPresenter(
         messages = (uiChatMessages + failedChatMessages)
           .sortedByDescending { it.chatMessage.sentAt }
           .toPersistentList(),
-        bannerText = bannerText,
         fetchMoreMessagesUiState = fetchMoreMessagesUiState,
+        bannerText = bannerText,
       )
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/ChatRepositoryImpl.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/ChatRepositoryImpl.kt
@@ -77,7 +77,7 @@ internal class ChatRepositoryImpl(
         messages = result.chat.messages.mapNotNull { it.toChatMessage() },
         nextUntil = result.chat.nextUntil,
         hasNext = result.chat.hasNext,
-        informationMessage = null, // TODO query from schema
+        informationMessage = result.chat.bannerText?.string,
       )
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatBanner.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatBanner.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.feature.chat.ui
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -11,6 +10,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -21,6 +21,8 @@ import com.hedvig.android.core.designsystem.component.card.HedvigInfoCard
 import com.hedvig.android.core.designsystem.material3.infoContainer
 import com.hedvig.android.core.designsystem.material3.infoElement
 import com.hedvig.android.core.designsystem.material3.onInfoContainer
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.icons.Hedvig
 import com.hedvig.android.core.icons.hedvig.normal.InfoFilled
 
@@ -49,12 +51,20 @@ internal fun ChatBanner(text: String, modifier: Modifier = Modifier) {
       tint = MaterialTheme.colorScheme.infoElement,
     )
     Spacer(Modifier.width(8.dp))
-    Column {
-      ProvideTextStyle(MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onInfoContainer)) {
-        RichText {
-          Markdown(content = text)
-        }
+    ProvideTextStyle(MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onInfoContainer)) {
+      RichText {
+        Markdown(content = text)
       }
+    }
+  }
+}
+
+@HedvigPreview
+@Composable
+private fun PreviewChatBanner() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      ChatBanner("HHHHHH".repeat(15))
     }
   }
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
@@ -215,8 +215,8 @@ private class ChatUiStateProvider : CollectionPreviewParameterProvider<ChatUiSta
           ChatUiState.Loaded.UiChatMessage(it, false)
         }
         .toImmutableList(),
-      bannerText = "Test",
       fetchMoreMessagesUiState = ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore,
+      bannerText = "Test",
     ),
   ),
 )

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -115,6 +116,35 @@ internal fun ChatLoadedScreen(
   onSendMedia: (Uri) -> Unit,
   onFetchMoreMessages: () -> Unit,
 ) {
+  ChatLoadedScreen(
+    uiState = uiState,
+    imageLoader = imageLoader,
+    topAppBarScrollBehavior = topAppBarScrollBehavior,
+    openUrl = openUrl,
+    onRetrySendChatMessage = onRetrySendChatMessage,
+    onFetchMoreMessages = onFetchMoreMessages,
+    chatInput = {
+      ChatInput(
+        onSendMessage = onSendMessage,
+        onSendPhoto = onSendPhoto,
+        onSendMedia = onSendMedia,
+        appPackageId = appPackageId,
+        modifier = Modifier.padding(16.dp),
+      )
+    },
+  )
+}
+
+@Composable
+private fun ChatLoadedScreen(
+  uiState: ChatUiState.Loaded,
+  imageLoader: ImageLoader,
+  topAppBarScrollBehavior: TopAppBarScrollBehavior,
+  openUrl: (String) -> Unit,
+  onRetrySendChatMessage: (messageId: String) -> Unit,
+  onFetchMoreMessages: () -> Unit,
+  chatInput: @Composable () -> Unit,
+) {
   val lazyListState = rememberLazyListState()
 
   ScrollToBottomOnKeyboardShownEffect(lazyListState = lazyListState)
@@ -142,10 +172,10 @@ internal fun ChatLoadedScreen(
           .clearFocusOnTap()
           .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
       )
-      uiState.bannerText?.let {
+      if (uiState.bannerText != null) {
         Divider(Modifier.fillMaxWidth())
         ChatBanner(
-          text = it,
+          text = uiState.bannerText,
           modifier = Modifier.fillMaxWidth(),
         )
       }
@@ -156,13 +186,7 @@ internal fun ChatLoadedScreen(
           .fillMaxWidth()
           .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
       ) {
-        ChatInput(
-          onSendMessage = onSendMessage,
-          onSendPhoto = onSendPhoto,
-          onSendMedia = onSendMedia,
-          appPackageId = appPackageId,
-          modifier = Modifier.padding(16.dp),
-        )
+        chatInput()
       }
     }
   }
@@ -620,14 +644,12 @@ internal fun ChatMessageWithTimeAndDeliveryStatus(
 
 @HedvigPreview
 @Composable
-private fun PreviewChatLazyColumn() {
+private fun PreviewChatLoadedScreen() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-      val listSize = 10
-      ChatLazyColumn(
-        lazyListState = rememberLazyListState(),
+      ChatLoadedScreen(
         uiState = ChatUiState.Loaded(
-          messages = List(listSize) { index ->
+          messages = List(10) { index ->
             ChatUiState.Loaded.UiChatMessage(
               chatMessage = ChatMessage.ChatMessageText(
                 index.toString(),
@@ -641,13 +663,15 @@ private fun PreviewChatLazyColumn() {
               isLastDeliveredMessage = index == 0,
             )
           }.toPersistentList(),
-          bannerText = null,
           fetchMoreMessagesUiState = ChatUiState.Loaded.FetchMoreMessagesUiState.NothingMoreToFetch,
+          bannerText = "Banner text",
         ),
         imageLoader = rememberPreviewImageLoader(),
+        topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
         openUrl = {},
         onRetrySendChatMessage = {},
         onFetchMoreMessages = {},
+        chatInput = {},
       )
     }
   }

--- a/app/tracking/tracking-core/src/main/kotlin/com/hedvig/android/core/tracking/ActionLogger.kt
+++ b/app/tracking/tracking-core/src/main/kotlin/com/hedvig/android/core/tracking/ActionLogger.kt
@@ -3,11 +3,7 @@ package com.hedvig.android.core.tracking
 import com.hedvig.android.logger.logcat
 
 interface ActionLogger {
-  fun logAction(
-    type: ActionType,
-    name: String,
-    attributes: Map<String, Any?>,
-  )
+  fun logAction(type: ActionType, name: String, attributes: Map<String, Any?>)
 
   fun logError(
     message: String,
@@ -50,7 +46,7 @@ interface ActionLogger {
       source: ErrorSource,
       attributes: Map<String, Any?>,
       throwable: Throwable?,
-      stacktrace: String?
+      stacktrace: String?,
     ) {
       error("Should never receive any error")
     }
@@ -74,7 +70,7 @@ enum class ActionType {
   BACK,
 
   /** A custom action. */
-  CUSTOM
+  CUSTOM,
 }
 
 enum class ErrorSource {

--- a/app/tracking/tracking-core/src/main/kotlin/com/hedvig/android/core/tracking/LogAction.kt
+++ b/app/tracking/tracking-core/src/main/kotlin/com/hedvig/android/core/tracking/LogAction.kt
@@ -1,11 +1,7 @@
 package com.hedvig.android.core.tracking
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun logAction(
-  type: ActionType,
-  name: String,
-  attributes: Map<String, Any?>,
-) {
+inline fun logAction(type: ActionType, name: String, attributes: Map<String, Any?>) {
   with(ActionLogger.actionLogger) {
     logAction(type, name, attributes)
   }

--- a/app/tracking/tracking-datadog/src/main/kotlin/com/hedvig/android/tracking/datadog/DatadogActionLogger.kt
+++ b/app/tracking/tracking-datadog/src/main/kotlin/com/hedvig/android/tracking/datadog/DatadogActionLogger.kt
@@ -13,6 +13,7 @@ class DatadogActionLogger(
   private val sdkCore: SdkCore,
 ) : ActionLogger {
   val rumMonitor = GlobalRumMonitor.get(sdkCore)
+
   override fun logAction(type: ActionType, name: String, attributes: Map<String, Any?>) {
     rumMonitor.addAction(
       when (type) {

--- a/hedvig-lint/lint-baseline/lint-baseline-core-markdown.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-markdown.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
+
+</issues>


### PR DESCRIPTION
Adds a module which will contain just a simple Markdown type, which is necessary for GQL to know what to map the `Markdown` scalar that now exists on the supergraph's scehma.

A small change in ChatLoadedScreen composable so that it takes in a slot for the chat input composable. This is because that composable sets up a state object which requires an activity to be present, which made it impossible to create in a @Preview