### PR TITLE
show net amount instead of gross

### DIFF
--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/PreviewData.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/PreviewData.kt
@@ -209,7 +209,7 @@ internal val chargeHistoryPreviewData = listOf(
 
 internal val paymentOverViewPreviewData = PaymentOverview(
   memberChargeShortInfo = MemberChargeShortInfo(
-    grossAmount = UiMoney(200.0, CurrencyCode.SEK),
+    netAmount = UiMoney(200.0, CurrencyCode.SEK),
     id = "123",
     status = MemberCharge.MemberChargeStatus.FAILED,
     dueDate = LocalDate.fromEpochDays(400),

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentOverview.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentOverview.kt
@@ -12,7 +12,7 @@ internal data class PaymentOverview(
 
 @Serializable
 internal data class MemberChargeShortInfo(
-  val grossAmount: UiMoney,
+  val netAmount: UiMoney,
   val dueDate: LocalDate,
   val id: String,
   val status: MemberCharge.MemberChargeStatus,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
@@ -70,7 +70,7 @@ internal data class GetUpcomingPaymentUseCaseImpl(
 
 private fun MemberChargeFragment.toMemberChargeShortInfo() = MemberChargeShortInfo(
   id = id ?: "",
-  grossAmount = UiMoney.fromMoneyFragment(gross),
+  netAmount = UiMoney.fromMoneyFragment(net),
   dueDate = date,
   failedCharge = toFailedCharge(),
   status = when (status) {
@@ -88,7 +88,7 @@ internal class GetUpcomingPaymentUseCaseDemo(
   override suspend fun invoke(): Either<ErrorMessage, PaymentOverview> {
     return PaymentOverview(
       MemberChargeShortInfo(
-        grossAmount = UiMoney(100.0, CurrencyCode.SEK),
+        netAmount = UiMoney(100.0, CurrencyCode.SEK),
         id = "id",
         status = MemberCharge.MemberChargeStatus.SUCCESS,
         dueDate = (clock.now() + 10.days).toLocalDateTime(TimeZone.UTC).date,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/payments/PaymentsDestination.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/payments/PaymentsDestination.kt
@@ -374,7 +374,7 @@ private fun PaymentAmountCard(
             verticalAlignment = Alignment.CenterVertically,
           ) {
             Text(
-              text = upcomingPayment.grossAmount.toString(),
+              text = upcomingPayment.netAmount.toString(),
               textAlign = TextAlign.End,
             )
             Spacer(Modifier.width(8.dp))

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/payments/PaymentsPresenter.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/payments/PaymentsPresenter.kt
@@ -46,7 +46,7 @@ internal class PaymentsPresenter(
             isLoading = false,
             upcomingPayment = paymentOverview.memberChargeShortInfo?.let { memberCharge ->
               PaymentsUiState.Content.UpcomingPayment(
-                grossAmount = memberCharge.grossAmount,
+                netAmount = memberCharge.netAmount,
                 dueDate = memberCharge.dueDate,
                 id = memberCharge.id,
               )
@@ -100,7 +100,7 @@ internal sealed interface PaymentsUiState {
     val connectedPaymentInfo: ConnectedPaymentInfo,
   ) : PaymentsUiState {
     data class UpcomingPayment(
-      val grossAmount: UiMoney,
+      val netAmount: UiMoney,
       val dueDate: LocalDate,
       val id: String,
     )


### PR DESCRIPTION
Use "net" amount for upcoming payment info section on Payments screen instead of gross (that's how it's done on iOs too).