### PR TITLE
Cleanup: remove clutter from main activity

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -180,36 +180,6 @@ class MainActivity : AppCompatActivity() {
     openEmail(getString(R.string.login_bottom_sheet_view_code))
   }
 
-  private fun tryShowAppStoreReviewDialog() {
-    val tag = "PlayStoreReview"
-    val manager = ReviewManagerFactory.create(this@MainActivity)
-    logcat(LogPriority.INFO) { "$tag: requestReviewFlow" }
-    manager.requestReviewFlow().apply {
-      addOnFailureListener { logcat(LogPriority.INFO, it) { "$tag: requestReviewFlow failed:${it.message}" } }
-      addOnCanceledListener { logcat(LogPriority.INFO) { "$tag: requestReviewFlow cancelled" } }
-      addOnCompleteListener { task ->
-        if (task.isSuccessful) {
-          logcat(LogPriority.INFO) { "$tag: requestReviewFlow completed" }
-          val reviewInfo = task.result
-          logcat(LogPriority.INFO) { "$tag: launchReviewFlow with ReviewInfo:$reviewInfo" }
-          manager.launchReviewFlow(this@MainActivity, reviewInfo).apply {
-            addOnFailureListener { logcat(LogPriority.INFO, it) { "$tag: launchReviewFlow failed:${it.message}" } }
-            addOnCanceledListener { logcat(LogPriority.INFO) { "$tag: launchReviewFlow canceled" } }
-            addOnCompleteListener { logcat(LogPriority.INFO) { "$tag: launchReviewFlow completed" } }
-          }
-        } else {
-          val exception = task.exception
-          val errorMessage = if (exception != null && exception is ReviewException) {
-            "ReviewException:${exception.message}. ReviewException::errorCode:${exception.errorCode}"
-          } else {
-            "Unknown error with message: ${exception?.message}"
-          }
-          logcat(LogPriority.INFO, exception) { "$tag: requestReviewFlow failed. Error:$errorMessage" }
-        }
-      }
-    }
-  }
-
   companion object {
     fun newInstance(context: Context, withoutHistory: Boolean = false): Intent =
       Intent(context, MainActivity::class.java).apply {
@@ -251,6 +221,36 @@ private fun applyTheme(theme: Theme?, uiModeManager: UiModeManager?) {
       }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         uiModeManager?.setApplicationNightMode(MODE_NIGHT_CUSTOM)
+      }
+    }
+  }
+}
+
+private fun Activity.tryShowAppStoreReviewDialog() {
+  val tag = "PlayStoreReview"
+  val manager = ReviewManagerFactory.create(this)
+  logcat(LogPriority.INFO) { "$tag: requestReviewFlow" }
+  manager.requestReviewFlow().apply {
+    addOnFailureListener { logcat(LogPriority.INFO, it) { "$tag: requestReviewFlow failed:${it.message}" } }
+    addOnCanceledListener { logcat(LogPriority.INFO) { "$tag: requestReviewFlow cancelled" } }
+    addOnCompleteListener { task ->
+      if (task.isSuccessful) {
+        logcat(LogPriority.INFO) { "$tag: requestReviewFlow completed" }
+        val reviewInfo = task.result
+        logcat(LogPriority.INFO) { "$tag: launchReviewFlow with ReviewInfo:$reviewInfo" }
+        manager.launchReviewFlow(this@tryShowAppStoreReviewDialog, reviewInfo).apply {
+          addOnFailureListener { logcat(LogPriority.INFO, it) { "$tag: launchReviewFlow failed:${it.message}" } }
+          addOnCanceledListener { logcat(LogPriority.INFO) { "$tag: launchReviewFlow canceled" } }
+          addOnCompleteListener { logcat(LogPriority.INFO) { "$tag: launchReviewFlow completed" } }
+        }
+      } else {
+        val exception = task.exception
+        val errorMessage = if (exception != null && exception is ReviewException) {
+          "ReviewException:${exception.message}. ReviewException::errorCode:${exception.errorCode}"
+        } else {
+          "Unknown error with message: ${exception?.message}"
+        }
+        logcat(LogPriority.INFO, exception) { "$tag: requestReviewFlow failed. Error:$errorMessage" }
       }
     }
   }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -18,52 +18,27 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale
 import androidx.core.content.getSystemService
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleStartEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
-import androidx.navigation.NavDestination.Companion.hierarchy
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import arrow.fx.coroutines.raceN
 import coil.ImageLoader
 import com.google.android.play.core.review.ReviewException
 import com.google.android.play.core.review.ReviewManagerFactory
-import com.hedvig.android.app.ui.DeepLinkFirstUriHandler
 import com.hedvig.android.app.ui.HedvigApp
-import com.hedvig.android.app.ui.HedvigAppState
-import com.hedvig.android.app.ui.SafeAndroidUriHandler
-import com.hedvig.android.app.ui.rememberHedvigAppState
-import com.hedvig.android.auth.AuthStatus
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.core.appreview.WaitUntilAppReviewDialogShouldBeOpenedUseCase
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
 import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.demomode.DemoManager
-import com.hedvig.android.core.demomode.Provider
-import com.hedvig.android.core.designsystem.theme.HedvigTheme
-import com.hedvig.android.data.paying.member.GetOnlyHasNonPayingContractsUseCase
 import com.hedvig.android.data.paying.member.GetOnlyHasNonPayingContractsUseCaseProvider
 import com.hedvig.android.data.settings.datastore.SettingsDataStore
-import com.hedvig.android.feature.force.upgrade.ForceUpgradeBlockingScreen
-import com.hedvig.android.feature.login.navigation.LoginDestination
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.language.LanguageAndMarketLaunchCheckUseCase
 import com.hedvig.android.language.LanguageService
@@ -75,19 +50,12 @@ import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.navigation.core.allDeepLinkUriPatterns
 import com.hedvig.android.notification.badge.data.tab.TabNotificationBadgeService
 import com.hedvig.android.theme.Theme
-import com.kiwi.navigationcompose.typed.createRoutePattern
 import com.stylianosgakis.navigation.recents.url.sharing.provideAssistContent
 import hedvig.resources.R
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
@@ -141,7 +109,6 @@ class MainActivity : AppCompatActivity() {
       languageAndMarketLaunchCheckUseCase.invoke()
     }
     val uiModeManager = getSystemService<UiModeManager>()
-
     lifecycleScope.launch {
       launch {
         lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
@@ -159,14 +126,6 @@ class MainActivity : AppCompatActivity() {
           showSplash.update { false }
         }
       }
-      launch {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-          authTokenService.authStatus.first { it is AuthStatus.LoggedIn }
-          waitUntilAppReviewDialogShouldBeOpenedUseCase.invoke()
-          delay(REVIEW_DIALOG_DELAY_MILLIS)
-          tryShowAppStoreReviewDialog()
-        }
-      }
     }
 
     setContent {
@@ -179,7 +138,6 @@ class MainActivity : AppCompatActivity() {
         }
       }
       HedvigApp(
-        windowSizeClass = windowSizeClass,
         navHostController = navHostController,
         tabNotificationBadgeService = tabNotificationBadgeService,
         settingsDataStore = settingsDataStore,
@@ -194,6 +152,7 @@ class MainActivity : AppCompatActivity() {
         imageLoader = imageLoader,
         languageService = languageService,
         hedvigBuildConstants = hedvigBuildConstants,
+        waitUntilAppReviewDialogShouldBeOpenedUseCase = waitUntilAppReviewDialogShouldBeOpenedUseCase,
         enableEdgeToEdge = { systemBarStyle ->
           enableEdgeToEdge(
             statusBarStyle = systemBarStyle,
@@ -201,8 +160,11 @@ class MainActivity : AppCompatActivity() {
           )
         },
         shouldShowRequestPermissionRationale = ::shouldShowRequestPermissionRationale,
+        goToPlayStore = { activityNavigator.tryOpenPlayStore(this) },
         openEmailApp = ::openEmailApp,
         finishApp = ::finish,
+        tryShowAppStoreReviewDialog = ::tryShowAppStoreReviewDialog,
+        windowSizeClass = windowSizeClass,
       )
     }
   }
@@ -213,6 +175,10 @@ class MainActivity : AppCompatActivity() {
     outContent.webUri?.let {
       logcat { "Providing a deep link to current screen: $it" }
     }
+  }
+
+  private fun openEmailApp() {
+    openEmail(getString(R.string.login_bottom_sheet_view_code))
   }
 
   private fun tryShowAppStoreReviewDialog() {
@@ -245,13 +211,7 @@ class MainActivity : AppCompatActivity() {
     }
   }
 
-  private fun openEmailApp() {
-    openEmail(getString(R.string.login_bottom_sheet_view_code))
-  }
-
   companion object {
-    private const val REVIEW_DIALOG_DELAY_MILLIS = 2000L
-
     fun newInstance(context: Context, withoutHistory: Boolean = false): Intent =
       Intent(context, MainActivity::class.java).apply {
         logcat(LogPriority.INFO) { "LoggedInActivity.newInstance was called. withoutHistory:$withoutHistory" }
@@ -260,137 +220,6 @@ class MainActivity : AppCompatActivity() {
           addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
         }
       }
-  }
-}
-
-@Composable
-private fun HedvigApp(
-  windowSizeClass: WindowSizeClass,
-  navHostController: NavHostController,
-  tabNotificationBadgeService: TabNotificationBadgeService,
-  settingsDataStore: SettingsDataStore,
-  getOnlyHasNonPayingContractsUseCase: Provider<GetOnlyHasNonPayingContractsUseCase>,
-  featureManager: FeatureManager,
-  splashIsRemovedSignal: Channel<Unit>,
-  activityNavigator: ActivityNavigator,
-  authTokenService: AuthTokenService,
-  demoManager: DemoManager,
-  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
-  marketManager: MarketManager,
-  imageLoader: ImageLoader,
-  languageService: LanguageService,
-  hedvigBuildConstants: HedvigBuildConstants,
-  enableEdgeToEdge: (SystemBarStyle) -> Unit,
-  shouldShowRequestPermissionRationale: (String) -> Boolean,
-  openEmailApp: () -> Unit,
-  finishApp: () -> Unit,
-) {
-  val hedvigAppState = rememberHedvigAppState(
-    windowSizeClass = windowSizeClass,
-    tabNotificationBadgeService = tabNotificationBadgeService,
-    settingsDataStore = settingsDataStore,
-    getOnlyHasNonPayingContractsUseCase = getOnlyHasNonPayingContractsUseCase,
-    featureManager = featureManager,
-    navHostController = navHostController,
-  )
-  val darkTheme = hedvigAppState.darkTheme
-  HedvigTheme(darkTheme = darkTheme) {
-    EnableEdgeToEdgeSideEffect(darkTheme, splashIsRemovedSignal, enableEdgeToEdge)
-    val mustForceUpdate by hedvigAppState.mustForceUpdate.collectAsStateWithLifecycle()
-    if (mustForceUpdate) {
-      ForceUpgradeBlockingScreen(
-        goToPlayStore = { activityNavigator.tryOpenPlayStore(this) },
-      )
-    } else {
-      LogoutOnInvalidCredentialsEffect(hedvigAppState, authTokenService, demoManager)
-      val deepLinkFirstUriHandler = DeepLinkFirstUriHandler(
-        navController = hedvigAppState.navController,
-        delegate = SafeAndroidUriHandler(LocalContext.current),
-      )
-      CompositionLocalProvider(LocalUriHandler provides deepLinkFirstUriHandler) {
-        HedvigApp(
-          hedvigAppState = hedvigAppState,
-          hedvigDeepLinkContainer = hedvigDeepLinkContainer,
-          activityNavigator = activityNavigator,
-          shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale,
-          openUrl = deepLinkFirstUriHandler::openUri,
-          onOpenEmailApp = openEmailApp,
-          finishApp = finishApp,
-          market = marketManager.market.collectAsStateWithLifecycle().value,
-          imageLoader = imageLoader,
-          languageService = languageService,
-          hedvigBuildConstants = hedvigBuildConstants,
-        )
-      }
-    }
-  }
-}
-
-@Composable
-private fun EnableEdgeToEdgeSideEffect(
-  darkTheme: Boolean,
-  splashIsRemovedSignal: Channel<Unit>,
-  enableEdgeToEdge: (SystemBarStyle) -> Unit,
-) {
-  val splashIsRemovedIndex by produceState(0) {
-    splashIsRemovedSignal.receiveAsFlow().collectLatest { value = value + 1 }
-  }
-  DisposableEffect(darkTheme, splashIsRemovedIndex) {
-    enableEdgeToEdge(
-      when (darkTheme) {
-        true -> SystemBarStyle.dark(Color.TRANSPARENT)
-        false -> SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
-      },
-    )
-    onDispose {}
-  }
-}
-
-/**
- * Automatically logs out when we are no longer in demo mode and we are also not considered to have active tokens
- */
-@Composable
-private fun LogoutOnInvalidCredentialsEffect(
-  hedvigAppState: HedvigAppState,
-  authTokenService: AuthTokenService,
-  demoManager: DemoManager,
-) {
-  val authStatusLog: (AuthStatus?) -> Unit = { authStatus ->
-    logcat {
-      buildString {
-        append("Owner: LoggedInActivity | Received authStatus: ")
-        append(
-          when (authStatus) {
-            is AuthStatus.LoggedIn -> "LoggedIn"
-            AuthStatus.LoggedOut -> "LoggedOut"
-            null -> "null"
-          },
-        )
-      }
-    }
-  }
-  val lifecycle = LocalLifecycleOwner.current.lifecycle
-  LaunchedEffect(lifecycle, hedvigAppState, authTokenService, demoManager) {
-    val loginGraphRoute = createRoutePattern<LoginDestination>()
-    lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-      combine(
-        authTokenService.authStatus.onEach(authStatusLog).filterNotNull().distinctUntilChanged(),
-        demoManager.isDemoMode().distinctUntilChanged(),
-      ) { authStatus: AuthStatus, isDemoMode: Boolean ->
-        authStatus to isDemoMode
-      }.collect { (authStatus, isDemoMode) ->
-        val navBackStackEntry: NavBackStackEntry = hedvigAppState.navController.currentBackStackEntryFlow.first()
-        val isLoggedOut = navBackStackEntry.destination.hierarchy.any { navDestination ->
-          navDestination.route?.contains(loginGraphRoute) == true
-        }
-        if (isLoggedOut) {
-          return@collect
-        }
-        if (!isDemoMode && authStatus !is AuthStatus.LoggedIn) {
-          hedvigAppState.navigateToLoggedOut()
-        }
-      }
-    }
   }
 }
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -160,7 +160,7 @@ class MainActivity : AppCompatActivity() {
         },
         shouldShowRequestPermissionRationale = ::shouldShowRequestPermissionRationale,
         goToPlayStore = { activityNavigator.tryOpenPlayStore(this) },
-        openEmailApp = ::openEmailApp,
+        openEmailApp = { openEmail(getString(R.string.login_bottom_sheet_view_code)) },
         finishApp = ::finish,
         tryShowAppStoreReviewDialog = ::tryShowAppStoreReviewDialog,
         windowSizeClass = windowSizeClass,
@@ -174,10 +174,6 @@ class MainActivity : AppCompatActivity() {
     outContent.webUri?.let {
       logcat { "Providing a deep link to current screen: $it" }
     }
-  }
-
-  private fun openEmailApp() {
-    openEmail(getString(R.string.login_bottom_sheet_view_code))
   }
 
   companion object {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -75,8 +75,8 @@ class MainActivity : AppCompatActivity() {
   private val tabNotificationBadgeService: TabNotificationBadgeService by inject()
   private val waitUntilAppReviewDialogShouldBeOpenedUseCase: WaitUntilAppReviewDialogShouldBeOpenedUseCase by inject()
   private val languageAndMarketLaunchCheckUseCase: LanguageAndMarketLaunchCheckUseCase by inject()
-
   private val activityNavigator: ActivityNavigator by inject()
+
   private var navController: NavController? = null
 
   // Shows the splash screen as long as the auth status or the demo mode status is still undetermined
@@ -110,21 +110,20 @@ class MainActivity : AppCompatActivity() {
     }
     val uiModeManager = getSystemService<UiModeManager>()
     lifecycleScope.launch {
-      launch {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
-          settingsDataStore.observeTheme().collectLatest { theme ->
-            applyTheme(theme, uiModeManager)
-          }
+      lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+        settingsDataStore.observeTheme().collectLatest { theme ->
+          applyTheme(theme, uiModeManager)
         }
       }
-      launch {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
-          raceN(
-            { authTokenService.authStatus.first { it != null } },
-            { demoManager.isDemoMode().first { it == true } },
-          )
-          showSplash.update { false }
-        }
+    }
+    lifecycleScope.launch {
+      lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+        if (showSplash.value == false) return@repeatOnLifecycle
+        raceN(
+          { authTokenService.authStatus.first { it != null } },
+          { demoManager.isDemoMode().first { it == true } },
+        )
+        showSplash.update { false }
       }
     }
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -1,131 +1,206 @@
 package com.hedvig.android.app.ui
 
-import androidx.compose.animation.core.AnimationVector4D
-import androidx.compose.animation.core.TwoWayConverter
-import androidx.compose.animation.core.animateValueAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.union
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import android.graphics.Color
+import androidx.activity.SystemBarStyle
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavHostController
 import coil.ImageLoader
-import com.hedvig.android.app.navigation.HedvigNavHost
+import com.hedvig.android.auth.AuthStatus
+import com.hedvig.android.auth.AuthTokenService
+import com.hedvig.android.core.appreview.WaitUntilAppReviewDialogShouldBeOpenedUseCase
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
-import com.hedvig.android.core.designsystem.material3.motion.MotionTokens
+import com.hedvig.android.core.demomode.DemoManager
+import com.hedvig.android.core.demomode.Provider
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.data.paying.member.GetOnlyHasNonPayingContractsUseCase
+import com.hedvig.android.data.settings.datastore.SettingsDataStore
+import com.hedvig.android.feature.force.upgrade.ForceUpgradeBlockingScreen
+import com.hedvig.android.feature.login.navigation.LoginDestination
+import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.language.LanguageService
-import com.hedvig.android.market.Market
+import com.hedvig.android.logger.logcat
+import com.hedvig.android.market.MarketManager
 import com.hedvig.android.navigation.activity.ActivityNavigator
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
+import com.hedvig.android.notification.badge.data.tab.TabNotificationBadgeService
+import com.kiwi.navigationcompose.typed.createRoutePattern
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 
 @Composable
 internal fun HedvigApp(
-  hedvigAppState: HedvigAppState,
-  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
+  navHostController: NavHostController,
+  tabNotificationBadgeService: TabNotificationBadgeService,
+  settingsDataStore: SettingsDataStore,
+  getOnlyHasNonPayingContractsUseCase: Provider<GetOnlyHasNonPayingContractsUseCase>,
+  featureManager: FeatureManager,
+  splashIsRemovedSignal: Channel<Unit>,
   activityNavigator: ActivityNavigator,
-  finishApp: () -> Unit,
-  shouldShowRequestPermissionRationale: (String) -> Boolean,
-  openUrl: (String) -> Unit,
-  onOpenEmailApp: () -> Unit,
-  market: Market,
+  authTokenService: AuthTokenService,
+  demoManager: DemoManager,
+  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
+  marketManager: MarketManager,
   imageLoader: ImageLoader,
   languageService: LanguageService,
   hedvigBuildConstants: HedvigBuildConstants,
+  waitUntilAppReviewDialogShouldBeOpenedUseCase: WaitUntilAppReviewDialogShouldBeOpenedUseCase,
+  enableEdgeToEdge: (SystemBarStyle) -> Unit,
+  shouldShowRequestPermissionRationale: (String) -> Boolean,
+  goToPlayStore: () -> Unit,
+  openEmailApp: () -> Unit,
+  finishApp: () -> Unit,
+  tryShowAppStoreReviewDialog: () -> Unit,
+  windowSizeClass: WindowSizeClass,
 ) {
-  Surface(
-    color = MaterialTheme.colorScheme.background,
-    contentColor = MaterialTheme.colorScheme.onBackground,
-    modifier = Modifier.fillMaxSize(),
-  ) {
-    NavigationSuite(
-      navigationSuiteType = hedvigAppState.navigationSuiteType,
-      topLevelGraphs = hedvigAppState.topLevelGraphs.collectAsState().value,
-      topLevelGraphsWithNotifications = hedvigAppState.topLevelGraphsWithNotifications.collectAsState().value,
-      currentDestination = hedvigAppState.currentDestination,
-      onNavigateToTopLevelGraph = hedvigAppState::navigateToTopLevelGraph,
-    ) {
-      HedvigNavHost(
-        hedvigAppState = hedvigAppState,
-        hedvigDeepLinkContainer = hedvigDeepLinkContainer,
-        activityNavigator = activityNavigator,
-        finishApp = finishApp,
-        shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale,
-        openUrl = openUrl,
-        onOpenEmailApp = onOpenEmailApp,
-        imageLoader = imageLoader,
-        market = market,
-        languageService = languageService,
-        hedvigBuildConstants = hedvigBuildConstants,
-        modifier = Modifier
-          .fillMaxHeight()
-          .weight(1f)
-          .animatedNavigationBarInsetsConsumption(hedvigAppState),
+  val hedvigAppState = rememberHedvigAppState(
+    windowSizeClass = windowSizeClass,
+    tabNotificationBadgeService = tabNotificationBadgeService,
+    settingsDataStore = settingsDataStore,
+    getOnlyHasNonPayingContractsUseCase = getOnlyHasNonPayingContractsUseCase,
+    featureManager = featureManager,
+    navHostController = navHostController,
+  )
+  val darkTheme = hedvigAppState.darkTheme
+  HedvigTheme(darkTheme = darkTheme) {
+    EnableEdgeToEdgeSideEffect(darkTheme, splashIsRemovedSignal, enableEdgeToEdge)
+    val mustForceUpdate by hedvigAppState.mustForceUpdate.collectAsStateWithLifecycle()
+    if (mustForceUpdate) {
+      ForceUpgradeBlockingScreen(
+        goToPlayStore = goToPlayStore,
       )
+    } else {
+      TryShowAppStoreReviewDialogEffect(
+        authTokenService,
+        waitUntilAppReviewDialogShouldBeOpenedUseCase,
+        tryShowAppStoreReviewDialog,
+      )
+      LogoutOnInvalidCredentialsEffect(hedvigAppState, authTokenService, demoManager)
+      val deepLinkFirstUriHandler = DeepLinkFirstUriHandler(
+        navController = hedvigAppState.navController,
+        delegate = SafeAndroidUriHandler(LocalContext.current),
+      )
+      CompositionLocalProvider(LocalUriHandler provides deepLinkFirstUriHandler) {
+        HedvigAppUi(
+          hedvigAppState = hedvigAppState,
+          hedvigDeepLinkContainer = hedvigDeepLinkContainer,
+          activityNavigator = activityNavigator,
+          shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale,
+          openUrl = deepLinkFirstUriHandler::openUri,
+          onOpenEmailApp = openEmailApp,
+          finishApp = finishApp,
+          market = marketManager.market.collectAsStateWithLifecycle().value,
+          imageLoader = imageLoader,
+          languageService = languageService,
+          hedvigBuildConstants = hedvigBuildConstants,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun EnableEdgeToEdgeSideEffect(
+  darkTheme: Boolean,
+  splashIsRemovedSignal: Channel<Unit>,
+  enableEdgeToEdge: (SystemBarStyle) -> Unit,
+) {
+  val splashIsRemovedIndex by produceState(0) {
+    splashIsRemovedSignal.receiveAsFlow().collectLatest { value = value + 1 }
+  }
+  DisposableEffect(darkTheme, splashIsRemovedIndex) {
+    enableEdgeToEdge(
+      when (darkTheme) {
+        true -> SystemBarStyle.dark(Color.TRANSPARENT)
+        false -> SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+      },
+    )
+    onDispose {}
+  }
+}
+
+@Composable
+private fun TryShowAppStoreReviewDialogEffect(
+  authTokenService: AuthTokenService,
+  waitUntilAppReviewDialogShouldBeOpenedUseCase: WaitUntilAppReviewDialogShouldBeOpenedUseCase,
+  tryShowAppStoreReviewDialog: () -> Unit,
+) {
+  val REVIEW_DIALOG_DELAY_MILLIS = 2000L
+  val lifecycle = LocalLifecycleOwner.current.lifecycle
+  LaunchedEffect(lifecycle) {
+    lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+      authTokenService.authStatus.first { it is AuthStatus.LoggedIn }
+      waitUntilAppReviewDialogShouldBeOpenedUseCase.invoke()
+      delay(REVIEW_DIALOG_DELAY_MILLIS)
+      tryShowAppStoreReviewDialog()
     }
   }
 }
 
 /**
- * Animates how we consume the insets, so that when we leave a screen which does not consume any insets, and we enter a
- * screen which does (by showing the bottom nav for example) then we don't want the outgoing screen to have its
- * contents snap to the bounds of the new insets immediately. This animation makes this visual effect look much more
- * fluid.
+ * Automatically logs out when we are no longer in demo mode and we are also not considered to have active tokens
  */
-@OptIn(ExperimentalLayoutApi::class)
-private fun Modifier.animatedNavigationBarInsetsConsumption(hedvigAppState: HedvigAppState) = composed {
-  val density = LocalDensity.current
-  val insetsToConsume = when (hedvigAppState.navigationSuiteType) {
-    NavigationSuiteType.NavigationBar -> WindowInsets.systemBars.only(WindowInsetsSides.Bottom).asPaddingValues(density)
-    NavigationSuiteType.NavigationRail -> WindowInsets.systemBars.union(WindowInsets.displayCutout)
-      .only(WindowInsetsSides.Left).asPaddingValues(density)
-
-    else -> PaddingValues(0.dp)
+@Composable
+private fun LogoutOnInvalidCredentialsEffect(
+  hedvigAppState: HedvigAppState,
+  authTokenService: AuthTokenService,
+  demoManager: DemoManager,
+) {
+  val authStatusLog: (AuthStatus?) -> Unit = { authStatus ->
+    logcat {
+      buildString {
+        append("Owner: LoggedInActivity | Received authStatus: ")
+        append(
+          when (authStatus) {
+            is AuthStatus.LoggedIn -> "LoggedIn"
+            AuthStatus.LoggedOut -> "LoggedOut"
+            null -> "null"
+          },
+        )
+      }
+    }
   }
-
-  val paddingValuesVectorConverter: TwoWayConverter<PaddingValues, AnimationVector4D> = TwoWayConverter(
-    convertToVector = { paddingValues ->
-      AnimationVector4D(
-        paddingValues.calculateLeftPadding(LayoutDirection.Ltr).value,
-        paddingValues.calculateRightPadding(LayoutDirection.Ltr).value,
-        paddingValues.calculateTopPadding().value,
-        paddingValues.calculateBottomPadding().value,
-      )
-    },
-    convertFromVector = { animationVector4d ->
-      val leftPadding = animationVector4d.v1
-      val rightPadding = animationVector4d.v2
-      val topPadding = animationVector4d.v3
-      val bottomPadding = animationVector4d.v4
-      PaddingValues(
-        start = leftPadding.dp,
-        end = rightPadding.dp,
-        top = topPadding.dp,
-        bottom = bottomPadding.dp,
-      )
-    },
-  )
-  val animatedInsetsToConsume: PaddingValues by animateValueAsState(
-    targetValue = insetsToConsume,
-    typeConverter = paddingValuesVectorConverter,
-    animationSpec = tween(MotionTokens.DurationMedium1.toInt()),
-    label = "Padding values inset animation",
-  )
-  consumeWindowInsets(animatedInsetsToConsume)
+  val lifecycle = LocalLifecycleOwner.current.lifecycle
+  LaunchedEffect(lifecycle, hedvigAppState, authTokenService, demoManager) {
+    val loginGraphRoute = createRoutePattern<LoginDestination>()
+    lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+      combine(
+        authTokenService.authStatus.onEach(authStatusLog).filterNotNull().distinctUntilChanged(),
+        demoManager.isDemoMode().distinctUntilChanged(),
+      ) { authStatus: AuthStatus, isDemoMode: Boolean ->
+        authStatus to isDemoMode
+      }.collect { (authStatus, isDemoMode) ->
+        val navBackStackEntry: NavBackStackEntry = hedvigAppState.navController.currentBackStackEntryFlow.first()
+        val isLoggedOut = navBackStackEntry.destination.hierarchy.any { navDestination ->
+          navDestination.route?.contains(loginGraphRoute) == true
+        }
+        if (isLoggedOut) {
+          return@collect
+        }
+        if (!isDemoMode && authStatus !is AuthStatus.LoggedIn) {
+          hedvigAppState.navigateToLoggedOut()
+        }
+      }
+    }
+  }
 }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppUi.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppUi.kt
@@ -1,0 +1,131 @@
+package com.hedvig.android.app.ui
+
+import androidx.compose.animation.core.AnimationVector4D
+import androidx.compose.animation.core.TwoWayConverter
+import androidx.compose.animation.core.animateValueAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import coil.ImageLoader
+import com.hedvig.android.app.navigation.HedvigNavHost
+import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.designsystem.material3.motion.MotionTokens
+import com.hedvig.android.language.LanguageService
+import com.hedvig.android.market.Market
+import com.hedvig.android.navigation.activity.ActivityNavigator
+import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
+
+@Composable
+internal fun HedvigAppUi(
+  hedvigAppState: HedvigAppState,
+  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
+  activityNavigator: ActivityNavigator,
+  finishApp: () -> Unit,
+  shouldShowRequestPermissionRationale: (String) -> Boolean,
+  openUrl: (String) -> Unit,
+  onOpenEmailApp: () -> Unit,
+  market: Market,
+  imageLoader: ImageLoader,
+  languageService: LanguageService,
+  hedvigBuildConstants: HedvigBuildConstants,
+) {
+  Surface(
+    color = MaterialTheme.colorScheme.background,
+    contentColor = MaterialTheme.colorScheme.onBackground,
+    modifier = Modifier.fillMaxSize(),
+  ) {
+    NavigationSuite(
+      navigationSuiteType = hedvigAppState.navigationSuiteType,
+      topLevelGraphs = hedvigAppState.topLevelGraphs.collectAsState().value,
+      topLevelGraphsWithNotifications = hedvigAppState.topLevelGraphsWithNotifications.collectAsState().value,
+      currentDestination = hedvigAppState.currentDestination,
+      onNavigateToTopLevelGraph = hedvigAppState::navigateToTopLevelGraph,
+    ) {
+      HedvigNavHost(
+        hedvigAppState = hedvigAppState,
+        hedvigDeepLinkContainer = hedvigDeepLinkContainer,
+        activityNavigator = activityNavigator,
+        finishApp = finishApp,
+        shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale,
+        openUrl = openUrl,
+        onOpenEmailApp = onOpenEmailApp,
+        imageLoader = imageLoader,
+        market = market,
+        languageService = languageService,
+        hedvigBuildConstants = hedvigBuildConstants,
+        modifier = Modifier
+          .fillMaxHeight()
+          .weight(1f)
+          .animatedNavigationBarInsetsConsumption(hedvigAppState),
+      )
+    }
+  }
+}
+
+/**
+ * Animates how we consume the insets, so that when we leave a screen which does not consume any insets, and we enter a
+ * screen which does (by showing the bottom nav for example) then we don't want the outgoing screen to have its
+ * contents snap to the bounds of the new insets immediately. This animation makes this visual effect look much more
+ * fluid.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+private fun Modifier.animatedNavigationBarInsetsConsumption(hedvigAppState: HedvigAppState) = composed {
+  val density = LocalDensity.current
+  val insetsToConsume = when (hedvigAppState.navigationSuiteType) {
+    NavigationSuiteType.NavigationBar -> WindowInsets.systemBars.only(WindowInsetsSides.Bottom).asPaddingValues(density)
+    NavigationSuiteType.NavigationRail -> WindowInsets.systemBars.union(WindowInsets.displayCutout)
+      .only(WindowInsetsSides.Left).asPaddingValues(density)
+
+    else -> PaddingValues(0.dp)
+  }
+
+  val paddingValuesVectorConverter: TwoWayConverter<PaddingValues, AnimationVector4D> = TwoWayConverter(
+    convertToVector = { paddingValues ->
+      AnimationVector4D(
+        paddingValues.calculateLeftPadding(LayoutDirection.Ltr).value,
+        paddingValues.calculateRightPadding(LayoutDirection.Ltr).value,
+        paddingValues.calculateTopPadding().value,
+        paddingValues.calculateBottomPadding().value,
+      )
+    },
+    convertFromVector = { animationVector4d ->
+      val leftPadding = animationVector4d.v1
+      val rightPadding = animationVector4d.v2
+      val topPadding = animationVector4d.v3
+      val bottomPadding = animationVector4d.v4
+      PaddingValues(
+        start = leftPadding.dp,
+        end = rightPadding.dp,
+        top = topPadding.dp,
+        bottom = bottomPadding.dp,
+      )
+    },
+  )
+  val animatedInsetsToConsume: PaddingValues by animateValueAsState(
+    targetValue = insetsToConsume,
+    typeConverter = paddingValuesVectorConverter,
+    animationSpec = tween(MotionTokens.DurationMedium1.toInt()),
+    label = "Padding values inset animation",
+  )
+  consumeWindowInsets(animatedInsetsToConsume)
+}


### PR DESCRIPTION
Moves most of the things outside of the activity so that it can serve as a place to grab the things from DI and then delegate as much as possible to composables.
Things around the splash screen and the theme applying stay there, along with the integration with the recents deep link url sharing