### PR TITLE
fix incorrect ssn crash

### DIFF
--- a/app/core/core-common-public/src/main/kotlin/com/hedvig/android/core/common/PersonalInfoStringBuilders.kt
+++ b/app/core/core-common-public/src/main/kotlin/com/hedvig/android/core/common/PersonalInfoStringBuilders.kt
@@ -12,26 +12,6 @@ fun formatSsn(ssn: String): String {
   }
 }
 
-fun formatShortSsn(ssn: String): String {
-  val formattedSSN = ssn.replace("-", "")
-  if (formattedSSN.length == 10) {
-    val ssnLastTwoDigitsOfYear = formattedSSN.substring(0, 2)
-    val currentYear = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
-    val firstTwoDigitsOfTheYear = currentYear / 100
-    val lastTwoDigitsOfTheYear = currentYear % 100
-
-    val ssnLastTwoDigits = ssnLastTwoDigitsOfYear.toIntOrNull()
-
-    return if (ssnLastTwoDigits != null && ssnLastTwoDigits > lastTwoDigitsOfTheYear) {
-      "${firstTwoDigitsOfTheYear - 1}$ssn"
-    } else {
-      "$firstTwoDigitsOfTheYear$ssn"
-    }
-  } else {
-    return ssn
-  }
-}
-
 fun formatName(firstName: String?, lastName: String?): String {
   return buildString {
     if (firstName != null) {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/FetchCoInsuredPersonalInformationUseCase.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/FetchCoInsuredPersonalInformationUseCase.kt
@@ -51,7 +51,7 @@ private fun convertSsnToBirthDateOrNull(ssn: String): LocalDate? {
   if (stringMonth !in 1..12) return null
   val result = try {
     LocalDate(year = stringYear, month = Month(stringMonth), dayOfMonth = stringDate)
-  } catch (e: Exception) {
+  } catch (e: IllegalArgumentException) {
     null
   }
   return result

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/FetchCoInsuredPersonalInformationUseCase.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/FetchCoInsuredPersonalInformationUseCase.kt
@@ -49,5 +49,10 @@ private fun convertSsnToBirthDateOrNull(ssn: String): LocalDate? {
   val stringDate = ssn.substring(6, 8).toIntOrNull()
   if (stringYear == null || stringMonth == null || stringDate == null) return null
   if (stringMonth !in 1..12) return null
-  return LocalDate(year = stringYear, month = Month(stringMonth), dayOfMonth = stringDate)
+  val result = try {
+    LocalDate(year = stringYear, month = Month(stringMonth), dayOfMonth = stringDate)
+  } catch (e: Exception) {
+    null
+  }
+  return result
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -7,9 +7,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -169,7 +174,8 @@ internal fun AddCoInsuredBottomSheetContent(
       text = stringResource(id = R.string.general_cancel_button),
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(32.dp))
+    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)))
   }
 }
 

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import arrow.core.raise.either
-import com.hedvig.android.core.common.formatShortSsn
 import com.hedvig.android.core.common.safeCast
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
@@ -187,18 +186,18 @@ internal class EditCoInsuredPresenter(
       addBottomSheetState = addBottomSheetState.copy(errorMessage = null)
       val ssn = addBottomSheetState.ssn
       if (ssn != null) {
-        val paddedSsn = formatShortSsn(ssn)
         either {
-          val result = fetchCoInsuredPersonalInformationUseCase.invoke(paddedSsn).bind()
+          val result = fetchCoInsuredPersonalInformationUseCase.invoke(ssn).bind()
           when (result) {
             is CoInsuredPersonalInformation.FullInfo -> {
               addBottomSheetState = addBottomSheetState.copy(
                 firstName = result.firstName,
                 lastName = result.lastName,
-                ssn = paddedSsn,
+                ssn = ssn,
                 errorMessage = null,
               )
             }
+
             is CoInsuredPersonalInformation.EmptyInfo -> {
               addBottomSheetState =
                 Loaded.AddBottomSheetState(


### PR DESCRIPTION
The bug was: incorrectly written SSN with impossible date (like 31st of April), which of course empty info when fetching personal info, then we try to convert it to the date, but it crashes bc of the date being impossible.