### PR TITLE
Fix/dark mode bottom sheet

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigBottomBar.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigBottomBar.kt
@@ -87,9 +87,11 @@ private fun HedvigBottomBar(
         },
         label = { Text(stringResource(destination.titleTextId())) },
         colors = NavigationBarItemDefaults.colors(
-          indicatorColor = MaterialTheme.colorScheme.surface,
           selectedIconColor = MaterialTheme.colorScheme.onSurface,
+          selectedTextColor = MaterialTheme.colorScheme.onSurface,
+          indicatorColor = MaterialTheme.colorScheme.surface,
           unselectedIconColor = MaterialTheme.colorScheme.onSurface,
+          unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
         ),
         modifier = Modifier.testTag(destination.toName()),
       )

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigNavRail.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigNavRail.kt
@@ -3,6 +3,7 @@ package com.hedvig.android.app.ui
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
@@ -17,8 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
@@ -95,9 +98,11 @@ private fun HedvigNavRail(
         },
         label = { Text(stringResource(destination.titleTextId())) },
         colors = NavigationRailItemDefaults.colors(
-          indicatorColor = MaterialTheme.colorScheme.surfaceVariant,
           selectedIconColor = MaterialTheme.colorScheme.onSurface,
+          selectedTextColor = MaterialTheme.colorScheme.onSurface,
+          indicatorColor = MaterialTheme.colorScheme.surfaceVariant,
           unselectedIconColor = MaterialTheme.colorScheme.onSurface,
+          unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
         ),
         modifier = Modifier.testTag(destination.toName()),
       )
@@ -109,7 +114,7 @@ private fun HedvigNavRail(
 @Composable
 private fun PreviewHedvigNavRail() {
   HedvigTheme {
-    Surface(color = MaterialTheme.colorScheme.background) {
+    Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.height(300.dp)) {
       HedvigNavRail(
         destinations = persistentSetOf(
           TopLevelGraph.HOME,


### PR DESCRIPTION
m3 1.2.0 has a bug which does not set these colors right
https://issuetracker.google.com/issues/326894020

Before:
![image](https://github.com/HedvigInsurance/android/assets/44558292/d4827307-b1ba-48e6-b7ec-da70430cf41b)

After:
![image](https://github.com/HedvigInsurance/android/assets/44558292/293d794b-18da-451a-a8ed-655457064f12)
