### PR TITLE
Move the language migration from Application to LIActivity

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/HedvigApplication.kt
@@ -3,14 +3,10 @@ package com.hedvig.app
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import com.hedvig.android.app.AppInitializers
-import com.hedvig.android.language.LanguageAndMarketLaunchCheckUseCase
 import com.hedvig.app.feature.tracking.ActivityChangeTracker
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 open class HedvigApplication : Application() {
-  private val languageAndMarketLaunchCheckUseCase: LanguageAndMarketLaunchCheckUseCase by inject()
   private val appInitializers: AppInitializers by inject()
 
   override fun onCreate() {
@@ -18,8 +14,5 @@ open class HedvigApplication : Application() {
     registerActivityLifecycleCallbacks(ActivityChangeTracker())
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
     appInitializers.initialize()
-    MainScope().launch {
-      languageAndMarketLaunchCheckUseCase.invoke()
-    }
   }
 }

--- a/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/app/feature/loggedin/ui/LoggedInActivity.kt
@@ -42,12 +42,14 @@ import com.hedvig.android.auth.AuthStatus
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.core.appreview.WaitUntilAppReviewDialogShouldBeOpenedUseCase
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.data.paying.member.GetOnlyHasNonPayingContractsUseCaseProvider
 import com.hedvig.android.data.settings.datastore.SettingsDataStore
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
+import com.hedvig.android.language.LanguageAndMarketLaunchCheckUseCase
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
@@ -73,6 +75,7 @@ import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 class LoggedInActivity : AppCompatActivity() {
+  private val applicationScope: ApplicationScope by inject()
   private val authTokenService: AuthTokenService by inject()
   private val demoManager: DemoManager by inject()
   private val featureManager: FeatureManager by inject()
@@ -85,6 +88,7 @@ class LoggedInActivity : AppCompatActivity() {
   private val settingsDataStore: SettingsDataStore by inject()
   private val tabNotificationBadgeService: TabNotificationBadgeService by inject()
   private val waitUntilAppReviewDialogShouldBeOpenedUseCase: WaitUntilAppReviewDialogShouldBeOpenedUseCase by inject()
+  private val languageAndMarketLaunchCheckUseCase: LanguageAndMarketLaunchCheckUseCase by inject()
 
   private val activityNavigator: ActivityNavigator by inject()
   private var navController: NavController? = null
@@ -115,6 +119,9 @@ class LoggedInActivity : AppCompatActivity() {
       navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
     )
     super.onCreate(savedInstanceState)
+    applicationScope.launch {
+      languageAndMarketLaunchCheckUseCase.invoke()
+    }
     val uiModeManager = getSystemService<UiModeManager>()
 
     lifecycleScope.launch {

--- a/app/language/language-core/src/main/kotlin/com/hedvig/android/language/LanguageService.kt
+++ b/app/language/language-core/src/main/kotlin/com/hedvig/android/language/LanguageService.kt
@@ -8,6 +8,11 @@ import com.hedvig.android.logger.logcat
 import java.util.Locale
 
 interface LanguageService {
+  /**
+   * Note that AppCompatDelegate.setApplicationLocales must be called at least after Activity.onCreate()
+   * https://developer.android.com/guide/topics/resources/app-languages#androidx-impl
+   * https://cs.android.com/androidx/platform/frameworks/support/+/336a1f14a9e8e6729e833b3022ad3ffa8a3f0433:appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDelegate.java;l=733-734
+   */
   @MainThread
   fun setLanguage(language: Language)
 


### PR DESCRIPTION
These sources talk a bit more about this.
https://developer.android.com/guide/topics/resources/app-languages#androidx-impl https://cs.android.com/androidx/platform/frameworks/support/+/336a1f14a9e8e6729e833b3022ad3ffa8a3f0433:appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDelegate.java;l=733-734

I suspect us doing it in the Application is the reason it simply didn't properly select the language for people who did not go ahead and do a language selection manually which has confused me for a very long time.

This along with getting rid of the other activities should meant that this happens just fine for all members soon.