### PR TITLE
GEN-1994: Fix/missing payment info

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -134,11 +134,6 @@ internal fun HedvigNavHost(
       },
       openAppSettings = externalNavigator::openAppSettings,
       openUrl = openUrl,
-      openChat = { backStackEntry, chatContext ->
-        with(navigator) {
-          backStackEntry.navigate(AppDestination.Chat(chatContext))
-        }
-      },
     )
     insuranceGraph(
       nestedGraphs = {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -134,6 +134,11 @@ internal fun HedvigNavHost(
       },
       openAppSettings = externalNavigator::openAppSettings,
       openUrl = openUrl,
+      openChat = { backStackEntry, chatContext ->
+        with(navigator) {
+          backStackEntry.navigate(AppDestination.Chat(chatContext))
+        }
+      }
     )
     insuranceGraph(
       nestedGraphs = {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -138,7 +138,7 @@ internal fun HedvigNavHost(
         with(navigator) {
           backStackEntry.navigate(AppDestination.Chat(chatContext))
         }
-      }
+      },
     )
     insuranceGraph(
       nestedGraphs = {
@@ -233,6 +233,11 @@ internal fun HedvigNavHost(
       },
       openAppSettings = externalNavigator::openAppSettings,
       openUrl = openUrl,
+      openChat = { backStackEntry ->
+        with(navigator) {
+          backStackEntry.navigate(AppDestination.Chat())
+        }
+      },
     )
     chatGraph(
       hedvigDeepLinkContainer = hedvigDeepLinkContainer,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
@@ -51,7 +51,7 @@ fun NavGraphBuilder.homeGraph(
         openAppSettings = openAppSettings,
         openChat = {
           openChat(backStackEntry, null)
-        }
+        },
       )
     }
     nestedGraphs()

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.navDeepLink
 import com.hedvig.android.core.designsystem.material3.motion.MotionDefaults
 import com.hedvig.android.feature.home.home.ui.HomeDestination
 import com.hedvig.android.feature.home.home.ui.HomeViewModel
+import com.hedvig.android.navigation.core.AppDestination
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.kiwi.navigationcompose.typed.composable
 import com.kiwi.navigationcompose.typed.createRoutePattern
@@ -23,6 +24,7 @@ fun NavGraphBuilder.homeGraph(
   navigateToHelpCenter: (NavBackStackEntry) -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
+  openChat: (NavBackStackEntry, AppDestination.Chat.ChatContext?) -> Unit,
 ) {
   navigation<HomeDestination.Graph>(
     startDestination = createRoutePattern<HomeDestination.Home>(),
@@ -47,6 +49,9 @@ fun NavGraphBuilder.homeGraph(
         navigateToHelpCenter = { navigateToHelpCenter(backStackEntry) },
         openUrl = openUrl,
         openAppSettings = openAppSettings,
+        openChat = {
+          openChat(backStackEntry, null)
+        }
       )
     }
     nestedGraphs()

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
@@ -6,7 +6,6 @@ import androidx.navigation.navDeepLink
 import com.hedvig.android.core.designsystem.material3.motion.MotionDefaults
 import com.hedvig.android.feature.home.home.ui.HomeDestination
 import com.hedvig.android.feature.home.home.ui.HomeViewModel
-import com.hedvig.android.navigation.core.AppDestination
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.kiwi.navigationcompose.typed.composable
 import com.kiwi.navigationcompose.typed.createRoutePattern
@@ -24,7 +23,6 @@ fun NavGraphBuilder.homeGraph(
   navigateToHelpCenter: (NavBackStackEntry) -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
-  openChat: (NavBackStackEntry, AppDestination.Chat.ChatContext?) -> Unit,
 ) {
   navigation<HomeDestination.Graph>(
     startDestination = createRoutePattern<HomeDestination.Home>(),
@@ -49,9 +47,6 @@ fun NavGraphBuilder.homeGraph(
         navigateToHelpCenter = { navigateToHelpCenter(backStackEntry) },
         openUrl = openUrl,
         openAppSettings = openAppSettings,
-        openChat = {
-          openChat(backStackEntry, null)
-        },
       )
     }
     nestedGraphs()

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -112,7 +112,6 @@ internal fun HomeDestination(
   openUrl: (String) -> Unit,
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String) -> Unit,
-  openChat: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   val notificationPermissionState = rememberNotificationPermissionState()
@@ -128,7 +127,6 @@ internal fun HomeDestination(
     openUrl = openUrl,
     openAppSettings = openAppSettings,
     navigateToMissingInfo = navigateToMissingInfo,
-    openChat = openChat,
     markMessageAsSeen = { viewModel.emit(HomeEvent.MarkMessageAsSeen(it)) },
   )
 }
@@ -147,7 +145,6 @@ private fun HomeScreen(
   markMessageAsSeen: (String) -> Unit,
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String) -> Unit,
-  openChat: () -> Unit,
 ) {
   val context = LocalContext.current
   val systemBarInsetTopDp = with(LocalDensity.current) {
@@ -197,7 +194,7 @@ private fun HomeScreen(
             openAppSettings = openAppSettings,
             openUrl = openUrl,
             navigateToMissingInfo = navigateToMissingInfo,
-            openChat = openChat,
+            openChat = onStartChat,
             markMessageAsSeen = markMessageAsSeen,
           )
         }
@@ -545,7 +542,6 @@ private fun PreviewHomeScreen(
         openAppSettings = {},
         navigateToMissingInfo = {},
         markMessageAsSeen = {},
-        openChat = {},
       )
     }
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavBackStackEntry
 import arrow.core.nonEmptyListOf
 import com.google.accompanist.permissions.isGranted
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
@@ -73,6 +74,7 @@ import com.hedvig.android.feature.home.home.data.HomeData
 import com.hedvig.android.memberreminders.MemberReminder
 import com.hedvig.android.memberreminders.MemberReminders
 import com.hedvig.android.memberreminders.ui.MemberReminderCardsWithoutNotification
+import com.hedvig.android.navigation.core.AppDestination
 import com.hedvig.android.notification.permission.NotificationPermissionDialog
 import com.hedvig.android.notification.permission.NotificationPermissionState
 import com.hedvig.android.notification.permission.rememberNotificationPermissionState
@@ -105,6 +107,7 @@ internal fun HomeDestination(
   openUrl: (String) -> Unit,
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String) -> Unit,
+  openChat: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   val notificationPermissionState = rememberNotificationPermissionState()
@@ -120,6 +123,7 @@ internal fun HomeDestination(
     openUrl = openUrl,
     openAppSettings = openAppSettings,
     navigateToMissingInfo = navigateToMissingInfo,
+    openChat = openChat
   )
 }
 
@@ -136,6 +140,7 @@ private fun HomeScreen(
   openUrl: (String) -> Unit,
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String) -> Unit,
+  openChat: () -> Unit,
 ) {
   val context = LocalContext.current
   val systemBarInsetTopDp = with(LocalDensity.current) {
@@ -185,6 +190,7 @@ private fun HomeScreen(
             openAppSettings = openAppSettings,
             openUrl = openUrl,
             navigateToMissingInfo = navigateToMissingInfo,
+            openChat = openChat
           )
         }
       }
@@ -245,6 +251,7 @@ private fun HomeScreenSuccess(
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
   navigateToMissingInfo: (String) -> Unit,
+  openChat: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   var fullScreenSize: IntSize? by remember { mutableStateOf(null) }
@@ -305,6 +312,7 @@ private fun HomeScreenSuccess(
             memberReminders = memberReminders,
             navigateToConnectPayment = navigateToConnectPayment,
             navigateToAddMissingInfo = navigateToMissingInfo,
+            openChat = openChat,
             openUrl = openUrl,
             contentPadding = PaddingValues(horizontal = 16.dp) + WindowInsets.safeDrawing
               .exclude(consumedWindowInsets)
@@ -439,7 +447,7 @@ private fun PreviewHomeScreen(
           ),
           veryImportantMessages = persistentListOf(HomeData.VeryImportantMessage("id", "Beware of the earthquake", "")),
           memberReminders = MemberReminders(
-            connectPayment = MemberReminder.ConnectPayment(),
+            connectPayment = MemberReminder.PaymentReminder.ConnectPayment(),
           ),
           isHelpCenterEnabled = true,
           showChatIcon = true,
@@ -455,6 +463,7 @@ private fun PreviewHomeScreen(
         openUrl = {},
         openAppSettings = {},
         navigateToMissingInfo = {},
+        openChat = {}
       )
     }
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavBackStackEntry
 import arrow.core.nonEmptyListOf
 import com.google.accompanist.permissions.isGranted
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
@@ -74,7 +73,6 @@ import com.hedvig.android.feature.home.home.data.HomeData
 import com.hedvig.android.memberreminders.MemberReminder
 import com.hedvig.android.memberreminders.MemberReminders
 import com.hedvig.android.memberreminders.ui.MemberReminderCardsWithoutNotification
-import com.hedvig.android.navigation.core.AppDestination
 import com.hedvig.android.notification.permission.NotificationPermissionDialog
 import com.hedvig.android.notification.permission.NotificationPermissionState
 import com.hedvig.android.notification.permission.rememberNotificationPermissionState
@@ -123,7 +121,7 @@ internal fun HomeDestination(
     openUrl = openUrl,
     openAppSettings = openAppSettings,
     navigateToMissingInfo = navigateToMissingInfo,
-    openChat = openChat
+    openChat = openChat,
   )
 }
 
@@ -190,7 +188,7 @@ private fun HomeScreen(
             openAppSettings = openAppSettings,
             openUrl = openUrl,
             navigateToMissingInfo = navigateToMissingInfo,
-            openChat = openChat
+            openChat = openChat,
           )
         }
       }
@@ -463,7 +461,7 @@ private fun PreviewHomeScreen(
         openUrl = {},
         openAppSettings = {},
         navigateToMissingInfo = {},
-        openChat = {}
+        openChat = {},
       )
     }
   }

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
@@ -85,7 +85,7 @@ internal class GetHomeUseCaseTest {
 
     testGetMemberRemindersUseCase.memberReminders.add(
       MemberReminders(
-        MemberReminder.ConnectPayment(id = testId),
+        MemberReminder.PaymentReminder.ConnectPayment(id = testId),
         listOf(MemberReminder.UpcomingRenewal("", LocalDate.parse("2023-01-01"), "", testId)),
         MemberReminder.EnableNotifications(id = testId),
       ),
@@ -98,7 +98,7 @@ internal class GetHomeUseCaseTest {
       .prop(HomeData::memberReminders)
       .isEqualTo(
         MemberReminders(
-          MemberReminder.ConnectPayment(id = testId),
+          MemberReminder.PaymentReminder.ConnectPayment(id = testId),
           listOf(MemberReminder.UpcomingRenewal("", LocalDate.parse("2023-01-01"), "", testId)),
           MemberReminder.EnableNotifications(id = testId),
         ),

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
@@ -83,6 +83,7 @@ internal fun ProfileDestination(
   navigateToAddMissingInfo: (contractId: String) -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
+  openChat: () -> Unit,
   viewModel: ProfileViewModel,
 ) {
   val uiState by viewModel.data.collectAsStateWithLifecycle()
@@ -100,6 +101,7 @@ internal fun ProfileDestination(
     openUrl = openUrl,
     snoozeNotificationPermission = viewModel::snoozeNotificationPermission,
     onLogout = viewModel::onLogout,
+    openChat = openChat,
   )
 }
 
@@ -116,6 +118,7 @@ private fun ProfileScreen(
   navigateToAddMissingInfo: (contractId: String) -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
+  openChat: () -> Unit,
   snoozeNotificationPermission: () -> Unit,
   onLogout: () -> Unit,
 ) {
@@ -187,6 +190,7 @@ private fun ProfileScreen(
           .exclude(consumedWindowInsets)
           .only(WindowInsetsSides.Horizontal)
           .asPaddingValues(),
+        openChat = openChat,
         modifier = Modifier.onConsumedWindowInsetsChanged { consumedWindowInsets = it },
       )
       if (memberReminders.isNotEmpty()) {
@@ -303,6 +307,7 @@ private fun PreviewProfileSuccessScreen() {
         navigateToAddMissingInfo = {},
         openAppSettings = {},
         openUrl = {},
+        openChat = {},
         snoozeNotificationPermission = {},
       ) {}
     }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
@@ -71,6 +71,7 @@ fun NavGraphBuilder.profileGraph(
         openAppSettings = openAppSettings,
         openUrl = openUrl,
         viewModel = viewModel,
+        openChat = openChat
       )
     }
     composable<ProfileDestinations.Eurobonus>(

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
@@ -35,6 +35,7 @@ fun NavGraphBuilder.profileGraph(
   navigateToAddMissingInfo: (navBackStackEntry: NavBackStackEntry, contractId: String) -> Unit,
   navigateToDeleteAccountFeature: (navBackStackEntry: NavBackStackEntry) -> Unit,
   openAppSettings: () -> Unit,
+  openChat: (navBackStackEntry: NavBackStackEntry) -> Unit,
   openUrl: (String) -> Unit,
 ) {
   navigation<ProfileDestination.Graph>(
@@ -71,7 +72,9 @@ fun NavGraphBuilder.profileGraph(
         openAppSettings = openAppSettings,
         openUrl = openUrl,
         viewModel = viewModel,
-        openChat = openChat
+        openChat = {
+          openChat(backStackEntry)
+        },
       )
     }
     composable<ProfileDestinations.Eurobonus>(

--- a/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModelTest.kt
+++ b/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModelTest.kt
@@ -285,8 +285,11 @@ class ProfileViewModelTest {
           showPaymentScreen = true,
         ),
       )
-      getMemberRemindersUseCase.memberReminders.add(MemberReminders(
-        connectPayment = MemberReminder.PaymentReminder.ConnectPayment()))
+      getMemberRemindersUseCase.memberReminders.add(
+        MemberReminders(
+          connectPayment = MemberReminder.PaymentReminder.ConnectPayment(),
+        ),
+      )
       runCurrent()
       val connectPayment = (viewModel.data.value as ProfileUiState.Success).memberReminders.connectPayment
       assertThat(connectPayment).isNotNull()
@@ -413,7 +416,9 @@ class ProfileViewModelTest {
           euroBonus = EuroBonus("abc"),
           travelCertificateAvailable = true,
           showPaymentScreen = true,
-          memberReminders = MemberReminders(connectPayment = MemberReminder.PaymentReminder.ConnectPayment(id = testId)),
+          memberReminders = MemberReminders(
+            connectPayment = MemberReminder.PaymentReminder.ConnectPayment(id = testId),
+          ),
         ),
       )
       cancelAndIgnoreRemainingEvents()

--- a/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModelTest.kt
+++ b/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModelTest.kt
@@ -285,7 +285,8 @@ class ProfileViewModelTest {
           showPaymentScreen = true,
         ),
       )
-      getMemberRemindersUseCase.memberReminders.add(MemberReminders(connectPayment = MemberReminder.ConnectPayment()))
+      getMemberRemindersUseCase.memberReminders.add(MemberReminders(
+        connectPayment = MemberReminder.PaymentReminder.ConnectPayment()))
       runCurrent()
       val connectPayment = (viewModel.data.value as ProfileUiState.Success).memberReminders.connectPayment
       assertThat(connectPayment).isNotNull()
@@ -348,7 +349,7 @@ class ProfileViewModelTest {
 
       getMemberRemindersUseCase.memberReminders.add(
         MemberReminders(
-          connectPayment = MemberReminder.ConnectPayment(),
+          connectPayment = MemberReminder.PaymentReminder.ConnectPayment(),
           enableNotifications = MemberReminder.EnableNotifications(),
         ),
       )
@@ -404,7 +405,7 @@ class ProfileViewModelTest {
       travelCertificateAvailabilityUseCase.apply { turbine.add(Unit.right()) }
       featureManager.featureTurbine.add(Feature.PAYMENT_SCREEN to true)
       getMemberRemindersUseCase.memberReminders.add(
-        MemberReminders(connectPayment = MemberReminder.ConnectPayment(id = testId)),
+        MemberReminders(connectPayment = MemberReminder.PaymentReminder.ConnectPayment(id = testId)),
       )
       runCurrent()
       assertThat(viewModel.data.value).isEqualTo(
@@ -412,7 +413,7 @@ class ProfileViewModelTest {
           euroBonus = EuroBonus("abc"),
           travelCertificateAvailable = true,
           showPaymentScreen = true,
-          memberReminders = MemberReminders(connectPayment = MemberReminder.ConnectPayment(id = testId)),
+          memberReminders = MemberReminders(connectPayment = MemberReminder.PaymentReminder.ConnectPayment(id = testId)),
         ),
       )
       cancelAndIgnoreRemainingEvents()

--- a/app/member-reminders/member-reminders-public/src/main/graphql/QueryGetPayinMethodStatus.graphql
+++ b/app/member-reminders/member-reminders-public/src/main/graphql/QueryGetPayinMethodStatus.graphql
@@ -3,5 +3,10 @@ query GetPayinMethodStatus {
     paymentInformation {
       status
     }
+    activeContracts {
+      terminationDate
+      terminationDueToMissedPayments
+      id
+    }
   }
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
@@ -55,6 +55,6 @@ sealed interface ConnectPaymentReminderError {
 
 sealed interface PaymentReminder {
   data object ShowConnectPaymentReminder : PaymentReminder
+
   data class ShowMissingPaymentsReminder(val terminationDate: LocalDate) : PaymentReminder
 }
-

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
@@ -26,12 +26,12 @@ internal class GetConnectPaymentReminderUseCaseImpl(
         .toEither(::ErrorMessage)
         .mapLeft(ConnectPaymentReminderError::NetworkError)
         .bind()
-      val missingPayments = result.currentMember.activeContracts
+      val missingPaymentsContractTerminationDate = result.currentMember.activeContracts
         .filter { it.terminationDueToMissedPayments }
         .sortedBy { it.terminationDate }
         .firstOrNull()?.terminationDate
-      if (missingPayments != null) {
-        PaymentReminder.ShowMissingPaymentsReminder(missingPayments)
+      if (missingPaymentsContractTerminationDate != null) {
+        PaymentReminder.ShowMissingPaymentsReminder(missingPaymentsContractTerminationDate)
       } else {
         val payStatus = result.currentMember.paymentInformation.status
         ensure(payStatus == MemberPaymentConnectionStatus.NEEDS_SETUP) {

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
@@ -32,14 +32,13 @@ internal class GetConnectPaymentReminderUseCaseImpl(
         .firstOrNull()
         ?.terminationDate
       if (missingPaymentsContractTerminationDate != null) {
-        PaymentReminder.ShowMissingPaymentsReminder(missingPaymentsContractTerminationDate)
-      } else {
-        val payStatus = result.currentMember.paymentInformation.status
-        ensure(payStatus == MemberPaymentConnectionStatus.NEEDS_SETUP) {
-          ConnectPaymentReminderError.AlreadySetup
-        }
-        PaymentReminder.ShowConnectPaymentReminder
+        return@either PaymentReminder.ShowMissingPaymentsReminder(missingPaymentsContractTerminationDate)
       }
+      val payStatus = result.currentMember.paymentInformation.status
+      ensure(payStatus == MemberPaymentConnectionStatus.NEEDS_SETUP) {
+        ConnectPaymentReminderError.AlreadySetup
+      }
+      PaymentReminder.ShowConnectPaymentReminder
     }.onLeft {
       logcat { "GetConnectPaymentReminderUseCase failed with error:$it" }
     }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
@@ -29,7 +29,8 @@ internal class GetConnectPaymentReminderUseCaseImpl(
       val missingPaymentsContractTerminationDate = result.currentMember.activeContracts
         .filter { it.terminationDueToMissedPayments }
         .sortedBy { it.terminationDate }
-        .firstOrNull()?.terminationDate
+        .firstOrNull()
+        ?.terminationDate
       if (missingPaymentsContractTerminationDate != null) {
         PaymentReminder.ShowMissingPaymentsReminder(missingPaymentsContractTerminationDate)
       } else {

--- a/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCaseTest.kt
+++ b/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCaseTest.kt
@@ -68,7 +68,7 @@ class GetMemberRemindersUseCaseTest {
     getMemberRemindersUseCase.invoke().test {
       expectNoEvents()
       enableNotificationsReminderManager.showNotification.add(true)
-      getConnectPaymentReminderUseCase.turbine.add(ShowConnectPaymentReminder.right())
+      getConnectPaymentReminderUseCase.turbine.add(PaymentReminder.ShowConnectPaymentReminder.right())
       getUpcomingRenewalRemindersUseCase.turbine.add(
         nonEmptyListOf(UpcomingRenewal("", LocalDate.parse("2023-01-01"), "", testId)).right(),
       )
@@ -91,9 +91,9 @@ class GetMemberRemindersUseCaseTest {
   }
 
   class TestGetConnectPaymentReminderUseCase : GetConnectPaymentReminderUseCase {
-    val turbine = Turbine<Either<ConnectPaymentReminderError, ShowConnectPaymentReminder>>()
+    val turbine = Turbine<Either<ConnectPaymentReminderError, PaymentReminder.ShowConnectPaymentReminder>>()
 
-    override suspend fun invoke(): Either<ConnectPaymentReminderError, ShowConnectPaymentReminder> {
+    override suspend fun invoke(): Either<ConnectPaymentReminderError, PaymentReminder.ShowConnectPaymentReminder> {
       return turbine.awaitItem()
     }
   }

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
@@ -70,7 +70,7 @@ fun MemberReminderCards(
   openUrl: (String) -> Unit,
   navigateToAddMissingInfo: (String) -> Unit,
   snoozeNotificationPermissionReminder: () -> Unit,
-  openChat: () -> Unit, //todo!!!
+  openChat: () -> Unit,
   notificationPermissionState: NotificationPermissionState?,
   contentPadding: PaddingValues,
   modifier: Modifier = Modifier,
@@ -82,6 +82,7 @@ fun MemberReminderCards(
         navigateToAddMissingInfo = navigateToAddMissingInfo,
         navigateToConnectPayment = navigateToConnectPayment,
         openUrl = openUrl,
+        openChat = openChat,
         snoozeNotificationPermissionReminder = snoozeNotificationPermissionReminder,
         notificationPermissionState = notificationPermissionState,
         modifier = modifier.padding(contentPadding),
@@ -103,6 +104,7 @@ fun MemberReminderCards(
           navigateToAddMissingInfo = navigateToAddMissingInfo,
           navigateToConnectPayment = navigateToConnectPayment,
           openUrl = openUrl,
+          openChat = openChat,
           snoozeNotificationPermissionReminder = snoozeNotificationPermissionReminder,
           notificationPermissionState = notificationPermissionState,
           modifier = modifier.fillMaxWidth(),
@@ -130,6 +132,7 @@ private fun ColumnScope.MemberReminderCard(
   navigateToConnectPayment: () -> Unit,
   openUrl: (String) -> Unit,
   snoozeNotificationPermissionReminder: () -> Unit,
+  openChat: () -> Unit,
   notificationPermissionState: NotificationPermissionState?,
   modifier: Modifier = Modifier,
 ) {
@@ -146,7 +149,11 @@ private fun ColumnScope.MemberReminderCard(
       modifier = modifier,
     )
 
-    is MemberReminder.PaymentReminder.TerminationDueToMissedPayments -> TODO()
+    is MemberReminder.PaymentReminder.TerminationDueToMissedPayments -> ReminderCardMissingPayment(
+      terminationDate = memberReminder.terminationDate,
+      openChat = openChat,
+      modifier = modifier,
+    )
 
     is MemberReminder.UpcomingRenewal -> ReminderCardUpcomingRenewals(
       upcomingRenewal = memberReminder,
@@ -217,6 +224,24 @@ private fun ReminderCardConnectPayment(navigateToConnectPayment: () -> Unit, mod
     InfoCardTextButton(
       onClick = navigateToConnectPayment,
       text = stringResource(R.string.PROFILE_PAYMENT_CONNECT_DIRECT_DEBIT_BUTTON),
+      modifier = Modifier.fillMaxWidth(),
+    )
+  }
+}
+
+@Composable
+private fun ReminderCardMissingPayment(
+  terminationDate: LocalDate,
+  openChat: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  VectorWarningCard(
+    text = stringResource(R.string.info_card_missing_payment_missing_payments_body, terminationDate),
+    modifier = modifier,
+  ) {
+    InfoCardTextButton(
+      onClick = openChat,
+      text = stringResource(R.string.open_chat),
       modifier = Modifier.fillMaxWidth(),
     )
   }

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
@@ -46,6 +46,7 @@ fun MemberReminderCardsWithoutNotification(
   navigateToConnectPayment: () -> Unit,
   openUrl: (String) -> Unit,
   navigateToAddMissingInfo: (String) -> Unit,
+  openChat: () -> Unit,
   contentPadding: PaddingValues,
   modifier: Modifier = Modifier,
 ) {
@@ -54,6 +55,7 @@ fun MemberReminderCardsWithoutNotification(
     navigateToConnectPayment = navigateToConnectPayment,
     openUrl = openUrl,
     navigateToAddMissingInfo = navigateToAddMissingInfo,
+    openChat = openChat,
     snoozeNotificationPermissionReminder = {},
     notificationPermissionState = null,
     contentPadding = contentPadding,
@@ -68,6 +70,7 @@ fun MemberReminderCards(
   openUrl: (String) -> Unit,
   navigateToAddMissingInfo: (String) -> Unit,
   snoozeNotificationPermissionReminder: () -> Unit,
+  openChat: () -> Unit, //todo!!!
   notificationPermissionState: NotificationPermissionState?,
   contentPadding: PaddingValues,
   modifier: Modifier = Modifier,
@@ -138,10 +141,12 @@ private fun ColumnScope.MemberReminderCard(
       modifier = modifier,
     )
 
-    is MemberReminder.ConnectPayment -> ReminderCardConnectPayment(
+    is MemberReminder.PaymentReminder.ConnectPayment -> ReminderCardConnectPayment(
       navigateToConnectPayment = navigateToConnectPayment,
       modifier = modifier,
     )
+
+    is MemberReminder.PaymentReminder.TerminationDueToMissedPayments -> TODO()
 
     is MemberReminder.UpcomingRenewal -> ReminderCardUpcomingRenewals(
       upcomingRenewal = memberReminder,


### PR DESCRIPTION
Fix wrong reminder (we showed 'connect payment' when there were missed payments causing member's  insurance to be cancelled soon)
[description in the ticket](https://www.notion.so/hedviginsurance/Connect-payment-banner-text-when-we-have-missed-payments-2b2316d35ab34dcea505aea7fb07bcbd)