### PR TITLE
Bump retrofit

### DIFF
--- a/app/app/proguard-rules.pro
+++ b/app/app/proguard-rules.pro
@@ -1,14 +1,3 @@
-# region Retrofit
-# https://github.com/square/retrofit/issues/3751#issuecomment-1192043644
-# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking interface retrofit2.Call
--keep,allowobfuscation,allowshrinking class retrofit2.Response
-# With R8 full mode generic signatures are stripped for classes that are not
-# kept. Suspend functions are wrapped in continuations where the type argument
-# is used.
--keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
-# endregion
-
 # arrow-integrations-retrofit-adapter - https://github.com/arrow-kt/arrow-integrations/issues/121
 # `Either` class needs to exist after minification for Retrofit to know how to adapt the response to it
 -keep,allowobfuscation,allowshrinking class arrow.core.Either

--- a/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileUploadModule.kt
+++ b/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileUploadModule.kt
@@ -3,13 +3,13 @@ package com.hedvig.android.core.fileupload
 import android.content.Context
 import arrow.retrofit.adapter.either.EitherCallAdapterFactory
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 val fileUploadModule = module {
   single<FileService> { FileService(get<Context>().contentResolver) }

--- a/app/data/data-claim-flow/src/main/kotlin/com/hedvig/android/data/claimflow/di/ClaimFlowDataModule.kt
+++ b/app/data/data-claim-flow/src/main/kotlin/com/hedvig/android/data/claimflow/di/ClaimFlowDataModule.kt
@@ -11,12 +11,12 @@ import com.hedvig.android.data.claimflow.ClaimFlowContextStorage
 import com.hedvig.android.data.claimflow.ClaimFlowRepository
 import com.hedvig.android.data.claimflow.ClaimFlowRepositoryImpl
 import com.hedvig.android.data.claimflow.OdysseyService
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 val claimFlowDataModule = module {
   single<ClaimFlowRepository> {

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/di/ChatModule.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/di/ChatModule.kt
@@ -13,7 +13,6 @@ import com.hedvig.android.feature.chat.data.ChatRepositoryDemo
 import com.hedvig.android.feature.chat.data.ChatRepositoryImpl
 import com.hedvig.android.feature.chat.data.GetChatRepositoryProvider
 import com.hedvig.android.navigation.core.AppDestination
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -21,6 +20,7 @@ import okhttp3.OkHttpClient
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 val chatModule = module {
   viewModel<ChatViewModel> { parametersHolder ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ androidx-other-startup = "1.1.1"
 androidx-other-workManager = "2.9.0"
 androidx-profileInstaller = "1.3.1"
 androidxGraphicsShapes = "1.0.0-alpha05"
-arrow = "1.2.3"
+arrow = "1.2.4"
 assertK = "0.28.0"
 coil = "2.6.0"
 composeRichtext = "0.20.0"
@@ -66,9 +66,8 @@ navigationRecentsUrlSharing = "0.0.2"
 okhttp = "4.12.0"
 okio = "3.9.0"
 playReview = "2.0.1"
-retrofit = "2.9.0"
-retrofitArrow = "1.2.3"
-retrofitKotlinxSerializationConverter = "1.0.0"
+retrofit = "2.11.0"
+retrofitArrow = "1.2.4"
 slimber = "2.0.0"
 testParameterInjector = "1.15"
 timber = "5.0.1"
@@ -178,7 +177,7 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 playReview = { module = "com.google.android.play:review-ktx", version.ref = "playReview" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofitArrow = { module = "io.arrow-kt:arrow-core-retrofit", version.ref = "retrofitArrow" }
-retrofitKotlinxSerializationConverter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }
+retrofitKotlinxSerializationConverter = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 slimber = { module = "com.github.PaulWoitaschek:Slimber", version.ref = "slimber" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "testParameterInjector" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }


### PR DESCRIPTION
Use the kotlinx serialization converter shipped with the library now
https://github.com/square/retrofit/tree/dfdad425e9d1c47dbce335c9808c75c72ef912cc/retrofit-converters/kotlinx-serialization

Also remove the proguard rules that are now shipped with the library
https://github.com/square/retrofit/issues/3751#issuecomment-1911000730