### PR TITLE
Augment link handling for chat banner to logAction the navigation to HC

### DIFF
--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatPresenter.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatPresenter.kt
@@ -93,7 +93,7 @@ internal class ChatPresenter(
       )
     }
     var bannerText: String? by remember { mutableStateOf(lastState.safeCast<ChatUiState.Loaded>()?.bannerText) }
-    var haveSendAtLeastOneMessage: Boolean by remember {
+    var haveSentAtLeastOneMessage: Boolean by remember {
       mutableStateOf(lastState.safeCast<ChatUiState.Loaded>()?.haveSentAtLeastOneMessage ?: false)
     }
 
@@ -175,17 +175,17 @@ internal class ChatPresenter(
         }
 
         is ChatEvent.SendPhotoMessage -> {
-          haveSendAtLeastOneMessage = true
+          haveSentAtLeastOneMessage = true
           photosToSend.trySend(event.uri)
         }
 
         is ChatEvent.SendMediaMessage -> {
-          haveSendAtLeastOneMessage = true
+          haveSentAtLeastOneMessage = true
           mediaToSend.trySend(event.uri)
         }
 
         is ChatEvent.SendTextMessage -> {
-          haveSendAtLeastOneMessage = true
+          haveSentAtLeastOneMessage = true
           messagesToSend.trySend(event.message)
         }
 
@@ -248,7 +248,7 @@ internal class ChatPresenter(
           .toPersistentList(),
         fetchMoreMessagesUiState = fetchMoreMessagesUiState,
         bannerText = bannerText,
-        haveSentAtLeastOneMessage = haveSendAtLeastOneMessage,
+        haveSentAtLeastOneMessage = haveSentAtLeastOneMessage,
       )
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/ChatGraph.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/ChatGraph.kt
@@ -33,6 +33,7 @@ fun NavGraphBuilder.chatGraph(
       viewModel = viewModel,
       imageLoader = imageLoader,
       appPackageId = hedvigBuildConstants.appId,
+      hedvigDeepLinkContainer = hedvigDeepLinkContainer,
       openUrl = openUrl,
       onNavigateUp = navigator::navigateUp,
     )

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatBanner.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatBanner.kt
@@ -27,7 +27,7 @@ import com.hedvig.android.core.icons.Hedvig
 import com.hedvig.android.core.icons.hedvig.normal.InfoFilled
 
 @Composable
-internal fun ChatBanner(text: String, modifier: Modifier = Modifier) {
+internal fun ChatBanner(text: String, onBannerLinkClicked: (String) -> Unit, modifier: Modifier = Modifier) {
   HedvigInfoCard(
     modifier = modifier,
     contentPadding = PaddingValues(
@@ -53,7 +53,7 @@ internal fun ChatBanner(text: String, modifier: Modifier = Modifier) {
     Spacer(Modifier.width(8.dp))
     ProvideTextStyle(MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onInfoContainer)) {
       RichText {
-        Markdown(content = text)
+        Markdown(content = text, onLinkClicked = onBannerLinkClicked)
       }
     }
   }
@@ -64,7 +64,7 @@ internal fun ChatBanner(text: String, modifier: Modifier = Modifier) {
 private fun PreviewChatBanner() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-      ChatBanner("HHHHHH".repeat(15))
+      ChatBanner("HHHHHH".repeat(15), {})
     }
   }
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatDestination.kt
@@ -21,15 +21,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.ImageLoader
+import com.hedvig.android.core.common.safeCast
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgress
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.tracking.ActionType
+import com.hedvig.android.core.tracking.logAction
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.feature.chat.ChatEvent
@@ -37,6 +41,7 @@ import com.hedvig.android.feature.chat.ChatUiState
 import com.hedvig.android.feature.chat.ChatViewModel
 import com.hedvig.android.feature.chat.model.ChatMessage
 import com.hedvig.android.logger.logcat
+import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import hedvig.resources.R
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.collections.immutable.toImmutableList
@@ -47,15 +52,31 @@ internal fun ChatDestination(
   viewModel: ChatViewModel,
   imageLoader: ImageLoader,
   appPackageId: String,
+  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
   openUrl: (String) -> Unit,
   onNavigateUp: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+  val urihandler = LocalUriHandler.current
+  val onBannerLinkClicked: (String) -> Unit = remember(urihandler, uiState, hedvigDeepLinkContainer) {
+    { url: String ->
+      if (url == hedvigDeepLinkContainer.helpCenter) {
+        val haveSentAtLeastOneMessage = uiState.safeCast<ChatUiState.Loaded>()?.haveSentAtLeastOneMessage ?: false
+        logAction(
+          ActionType.CUSTOM,
+          "Help center opened from the chat",
+          mapOf("haveSentAMessage" to haveSentAtLeastOneMessage),
+        )
+      }
+      urihandler.openUri(url)
+    }
+  }
   ChatScreen(
     uiState = uiState,
     imageLoader = imageLoader,
     appPackageId = appPackageId,
     openUrl = openUrl,
+    onBannerLinkClicked = onBannerLinkClicked,
     onNavigateUp = onNavigateUp,
     onSendMessage = { message: String ->
       viewModel.emit(ChatEvent.SendTextMessage(message))
@@ -84,6 +105,7 @@ private fun ChatScreen(
   imageLoader: ImageLoader,
   appPackageId: String,
   openUrl: (String) -> Unit,
+  onBannerLinkClicked: (String) -> Unit,
   onNavigateUp: () -> Unit,
   onSendMessage: (String) -> Unit,
   onSendPhoto: (Uri) -> Unit,
@@ -126,6 +148,7 @@ private fun ChatScreen(
               appPackageId = appPackageId,
               topAppBarScrollBehavior = topAppBarScrollBehavior,
               openUrl = openUrl,
+              onBannerLinkClicked = onBannerLinkClicked,
               onRetrySendChatMessage = onRetrySendChatMessage,
               onSendMessage = onSendMessage,
               onSendPhoto = onSendPhoto,
@@ -177,6 +200,7 @@ private fun ChatScreenPreview(
         imageLoader = rememberPreviewImageLoader(),
         appPackageId = "com.hedvig",
         openUrl = {},
+        onBannerLinkClicked = {},
         onNavigateUp = {},
         onSendMessage = {},
         onSendPhoto = {},
@@ -217,6 +241,7 @@ private class ChatUiStateProvider : CollectionPreviewParameterProvider<ChatUiSta
         .toImmutableList(),
       fetchMoreMessagesUiState = ChatUiState.Loaded.FetchMoreMessagesUiState.FetchingMore,
       bannerText = "Test",
+      haveSentAtLeastOneMessage = false,
     ),
   ),
 )

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/ChatLoadedScreen.kt
@@ -110,6 +110,7 @@ internal fun ChatLoadedScreen(
   appPackageId: String,
   topAppBarScrollBehavior: TopAppBarScrollBehavior,
   openUrl: (String) -> Unit,
+  onBannerLinkClicked: (String) -> Unit,
   onRetrySendChatMessage: (messageId: String) -> Unit,
   onSendMessage: (String) -> Unit,
   onSendPhoto: (Uri) -> Unit,
@@ -121,6 +122,7 @@ internal fun ChatLoadedScreen(
     imageLoader = imageLoader,
     topAppBarScrollBehavior = topAppBarScrollBehavior,
     openUrl = openUrl,
+    onBannerLinkClicked = onBannerLinkClicked,
     onRetrySendChatMessage = onRetrySendChatMessage,
     onFetchMoreMessages = onFetchMoreMessages,
     chatInput = {
@@ -141,6 +143,7 @@ private fun ChatLoadedScreen(
   imageLoader: ImageLoader,
   topAppBarScrollBehavior: TopAppBarScrollBehavior,
   openUrl: (String) -> Unit,
+  onBannerLinkClicked: (String) -> Unit,
   onRetrySendChatMessage: (messageId: String) -> Unit,
   onFetchMoreMessages: () -> Unit,
   chatInput: @Composable () -> Unit,
@@ -176,6 +179,7 @@ private fun ChatLoadedScreen(
         Divider(Modifier.fillMaxWidth())
         ChatBanner(
           text = uiState.bannerText,
+          onBannerLinkClicked = onBannerLinkClicked,
           modifier = Modifier.fillMaxWidth(),
         )
       }
@@ -665,10 +669,12 @@ private fun PreviewChatLoadedScreen() {
           }.toPersistentList(),
           fetchMoreMessagesUiState = ChatUiState.Loaded.FetchMoreMessagesUiState.NothingMoreToFetch,
           bannerText = "Banner text",
+          haveSentAtLeastOneMessage = false,
         ),
         imageLoader = rememberPreviewImageLoader(),
         topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
         openUrl = {},
+        onBannerLinkClicked = {},
         onRetrySendChatMessage = {},
         onFetchMoreMessages = {},
         chatInput = {},


### PR DESCRIPTION
This can be used to determine how often people go to the chat but end up first checking out the help center instead, or if they have chatted and then also decided to check out the help center

If a message has been sent is determined by the Presenter, exposing that information in the UI state. If one exits the chat and comes back into it again, that state is cleared, but that is working as intended, we do not plan to make this flag be tracked across app-starts or something more intricate than what we have in place here