### PR TITLE
Dismiss the dialog before opening chat

### DIFF
--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -157,7 +157,13 @@ internal fun YourInfoTab(
         ),
         sections = upcomingChangesInsuranceAgreement.displayItems
           .map { it.title to it.value },
-        onOpenChat = openChat,
+        onOpenChat = {
+          coroutineScope.launch {
+            sheetState.hide()
+            showUpcomingChangesBottomSheet = false
+            openChat()
+          }
+        },
         onDismiss = {
           coroutineScope.launch {
             sheetState.hide()


### PR DESCRIPTION
Without this, going back results in an awkward animation as the screen is coming in, but the dialog appears immediately and over both destinations at the same time.