### PR TITLE
Feature/new cancellation flow final touches

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -46,6 +46,7 @@ import com.hedvig.android.feature.odyssey.navigation.navigateToClaimFlowDestinat
 import com.hedvig.android.feature.odyssey.navigation.terminalClaimFlowStepDestinations
 import com.hedvig.android.feature.payments.navigation.paymentsGraph
 import com.hedvig.android.feature.profile.tab.profileGraph
+import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceGraphDestination
 import com.hedvig.android.feature.terminateinsurance.navigation.terminateInsuranceGraph
 import com.hedvig.android.feature.travelcertificate.navigation.travelCertificateGraph
 import com.hedvig.android.language.LanguageService
@@ -151,6 +152,7 @@ internal fun HedvigNavHost(
           hedvigDeepLinkContainer = hedvigDeepLinkContainer,
           closeTerminationFlow = {
             hedvigAppState.navController.popBackStack<AppDestination.TerminationFlow>(inclusive = true)
+            hedvigAppState.navController.popBackStack<TerminateInsuranceGraphDestination>(inclusive = true)
           },
         )
       },
@@ -168,10 +170,9 @@ internal fun HedvigNavHost(
       },
       startTerminationFlow = { backStackEntry: NavBackStackEntry, data: CancelInsuranceData ->
         with(navigator) {
-          val destination = AppDestination.TerminationFlow(
-            insuranceId = data.contractId,
+          backStackEntry.navigate(
+            TerminateInsuranceGraphDestination(insuranceId = data.contractId),
           )
-          backStackEntry.navigate(destination)
         }
       },
       hedvigDeepLinkContainer = hedvigDeepLinkContainer,
@@ -248,32 +249,20 @@ internal fun HedvigNavHost(
       hedvigDeepLinkContainer = hedvigDeepLinkContainer,
       navigator = navigator,
       onNavigateToQuickLink = { backStackEntry, quickLinkDestination ->
+        val destination = when (quickLinkDestination) {
+          is QuickLinkDestination.QuickLinkCoInsuredAddInfo ->
+            AppDestination.CoInsuredAddInfo(quickLinkDestination.contractId)
+
+          is QuickLinkDestination.QuickLinkCoInsuredAddOrRemove ->
+            AppDestination.CoInsuredAddOrRemove(quickLinkDestination.contractId)
+
+          QuickLinkDestination.QuickLinkChangeAddress -> AppDestination.ChangeAddress
+          QuickLinkDestination.QuickLinkConnectPayment -> AppDestination.ConnectPayment
+          QuickLinkDestination.QuickLinkTermination -> TerminateInsuranceGraphDestination(null)
+          QuickLinkDestination.QuickLinkTravelCertificate -> AppDestination.TravelCertificate
+        }
         with(navigator) {
-          when (quickLinkDestination) {
-            is QuickLinkDestination.QuickLinkCoInsuredAddInfo -> {
-              backStackEntry.navigate(AppDestination.CoInsuredAddInfo(quickLinkDestination.contractId))
-            }
-
-            is QuickLinkDestination.QuickLinkCoInsuredAddOrRemove -> {
-              backStackEntry.navigate(AppDestination.CoInsuredAddOrRemove(quickLinkDestination.contractId))
-            }
-
-            QuickLinkDestination.QuickLinkChangeAddress -> {
-              backStackEntry.navigate(AppDestination.ChangeAddress)
-            }
-
-            QuickLinkDestination.QuickLinkConnectPayment -> {
-              backStackEntry.navigate(AppDestination.ConnectPayment)
-            }
-
-            QuickLinkDestination.QuickLinkTermination -> {
-              backStackEntry.navigate(AppDestination.TerminationFlow(null))
-            }
-
-            QuickLinkDestination.QuickLinkTravelCertificate -> {
-              backStackEntry.navigate(AppDestination.TravelCertificate)
-            }
-          }
+          backStackEntry.navigate(destination)
         }
       },
       openChat = { backStackEntry, chatContext ->

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -41,6 +41,7 @@ import com.hedvig.android.feature.home.home.navigation.HomeDestination
 import com.hedvig.android.feature.home.home.navigation.homeGraph
 import com.hedvig.android.feature.insurances.data.CancelInsuranceData
 import com.hedvig.android.feature.insurances.insurance.insuranceGraph
+import com.hedvig.android.feature.insurances.navigation.InsurancesDestination
 import com.hedvig.android.feature.odyssey.navigation.claimFlowGraph
 import com.hedvig.android.feature.odyssey.navigation.navigateToClaimFlowDestination
 import com.hedvig.android.feature.odyssey.navigation.terminalClaimFlowStepDestinations
@@ -150,6 +151,9 @@ internal fun HedvigNavHost(
           openUrl = openUrl,
           openPlayStore = { activityNavigator.tryOpenPlayStore(context) },
           hedvigDeepLinkContainer = hedvigDeepLinkContainer,
+          navigateToInsurances = { navOptions ->
+            hedvigAppState.navController.navigate(InsurancesDestination.Graph, navOptions)
+          },
           closeTerminationFlow = {
             /**
              * If we fail to pop the backstack including TerminateInsuranceGraphDestination here it means we were deep

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -151,8 +151,15 @@ internal fun HedvigNavHost(
           openPlayStore = { activityNavigator.tryOpenPlayStore(context) },
           hedvigDeepLinkContainer = hedvigDeepLinkContainer,
           closeTerminationFlow = {
-            hedvigAppState.navController.popBackStack<AppDestination.TerminationFlow>(inclusive = true)
-            hedvigAppState.navController.popBackStack<TerminateInsuranceGraphDestination>(inclusive = true)
+            /**
+             * If we fail to pop the backstack including TerminateInsuranceGraphDestination here it means we were deep
+             * linked into this screen only, and they do not wish to continue with the flow they were deep linked to.
+             * The right way to handle this is to simply finish the app as per the docs:
+             * https://developer.android.com/guide/navigation/backstack#handle-failure
+             */
+            if (!hedvigAppState.navController.popBackStack<TerminateInsuranceGraphDestination>(inclusive = true)) {
+              finishApp()
+            }
           },
         )
       },

--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/TopAppbar.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/TopAppbar.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.core.ui.appbar
 
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
@@ -96,6 +97,7 @@ fun TopAppBarWithBackAndClose(
     scrolledContainerColor = MaterialTheme.colorScheme.surface,
   ),
   scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
+  extraActions: @Composable RowScope.() -> Unit = {},
 ) {
   TopAppBar(
     modifier = modifier,
@@ -117,56 +119,7 @@ fun TopAppBarWithBackAndClose(
       )
     },
     actions = {
-      IconButton(
-        onClick = onClose,
-        content = {
-          Icon(
-            imageVector = Icons.Hedvig.X,
-            contentDescription = null,
-          )
-        },
-      )
-    },
-    windowInsets = windowInsets,
-    colors = colors,
-    scrollBehavior = scrollBehavior,
-  )
-}
-
-@Composable
-fun TopAppBarWithInfoAndClose(
-  title: String,
-  onClose: () -> Unit,
-  onInfoClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets
-    .union(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)),
-  colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(
-    containerColor = MaterialTheme.colorScheme.background,
-    scrolledContainerColor = MaterialTheme.colorScheme.surface,
-  ),
-  scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
-) {
-  TopAppBar(
-    modifier = modifier,
-    title = {
-      Text(
-        text = title,
-        style = MaterialTheme.typography.titleLarge,
-      )
-    },
-    navigationIcon = {
-      IconButton(
-        onClick = onInfoClick,
-        content = {
-          Icon(
-            imageVector = Icons.Hedvig.Info,
-            contentDescription = null,
-          )
-        },
-      )
-    },
-    actions = {
+      extraActions()
       IconButton(
         onClick = onClose,
         content = {

--- a/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/TopAppbar.kt
+++ b/app/core/core-ui/src/main/kotlin/com/hedvig/android/core/ui/appbar/TopAppbar.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.hedvig.android.core.icons.Hedvig
 import com.hedvig.android.core.icons.hedvig.normal.ArrowBack
-import com.hedvig.android.core.icons.hedvig.normal.Info
 import com.hedvig.android.core.icons.hedvig.normal.X
 
 @Composable

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -65,6 +66,7 @@ import com.hedvig.android.core.designsystem.material3.typeContainer
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.card.InsuranceCard
+import com.hedvig.android.core.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.ContractType
@@ -372,77 +374,50 @@ private fun TerminatedContractsButton(text: String, onClick: () -> Unit, modifie
 
 @HedvigPreview
 @Composable
-private fun PreviewInsuranceScreenEmptyList() {
+private fun PreviewInsuranceScreen(
+  @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) withContracts: Boolean,
+) {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       InsuranceScreen(
         InsuranceUiState(
-          contracts = persistentListOf(),
-          crossSells = persistentListOf(
-            CrossSell(
-              id = "1",
-              title = "Pet".repeat(5),
-              subtitle = "Unlimited FirstVet calls".repeat(2),
-              storeUrl = "",
-              type = CrossSell.CrossSellType.HOME,
-            ),
-          ),
-          showNotificationBadge = false,
-          quantityOfCancelledInsurances = 1,
-          hasError = false,
-          isLoading = false,
-          isRetrying = false,
-        ),
-        {},
-        {},
-        {},
-        {},
-        rememberPreviewImageLoader(),
-      )
-    }
-  }
-}
-
-@HedvigPreview
-@Composable
-private fun PreviewInsuranceScreen() {
-  HedvigTheme {
-    Surface(color = MaterialTheme.colorScheme.background) {
-      InsuranceScreen(
-        InsuranceUiState(
-          contracts = persistentListOf(
-            InsuranceContract(
-              "1",
-              "Test123",
-              exposureDisplayName = "Test exposure",
-              inceptionDate = LocalDate.fromEpochDays(200),
-              terminationDate = LocalDate.fromEpochDays(400),
-              currentInsuranceAgreement = InsuranceAgreement(
-                activeFrom = LocalDate.fromEpochDays(240),
-                activeTo = LocalDate.fromEpochDays(340),
-                displayItems = persistentListOf(),
-                productVariant = ProductVariant(
-                  displayName = "Variant",
-                  contractGroup = ContractGroup.RENTAL,
-                  contractType = ContractType.SE_APARTMENT_RENT,
-                  partner = null,
-                  perils = persistentListOf(),
-                  insurableLimits = persistentListOf(),
-                  documents = persistentListOf(),
+          contracts = if (withContracts) {
+            persistentListOf(
+              InsuranceContract(
+                "1",
+                "Test123",
+                exposureDisplayName = "Test exposure",
+                inceptionDate = LocalDate.fromEpochDays(200),
+                terminationDate = LocalDate.fromEpochDays(400),
+                currentInsuranceAgreement = InsuranceAgreement(
+                  activeFrom = LocalDate.fromEpochDays(240),
+                  activeTo = LocalDate.fromEpochDays(340),
+                  displayItems = persistentListOf(),
+                  productVariant = ProductVariant(
+                    displayName = "Variant",
+                    contractGroup = ContractGroup.RENTAL,
+                    contractType = ContractType.SE_APARTMENT_RENT,
+                    partner = null,
+                    perils = persistentListOf(),
+                    insurableLimits = persistentListOf(),
+                    documents = persistentListOf(),
+                  ),
+                  certificateUrl = null,
+                  coInsured = persistentListOf(),
+                  creationCause = InsuranceAgreement.CreationCause.NEW_CONTRACT,
                 ),
-                certificateUrl = null,
-                coInsured = persistentListOf(),
-                creationCause = InsuranceAgreement.CreationCause.NEW_CONTRACT,
+                upcomingInsuranceAgreement = null,
+                renewalDate = LocalDate.fromEpochDays(500),
+                supportsAddressChange = false,
+                supportsEditCoInsured = true,
+                isTerminated = false,
+                contractHolderDisplayName = "Hugo Linder",
+                contractHolderSSN = "19910113-1093",
               ),
-              upcomingInsuranceAgreement = null,
-              renewalDate = LocalDate.fromEpochDays(500),
-              supportsAddressChange = false,
-              supportsEditCoInsured = true,
-              isTerminated = false,
-              contractHolderDisplayName = "Hugo Linder",
-              contractHolderSSN = "19910113-1093",
-            ),
-          ),
+            )
+          } else {
+            persistentListOf()
+          },
           crossSells = persistentListOf(
             CrossSell(
               id = "1",

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceDestination.kt
@@ -11,6 +11,7 @@ data class TerminateInsuranceGraphDestination(
   /**
    * The ID to the contract which needs to be pre-selected in the termination flow
    */
+  @SerialName("contractId")
   val insuranceId: String?,
 ) : Destination
 

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceDestination.kt
@@ -3,7 +3,16 @@ package com.hedvig.android.feature.terminateinsurance.navigation
 import com.hedvig.android.data.contract.ContractGroup
 import com.kiwi.navigationcompose.typed.Destination
 import kotlinx.datetime.LocalDate
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+@Serializable
+data class TerminateInsuranceGraphDestination(
+  /**
+   * The ID to the contract which needs to be pre-selected in the termination flow
+   */
+  val insuranceId: String?,
+) : Destination
 
 internal sealed interface TerminateInsuranceDestination : Destination {
   @Serializable

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateDestination.kt
@@ -50,13 +50,16 @@ internal fun ChooseInsuranceToTerminateDestination(
   navigateToNextStep: (step: TerminateInsuranceStep, terminatableInsurance: TerminatableInsurance) -> Unit,
 ) {
   val uiState: ChooseInsuranceToTerminateStepUiState by viewModel.uiState.collectAsStateWithLifecycle()
+  LaunchedEffect(uiState) {
+    val uiStateValue = uiState as? ChooseInsuranceToTerminateStepUiState.Success ?: return@LaunchedEffect
+    if (uiStateValue.nextStepWithInsurance != null) {
+      viewModel.emit(ChooseInsuranceToTerminateEvent.ClearTerminationStep)
+      navigateToNextStep(uiStateValue.nextStepWithInsurance.first, uiStateValue.nextStepWithInsurance.second)
+    }
+  }
   ChooseInsuranceToTerminateScreen(
     uiState = uiState,
     navigateUp = navigateUp,
-    navigateToNextStep = { step, insurance ->
-      viewModel.emit(ChooseInsuranceToTerminateEvent.ClearTerminationStep)
-      navigateToNextStep(step, insurance)
-    },
     openChat = openChat,
     closeTerminationFlow = closeTerminationFlow,
     reload = { viewModel.emit(ChooseInsuranceToTerminateEvent.RetryLoadData) },
@@ -74,7 +77,6 @@ private fun ChooseInsuranceToTerminateScreen(
   closeTerminationFlow: () -> Unit,
   fetchTerminationStep: () -> Unit,
   selectInsurance: (insurance: TerminatableInsurance) -> Unit,
-  navigateToNextStep: (step: TerminateInsuranceStep, terminatableInsurance: TerminatableInsurance) -> Unit,
 ) {
   when (uiState) {
     ChooseInsuranceToTerminateStepUiState.NotAllowed -> {
@@ -102,12 +104,6 @@ private fun ChooseInsuranceToTerminateScreen(
     ChooseInsuranceToTerminateStepUiState.Loading -> HedvigFullScreenCenterAlignedProgress()
 
     is ChooseInsuranceToTerminateStepUiState.Success -> {
-      LaunchedEffect(uiState.nextStepWithInsurance) {
-        if (uiState.nextStepWithInsurance != null) {
-          navigateToNextStep(uiState.nextStepWithInsurance.first, uiState.nextStepWithInsurance.second)
-        }
-      }
-
       TerminationScaffold(
         navigateUp = navigateUp,
         closeTerminationFlow = closeTerminationFlow,
@@ -196,7 +192,6 @@ private fun PreviewChooseInsuranceToTerminateScreen(
         {},
         {},
         {},
-        { step, insurance -> },
       )
     }
   }

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateDestination.kt
@@ -1,5 +1,8 @@
 package com.hedvig.android.feature.terminateinsurance.step.choose
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +38,7 @@ import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.SelectIndicationCircle
 import com.hedvig.android.core.ui.scaffold.HedvigScaffold
+import com.hedvig.android.core.ui.text.WarningTextWithIcon
 import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.termination.data.TerminatableInsurance
 import com.hedvig.android.feature.terminateinsurance.data.TerminateInsuranceStep
@@ -63,7 +68,7 @@ internal fun ChooseInsuranceToTerminateDestination(
     openChat = openChat,
     closeTerminationFlow = closeTerminationFlow,
     reload = { viewModel.emit(ChooseInsuranceToTerminateEvent.RetryLoadData) },
-    fetchTerminationStep = { viewModel.emit(ChooseInsuranceToTerminateEvent.FetchTerminationStep) },
+    fetchTerminationStep = { viewModel.emit(ChooseInsuranceToTerminateEvent.SubmitSelectedInsuranceToTerminate(it)) },
     selectInsurance = { viewModel.emit(ChooseInsuranceToTerminateEvent.SelectInsurance(it)) },
   )
 }
@@ -75,7 +80,7 @@ private fun ChooseInsuranceToTerminateScreen(
   reload: () -> Unit,
   openChat: () -> Unit,
   closeTerminationFlow: () -> Unit,
-  fetchTerminationStep: () -> Unit,
+  fetchTerminationStep: (insurance: TerminatableInsurance) -> Unit,
   selectInsurance: (insurance: TerminatableInsurance) -> Unit,
 ) {
   when (uiState) {
@@ -119,6 +124,22 @@ private fun ChooseInsuranceToTerminateScreen(
         )
         Spacer(Modifier.weight(1f))
         Spacer(Modifier.height(16.dp))
+        AnimatedVisibility(
+          visible = uiState.navigationStepFailedToLoad,
+          enter = fadeIn(),
+          exit = fadeOut(),
+        ) {
+          Column {
+            WarningTextWithIcon(
+              modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth()
+                .wrapContentWidth(),
+              text = stringResource(R.string.something_went_wrong),
+            )
+            Spacer(Modifier.height(16.dp))
+          }
+        }
         for (insurance in uiState.insuranceList) {
           HedvigCard(
             onClick = { selectInsurance(insurance) },
@@ -166,7 +187,11 @@ private fun ChooseInsuranceToTerminateScreen(
             disabledContainerColor = MaterialTheme.colorScheme.surface,
             disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
           ),
-          onClick = fetchTerminationStep,
+          onClick = {
+            uiState.selectedInsurance?.let { selectedInsurance ->
+              fetchTerminationStep(selectedInsurance)
+            }
+          },
           isLoading = uiState.isNavigationStepLoading,
         )
         Spacer(Modifier.height(16.dp))
@@ -220,6 +245,7 @@ private class ChooseInsuranceToTerminateStepUiStateProvider :
         ),
         selectedInsurance = null,
         isNavigationStepLoading = false,
+        navigationStepFailedToLoad = false,
       ),
       ChooseInsuranceToTerminateStepUiState.Success(
         nextStepWithInsurance = null,
@@ -247,6 +273,7 @@ private class ChooseInsuranceToTerminateStepUiStateProvider :
           activateFrom = LocalDate(2024, 6, 27),
         ),
         isNavigationStepLoading = true,
+        navigationStepFailedToLoad = true,
       ),
       ChooseInsuranceToTerminateStepUiState.Failure,
       ChooseInsuranceToTerminateStepUiState.NotAllowed,

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateViewModel.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateViewModel.kt
@@ -23,13 +23,13 @@ internal class ChooseInsuranceToTerminateViewModel(
   getTerminatableContractsUseCase: GetTerminatableContractsUseCase,
   terminateInsuranceRepository: TerminateInsuranceRepository,
 ) : MoleculeViewModel<ChooseInsuranceToTerminateEvent, ChooseInsuranceToTerminateStepUiState>(
-  initialState = ChooseInsuranceToTerminateStepUiState.Loading,
-  presenter = ChooseInsuranceToTerminatePresenter(
-    insuranceId = insuranceId,
-    getTerminatableContractsUseCase = getTerminatableContractsUseCase,
-    terminateInsuranceRepository = terminateInsuranceRepository,
-  ),
-)
+    initialState = ChooseInsuranceToTerminateStepUiState.Loading,
+    presenter = ChooseInsuranceToTerminatePresenter(
+      insuranceId = insuranceId,
+      getTerminatableContractsUseCase = getTerminatableContractsUseCase,
+      terminateInsuranceRepository = terminateInsuranceRepository,
+    ),
+  )
 
 private class ChooseInsuranceToTerminatePresenter(
   private val insuranceId: String?,
@@ -139,7 +139,7 @@ private class ChooseInsuranceToTerminatePresenter(
                 false,
               )
             }
-          }
+          },
         )
       }
     }

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateViewModel.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateViewModel.kt
@@ -23,13 +23,13 @@ internal class ChooseInsuranceToTerminateViewModel(
   getTerminatableContractsUseCase: GetTerminatableContractsUseCase,
   terminateInsuranceRepository: TerminateInsuranceRepository,
 ) : MoleculeViewModel<ChooseInsuranceToTerminateEvent, ChooseInsuranceToTerminateStepUiState>(
-    initialState = ChooseInsuranceToTerminateStepUiState.Loading,
-    presenter = ChooseInsuranceToTerminatePresenter(
-      insuranceId = insuranceId,
-      getTerminatableContractsUseCase = getTerminatableContractsUseCase,
-      terminateInsuranceRepository = terminateInsuranceRepository,
-    ),
-  )
+  initialState = ChooseInsuranceToTerminateStepUiState.Loading,
+  presenter = ChooseInsuranceToTerminatePresenter(
+    insuranceId = insuranceId,
+    getTerminatableContractsUseCase = getTerminatableContractsUseCase,
+    terminateInsuranceRepository = terminateInsuranceRepository,
+  ),
+)
 
 private class ChooseInsuranceToTerminatePresenter(
   private val insuranceId: String?,
@@ -69,12 +69,12 @@ private class ChooseInsuranceToTerminatePresenter(
         }
 
         ChooseInsuranceToTerminateEvent.ClearTerminationStep -> {
-          if (currentState is ChooseInsuranceToTerminateStepUiState.Success) {
-            currentState =
-              (currentState as ChooseInsuranceToTerminateStepUiState.Success).copy(
-                nextStepWithInsurance = null,
-                isNavigationStepLoading = false,
-              )
+          val currentStateValue = currentState
+          if (currentStateValue is ChooseInsuranceToTerminateStepUiState.Success) {
+            currentState = currentStateValue.copy(
+              nextStepWithInsurance = null,
+              isNavigationStepLoading = false,
+            )
           }
         }
       }

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationsuccess/TerminationSuccessDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationsuccess/TerminationSuccessDestination.kt
@@ -40,7 +40,7 @@ import kotlinx.datetime.toJavaLocalDate
 internal fun TerminationSuccessDestination(
   terminationDate: LocalDate?,
   onSurveyClicked: () -> Unit,
-  navigateBack: () -> Unit,
+  onDone: () -> Unit,
 ) {
   Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.fillMaxSize()) {
     Column(
@@ -68,7 +68,7 @@ internal fun TerminationSuccessDestination(
       Spacer(Modifier.height(16.dp))
       HedvigContainedButton(
         text = stringResource(id = R.string.general_done_button),
-        onClick = navigateBack,
+        onClick = onDone,
         modifier = Modifier.padding(horizontal = 16.dp),
       )
       Spacer(Modifier.height(8.dp))

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationOverviewScreenScaffold.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationOverviewScreenScaffold.kt
@@ -14,6 +14,9 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -36,8 +39,9 @@ import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.material3.squircleLargeTop
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.core.icons.Hedvig
+import com.hedvig.android.core.icons.hedvig.normal.Info
 import com.hedvig.android.core.ui.appbar.TopAppBarWithBackAndClose
-import com.hedvig.android.core.ui.appbar.TopAppBarWithInfoAndClose
 import com.hedvig.android.core.ui.rememberHedvigDateTimeFormatter
 import hedvig.resources.R
 import kotlinx.coroutines.launch
@@ -78,32 +82,34 @@ internal fun TerminationScaffold(
   ) {
     Column {
       val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-      if (textForInfoIcon != null) {
-        TopAppBarWithInfoAndClose(
-          onInfoClick = { showExplanationBottomSheet = true },
-          onClose = closeTerminationFlow,
-          title = "",
-          scrollBehavior = topAppBarScrollBehavior,
-        )
-      } else {
-        TopAppBarWithBackAndClose(
-          onNavigateUp = navigateUp,
-          onClose = closeTerminationFlow,
-          title = "",
-          scrollBehavior = topAppBarScrollBehavior,
-        )
-      }
+      TopAppBarWithBackAndClose(
+        onNavigateUp = navigateUp,
+        onClose = closeTerminationFlow,
+        title = "",
+        scrollBehavior = topAppBarScrollBehavior,
+        extraActions = {
+          IconButton(
+            onClick = { showExplanationBottomSheet = true },
+            content = {
+              Icon(
+                imageVector = Icons.Hedvig.Info,
+                contentDescription = null,
+              )
+            },
+          )
+        },
+      )
 
       Column(
         modifier = Modifier
-          .fillMaxSize()
-          .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-          .verticalScroll(rememberScrollState())
-          .windowInsetsPadding(
-            WindowInsets.safeDrawing.only(
-              WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+            .fillMaxSize()
+            .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
+            .verticalScroll(rememberScrollState())
+            .windowInsetsPadding(
+                WindowInsets.safeDrawing.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                ),
             ),
-          ),
       ) {
         Spacer(modifier = Modifier.height(8.dp))
         Text(
@@ -177,16 +183,16 @@ internal fun ExplanationBottomSheet(onDismiss: () -> Unit, sheetState: SheetStat
     Text(
       text = stringResource(id = R.string.TERMINATION_FLOW_CANCEL_INFO_TITLE),
       modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 24.dp),
+          .fillMaxWidth()
+          .padding(horizontal = 24.dp),
     )
     Spacer(Modifier.height(8.dp))
     Text(
       text = text,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
       modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 24.dp),
+          .fillMaxWidth()
+          .padding(horizontal = 24.dp),
     )
     Spacer(Modifier.height(32.dp))
     HedvigTextButton(

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationScaffold.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationScaffold.kt
@@ -170,7 +170,7 @@ private fun CommonQuestions(modifier: Modifier = Modifier) {
 }
 
 @Composable
-internal fun ExplanationBottomSheet(onDismiss: () -> Unit, sheetState: SheetState, text: String) {
+private fun ExplanationBottomSheet(onDismiss: () -> Unit, sheetState: SheetState, text: String) {
   ModalBottomSheet(
     containerColor = MaterialTheme.colorScheme.background,
     onDismissRequest = {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationScaffold.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationScaffold.kt
@@ -88,28 +88,30 @@ internal fun TerminationScaffold(
         title = "",
         scrollBehavior = topAppBarScrollBehavior,
         extraActions = {
-          IconButton(
-            onClick = { showExplanationBottomSheet = true },
-            content = {
-              Icon(
-                imageVector = Icons.Hedvig.Info,
-                contentDescription = null,
-              )
-            },
-          )
+          if (textForInfoIcon != null) {
+            IconButton(
+              onClick = { showExplanationBottomSheet = true },
+              content = {
+                Icon(
+                  imageVector = Icons.Hedvig.Info,
+                  contentDescription = null,
+                )
+              },
+            )
+          }
         },
       )
 
       Column(
         modifier = Modifier
-            .fillMaxSize()
-            .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-            .verticalScroll(rememberScrollState())
-            .windowInsetsPadding(
-                WindowInsets.safeDrawing.only(
-                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
-                ),
+          .fillMaxSize()
+          .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
+          .verticalScroll(rememberScrollState())
+          .windowInsetsPadding(
+            WindowInsets.safeDrawing.only(
+              WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
             ),
+          ),
       ) {
         Spacer(modifier = Modifier.height(8.dp))
         Text(
@@ -183,16 +185,16 @@ private fun ExplanationBottomSheet(onDismiss: () -> Unit, sheetState: SheetState
     Text(
       text = stringResource(id = R.string.TERMINATION_FLOW_CANCEL_INFO_TITLE),
       modifier = Modifier
-          .fillMaxWidth()
-          .padding(horizontal = 24.dp),
+        .fillMaxWidth()
+        .padding(horizontal = 24.dp),
     )
     Spacer(Modifier.height(8.dp))
     Text(
       text = text,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
       modifier = Modifier
-          .fillMaxWidth()
-          .padding(horizontal = 24.dp),
+        .fillMaxWidth()
+        .padding(horizontal = 24.dp),
     )
     Spacer(Modifier.height(32.dp))
     HedvigTextButton(

--- a/app/navigation/navigation-compose-typed/src/main/kotlin/com/hedvig/android/navigation/compose/typed/getRouteFromBackStack.kt
+++ b/app/navigation/navigation-compose-typed/src/main/kotlin/com/hedvig/android/navigation/compose/typed/getRouteFromBackStack.kt
@@ -1,0 +1,19 @@
+package com.hedvig.android.navigation.compose.typed
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+import com.kiwi.navigationcompose.typed.Destination
+import com.kiwi.navigationcompose.typed.createRoutePattern
+import com.kiwi.navigationcompose.typed.decodeArguments
+import kotlinx.serialization.serializer
+
+@Composable
+inline fun <reified T : Destination> NavController.getRouteFromBackStack(
+  backStackEntry: NavBackStackEntry,
+): T {
+  return remember(this, backStackEntry) {
+    decodeArguments(serializer<T>(), getBackStackEntry(createRoutePattern<T>()))
+  }
+}

--- a/app/navigation/navigation-compose-typed/src/main/kotlin/com/hedvig/android/navigation/compose/typed/getRouteFromBackStack.kt
+++ b/app/navigation/navigation-compose-typed/src/main/kotlin/com/hedvig/android/navigation/compose/typed/getRouteFromBackStack.kt
@@ -10,9 +10,7 @@ import com.kiwi.navigationcompose.typed.decodeArguments
 import kotlinx.serialization.serializer
 
 @Composable
-inline fun <reified T : Destination> NavController.getRouteFromBackStack(
-  backStackEntry: NavBackStackEntry,
-): T {
+inline fun <reified T : Destination> NavController.getRouteFromBackStack(backStackEntry: NavBackStackEntry): T {
   return remember(this, backStackEntry) {
     decodeArguments(serializer<T>(), getBackStackEntry(createRoutePattern<T>()))
   }

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/AppDestination.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/AppDestination.kt
@@ -33,12 +33,6 @@ sealed interface AppDestination : Destination {
   @Serializable
   data object ClaimsFlow : AppDestination
 
-  @Serializable
-  data class TerminationFlow(
-    @SerialName("insuranceId")
-    val insuranceId: String?,
-  ) : AppDestination
-
   // Handles connecting payment with Trustly. Auto-navigates to Adyen for NO/DK
   @Serializable
   data object ConnectPayment : AppDestination

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/AppDestination.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/AppDestination.kt
@@ -1,7 +1,6 @@
 package com.hedvig.android.navigation.core
 
 import com.kiwi.navigationcompose.typed.Destination
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 sealed interface AppDestination : Destination {

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
@@ -51,7 +51,7 @@ internal class HedvigDeepLinkContainerImpl(
   override val contractWithoutContractId: String = "$baseDeepLinkDomain/contract"
   override val contract: String = "$baseDeepLinkDomain/contract?contractId={contractId}"
 
-  override val terminateInsurance: String = "$baseDeepLinkDomain/terminateInsurance?insuranceId={insuranceId}"
+  override val terminateInsurance: String = "$baseDeepLinkDomain/terminate-contract?contractId={contractId}"
 
   override val forever: String = "$baseDeepLinkDomain/forever"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
For the presenter logic:

Adds error message for when someone submits the insurance to cancel but the network request fails. Clears that error message when they try again or select another insurance. A bit of a rough UI work but I did the same thing that we do over in claim's flow in the triaging steps

And just did a few small code styling changes in the meantime which I did as I was trying to understand the logic.

---

For UI fixes:

I added a back button on the first screen of termination flow. I know design does not specify that but we need to have that button there for Android. I moved the info icon on the right side next to the X instead.

---

For nav:

Fixed the X button to still work if we were deep linked, but popping the entire app's backstack and just exiting the app, as per the docs https://developer.android.com/guide/navigation/backstack#handle-failure

On done with the flow in the success screen, we just try to pop the backstack to go to where we came from, but if we were deep linked and there's nothing in the backstack to go to we just pop the success destination and go to the insurances tab instead.

---

Also added `getRouteFromBackStack` to have a single way to do this in other places we want to get the parent backstack too. So we don't need to create a different implementation on each graph that needs it

---

Draft because I want to test some final things 