### PR TITLE
Contract deep link + LocalUriHandler which tries to treat URIs as deep links in our app before delegating to the default UriHandler

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/DeepLinkFirstUriHandler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/DeepLinkFirstUriHandler.kt
@@ -14,11 +14,11 @@ internal class DeepLinkFirstUriHandler(
   private val delegate: UriHandler,
 ) : UriHandler {
   override fun openUri(uri: String) {
-    try {
+    if (navController.graph.hasDeepLink(uri.toUri())) {
       logcat { "DeepLinkFirstUriHandler will try to navigate to uri:$uri" }
       navController.navigate(uri.toUri())
       logcat { "DeepLinkFirstUriHandler did deep link to uri:$uri" }
-    } catch (e: IllegalArgumentException) {
+    } else {
       logcat { "DeepLinkFirstUriHandler falling back to default UriHandler for uri:$uri" }
       delegate.openUri(uri)
     }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/DeepLinkFirstUriHandler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/DeepLinkFirstUriHandler.kt
@@ -9,7 +9,10 @@ import com.hedvig.android.logger.logcat
  * Tries to open a deep link with the [navController] and falls back to the [delegate] if the uri is not a valid deep
  * link to our app
  */
-internal class DeepLinkFirstUriHandler(private val navController: NavController, private val delegate: UriHandler) : UriHandler {
+internal class DeepLinkFirstUriHandler(
+  private val navController: NavController,
+  private val delegate: UriHandler,
+) : UriHandler {
   override fun openUri(uri: String) {
     try {
       logcat { "DeepLinkFirstUriHandler will try to navigate to uri:$uri" }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/DeepLinkFirstUriHandler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/DeepLinkFirstUriHandler.kt
@@ -1,0 +1,23 @@
+package com.hedvig.android.app.ui
+
+import androidx.compose.ui.platform.UriHandler
+import androidx.core.net.toUri
+import androidx.navigation.NavController
+import com.hedvig.android.logger.logcat
+
+/**
+ * Tries to open a deep link with the [navController] and falls back to the [delegate] if the uri is not a valid deep
+ * link to our app
+ */
+internal class DeepLinkFirstUriHandler(private val navController: NavController, private val delegate: UriHandler) : UriHandler {
+  override fun openUri(uri: String) {
+    try {
+      logcat { "DeepLinkFirstUriHandler will try to navigate to uri:$uri" }
+      navController.navigate(uri.toUri())
+      logcat { "DeepLinkFirstUriHandler did deep link to uri:$uri" }
+    } catch (e: IllegalArgumentException) {
+      logcat { "DeepLinkFirstUriHandler falling back to default UriHandler for uri:$uri" }
+      delegate.openUri(uri)
+    }
+  }
+}

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -14,9 +14,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.core.content.getSystemService
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
@@ -27,6 +29,7 @@ import arrow.fx.coroutines.raceN
 import coil.ImageLoader
 import com.google.android.play.core.review.ReviewException
 import com.google.android.play.core.review.ReviewManagerFactory
+import com.hedvig.android.app.ui.DeepLinkFirstUriHandler
 import com.hedvig.android.app.ui.HedvigApp
 import com.hedvig.android.app.ui.rememberHedvigAppState
 import com.hedvig.android.auth.AuthStatus
@@ -175,25 +178,29 @@ class LoggedInActivity : AppCompatActivity() {
       )
       val darkTheme = hedvigAppState.darkTheme
       EnableEdgeToEdgeSideEffect(darkTheme)
-      HedvigTheme(darkTheme = darkTheme) {
-        HedvigApp(
-          hedvigAppState = hedvigAppState,
-          hedvigDeepLinkContainer = hedvigDeepLinkContainer,
-          activityNavigator = activityNavigator,
-          getInitialTab = {
-            intent.extras?.getString(INITIAL_TAB)?.let {
-              TopLevelGraph.fromName(it)
-            }
-          },
-          clearInitialTab = {
-            intent.removeExtra(INITIAL_TAB)
-          },
-          shouldShowRequestPermissionRationale = ::shouldShowRequestPermissionRationale,
-          market = market,
-          imageLoader = imageLoader,
-          languageService = languageService,
-          hedvigBuildConstants = hedvigBuildConstants,
-        )
+      CompositionLocalProvider(
+        LocalUriHandler provides DeepLinkFirstUriHandler(hedvigAppState.navController, LocalUriHandler.current),
+      ) {
+        HedvigTheme(darkTheme = darkTheme) {
+          HedvigApp(
+            hedvigAppState = hedvigAppState,
+            hedvigDeepLinkContainer = hedvigDeepLinkContainer,
+            activityNavigator = activityNavigator,
+            getInitialTab = {
+              intent.extras?.getString(INITIAL_TAB)?.let {
+                TopLevelGraph.fromName(it)
+              }
+            },
+            clearInitialTab = {
+              intent.removeExtra(INITIAL_TAB)
+            },
+            shouldShowRequestPermissionRationale = ::shouldShowRequestPermissionRationale,
+            market = market,
+            imageLoader = imageLoader,
+            languageService = languageService,
+            hedvigBuildConstants = hedvigBuildConstants,
+          )
+        }
       }
     }
   }

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/error/HedvigErrorSection.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/error/HedvigErrorSection.kt
@@ -35,7 +35,7 @@ import hedvig.resources.R
 
 @Composable
 fun HedvigErrorSection(
-  retry: () -> Unit,
+  onButtonClick: () -> Unit,
   modifier: Modifier = Modifier,
   title: String = stringResource(R.string.something_went_wrong),
   subTitle: String? = stringResource(R.string.GENERAL_ERROR_BODY),
@@ -80,7 +80,7 @@ fun HedvigErrorSection(
     Spacer(Modifier.height(24.dp))
     HedvigContainedSmallButton(
       text = buttonText,
-      onClick = retry,
+      onClick = onButtonClick,
     )
     if (withDefaultVerticalSpacing) {
       Spacer(Modifier.height(32.dp))

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/TextWithClickableUrls.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ui/TextWithClickableUrls.kt
@@ -1,13 +1,12 @@
 package com.hedvig.android.feature.chat.ui
 
-import android.content.Intent
 import android.net.Uri
 import android.util.Patterns
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
@@ -34,8 +33,8 @@ internal fun TextWithClickableUrls(
     textDecoration = TextDecoration.Underline,
   ),
   linkMatcher: Regex = Patterns.WEB_URL.toRegex(),
-  onClick: (url: String) -> Unit = with(LocalContext.current) {
-    { url -> startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
+  onClick: (url: String) -> Unit = with(LocalUriHandler.current) {
+    { url -> this.openUri(url) }
   },
 ) {
   val annotatedText = buildAnnotatedString {

--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
@@ -172,7 +172,7 @@ private fun ClaimDetailScreen(
           )
         }
 
-        ClaimDetailUiState.Error -> HedvigErrorSection(retry = retry)
+        ClaimDetailUiState.Error -> HedvigErrorSection(onButtonClick = retry)
         ClaimDetailUiState.Loading -> HedvigFullScreenCenterAlignedProgressDebounced()
       }
     }

--- a/app/feature/feature-claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimgroups/ClaimGroupsDestination.kt
+++ b/app/feature/feature-claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/claimgroups/ClaimGroupsDestination.kt
@@ -109,7 +109,7 @@ private fun ClaimGroupsScreen(
   ) {
     Spacer(Modifier.height(16.dp))
     if (uiState.chipLoadingErrorMessage != null) {
-      HedvigErrorSection(retry = loadClaimGroups)
+      HedvigErrorSection(onButtonClick = loadClaimGroups)
     } else {
       Text(
         text = stringResource(R.string.CLAIM_TRIAGING_NAVIGATION_TITLE),

--- a/app/feature/feature-connect-payment-adyen/src/main/kotlin/com/hedvig/android/feature/connect/payment/adyen/AdyenDestination.kt
+++ b/app/feature/feature-connect-payment-adyen/src/main/kotlin/com/hedvig/android/feature/connect/payment/adyen/AdyenDestination.kt
@@ -83,14 +83,14 @@ private fun AdyenScreen(
       }
       AdyenUiState.FailedToConnectCard -> {
         HedvigErrorSection(
-          retry = retryConnectingCard,
+          onButtonClick = retryConnectingCard,
           title = stringResource(R.string.something_went_wrong),
           subTitle = stringResource(R.string.pay_in_error_body),
         )
       }
       AdyenUiState.FailedToGetPaymentLink -> {
         HedvigErrorSection(
-          retry = retryConnectingCard,
+          onButtonClick = retryConnectingCard,
           title = stringResource(R.string.something_went_wrong),
           subTitle = null,
         )

--- a/app/feature/feature-connect-payment-trustly/src/main/kotlin/com/hedvig/android/feature/connect/payment/trustly/ui/TrustlyDestination.kt
+++ b/app/feature/feature-connect-payment-trustly/src/main/kotlin/com/hedvig/android/feature/connect/payment/trustly/ui/TrustlyDestination.kt
@@ -94,7 +94,7 @@ private fun TrustlyScreen(
 
       TrustlyUiState.FailedToConnectCard -> {
         HedvigErrorSection(
-          retry = retryConnectingCard,
+          onButtonClick = retryConnectingCard,
           title = stringResource(R.string.something_went_wrong),
           subTitle = stringResource(R.string.pay_in_error_body),
         )
@@ -102,7 +102,7 @@ private fun TrustlyScreen(
 
       TrustlyUiState.FailedToStartSession -> {
         HedvigErrorSection(
-          retry = retryConnectingCard,
+          onButtonClick = retryConnectingCard,
           title = stringResource(R.string.something_went_wrong),
           subTitle = null,
         )

--- a/app/feature/feature-delete-account/src/main/kotlin/com/hedvig/android/feature/deleteaccount/DeleteAccountDestination.kt
+++ b/app/feature/feature-delete-account/src/main/kotlin/com/hedvig/android/feature/deleteaccount/DeleteAccountDestination.kt
@@ -57,7 +57,7 @@ private fun DeleteAccountScreen(
   HedvigScaffold(navigateUp = navigateUp) {
     when (uiState) {
       DeleteAccountUiState.FailedToLoadDeleteAccountState -> {
-        HedvigErrorSection(retry = retryLoading, Modifier.weight(1f))
+        HedvigErrorSection(onButtonClick = retryLoading, Modifier.weight(1f))
       }
 
       DeleteAccountUiState.Loading -> {
@@ -76,7 +76,7 @@ private fun DeleteAccountScreen(
 
       is DeleteAccountUiState.CanDelete -> {
         if (uiState.failedToPerformDeletion) {
-          HedvigErrorSection(retry = retryLoading, Modifier.weight(1f))
+          HedvigErrorSection(onButtonClick = retryLoading, Modifier.weight(1f))
         } else {
           DeleteScreenContents(
             title = stringResource(R.string.DELETE_ACCOUNT_DELETE_ACCOUNT_TITLE),

--- a/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/ForeverDestination.kt
+++ b/app/feature/feature-forever/src/main/kotlin/com/hedvig/android/feature/forever/ui/ForeverDestination.kt
@@ -141,7 +141,7 @@ private fun ForeverScreen(
       contentKey = { it.foreverDataErrorMessage },
     ) { uiState ->
       if (uiState.foreverDataErrorMessage != null) {
-        HedvigErrorSection(retry = reload)
+        HedvigErrorSection(onButtonClick = reload)
       } else {
         val shareSheetTitle = stringResource(R.string.REFERRALS_SHARE_SHEET_TITLE)
         ForeverContent(

--- a/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/question/HelpCenterQuestionDestination.kt
+++ b/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/question/HelpCenterQuestionDestination.kt
@@ -89,7 +89,7 @@ private fun HelpCenterQuestionScreen(
       )
       if (question == null) {
         HedvigErrorSection(
-          retry = onNavigateBack,
+          onButtonClick = onNavigateBack,
           title = stringResource(R.string.HC_QUESTION_NOT_FOUND),
           subTitle = null,
           buttonText = stringResource(R.string.general_back_button),

--- a/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/topic/HelpCenterTopicDestination.kt
+++ b/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/topic/HelpCenterTopicDestination.kt
@@ -89,7 +89,7 @@ private fun HelpCenterTopicScreen(
       )
       if (topic == null) {
         HedvigErrorSection(
-          retry = onNavigateBack,
+          onButtonClick = onNavigateBack,
           title = stringResource(id = R.string.HC_TOPIC_NOT_FOUND),
           subTitle = null,
           buttonText = stringResource(R.string.general_back_button),
@@ -102,7 +102,7 @@ private fun HelpCenterTopicScreen(
         )
       } else if (commonQuestions.isEmpty() && allQuestions.isEmpty()) {
         HedvigErrorSection(
-          retry = onNavigateBack,
+          onButtonClick = onNavigateBack,
           title = stringResource(id = R.string.HC_TOPIC_NO_QUESTIONS),
           subTitle = null,
           buttonText = stringResource(R.string.general_back_button),

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -169,7 +169,7 @@ private fun HomeScreen(
 
         is HomeUiState.Error -> {
           HedvigErrorSection(
-            retry = reload,
+            onButtonClick = reload,
             modifier = Modifier
               .padding(16.dp)
               .windowInsetsPadding(WindowInsets.safeDrawing),

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
@@ -2,10 +2,8 @@ package com.hedvig.android.feature.insurances.di
 
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.core.demomode.DemoManager
-import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.feature.insurances.data.GetCrossSellsUseCaseDemo
 import com.hedvig.android.feature.insurances.data.GetCrossSellsUseCaseImpl
-import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseDemo
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseImpl
 import com.hedvig.android.feature.insurances.insurance.presentation.InsuranceViewModel

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/di/InsurancesModule.kt
@@ -2,12 +2,15 @@ package com.hedvig.android.feature.insurances.di
 
 import com.apollographql.apollo3.ApolloClient
 import com.hedvig.android.core.demomode.DemoManager
+import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.feature.insurances.data.GetCrossSellsUseCaseDemo
 import com.hedvig.android.feature.insurances.data.GetCrossSellsUseCaseImpl
+import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseDemo
 import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCaseImpl
 import com.hedvig.android.feature.insurances.insurance.presentation.InsuranceViewModel
 import com.hedvig.android.feature.insurances.insurancedetail.ContractDetailViewModel
+import com.hedvig.android.feature.insurances.insurancedetail.GetContractForContractIdUseCase
 import com.hedvig.android.feature.insurances.terminatedcontracts.TerminatedContractsViewModel
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.notification.badge.data.crosssell.CrossSellCardNotificationBadgeServiceProvider
@@ -27,9 +30,11 @@ val insurancesModule = module {
     TerminatedContractsViewModel(get<GetInsuranceContractsUseCaseProvider>())
   }
   viewModel<ContractDetailViewModel> { (contractId: String) ->
-    ContractDetailViewModel(contractId, get<FeatureManager>(), get<GetInsuranceContractsUseCaseProvider>())
+    ContractDetailViewModel(contractId, get<FeatureManager>(), get<GetContractForContractIdUseCase>())
   }
-
+  single<GetContractForContractIdUseCase> {
+    GetContractForContractIdUseCase(get<GetInsuranceContractsUseCaseProvider>())
+  }
   provideGetContractsUseCase()
   provideGetCrossSellsUseCase()
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
@@ -176,7 +176,7 @@ private fun InsuranceScreen(
             }
 
             if (uiState.hasError) {
-              HedvigErrorSection(retry = reload)
+              HedvigErrorSection(onButtonClick = reload)
             } else {
               InsuranceScreenContent(
                 imageLoader = imageLoader,

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceGraph.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceGraph.kt
@@ -82,6 +82,7 @@ fun NavGraphBuilder.insuranceGraph(
         openChat = { openChat(backStackEntry) },
         openUrl = openUrl,
         navigateUp = navigator::navigateUp,
+        navigateBack = navigator::popBackStack,
         imageLoader = imageLoader,
       )
     }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceGraph.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceGraph.kt
@@ -60,7 +60,11 @@ fun NavGraphBuilder.insuranceGraph(
         imageLoader = imageLoader,
       )
     }
-    composable<InsurancesDestination.InsuranceContractDetail> { backStackEntry ->
+    composable<InsurancesDestination.InsuranceContractDetail>(
+      deepLinks = listOf(
+        navDeepLink { uriPattern = hedvigDeepLinkContainer.contract },
+      ),
+    ) { backStackEntry ->
       val contractDetail = this
       val viewModel: ContractDetailViewModel = koinViewModel { parametersOf(contractDetail.contractId) }
       ContractDetailDestination(

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -78,6 +78,7 @@ internal fun ContractDetailDestination(
   openChat: () -> Unit,
   openUrl: (String) -> Unit,
   navigateUp: () -> Unit,
+  navigateBack: () -> Unit,
   imageLoader: ImageLoader,
 ) {
   val uiState: ContractDetailsUiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -93,6 +94,7 @@ internal fun ContractDetailDestination(
     openUrl = openUrl,
     openWebsite = openWebsite,
     navigateUp = navigateUp,
+    navigateBack = navigateBack,
   )
 }
 
@@ -108,6 +110,7 @@ private fun ContractDetailScreen(
   onCancelInsuranceClick: (cancelInsuranceData: CancelInsuranceData) -> Unit,
   openWebsite: (Uri) -> Unit,
   navigateUp: () -> Unit,
+  navigateBack: () -> Unit,
   openChat: () -> Unit,
   openUrl: (String) -> Unit,
 ) {
@@ -122,6 +125,7 @@ private fun ContractDetailScreen(
       contentKey = { uiState ->
         when (uiState) {
           ContractDetailsUiState.Error -> "Error"
+          ContractDetailsUiState.NoContractFound -> "NoContractFound"
           ContractDetailsUiState.Loading -> "Loading"
           is ContractDetailsUiState.Success -> "Success"
         }
@@ -130,11 +134,19 @@ private fun ContractDetailScreen(
       modifier = Modifier.weight(1f),
     ) { state ->
       when (state) {
-        ContractDetailsUiState.Error -> HedvigErrorSection(retry = retry, modifier = Modifier.fillMaxSize())
+        ContractDetailsUiState.Error -> HedvigErrorSection(onButtonClick = retry, modifier = Modifier.fillMaxSize())
         ContractDetailsUiState.Loading -> HedvigFullScreenCenterAlignedProgressDebounced(
           show = state is ContractDetailsUiState.Loading,
           modifier = Modifier.fillMaxSize(),
         )
+        ContractDetailsUiState.NoContractFound -> {
+          HedvigErrorSection(
+            subTitle = stringResource(R.string.CONTRACT_DETAILS_ERROR),
+            buttonText = stringResource(R.string.general_back_button),
+            onButtonClick = navigateBack,
+            modifier = Modifier.fillMaxSize(),
+          )
+        }
 
         is ContractDetailsUiState.Success -> {
           LazyColumn(
@@ -336,6 +348,7 @@ private fun PreviewContractDetailScreen() {
         },
         openWebsite = {},
         navigateUp = {},
+        navigateBack = {},
         openChat = {},
         onMissingInfoClick = {},
         openUrl = {},

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailViewModel.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailViewModel.kt
@@ -2,51 +2,36 @@ package com.hedvig.android.feature.insurances.insurancedetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.raise.either
-import arrow.core.raise.ensureNotNull
-import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.RetryChannel
-import com.hedvig.android.core.demomode.Provider
-import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
 import com.hedvig.android.feature.insurances.data.InsuranceContract
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
-import com.hedvig.android.logger.LogPriority
-import com.hedvig.android.logger.logcat
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 internal class ContractDetailViewModel(
   contractId: String,
   private val featureManager: FeatureManager,
-  private val getInsuranceContractsUseCaseProvider: Provider<GetInsuranceContractsUseCase>,
+  private val getContractForContractIdUseCase: GetContractForContractIdUseCase,
 ) : ViewModel() {
   private val retryChannel = RetryChannel()
   val uiState: StateFlow<ContractDetailsUiState> = retryChannel.transformLatest {
     emit(ContractDetailsUiState.Loading)
     combine(
-      getInsuranceContractsUseCaseProvider
-        .provide()
-        .invoke(forceNetworkFetch = false)
-        .map { insuranceContractResult ->
-          either {
-            val contract = insuranceContractResult.bind().firstOrNull { it.id == contractId }
-            ensureNotNull(contract) {
-              ErrorMessage("No contract found with id: $contractId").also {
-                logcat(LogPriority.ERROR) { it.message.toString() }
-              }
-            }
-          }
-        },
+      getContractForContractIdUseCase.invoke(contractId),
       featureManager.isFeatureEnabled(Feature.TERMINATION_FLOW),
     ) { insuranceContractResult, isTerminationFlowEnabled ->
       insuranceContractResult.fold(
-        ifLeft = { ContractDetailsUiState.Error },
+        ifLeft = { error ->
+          when (error) {
+            is GetContractForContractIdError.GenericError -> ContractDetailsUiState.Error
+            is GetContractForContractIdError.NoContractFound -> ContractDetailsUiState.NoContractFound
+          }
+        },
         ifRight = { contract ->
           ContractDetailsUiState.Success(
             insuranceContract = contract,
@@ -73,6 +58,8 @@ internal sealed interface ContractDetailsUiState {
   ) : ContractDetailsUiState
 
   data object Error : ContractDetailsUiState
+
+  data object NoContractFound : ContractDetailsUiState
 
   data object Loading : ContractDetailsUiState
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/GetContractForContractIdUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/GetContractForContractIdUseCase.kt
@@ -1,0 +1,50 @@
+package com.hedvig.android.feature.insurances.insurancedetail
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
+import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.core.demomode.Provider
+import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
+import com.hedvig.android.feature.insurances.data.InsuranceContract
+import com.hedvig.android.logger.LogPriority
+import com.hedvig.android.logger.logcat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+
+internal class GetContractForContractIdUseCase(
+  private val getInsuranceContractsUseCaseProvider: Provider<GetInsuranceContractsUseCase>,
+) {
+  fun invoke(contractId: String): Flow<Either<GetContractForContractIdError, InsuranceContract>> {
+    return flow {
+      getInsuranceContractsUseCaseProvider
+        .provide()
+        .invoke(forceNetworkFetch = false)
+        .map { insuranceContractResult ->
+          either {
+            val contract = insuranceContractResult
+              .mapLeft { GetContractForContractIdError.GenericError(it) }
+              .bind()
+              .firstOrNull { it.id == contractId }
+            ensureNotNull(contract) {
+              GetContractForContractIdError.NoContractFound(
+                ErrorMessage("No contract found with id: $contractId").also {
+                  logcat(LogPriority.ERROR) { it.message.toString() }
+                },
+              )
+            }
+          }
+        }
+        .collect(this)
+    }
+  }
+}
+
+internal sealed interface GetContractForContractIdError {
+  data class NoContractFound(
+    val errorMessage: ErrorMessage,
+  ) : GetContractForContractIdError, ErrorMessage by errorMessage
+
+  data class GenericError(val errorMessage: ErrorMessage) : GetContractForContractIdError, ErrorMessage by errorMessage
+}

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/navigation/InsurancesNavigation.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/navigation/InsurancesNavigation.kt
@@ -2,11 +2,14 @@ package com.hedvig.android.feature.insurances.navigation
 
 import com.kiwi.navigationcompose.typed.Destination
 import com.kiwi.navigationcompose.typed.createRoutePattern
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 sealed interface InsurancesDestination : Destination {
   @Serializable
   data class InsuranceContractDetail(
+    /** Must match the name of the param inside [com.hedvig.android.navigation.core.HedvigDeepLinkContainer.contract] */
+    @SerialName("contractId")
     val contractId: String,
   ) : InsurancesDestination
 

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsDestination.kt
@@ -75,7 +75,7 @@ private fun TerminatedContractsScreen(
       TerminatedContractsUiState.NoTerminatedInsurances -> {
         HedvigErrorSection(
           buttonText = stringResource(R.string.general_back_button),
-          retry = navigateUp,
+          onButtonClick = navigateUp,
         )
       }
       is TerminatedContractsUiState.Success -> {

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginDestination.kt
@@ -122,7 +122,7 @@ private fun SwedishLoginScreen(
           modifier = Modifier.weight(1f).fillMaxWidth(),
         ) {
           Column {
-            HedvigErrorSection(retry = retry, subTitle = null, withDefaultVerticalSpacing = false)
+            HedvigErrorSection(onButtonClick = retry, subTitle = null, withDefaultVerticalSpacing = false)
             Box(Modifier.size(48.dp).then(demoModeModifier))
           }
         }
@@ -137,7 +137,7 @@ private fun SwedishLoginScreen(
             HedvigErrorSection(
               title = stringResource(R.string.general_error),
               subTitle = uiState.message,
-              retry = retry,
+              onButtonClick = retry,
               withDefaultVerticalSpacing = false,
             )
             Box(Modifier.size(48.dp).then(demoModeModifier))

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/unknownerror/UnknownErrorDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/unknownerror/UnknownErrorDestination.kt
@@ -55,7 +55,7 @@ private fun UnknownErrorScreen(openChat: () -> Unit, closeFailureScreenDestinati
       ) {
         HedvigErrorSection(
           buttonText = stringResource(R.string.open_chat),
-          retry = openChat,
+          onButtonClick = openChat,
         )
       }
       Spacer(Modifier.height(16.dp))

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/PaymentOverviewDestination.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/PaymentOverviewDestination.kt
@@ -119,7 +119,7 @@ private fun PaymentOverviewScreen(
     ) {
       if (uiState.error != null) {
         Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
-          HedvigErrorSection(retry = onRetry)
+          HedvigErrorSection(onButtonClick = onRetry)
         }
       } else if (uiState.isLoadingPaymentOverView) {
         HedvigFullScreenCenterAlignedProgressDebounced(Modifier.weight(1f))

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/myinfo/MyInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/myinfo/MyInfoDestination.kt
@@ -82,7 +82,7 @@ private fun MyInfoScreen(
             }
             uiState.errorMessage != null -> {
               Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
-                HedvigErrorSection(retry = dismissError)
+                HedvigErrorSection(onButtonClick = dismissError)
               }
             }
             else -> {

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/choose/ChooseContractForCertificate.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/choose/ChooseContractForCertificate.kt
@@ -134,7 +134,7 @@ private fun FailureScreen(navigateUp: () -> Unit, reload: () -> Unit) {
   HedvigScaffold(
     navigateUp = navigateUp,
   ) {
-    HedvigErrorSection(retry = reload, modifier = Modifier.weight(1f))
+    HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f))
   }
 }
 

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewhen/TravelCertificateDateInput.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewhen/TravelCertificateDateInput.kt
@@ -87,7 +87,7 @@ private fun TravelCertificateDateInput(
       HedvigScaffold(
         navigateUp = navigateUp,
       ) {
-        HedvigErrorSection(retry = reload, modifier = Modifier.weight(1f))
+        HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f))
       }
     }
 

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewho/TravelCertificateTravellersInput.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewho/TravelCertificateTravellersInput.kt
@@ -88,7 +88,7 @@ private fun TravelCertificateTravellersInput(
         HedvigScaffold(
           navigateUp = navigateUp,
         ) {
-          HedvigErrorSection(retry = reload, modifier = Modifier.weight(1f))
+          HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f))
         }
       }
 

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
@@ -115,7 +115,7 @@ private fun TravelCertificateHistoryScreen(
           }
         },
       ) {
-        HedvigErrorSection(retry = reload, modifier = Modifier.weight(1f))
+        HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f))
       }
     }
 

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/overview/TravelCertificateOverview.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/overview/TravelCertificateOverview.kt
@@ -68,7 +68,7 @@ internal fun TravelCertificateOverview(
         navigateUp = navigateUp,
         topAppBarActionType = TopAppBarActionType.CLOSE,
       ) {
-        HedvigErrorSection(retry = { onDownloadCertificate(travelCertificateUrl) }, modifier = Modifier.weight(1f))
+        HedvigErrorSection(onButtonClick = { onDownloadCertificate(travelCertificateUrl) }, modifier = Modifier.weight(1f))
       }
     }
 

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/overview/TravelCertificateOverview.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/overview/TravelCertificateOverview.kt
@@ -68,7 +68,10 @@ internal fun TravelCertificateOverview(
         navigateUp = navigateUp,
         topAppBarActionType = TopAppBarActionType.CLOSE,
       ) {
-        HedvigErrorSection(onButtonClick = { onDownloadCertificate(travelCertificateUrl) }, modifier = Modifier.weight(1f))
+        HedvigErrorSection(
+          onButtonClick = { onDownloadCertificate(travelCertificateUrl) },
+          modifier = Modifier.weight(1f),
+        )
       }
     }
 

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
@@ -9,6 +9,7 @@ interface HedvigDeepLinkContainer {
   val helpCenterQuestion: String // A specific question inside the help center
 
   val insurances: String // The insurances destination, which also shows cross sells
+  val contract: String // A specific contract destination with a contractId. If none match, an empty screen is shown
 
   val forever: String // The forever/referrals destination, showing the existing discount and the unique code
 
@@ -38,6 +39,7 @@ internal class HedvigDeepLinkContainerImpl(
   override val helpCenterQuestion: String = "$baseDeepLinkDomain/help-center/question&id={id}"
 
   override val insurances: String = "$baseDeepLinkDomain/insurances"
+  override val contract: String = "$baseDeepLinkDomain/contract?contractId={contractId}"
 
   override val forever: String = "$baseDeepLinkDomain/forever"
 

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/HedvigUiKit.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/ui/HedvigUiKit.kt
@@ -190,7 +190,7 @@ internal fun HedvigUiKit() {
       }
     }
     lightAndDarkItem {
-      HedvigErrorSection(retry = { })
+      HedvigErrorSection(onButtonClick = { })
     }
     lightAndDarkItem {
       HedvigSuccessSection("HedvigSuccessSection")


### PR DESCRIPTION
The `"$baseDeepLinkDomain/contract?contractId={contractId}"` deep link route is added to be able to deep link directly into a specific contract along with the contractId

A new NoContractFound case is added to differentiate in the UI between other retryable errors and if the deep link ID just did not match any contract.

Add DeepLinkFirstUriHandler as our global LocalUriHandler which should try to open uris as deep links before it tries to go outside of the app. This fixes the problem with opening our app again in a separate task as this issue https://issuetracker.google.com/issues/329046732 indicates which broke the behavior of pressing the back or the navigateUp buttons

A big part of this PR is me just renaming inside HedvigErrorSection the lambda for the button from `retry` to `onButtonClick` which I kinda regret for this PR, it could be another, but it is what it is. It now reflects better that this button does more than just retry.