### PR TITLE
Stop allowing to submit the wrong number of ssn digits

### DIFF
--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/GenericAuthDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/GenericAuthDestination.kt
@@ -78,6 +78,7 @@ private fun GenericAuthScreen(
           emailInput = uiState.ssnInput,
           error = uiState.error?.let { errorMessage(it) },
           loading = uiState.loading,
+          canSubmitSsn = uiState.canSubmitSsn,
         )
       }
     }

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/GenericAuthViewModel.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/GenericAuthViewModel.kt
@@ -149,11 +149,12 @@ data class GenericAuthViewState(
   val emailInputWithoutWhitespaces: EmailAddressWithTrimmedWhitespaces
     get() = EmailAddressWithTrimmedWhitespaces(emailInput)
 
-  val canSubmitSsn: Boolean = when (market) {
-    Market.SE -> error("Should not be able to enter SSN for generic auth for SE")
-    Market.NO -> ssnInput.length == 11
-    Market.DK -> ssnInput.length == 10
-  }
+  val canSubmitSsn: Boolean
+    get() = when (market) {
+      Market.SE -> error("Should not be able to enter SSN for generic auth for SE")
+      Market.NO -> ssnInput.length == 11
+      Market.DK -> ssnInput.length == 10
+    }
 
   sealed interface TextFieldError {
     data class Message(val message: String) : TextFieldError

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/GenericAuthViewModel.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/GenericAuthViewModel.kt
@@ -149,6 +149,12 @@ data class GenericAuthViewState(
   val emailInputWithoutWhitespaces: EmailAddressWithTrimmedWhitespaces
     get() = EmailAddressWithTrimmedWhitespaces(emailInput)
 
+  val canSubmitSsn: Boolean = when (market) {
+    Market.SE -> error("Should not be able to enter SSN for generic auth for SE")
+    Market.NO -> ssnInput.length == 11
+    Market.DK -> ssnInput.length == 10
+  }
+
   sealed interface TextFieldError {
     data class Message(val message: String) : TextFieldError
 

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/SsnInputScreen.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/genericauth/SsnInputScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.core.text.isDigitsOnly
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.component.textfield.HedvigTextField
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
@@ -37,6 +38,7 @@ fun SSNInputScreen(
   emailInput: String,
   error: String?,
   loading: Boolean,
+  canSubmitSsn: Boolean,
 ) {
   Column(
     modifier = Modifier
@@ -72,6 +74,7 @@ fun SSNInputScreen(
         text = stringResource(R.string.login_continue_button),
         onClick = onSubmitSSN,
         isLoading = loading,
+        enabled = canSubmitSsn,
       )
       Spacer(Modifier.height(16.dp))
     }
@@ -88,14 +91,15 @@ private fun SSNTextField(
 ) {
   HedvigTextField(
     value = input,
-    onValueChange = { newInput ->
+    onValueChange = onValueChange@{ newInput ->
+      if (!newInput.isDigitsOnly()) return@onValueChange
       val maxLengthAllowed = when (market) {
         Market.NO -> 11
         Market.DK -> 10
         Market.SE -> error("Should not be able to login with SSN in SE")
       }
       if (newInput.length > maxLengthAllowed) {
-        return@HedvigTextField
+        return@onValueChange
       }
       onInputChanged(newInput)
     },
@@ -152,6 +156,7 @@ private fun PreviewEmailInputScreenValid() {
         error = null,
         loading = false,
         market = Market.DK,
+        canSubmitSsn = true,
       )
     }
   }
@@ -170,6 +175,7 @@ private fun PreviewEmailInputScreenInvalid() {
         error = "Invalid email",
         loading = false,
         market = Market.DK,
+        canSubmitSsn = true,
       )
     }
   }


### PR DESCRIPTION
Otherwise since both DK and NO use the same login method one could try to login to DK when they've picked a NO locale (but not the other way around due to the max digit limit, by coincidence). This disallows sending it in the first place unless the ssn size is just right.