### PR TITLE
Stylianos/termination pr changes

### DIFF
--- a/app/apollo/apollo-octopus-public/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/termination/FragmentTerminationFlowStepFragment.graphql
+++ b/app/apollo/apollo-octopus-public/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/termination/FragmentTerminationFlowStepFragment.graphql
@@ -17,19 +17,22 @@ fragment FlowTerminationSurveyStepFragment on FlowTerminationSurveyStep {
 }
 
 fragment FlowTerminationSurveyOptionFragment on FlowTerminationSurveyOption {
+  id
+  title
+  suggestion {
+    ...FlowTerminationSurveyOptionSuggestionFragment
+  }
+  feedBack {
+    ... on FlowTerminationSurveyOptionFeedback {
+      id
+      isRequired
+    }
+  }
+  subOptions {
     id
     title
     suggestion {
-      ... on FlowTerminationSurveyOptionSuggestionAction {
-        id
-        action
-      }
-      ... on FlowTerminationSurveyOptionSuggestionRedirect {
-        buttonTitle
-        description
-        id
-        url
-      }
+      ...FlowTerminationSurveyOptionSuggestionFragment
     }
     feedBack {
       ... on FlowTerminationSurveyOptionFeedback {
@@ -37,28 +40,20 @@ fragment FlowTerminationSurveyOptionFragment on FlowTerminationSurveyOption {
         isRequired
       }
     }
-    subOptions {
-      id
-      title
-      suggestion {
-         ... on FlowTerminationSurveyOptionSuggestionAction {
-           id
-           action
-           }
-         ... on FlowTerminationSurveyOptionSuggestionRedirect {
-           buttonTitle
-           description
-           id
-           url
-           }
-      }
-      feedBack {
-      ... on FlowTerminationSurveyOptionFeedback {
-         id
-         isRequired
-         }
-      }
-    }
+  }
+}
+
+fragment FlowTerminationSurveyOptionSuggestionFragment on FlowTerminationSurveyOptionSuggestion {
+  ... on FlowTerminationSurveyOptionSuggestionAction {
+    id
+    action
+  }
+  ... on FlowTerminationSurveyOptionSuggestionRedirect {
+    buttonTitle
+    description
+    id
+    url
+  }
 }
 
 fragment FlowTerminationDateStepFragment on FlowTerminationDateStep {

--- a/app/feature/feature-help-center/build.gradle.kts
+++ b/app/feature/feature-help-center/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 dependencies {
   apolloMetadata(projects.apolloOctopusPublic)
 
-  implementation(project(":placeholder"))
   implementation(libs.androidx.compose.material3)
   implementation(libs.androidx.lifecycle.compose)
   implementation(libs.apollo.normalizedCache)
@@ -43,6 +42,7 @@ dependencies {
   implementation(projects.moleculePublic)
   implementation(projects.navigationComposeTyped)
   implementation(projects.navigationCore)
+  implementation(projects.placeholder)
   implementation(projects.uiEmergency)
 }
 

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceStep.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceStep.kt
@@ -5,7 +5,11 @@ import com.hedvig.android.feature.terminateinsurance.navigation.TerminationGraph
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import kotlinx.datetime.LocalDate
+import octopus.fragment.FlowTerminationSurveyOptionSuggestionActionFlowTerminationSurveyOptionSuggestionFragment
+import octopus.fragment.FlowTerminationSurveyOptionSuggestionFragment
+import octopus.fragment.FlowTerminationSurveyOptionSuggestionRedirectFlowTerminationSurveyOptionSuggestionFragment
 import octopus.fragment.TerminationFlowStepFragment
+import octopus.type.FlowTerminationSurveyRedirectAction
 
 internal sealed interface TerminateInsuranceStep {
   data class TerminateInsuranceDate(
@@ -87,14 +91,10 @@ private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentSte
   }
 }
 
-// todo: duplicate functions here
-private fun TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option.Suggestion.toSuggestion(): SurveyOptionSuggestion? {
+private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): SurveyOptionSuggestion? {
   return when (this) {
-    is TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep
-      .Option.FlowTerminationSurveyOptionSuggestionActionSuggestion,
-    -> {
-      val action = this.action.rawValue
-      if (action == "UPDATE_ADDRESS") {
+    is FlowTerminationSurveyOptionSuggestionActionFlowTerminationSurveyOptionSuggestionFragment -> {
+      if (action == FlowTerminationSurveyRedirectAction.UPDATE_ADDRESS) {
         SurveyOptionSuggestion.Action.UpdateAddress
       } else {
         logcat(
@@ -105,46 +105,7 @@ private fun TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Opt
       }
     }
 
-    is TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep
-      .Option.FlowTerminationSurveyOptionSuggestionRedirectSuggestion,
-    -> {
-      SurveyOptionSuggestion.Redirect(
-        buttonTitle = this.buttonTitle,
-        description = this.description,
-        url = this.url,
-      )
-    }
-
-    else -> {
-      logcat(
-        LogPriority.WARN,
-        message = { "FlowTerminationSurveyStepCurrentStep unknown suggestion type: $this" },
-      )
-      null
-    }
-  }
-}
-
-private fun TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option.SubOption.Suggestion.toSuggestion(): SurveyOptionSuggestion? {
-  return when (this) {
-    is TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep
-      .Option.FlowTerminationSurveyOptionSuggestionActionSuggestion,
-    -> {
-      val action = this.action.rawValue
-      if (action == "UPDATE_ADDRESS") {
-        SurveyOptionSuggestion.Action.UpdateAddress
-      } else {
-        logcat(
-          LogPriority.WARN,
-          message = { "FlowTerminationSurveyStepCurrentStep unknown suggestion type: ${this.action.rawValue}" },
-        )
-        null
-      }
-    }
-
-    is TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep
-      .Option.FlowTerminationSurveyOptionSuggestionRedirectSuggestion,
-    -> {
+    is FlowTerminationSurveyOptionSuggestionRedirectFlowTerminationSurveyOptionSuggestionFragment -> {
       SurveyOptionSuggestion.Redirect(
         buttonTitle = this.buttonTitle,
         description = this.description,

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
@@ -541,26 +542,12 @@ private class ShowSurveyUiStateProvider :
         selectedOption = previewReason3.surveyOption,
         reasons = listOf(previewReason1, previewReason2, previewReason3),
       ),
-//      TerminationSurveyState(
-//          nextNavigationStep = null,
-//          isNavigationStepLoading = true,
-//          feedbackEmptyWarning = false,
-//          selectedOption = previewReason2.surveyOption,
-//          reasons = listOf(previewReason1, previewReason2filled, previewReason3),
-//      ),
-      //      TerminationSurveyState(
-//          nextNavigationStep = null,
-//          isNavigationStepLoading = false,
-//          feedbackEmptyWarning = false,
-//          selectedOption = null,
-//          reasons = listOf(previewReason1, previewReason2filled, previewReason3),
-//      ),
       TerminationSurveyState(
         nextNavigationStep = null,
         navigationStepLoadingForReason = null,
         errorWhileLoadingNextStep = true,
         selectedOption = previewReason2.surveyOption,
-        reasons = listOf(previewReason1, previewReason2filled, previewReason3),
+        reasons = listOf(previewReason1, previewReason2, previewReason3),
       ),
     ),
   )
@@ -611,7 +598,7 @@ private val previewReason2 = TerminationReason(
     feedBackRequired = true,
     listIndex = 1,
   ),
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec nisi eget mi luctus suscipit. Donec at vestibulum turpis.",
+  feedBack = LoremIpsum(25).values.first(),
 )
 
 private val previewReason2filled = TerminationReason(

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -280,14 +280,14 @@ private fun TerminationSurveyScreen(
                       verticalAlignment = Alignment.Top,
                       modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = 16.dp, top = 10.dp, end = 16.dp),
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
                     ) {
                       Text(
                         overflow = TextOverflow.Ellipsis,
                         text = feedback ?: stringResource(id = R.string.TERMINATION_SURVEY_FEEDBACK_HINT),
                         style = MaterialTheme.typography.bodyLarge,
                         color = if (feedback != null) {
-                          MaterialTheme.typography.bodyLarge.color
+                          MaterialTheme.colorScheme.secondary
                         } else {
                           MaterialTheme.colorScheme.onSurfaceVariant
                         },
@@ -492,7 +492,6 @@ private fun FeedbackEditableText(
         ),
       )
     }
-    Spacer(modifier = Modifier.height(8.dp))
   }
 }
 

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyViewModel.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyViewModel.kt
@@ -152,8 +152,8 @@ internal data class TerminationSurveyState(
   val showFullScreenEditText: TerminationReason? = null,
   val selectedOption: TerminationSurveyOption? = null,
   val nextNavigationStep: SurveyNavigationStep? = null,
-  val navigationStepLoadingForReason: TerminationReason? = null,
   // this one is not Boolean entirely for the sake of more convenient testing
+  val navigationStepLoadingForReason: TerminationReason? = null,
   val errorWhileLoadingNextStep: Boolean = false,
 ) {
   val continueAllowed: Boolean = selectedOption != null

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationreview/TerminationConfirmationViewModel.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationreview/TerminationConfirmationViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.hedvig.android.feature.terminateinsurance.data.TerminateInsuranceRepository
 import com.hedvig.android.feature.terminateinsurance.data.TerminateInsuranceStep
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceDestination
-import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,8 +28,6 @@ internal class TerminationConfirmationViewModel(
   fun submitContractTermination() {
     _uiState.update { it.copy(isSubmittingContractTermination = true) }
     viewModelScope.launch {
-      // Make the success response take at least 3 seconds as per the design
-      val minimumTimeDelay = async { delay(3000) }
       when (terminationType) {
         TerminateInsuranceDestination.TerminationConfirmation.TerminationType.Deletion -> {
           terminateInsuranceRepository.confirmDeletion()
@@ -42,7 +38,6 @@ internal class TerminationConfirmationViewModel(
         }
       }.fold(
         ifLeft = { errorMessage ->
-          minimumTimeDelay.cancel()
           _uiState.update {
             it.copy(
               isSubmittingContractTermination = false,
@@ -51,7 +46,6 @@ internal class TerminationConfirmationViewModel(
           }
         },
         ifRight = { terminateInsuranceFlowStep ->
-          minimumTimeDelay.await()
           _uiState.update {
             it.copy(
               isSubmittingContractTermination = false,

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationInfoCard.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationInfoCard.kt
@@ -85,7 +85,6 @@ internal fun TerminationInfoCardDate(
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Spacer(modifier = Modifier.height(4.dp))
             Text(
               text = dateValue ?: stringResource(R.string.TERMINATION_FLOW_DATE_FIELD_PLACEHOLDER),
               style = MaterialTheme.typography.bodyLarge,

--- a/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyPresenterTest.kt
+++ b/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyPresenterTest.kt
@@ -73,7 +73,7 @@ class TerminationSurveyPresenterTest {
     presenter.test(initialState = TerminationSurveyState()) {
       assertThat(awaitItem().reasons.map { it.surveyOption }).isEqualTo(listOfOptionsForHome)
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[3]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.ShowFullScreenEditText(listOfOptionsForHome[3]))
       assertThat(awaitItem().showFullScreenEditText?.surveyOption).isEqualTo(listOfOptionsForHome[3])
     }
@@ -87,9 +87,9 @@ class TerminationSurveyPresenterTest {
       repository,
     )
     presenter.test(initialState = TerminationSurveyState()) {
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[3]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.ShowFullScreenEditText(listOfOptionsForHome[3]))
       assertThat(awaitItem().showFullScreenEditText).isNotNull()
       sendEvent(TerminationSurveyEvent.CloseFullScreenEditText)
@@ -117,15 +117,15 @@ class TerminationSurveyPresenterTest {
       repository,
     )
     presenter.test(initialState = TerminationSurveyState()) {
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[3]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.ChangeFeedbackForSelectedReason("new feedback!"))
       assertThat(
         awaitItem().reasons.first { it.surveyOption == listOfOptionsForHome[3] }.feedBack,
       ).isEqualTo("new feedback!")
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[2]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.ChangeFeedbackForSelectedReason("new feedback22!"))
       assertThat(
         awaitItem().reasons.first {
@@ -147,11 +147,11 @@ class TerminationSurveyPresenterTest {
       LocalDate(2024, 6, 29),
     )
     presenter.test(initialState = TerminationSurveyState()) {
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[3]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.ChangeFeedbackForSelectedReason("entirely new feedback"))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.Continue)
       assertThat(
         awaitItem().navigationStepLoadingForReason,
@@ -172,11 +172,11 @@ class TerminationSurveyPresenterTest {
       LocalDate(2024, 6, 29),
     )
     presenter.test(initialState = TerminationSurveyState()) {
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[3]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.Continue)
-      awaitItem()
+      skipItems(1)
       repository.terminationFlowTurbine.add(nextStep.right())
       assertThat(awaitItem().nextNavigationStep).isEqualTo(SurveyNavigationStep.NavigateToNextTerminationStep(nextStep))
     }
@@ -190,9 +190,9 @@ class TerminationSurveyPresenterTest {
       repository,
     )
     presenter.test(initialState = TerminationSurveyState()) {
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.SelectOption(listOfOptionsForHome[1]))
-      awaitItem()
+      skipItems(1)
       sendEvent(TerminationSurveyEvent.Continue)
       assertThat(awaitItem().nextNavigationStep).isEqualTo(SurveyNavigationStep.NavigateToSubOptions)
     }

--- a/app/feature/feature-travel-certificate/build.gradle.kts
+++ b/app/feature/feature-travel-certificate/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 dependencies {
   apolloMetadata(projects.apolloOctopusPublic)
 
-  implementation(project(":data-contract-public"))
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.compose.material3)
   implementation(libs.androidx.lifecycle.compose)
@@ -35,6 +34,7 @@ dependencies {
   implementation(projects.coreIcons)
   implementation(projects.coreResources)
   implementation(projects.coreUi)
+  implementation(projects.dataContractPublic)
   implementation(projects.languageCore)
   implementation(projects.moleculeAndroid)
   implementation(projects.moleculePublic)

--- a/app/molecule/molecule-test/src/main/kotlin/com/hedvig/android/molecule/test/MoleculeTest.kt
+++ b/app/molecule/molecule-test/src/main/kotlin/com/hedvig/android/molecule/test/MoleculeTest.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.molecule.test
 
+import androidx.compose.runtime.CheckResult
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.TurbineTestContext
@@ -45,6 +46,7 @@ private class MoleculePresenterTestContextImpl<Event, State>(
 
   private var lastModel: State? = null
 
+  @CheckResult("""skipItems(count = 1)""")
   override suspend fun awaitItem(): State {
     while (true) {
       val nextModel = turbineTestContext.awaitItem()
@@ -56,12 +58,9 @@ private class MoleculePresenterTestContextImpl<Event, State>(
   }
 
   override suspend fun skipItems(count: Int) {
-    while (true) {
-      val nextModel = turbineTestContext.awaitItem()
-      if (nextModel != lastModel) {
-        lastModel = nextModel
-        return
-      }
+    repeat(count) {
+      @Suppress("CheckResult")
+      awaitItem()
     }
   }
 


### PR DESCRIPTION
Just some changes I was doing as I was looking at the diff. Everything looks good, I just fixed the black background sliding thing that we discussed in the test session and the rest are smaller changes.
You might be interested in https://github.com/HedvigInsurance/android/commit/d267ff9191ba8a3da3d448995987c0f8c6561285 about the duplicated function for the option/suboption. I did it using a fragment on their common type, so only one extension function can now exist.

-----

Merge toSuggestion function by adding a fragment

Put comment above the right parameter

Use ui.tooling.preview.datasource.LoremIpsum and remove some dead code

Make background dark color only fade in instead of sliding 

The entire content can now fade in and out so that the dark color is
always filling the entire screen. While the contents can still slide in
with the same transition spec as they were doing before. The important
difference being that this modifier is only added to the content in
front of the dark background here.

Also ensure that the focus is cleared on either of the two buttons
pressed with FocusManager.clearFocus()
Use typed module import

Use skipItems instead of empty awaitItem()