### PR TITLE
Make sure that AuthEventBroadcaster runs on startup

### DIFF
--- a/app/datadog/datadog-core/build.gradle.kts
+++ b/app/datadog/datadog-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   implementation(projects.coreBuildConstants)
   implementation(projects.coreCommonPublic)
   implementation(projects.coreDatastorePublic)
+  implementation(projects.initializable)
   implementation(projects.trackingCore)
   implementation(projects.trackingDatadog)
 }

--- a/app/datadog/datadog-core/src/main/kotlin/com/hedvig/android/datadog/core/di/DatadogModule.kt
+++ b/app/datadog/datadog-core/src/main/kotlin/com/hedvig/android/datadog/core/di/DatadogModule.kt
@@ -5,8 +5,10 @@ import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.datadog.core.attributestracking.DatadogAttributesManager
 import com.hedvig.android.datadog.core.attributestracking.DatadogAttributesManagerImpl
 import com.hedvig.android.datadog.core.memberid.DatadogMemberIdUpdater
+import com.hedvig.android.initializable.Initializable
 import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val datadogModule = module {
@@ -16,7 +18,7 @@ val datadogModule = module {
       get<MemberIdService>(),
       get<ApplicationScope>(),
     )
-  }
+  } bind Initializable::class
   single<Tracer> { GlobalTracer.get() }
   single<DatadogAttributesManager> { DatadogAttributesManagerImpl() }
 }

--- a/app/datadog/datadog-core/src/main/kotlin/com/hedvig/android/datadog/core/memberid/DatadogMemberIdUpdater.kt
+++ b/app/datadog/datadog-core/src/main/kotlin/com/hedvig/android/datadog/core/memberid/DatadogMemberIdUpdater.kt
@@ -1,9 +1,12 @@
 package com.hedvig.android.datadog.core.memberid
 
 import com.hedvig.android.auth.MemberIdService
+import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.datadog.core.attributestracking.DatadogAttributesManager
+import com.hedvig.android.initializable.Initializable
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -11,10 +14,10 @@ import kotlinx.coroutines.launch
 internal class DatadogMemberIdUpdater(
   private val datadogAttributesManager: DatadogAttributesManager,
   private val memberIdService: MemberIdService,
-  coroutineScope: CoroutineScope,
-) {
-  init {
-    coroutineScope.launch {
+  private val applicationScope: ApplicationScope,
+) : Initializable {
+  override fun initialize() {
+    applicationScope.launch {
       memberIdService.getMemberId().collectLatest { memberId ->
         if (memberId == null) {
           logcat(LogPriority.INFO) { "Removing from global RUM attribute:$MEMBER_ID_TRACKING_KEY" }


### PR DESCRIPTION
Make it work exactly like DatadogDemoModeTracking does which properly shows up on the logs.

This was an oversight on my end when we re-wrote this class a bit.
The `init` block was the one that was supposed to kick-start the process. And we did wire the class in our koin graph, so Koin knew how to construct it. The problem was that nobody was asking for it, so it never was constructed in the first place, so this code simply never was called, resulting in not attaching the member id at all for the past few releases