### PR TITLE
Make travel certificate history show the start date of the certificate

### DIFF
--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
@@ -259,7 +259,7 @@ private fun ShowNotEmptyList(
       HorizontalItemsWithMaximumSpaceTaken(
         startSlot = {
           Text(
-            text = dateTimeFormatter.format(certificate.expiryDate.toJavaLocalDate()),
+            text = dateTimeFormatter.format(certificate.startDate.toJavaLocalDate()),
             color = color,
           )
         },


### PR DESCRIPTION
Context:
https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1709542445052319?thread_ts=1709542084.378979&cid=C03U9C6Q7TP