### PR TITLE
Fix crash when choosing the same file again

### DIFF
--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/fileupload/FileUploadViewModel.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/fileupload/FileUploadViewModel.kt
@@ -77,6 +77,9 @@ internal class FileUploadViewModel(
   }
 
   fun addLocalFile(uri: Uri) {
+    if (uri.toString() in _uiState.value.localFiles.map { it.id }) {
+      return
+    }
     _uiState.update {
       try {
         val mimeType = fileService.getMimeType(uri)


### PR DESCRIPTION
Fixes a crash reported in crashlytics

If the same local file is chosen again, it's best if we simply do not add it to the list in the first place, since it's already there. The existing behavior tries to add it to the list, but since the list assumes that all items are unique the app crashes
Context:
https://console.firebase.google.com/u/0/project/hedvig-app/crashlytics/app/android:com.hedvig.app/issues/fdc7606afb67952bbd76416f7674461a?time=last-thirty-days&types=crash&versions=12.5.2%20(1708595525)&sessionEventKey=65DE3CBD00B700010D3FAFD41DC34EFF_1918818661704692052