### PR TITLE
Claim overview files audio grid fix

### DIFF
--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/summary/ClaimSummaryDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/summary/ClaimSummaryDestination.kt
@@ -5,12 +5,13 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -20,7 +21,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -34,12 +40,11 @@ import com.hedvig.android.audio.player.SignedAudioUrl
 import com.hedvig.android.audio.player.state.PlayableAudioSource
 import com.hedvig.android.audio.player.state.rememberAudioPlayer
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
-import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.FilesLazyVerticalGrid
 import com.hedvig.android.core.ui.getLocale
 import com.hedvig.android.core.ui.infocard.VectorInfoCard
-import com.hedvig.android.core.ui.plus
 import com.hedvig.android.core.ui.preview.calculateForPreview
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.core.ui.snackbar.ErrorSnackbarState
@@ -93,8 +98,6 @@ private fun ClaimSummaryScreen(
   imageLoader: ImageLoader,
   windowSizeClass: WindowSizeClass,
 ) {
-  LocalConfiguration.current
-  val resources = LocalContext.current.resources
   ClaimFlowScaffold(
     windowSizeClass = windowSizeClass,
     navigateUp = navigateUp,
@@ -105,8 +108,50 @@ private fun ClaimSummaryScreen(
       showedError,
     ),
   ) { sideSpacingModifier ->
+    var layoutHeight by remember { mutableIntStateOf(-1) }
+    Layout(
+      content = {
+        BeforeGridContent(uiState = uiState)
+        FilesLazyVerticalGrid(
+          paddingValues = PaddingValues(horizontal = 8.dp),
+          files = uiState.claimSummaryInfoUiState.files,
+          imageLoader = imageLoader,
+          onRemoveFile = null,
+        )
+        AfterGridContent(uiState = uiState, submitSummary = submitSummary)
+      },
+      modifier = sideSpacingModifier
+        .fillMaxWidth()
+        .weight(1f)
+        .onSizeChanged { intSize -> layoutHeight = intSize.height }
+        .verticalScroll(rememberScrollState()),
+    ) { measurables, constraints ->
+      val beforeGridPlaceable = measurables[0].measure(constraints.copy(minWidth = 0, minHeight = 0))
+      val afterGridPlaceable = measurables[2].measure(constraints.copy(minWidth = 0, minHeight = 0))
+      val remainingHeightForGrid = layoutHeight - beforeGridPlaceable.height - afterGridPlaceable.height
+      val actualGridHeight = remainingHeightForGrid.coerceAtLeast(160.dp.roundToPx())
+      val gridPlaceable = measurables[1].measure(
+        constraints.copy(minWidth = 0, minHeight = actualGridHeight, maxHeight = actualGridHeight),
+      )
+      layout(
+        constraints.maxWidth,
+        beforeGridPlaceable.height + gridPlaceable.height + afterGridPlaceable.height,
+      ) {
+        beforeGridPlaceable.place(0, 0)
+        gridPlaceable.place(0, beforeGridPlaceable.height)
+        afterGridPlaceable.place(0, beforeGridPlaceable.height + gridPlaceable.height)
+      }
+    }
+  }
+}
+
+@Composable
+private fun BeforeGridContent(uiState: ClaimSummaryUiState, modifier: Modifier = Modifier) {
+  LocalConfiguration.current
+  val resources = LocalContext.current.resources
+  Column(modifier) {
     Spacer(Modifier.height(16.dp))
-    Text(stringResource(R.string.moving_summary_scroll_Details), sideSpacingModifier)
+    Text(stringResource(R.string.moving_summary_scroll_Details))
     Spacer(Modifier.height(8.dp))
     val detailPairs = uiState.claimSummaryInfoUiState.itemDetailPairs(resources, getLocale())
     CompositionLocalProvider(
@@ -114,7 +159,7 @@ private fun ClaimSummaryScreen(
         MaterialTheme.colorScheme.onSurfaceVariant,
       ),
     ) {
-      Column(sideSpacingModifier.fillMaxWidth()) {
+      Column(Modifier.fillMaxWidth()) {
         for ((left, right) in detailPairs) {
           HorizontalItemsWithMaximumSpaceTaken(
             startSlot = {
@@ -128,61 +173,44 @@ private fun ClaimSummaryScreen(
       }
     }
     Spacer(Modifier.height(24.dp))
-    Text(
-      stringResource(R.string.claim_status_detail_uploaded_files_info_title),
-      sideSpacingModifier,
-    )
-    Spacer(Modifier.height(8.dp))
+    Text(stringResource(R.string.claim_status_detail_uploaded_files_info_title))
     when (uiState.claimSummaryInfoUiState.submittedContent) {
       is SubmittedContent.Audio -> {
         val signedAudioUrl = SignedAudioUrl.fromSignedAudioUrlString(
           uiState.claimSummaryInfoUiState.submittedContent.audioURL,
         )
-        Column(sideSpacingModifier) {
-          val audioPlayer = rememberAudioPlayer(
-            playableAudioSource = PlayableAudioSource.RemoteUrl(signedAudioUrl),
-          )
-          HedvigAudioPlayer(audioPlayer = audioPlayer)
-        }
+        Spacer(Modifier.height(8.dp))
+        val audioPlayer = rememberAudioPlayer(
+          playableAudioSource = PlayableAudioSource.RemoteUrl(signedAudioUrl),
+        )
+        HedvigAudioPlayer(audioPlayer = audioPlayer)
       }
 
       else -> {}
     }
     Spacer(Modifier.height(8.dp))
-    val fileListSize = uiState.claimSummaryInfoUiState.files.size
-    val calculatedHeight =
-      if (fileListSize == 0) {
-        0.dp
-      } else {
-        300.dp
-      }
-    FilesLazyVerticalGrid(
-      modifier = Modifier.height(calculatedHeight),
-      paddingValues = PaddingValues(horizontal = 16.dp) + WindowInsets.safeDrawing
-        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
-        .asPaddingValues(),
-      files = uiState.claimSummaryInfoUiState.files,
-      imageLoader = imageLoader,
-      onRemoveFile = null,
-    )
-    Spacer(Modifier.weight(1f))
-    Spacer(Modifier.height(16.dp))
-    VectorInfoCard(stringResource(R.string.CLAIMS_COMPLEMENT__CLAIM), sideSpacingModifier.fillMaxWidth())
+  }
+}
+
+@Composable
+private fun AfterGridContent(uiState: ClaimSummaryUiState, submitSummary: () -> Unit, modifier: Modifier = Modifier) {
+  Column(modifier) {
+    Spacer(Modifier.height(8.dp))
+    VectorInfoCard(stringResource(R.string.CLAIMS_COMPLEMENT__CLAIM), Modifier.fillMaxWidth())
     Spacer(Modifier.height(16.dp))
     HedvigContainedButton(
       text = stringResource(R.string.EMBARK_SUBMIT_CLAIM),
       onClick = submitSummary,
       isLoading = uiState.claimSummaryStatusUiState.isLoading,
       enabled = uiState.canSubmit,
-      modifier = sideSpacingModifier,
     )
     Spacer(Modifier.height(16.dp))
     Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)))
   }
 }
 
-@Preview(locale = "sv")
-@HedvigPreview
+@Preview(device = "spec:width=1080px,height=1000px,dpi=440")
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewClaimSummaryScreen() {
   HedvigTheme {
@@ -213,20 +241,14 @@ private fun PreviewClaimSummaryScreen() {
               ItemProblem(displayName = "Other", itemProblemId = ""),
               ItemProblem(displayName = "Water", itemProblemId = ""),
             ),
-            files = listOf(
+            files = List(5) {
               UiFile(
-                id = "1",
-                name = "test",
+                id = "$it",
+                name = "$it",
                 mimeType = "",
-                path = "1",
-              ),
-              UiFile(
-                id = "2",
-                name = "test".repeat(10),
-                mimeType = "",
-                path = "1",
-              ),
-            ),
+                path = "$it",
+              )
+            },
             submittedContent = null,
           ),
           claimSummaryStatusUiState = ClaimSummaryStatusUiState(

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/ClaimFlowScaffold.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/ClaimFlowScaffold.kt
@@ -83,9 +83,9 @@ internal fun ClaimFlowScaffold(
         ) {
           val sideSpacingModifier = if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
             Modifier
+              .fillMaxWidth(1f)
+              .wrapContentWidth(Alignment.CenterHorizontally)
               .fillMaxWidth(0.8f)
-              .wrapContentWidth(Alignment.Start)
-              .align(Alignment.CenterHorizontally)
           } else {
             Modifier.padding(horizontal = 16.dp)
           }

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/ClaimFlowScaffold.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/ui/ClaimFlowScaffold.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.odyssey.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope


### PR DESCRIPTION
Fix a custom layout which always ensures that the grid takes up at least
160.dp worth of height, while still taking up as much space as it can
when there is enough space available which the other elements in the
layout are not taking up by themselves.