### PR TITLE
Fix insurance details view not showing up to date data

### DIFF
--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCaseDemo.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCaseDemo.kt
@@ -1,17 +1,19 @@
 package com.hedvig.android.feature.insurances.data
 
 import arrow.core.Either
-import arrow.core.raise.either
+import arrow.core.right
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.ContractType
 import com.hedvig.android.data.productvariant.ProductVariant
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.LocalDate
 
 internal class GetInsuranceContractsUseCaseDemo : GetInsuranceContractsUseCase {
-  override suspend fun invoke(forceNetworkFetch: Boolean): Either<ErrorMessage, List<InsuranceContract>> {
-    return either {
+  override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ErrorMessage, List<InsuranceContract>>> {
+    return flowOf(
       listOf(
         InsuranceContract(
           "1",
@@ -72,7 +74,7 @@ internal class GetInsuranceContractsUseCaseDemo : GetInsuranceContractsUseCase {
           contractHolderDisplayName = "Test Member",
           contractHolderSSN = "1111111111-33322",
         ),
-      )
-    }
+      ).right(),
+    )
   }
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenter.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenter.kt
@@ -28,6 +28,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import octopus.CrossSellsQuery
 import octopus.type.CrossSellType
@@ -144,7 +145,7 @@ private suspend fun loadInsuranceData(
 ): Either<ErrorMessage, InsuranceData> {
   return either {
     parZip(
-      { getInsuranceContractsUseCase.invoke(forceNetworkFetch).bind() },
+      { getInsuranceContractsUseCase.invoke(forceNetworkFetch).first().bind() },
       { getCrossSellsUseCase.invoke().bind() },
     ) {
         contracts: List<InsuranceContract>,

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -119,6 +119,13 @@ private fun ContractDetailScreen(
     val pagerState = rememberPagerState(pageCount = { 3 })
     FadeAnimatedContent(
       targetState = uiState,
+      contentKey = { uiState ->
+        when (uiState) {
+          ContractDetailsUiState.Error -> "Error"
+          ContractDetailsUiState.Loading -> "Loading"
+          is ContractDetailsUiState.Success -> "Success"
+        }
+      },
       label = "contract detail screen fade animated content",
       modifier = Modifier.weight(1f),
     ) { state ->

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsViewModel.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsViewModel.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.feature.insurances.terminatedcontracts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.hedvig.android.core.common.ErrorMessage
@@ -18,6 +19,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 
 internal class TerminatedContractsViewModel(
@@ -27,36 +30,41 @@ internal class TerminatedContractsViewModel(
 
   val uiState: StateFlow<TerminatedContractsUiState> = flow {
     emit(TerminatedContractsUiState.Loading)
-    either {
-      val terminatedContracts = getInsuranceContractsUseCaseProvider
-        .provide()
-        .invoke(forceNetworkFetch = false)
-        .bind()
-        .filter(InsuranceContract::isTerminated)
-      ensure(terminatedContracts.isNotEmpty()) {
-        ErrorMessage("", NoSuchElementException())
-      }
-      if (terminatedContracts.isEmpty()) {
-        logcat(LogPriority.ERROR) { "Terminated insurances screen got 0 terminated insurances" }
-        TerminatedContractsUiState.NoTerminatedInsurances
-      } else {
-        TerminatedContractsUiState.Success(terminatedContracts.toImmutableList())
-      }
-    }.fold(
-      ifLeft = { errorMessage ->
-        logcat(LogPriority.INFO, errorMessage.throwable) {
-          "Terminated contracts failed to load ${errorMessage.message}"
+    getInsuranceContractsUseCaseProvider
+      .provide()
+      .invoke(forceNetworkFetch = false)
+      .onEach { result: Either<ErrorMessage, List<InsuranceContract>> ->
+        result.onLeft { errorMessage ->
+          logcat(LogPriority.INFO, errorMessage.throwable) {
+            "Terminated contracts failed to load ${errorMessage.message}"
+          }
         }
-        emit(TerminatedContractsUiState.Error)
-      },
-      ifRight = { emit(it) },
-    )
-  }
-    .stateIn(
-      viewModelScope,
-      SharingStarted.WhileSubscribed(5.seconds),
-      TerminatedContractsUiState.Loading,
-    )
+      }
+      .map { insuranceContractResult ->
+        either {
+          val terminatedContracts = insuranceContractResult.bind().filter(InsuranceContract::isTerminated)
+          ensure(terminatedContracts.isNotEmpty()) {
+            ErrorMessage("", NoSuchElementException())
+          }
+          if (terminatedContracts.isEmpty()) {
+            logcat(LogPriority.ERROR) { "Terminated insurances screen got 0 terminated insurances" }
+            TerminatedContractsUiState.NoTerminatedInsurances
+          } else {
+            TerminatedContractsUiState.Success(terminatedContracts.toImmutableList())
+          }
+        }.fold(
+          ifLeft = { errorMessage ->
+            TerminatedContractsUiState.Error
+          },
+          ifRight = { it },
+        )
+      }
+      .collect(this)
+  }.stateIn(
+    viewModelScope,
+    SharingStarted.WhileSubscribed(5.seconds),
+    TerminatedContractsUiState.Loading,
+  )
 
   fun retry() {
     if (uiState.value is TerminatedContractsUiState.Error) {

--- a/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenterTest.kt
+++ b/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenterTest.kt
@@ -21,6 +21,8 @@ import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.notification.badge.data.crosssell.card.FakeCrossSellCardNotificationBadgeService
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import octopus.CrossSellsQuery
@@ -378,11 +380,15 @@ internal class InsurancePresenterTest {
     val errorMessages = Turbine<ErrorMessage>()
     val contracts = Turbine<List<InsuranceContract>>()
 
-    override suspend fun invoke(forceNetworkFetch: Boolean): Either<ErrorMessage, List<InsuranceContract>> {
-      return raceN(
-        { errorMessages.awaitItem() },
-        { contracts.awaitItem() },
-      )
+    override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ErrorMessage, List<InsuranceContract>>> {
+      return flow {
+        emit(
+          raceN(
+            { errorMessages.awaitItem() },
+            { contracts.awaitItem() },
+          ),
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Make GetInsuranceContractsUseCase return a flow of results. Now by default hits the cache *and* the network afterwards, which means that when one goes back to that screen after they've terminated their insurance, the cached value will immediatelly show, but then the real value will also be fetched from the network.
This also allows us to properly use the values from unleash, through listening to the value changes, and not just getting the first value and stopping there.