### PR TITLE
Fix top app bar using insets from the bottom

### DIFF
--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/m3/TopAppBar.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/m3/TopAppBar.kt
@@ -154,7 +154,8 @@ fun TopAppBarWithBackAndClose(
   onNavigateUp: () -> Unit,
   onClose: () -> Unit,
   modifier: Modifier = Modifier,
-  windowInsets: WindowInsets = WindowInsets.systemBars.union(WindowInsets.displayCutout),
+  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets
+    .union(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)),
   colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(
     containerColor = MaterialTheme.colorScheme.background,
     scrolledContainerColor = MaterialTheme.colorScheme.surface,


### PR DESCRIPTION
WindowInsets.systemBars does properly take into account to only use the horizontal and the top insets. The change to use
WindowInsets.systemBars here did not account for it, so this needs to be reverted back.
TopAppBarDefaults.windowInsets is using
WindowInsets.systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top) anyway, and we add the cutout to it as mentioned here https://issuetracker.google.com/issues/326526714