### PR TITLE
fix/stuck-in-login-screens-when-logged-out

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ChatNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ChatNotificationSender.kt
@@ -15,7 +15,6 @@ import androidx.core.graphics.drawable.IconCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.navigation.NavDestination
-import androidx.navigation.NavDestination.Companion.hasRoute
 import com.benasher44.uuid.Uuid
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.getMutablePendingIntentFlags
@@ -28,6 +27,7 @@ import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
 import com.hedvig.android.logger.LogPriority.ERROR
 import com.hedvig.android.logger.logcat
+import com.hedvig.android.navigation.compose.typedHasRoute
 import com.hedvig.android.navigation.core.AppDestination
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.NotificationSender
@@ -76,7 +76,7 @@ class ChatNotificationSender(
     val currentDestination = CurrentDestinationInMemoryStorage.currentDestination
     val currentlyOnDestinationWhichForbidsShowingChatNotification =
       listOfDestinationsWhichShouldNotShowChatNotification.any { clazz ->
-        currentDestination?.hasRoute(clazz) == true
+        currentDestination?.typedHasRoute(clazz) == true
       }
     if (currentlyOnDestinationWhichForbidsShowingChatNotification && isAppForegrounded) {
       logcat { "ChatNotificationSender ignoring notification since we are showing destination $currentDestination" }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavHostController
 import coil.ImageLoader
@@ -41,6 +40,7 @@ import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.badge.data.tab.TabNotificationBadgeService
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -197,20 +197,18 @@ private fun LogoutOnInvalidCredentialsEffect(
       combine(
         authTokenService.authStatus.onEach(authStatusLog).filterNotNull().distinctUntilChanged(),
         demoManager.isDemoMode().distinctUntilChanged(),
-      ) { authStatus: AuthStatus, isDemoMode: Boolean ->
-        authStatus to isDemoMode
-      }.collect { (authStatus, isDemoMode) ->
-        val navBackStackEntry: NavBackStackEntry = hedvigAppState.navController.currentBackStackEntryFlow.first()
+        hedvigAppState.navController.currentBackStackEntryFlow,
+      ) { authStatus: AuthStatus, isDemoMode: Boolean, navBackStackEntry ->
         val isLoggedOut = navBackStackEntry.destination.hierarchy.any { navDestination ->
           navDestination.typedHasRoute<LoginDestination>()
         }
         if (isLoggedOut) {
-          return@collect
+          return@combine
         }
         if (!isDemoMode && authStatus !is AuthStatus.LoggedIn) {
           hedvigAppState.navigateToLoggedOut()
         }
-      }
+      }.collect()
     }
   }
 }


### PR DESCRIPTION
I am not even sure how I've reproed this in the past, but one time I was doing something in debug mode and I ended up being in main screen while being logged out and not in demo mode.
Probably wasn't possible in production anyway, but this makes our check even more correct since it actually observes the navigation changes themselves and if we navigate anywhere we make sure that we are in the right login/logout graph as we must be.