### PR TITLE
close claim flow when opening the browser for Eir

### DIFF
--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigMaterial3Theme.kt
@@ -107,7 +107,7 @@ internal fun darkHedvigColorScheme(hedvigTonalPalette: HedvigTonalPalette) = Hed
   onContainedButtonContainer = hedvigTonalPalette.greyscale1000,
   secondaryContainedButtonContainer = hedvigTonalPalette.greyscale800,
   onSecondaryContainedButtonContainer = hedvigTonalPalette.greyscale100,
-  alwaysBlackContainer = hedvigTonalPalette.greyscale700,
+  alwaysBlackContainer = hedvigTonalPalette.greyscale900,
   onAlwaysBlackContainer = hedvigTonalPalette.greyscale25,
   // In the comments are the light mode colors, showing the equivalent and how it was chosen
   warningElement = hedvigTonalPalette.amber700,

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
@@ -17,11 +17,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -37,8 +32,6 @@ import com.hedvig.android.feature.odyssey.ui.ClaimFlowScaffold
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import hedvig.resources.R
-import kotlin.time.Duration.Companion.minutes
-import kotlinx.coroutines.delay
 
 @Composable
 internal fun DeflectCarOtherDamageDestination(
@@ -76,17 +69,6 @@ private fun DeflectCarOtherDamageScreen(
     closeClaimFlow = closeClaimFlow,
     topAppBarText = stringResource(id = R.string.SUBMIT_CLAIM_CAR_TITLE),
   ) {
-    var shouldCloseFlow by remember {
-      mutableStateOf(false)
-    }
-
-    LaunchedEffect(shouldCloseFlow) {
-      if (shouldCloseFlow) {
-        delay(3.minutes) // todo: on the test session decided to make a delay here
-        closeClaimFlow()
-      }
-    }
-
     Spacer(Modifier.height(16.dp))
     Text(
       text = stringResource(id = R.string.SUBMIT_CLAIM_CAR_REPORT_CLAIM_TITLE),
@@ -103,7 +85,6 @@ private fun DeflectCarOtherDamageScreen(
     HedvigContainedButton(
       onClick = {
         openUrl()
-        shouldCloseFlow = true
       },
       modifier = Modifier.padding(horizontal = 16.dp),
     ) {

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
@@ -83,7 +83,10 @@ private fun DeflectCarOtherDamageScreen(
     Spacer(modifier = Modifier.weight(1f))
     Spacer(Modifier.height(16.dp))
     HedvigContainedButton(
-      onClick = openUrl,
+      onClick = {
+        openUrl()
+        closeClaimFlow()
+      },
       modifier = Modifier.padding(horizontal = 16.dp),
     ) {
       Text(

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
@@ -17,6 +17,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -32,6 +37,8 @@ import com.hedvig.android.feature.odyssey.ui.ClaimFlowScaffold
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import hedvig.resources.R
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun DeflectCarOtherDamageDestination(
@@ -69,6 +76,17 @@ private fun DeflectCarOtherDamageScreen(
     closeClaimFlow = closeClaimFlow,
     topAppBarText = stringResource(id = R.string.SUBMIT_CLAIM_CAR_TITLE),
   ) {
+    var shouldCloseFlow by remember {
+      mutableStateOf(false)
+    }
+
+    LaunchedEffect(shouldCloseFlow) {
+      if (shouldCloseFlow) {
+        delay(3.minutes) // todo: on the test session decided to make a delay here
+        closeClaimFlow()
+      }
+    }
+
     Spacer(Modifier.height(16.dp))
     Text(
       text = stringResource(id = R.string.SUBMIT_CLAIM_CAR_REPORT_CLAIM_TITLE),
@@ -85,7 +103,7 @@ private fun DeflectCarOtherDamageScreen(
     HedvigContainedButton(
       onClick = {
         openUrl()
-        closeClaimFlow()
+        shouldCloseFlow = true
       },
       modifier = Modifier.padding(horizontal = 16.dp),
     ) {

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectGlassDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectGlassDamageDestination.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,9 +30,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
-import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedSmallButton
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
+import com.hedvig.android.core.designsystem.material3.alwaysBlackContainer
+import com.hedvig.android.core.designsystem.material3.onAlwaysBlackContainer
 import com.hedvig.android.core.designsystem.material3.rememberShapedColorPainter
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
@@ -102,8 +104,8 @@ private fun DeflectGlassDamageScreen(
       }
       HedvigCard(
         colors = CardDefaults.outlinedCardColors(
-          containerColor = MaterialTheme.colorScheme.surfaceVariant,
-          contentColor = MaterialTheme.colorScheme.onSurface,
+          containerColor = MaterialTheme.colorScheme.alwaysBlackContainer,
+          contentColor = MaterialTheme.colorScheme.onAlwaysBlackContainer,
         ),
         modifier = Modifier
           .padding(horizontal = 16.dp)
@@ -127,7 +129,12 @@ private fun DeflectGlassDamageScreen(
             modifier = Modifier.fillMaxWidth(),
           )
           Spacer(Modifier.height(16.dp))
-          HedvigContainedButton(
+          HedvigContainedSmallButton(
+            colors = ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.onAlwaysBlackContainer,
+              contentColor = MaterialTheme.colorScheme.alwaysBlackContainer,
+            ),
+            modifier = Modifier.fillMaxWidth(),
             text = stringResource(R.string.SUBMIT_CLAIM_GLASS_DAMAGE_ONLINE_BOOKING_BUTTON),
             onClick = {
               val url = partner.url

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectTowingDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectTowingDestination.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
-import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedSmallButton
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.material3.alwaysBlackContainer
@@ -131,7 +130,8 @@ private fun DeflectTowingScreen(
           )
           Spacer(Modifier.height(16.dp))
           val context = LocalContext.current
-          HedvigContainedButton(
+          HedvigContainedSmallButton(
+            modifier = Modifier.fillMaxWidth(),
             colors = ButtonDefaults.buttonColors(
               containerColor = MaterialTheme.colorScheme.onAlwaysBlackContainer,
               contentColor = MaterialTheme.colorScheme.alwaysBlackContainer,


### PR DESCRIPTION
Closing the claim flow when going to browser to open Eir link (other car damage claims) after 3 min delay (just decided). And small design changes, pointed out by William