### PR TITLE
GEN-2519 moving flow in insurances screen

### DIFF
--- a/app/design-system/design-system-hedvig/build.gradle.kts
+++ b/app/design-system/design-system-hedvig/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 dependencies {
-  implementation(libs.androidx.compose.foundation)
   implementation(libs.androidx.activity.compose)
+  implementation(libs.androidx.compose.foundation)
   implementation(libs.androidx.compose.foundationLayout)
   implementation(libs.androidx.compose.materialRipple)
   implementation(libs.androidx.compose.uiGraphics)

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Notification.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Notification.kt
@@ -1,10 +1,11 @@
 package com.hedvig.android.design.system.hedvig
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -17,7 +18,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Small
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.SecondaryAlt
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.InfoCardStyle
+import com.hedvig.android.design.system.hedvig.NotificationDefaults.InfoCardStyle.Button
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.InfoCardStyle.Buttons
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.InfoCardStyle.Default
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority
@@ -81,30 +85,47 @@ fun HedvigNotificationCard(
         }
         Column {
           HedvigText(text = message)
-          if (style is Buttons) {
-            Row {
-              HedvigTheme(darkTheme = false) {
-                HedvigButton(
-                  enabled = true,
-                  onClick = style.onLeftButtonClick,
-                  buttonStyle = ButtonDefaults.ButtonStyle.SecondaryAlt,
-                  buttonSize = ButtonDefaults.ButtonSize.Small,
-                  modifier = Modifier.weight(1f),
-                ) {
-                  HedvigText(style.leftButtonText, style = textStyle)
-                }
-                Spacer(Modifier.width(4.dp))
-                HedvigButton(
-                  enabled = true,
-                  onClick = style.onRightButtonClick,
-                  buttonStyle = ButtonDefaults.ButtonStyle.SecondaryAlt,
-                  buttonSize = ButtonDefaults.ButtonSize.Small,
-                  modifier = Modifier.weight(1f),
-                ) {
-                  HedvigText(style.rightButtonText, style = textStyle)
+          when (style) {
+            is Buttons -> {
+              Row {
+                HedvigTheme(darkTheme = false) {
+                  HedvigButton(
+                    enabled = true,
+                    onClick = style.onLeftButtonClick,
+                    buttonStyle = SecondaryAlt,
+                    buttonSize = Small,
+                    modifier = Modifier.weight(1f),
+                  ) {
+                    HedvigText(style.leftButtonText, style = textStyle)
+                  }
+                  Spacer(Modifier.width(4.dp))
+                  HedvigButton(
+                    enabled = true,
+                    onClick = style.onRightButtonClick,
+                    buttonStyle = SecondaryAlt,
+                    buttonSize = Small,
+                    modifier = Modifier.weight(1f),
+                  ) {
+                    HedvigText(style.rightButtonText, style = textStyle)
+                  }
                 }
               }
             }
+
+            is Button -> {
+              HedvigTheme(darkTheme = false) {
+                HedvigButton(
+                  enabled = true,
+                  onClick = style.onButtonClick,
+                  buttonStyle = SecondaryAlt,
+                  buttonSize = Small,
+                  modifier = Modifier.fillMaxWidth(),
+                ) {
+                  HedvigText(style.buttonText, style = textStyle)
+                }
+              }
+            }
+            Default -> {}
           }
         }
       }
@@ -273,6 +294,11 @@ object NotificationDefaults {
   sealed class InfoCardStyle {
     data object Default : InfoCardStyle()
 
+    data class Button(
+      val buttonText: String,
+      val onButtonClick: () -> Unit,
+    ) : InfoCardStyle()
+
     data class Buttons(
       val leftButtonText: String,
       val rightButtonText: String,
@@ -293,6 +319,7 @@ private fun PreviewNotificationCard(
         Modifier
           .width(330.dp)
           .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
       ) {
         HedvigNotificationCard(
           priority = priority,
@@ -300,28 +327,36 @@ private fun PreviewNotificationCard(
           withIcon = false,
           style = Default,
         )
-        Spacer(Modifier.height(16.dp))
         HedvigNotificationCard(
           priority = priority,
           message = "A short message about something that needs attention.",
           withIcon = true,
           style = Default,
         )
-        Spacer(Modifier.height(16.dp))
+        HedvigNotificationCard(
+          priority = priority,
+          message = "A short message about something that needs attention.",
+          withIcon = false,
+          style = Button("Button", {}),
+        )
+        HedvigNotificationCard(
+          priority = priority,
+          message = "A short message about something that needs attention.",
+          withIcon = true,
+          style = Button("Button", {}),
+        )
         HedvigNotificationCard(
           priority = priority,
           message = "A short message about something that needs attention.",
           withIcon = false,
           style = Buttons("Left", "Right", {}, {}),
         )
-        Spacer(Modifier.height(16.dp))
         HedvigNotificationCard(
           priority = priority,
           message = "A short message about something that needs attention.",
           withIcon = true,
           style = Buttons("Left", "Right", {}, {}),
         )
-        Spacer(Modifier.height(16.dp))
       }
     }
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -578,6 +578,7 @@ private fun CrossSellBottomSheet(
     onDismissed = onDismissed,
     content = {
       Column {
+        Spacer(Modifier.height(32.dp))
         CrossSellsSection(
           showNotificationBadge = false,
           crossSells = crossSells,

--- a/app/feature/feature-insurances/build.gradle.kts
+++ b/app/feature/feature-insurances/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
   implementation(projects.dataContractPublic)
   implementation(projects.dataProductVariantAndroid)
   implementation(projects.dataProductVariantPublic)
+  implementation(projects.designSystemHedvig)
   implementation(projects.featureFlagsPublic)
   implementation(projects.languageCore)
   implementation(projects.moleculeAndroid)

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
@@ -53,7 +53,6 @@ import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.card.InsuranceCard
 import com.hedvig.android.core.ui.card.InsuranceCardPlaceholder
-import com.hedvig.android.core.ui.debugBorder
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.crosssells.CrossSellItemPlaceholder
 import com.hedvig.android.crosssells.CrossSellsSection
@@ -61,6 +60,10 @@ import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.ContractType
 import com.hedvig.android.data.contract.android.CrossSell
 import com.hedvig.android.data.productvariant.ProductVariant
+import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
+import com.hedvig.android.design.system.hedvig.HedvigText
+import com.hedvig.android.design.system.hedvig.NotificationDefaults.InfoCardStyle
+import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority
 import com.hedvig.android.feature.insurances.data.InsuranceAgreement
 import com.hedvig.android.feature.insurances.data.InsuranceContract
 import com.hedvig.android.feature.insurances.insurance.presentation.InsuranceScreenEvent
@@ -219,6 +222,12 @@ private fun InsuranceScreenContent(
         onInsuranceCardClick = onInsuranceCardClick,
         contracts = uiState.contracts,
       )
+      if (uiState.shouldSuggestMovingFlow) {
+        MovingFlowSuggestionSection(
+          {},
+          Modifier.padding(horizontal = 16.dp),
+        )
+      }
       if (uiState.crossSells.isNotEmpty()) {
         CrossSellsSection(
           showNotificationBadge = showNotificationBadge,
@@ -268,7 +277,7 @@ private fun ContractsSection(
 }
 
 @Composable
-fun InsuranceCard(
+private fun InsuranceCard(
   contract: InsuranceContract,
   imageLoader: ImageLoader,
   modifier: Modifier = Modifier,
@@ -305,6 +314,24 @@ private fun TerminatedContractsButton(text: String, onClick: () -> Unit, modifie
     ) {
       Text(text)
     }
+  }
+}
+
+@Composable
+private fun MovingFlowSuggestionSection(onNavigateToMovingFlow: () -> Unit, modifier: Modifier = Modifier) {
+  Column(modifier, Arrangement.spacedBy(8.dp)) {
+    HedvigText(
+      stringResource(R.string.insurances_tab_moving_flow_section_title),
+      style = com.hedvig.android.design.system.hedvig.HedvigTheme.typography.headlineSmall,
+    )
+    HedvigNotificationCard(
+      message = stringResource(R.string.insurances_tab_moving_flow_info_title),
+      priority = NotificationPriority.Campaign,
+      style = InfoCardStyle.Button(
+        stringResource(R.string.insurances_tab_moving_flow_info_button_title),
+        onNavigateToMovingFlow,
+      ),
+    )
   }
 }
 

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
@@ -5,9 +5,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -53,6 +53,7 @@ import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.card.InsuranceCard
 import com.hedvig.android.core.ui.card.InsuranceCardPlaceholder
+import com.hedvig.android.core.ui.debugBorder
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.crosssells.CrossSellItemPlaceholder
 import com.hedvig.android.crosssells.CrossSellsSection
@@ -156,23 +157,22 @@ private fun InsuranceScreen(
         },
         label = "uiState",
       ) { state ->
-        Column(
-          Modifier
-            .fillMaxSize(),
-        ) {
-          if (state.hasError) {
-            HedvigErrorSection(onButtonClick = reload)
-          } else {
-            InsuranceScreenContent(
-              uiState = state,
-              imageLoader = imageLoader,
-              showNotificationBadge = state.showNotificationBadge,
-              onInsuranceCardClick = onInsuranceCardClick,
-              onCrossSellClick = onCrossSellClick,
-              navigateToCancelledInsurances = navigateToCancelledInsurances,
-              quantityOfCancelledInsurances = state.quantityOfCancelledInsurances,
-            )
-          }
+        if (state.hasError) {
+          HedvigErrorSection(
+            onButtonClick = reload,
+            modifier = Modifier.fillMaxSize(),
+          )
+        } else {
+          InsuranceScreenContent(
+            uiState = state,
+            imageLoader = imageLoader,
+            showNotificationBadge = state.showNotificationBadge,
+            onInsuranceCardClick = onInsuranceCardClick,
+            onCrossSellClick = onCrossSellClick,
+            navigateToCancelledInsurances = navigateToCancelledInsurances,
+            quantityOfCancelledInsurances = state.quantityOfCancelledInsurances,
+            modifier = Modifier.fillMaxSize(),
+          )
         }
       }
       Spacer(Modifier.height(16.dp))
@@ -189,7 +189,7 @@ private fun InsuranceScreen(
 
 @Suppress("UnusedReceiverParameter")
 @Composable
-private fun ColumnScope.InsuranceScreenContent(
+private fun InsuranceScreenContent(
   uiState: InsuranceUiState,
   imageLoader: ImageLoader,
   showNotificationBadge: Boolean,
@@ -197,48 +197,52 @@ private fun ColumnScope.InsuranceScreenContent(
   onCrossSellClick: (String) -> Unit,
   navigateToCancelledInsurances: () -> Unit,
   quantityOfCancelledInsurances: Int,
+  modifier: Modifier = Modifier,
 ) {
-  val insuranceCardModifier = Modifier
-    .padding(horizontal = 16.dp)
-    .clip(MaterialTheme.shapes.squircleMedium)
-  if (uiState.isLoading) {
-    Spacer(Modifier.height(16.dp))
-    InsuranceCardPlaceholder(
-      imageLoader = imageLoader,
-      modifier = insuranceCardModifier,
-    )
-    CrossSellItemPlaceholder()
-  } else {
-    ContractsSection(
-      imageLoader = imageLoader,
-      modifier = insuranceCardModifier,
-      onInsuranceCardClick = onInsuranceCardClick,
-      contracts = uiState.contracts,
-    )
-    if (uiState.crossSells.isNotEmpty()) {
-      CrossSellsSection(
-        showNotificationBadge = showNotificationBadge,
-        crossSells = uiState.crossSells,
-        onCrossSellClick = onCrossSellClick,
+  Column(
+    modifier = modifier.padding(top = 16.dp),
+    verticalArrangement = Arrangement.spacedBy(24.dp),
+  ) {
+    val insuranceCardModifier = Modifier
+      .padding(horizontal = 16.dp)
+      .clip(MaterialTheme.shapes.squircleMedium)
+    if (uiState.isLoading) {
+      InsuranceCardPlaceholder(
+        imageLoader = imageLoader,
+        modifier = insuranceCardModifier,
       )
-    }
-    if (quantityOfCancelledInsurances > 0) {
-      Spacer(Modifier.height(24.dp))
-      TerminatedContractsButton(
-        text = pluralStringResource(
-          R.plurals.insurances_tab_terminated_insurance_subtitile,
-          quantityOfCancelledInsurances,
-          quantityOfCancelledInsurances,
-        ),
-        onClick = navigateToCancelledInsurances,
-        modifier = Modifier.padding(horizontal = 16.dp),
+      CrossSellItemPlaceholder()
+    } else {
+      ContractsSection(
+        imageLoader = imageLoader,
+        modifier = insuranceCardModifier,
+        onInsuranceCardClick = onInsuranceCardClick,
+        contracts = uiState.contracts,
       )
+      if (uiState.crossSells.isNotEmpty()) {
+        CrossSellsSection(
+          showNotificationBadge = showNotificationBadge,
+          crossSells = uiState.crossSells,
+          onCrossSellClick = onCrossSellClick,
+        )
+      }
+      if (quantityOfCancelledInsurances > 0) {
+        TerminatedContractsButton(
+          text = pluralStringResource(
+            R.plurals.insurances_tab_terminated_insurance_subtitile,
+            quantityOfCancelledInsurances,
+            quantityOfCancelledInsurances,
+          ),
+          onClick = navigateToCancelledInsurances,
+          modifier = Modifier.padding(horizontal = 16.dp),
+        )
+      }
     }
   }
 }
 
 @Composable
-private fun ColumnScope.ContractsSection(
+private fun ContractsSection(
   contracts: List<InsuranceContract>,
   imageLoader: ImageLoader,
   onInsuranceCardClick: (contractId: String) -> Unit,
@@ -250,16 +254,14 @@ private fun ColumnScope.ContractsSection(
       withDefaultVerticalSpacing = true,
     )
   } else {
-    Spacer(Modifier.height(16.dp))
-    for ((index, contract) in contracts.withIndex()) {
-      InsuranceCard(
-        contract = contract,
-        imageLoader = imageLoader,
-        modifier = modifier,
-        onInsuranceCardClick = onInsuranceCardClick,
-      )
-      if (index != contracts.lastIndex) {
-        Spacer(Modifier.height(8.dp))
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      for (contract in contracts) {
+        InsuranceCard(
+          contract = contract,
+          imageLoader = imageLoader,
+          modifier = modifier,
+          onInsuranceCardClick = onInsuranceCardClick,
+        )
       }
     }
   }
@@ -331,6 +333,7 @@ private fun PreviewInsuranceScreen(
           ),
           showNotificationBadge = false,
           quantityOfCancelledInsurances = 1,
+          shouldSuggestMovingFlow = true,
           hasError = false,
           isLoading = false,
           isRetrying = false,
@@ -378,6 +381,7 @@ private class InsuranceUiStateProvider : CollectionPreviewParameterProvider<Insu
       isRetrying = false,
       quantityOfCancelledInsurances = 0,
       showNotificationBadge = false,
+      shouldSuggestMovingFlow = true,
     ),
     InsuranceUiState(
       contracts =
@@ -396,6 +400,7 @@ private class InsuranceUiStateProvider : CollectionPreviewParameterProvider<Insu
       hasError = false,
       isLoading = false,
       isRetrying = false,
+      shouldSuggestMovingFlow = true,
     ),
     InsuranceUiState(
       contracts = listOf(),
@@ -405,6 +410,7 @@ private class InsuranceUiStateProvider : CollectionPreviewParameterProvider<Insu
       isRetrying = false,
       quantityOfCancelledInsurances = 0,
       showNotificationBadge = false,
+      shouldSuggestMovingFlow = true,
     ),
     InsuranceUiState(
       contracts = listOf(),
@@ -429,6 +435,7 @@ private class InsuranceUiStateProvider : CollectionPreviewParameterProvider<Insu
       isRetrying = false,
       quantityOfCancelledInsurances = 0,
       showNotificationBadge = false,
+      shouldSuggestMovingFlow = true,
     ),
     InsuranceUiState(
       contracts = listOf(),
@@ -438,6 +445,7 @@ private class InsuranceUiStateProvider : CollectionPreviewParameterProvider<Insu
       isRetrying = false,
       quantityOfCancelledInsurances = 0,
       showNotificationBadge = false,
+      shouldSuggestMovingFlow = true,
     ),
     InsuranceUiState(
       contracts = listOf(),
@@ -447,6 +455,7 @@ private class InsuranceUiStateProvider : CollectionPreviewParameterProvider<Insu
       isRetrying = false,
       quantityOfCancelledInsurances = 0,
       showNotificationBadge = false,
+      shouldSuggestMovingFlow = true,
     ),
   ),
 )

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/InsuranceDestination.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.dropUnlessResumed
 import coil.ImageLoader
 import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.PreviewContentWithProvidedParametersAnimatedOnClick
@@ -84,6 +85,7 @@ internal fun InsuranceDestination(
   onInsuranceCardClick: (contractId: String) -> Unit,
   onCrossSellClick: (String) -> Unit,
   navigateToCancelledInsurances: () -> Unit,
+  onNavigateToMovingFlow: () -> Unit,
   imageLoader: ImageLoader,
 ) {
   val uiState: InsuranceUiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -111,6 +113,7 @@ internal fun InsuranceDestination(
     onInsuranceCardClick = onInsuranceCardClick,
     onCrossSellClick = onCrossSellClick,
     navigateToCancelledInsurances = navigateToCancelledInsurances,
+    onNavigateToMovingFlow = onNavigateToMovingFlow,
     imageLoader = imageLoader,
   )
 }
@@ -122,6 +125,7 @@ private fun InsuranceScreen(
   onInsuranceCardClick: (contractId: String) -> Unit,
   onCrossSellClick: (String) -> Unit,
   navigateToCancelledInsurances: () -> Unit,
+  onNavigateToMovingFlow: () -> Unit,
   imageLoader: ImageLoader,
 ) {
   val isRetrying = uiState.isRetrying
@@ -170,10 +174,11 @@ private fun InsuranceScreen(
             uiState = state,
             imageLoader = imageLoader,
             showNotificationBadge = state.showNotificationBadge,
+            quantityOfCancelledInsurances = state.quantityOfCancelledInsurances,
             onInsuranceCardClick = onInsuranceCardClick,
             onCrossSellClick = onCrossSellClick,
             navigateToCancelledInsurances = navigateToCancelledInsurances,
-            quantityOfCancelledInsurances = state.quantityOfCancelledInsurances,
+            onNavigateToMovingFlow = onNavigateToMovingFlow,
             modifier = Modifier.fillMaxSize(),
           )
         }
@@ -196,10 +201,11 @@ private fun InsuranceScreenContent(
   uiState: InsuranceUiState,
   imageLoader: ImageLoader,
   showNotificationBadge: Boolean,
+  quantityOfCancelledInsurances: Int,
   onInsuranceCardClick: (contractId: String) -> Unit,
   onCrossSellClick: (String) -> Unit,
   navigateToCancelledInsurances: () -> Unit,
-  quantityOfCancelledInsurances: Int,
+  onNavigateToMovingFlow: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Column(
@@ -224,8 +230,8 @@ private fun InsuranceScreenContent(
       )
       if (uiState.shouldSuggestMovingFlow) {
         MovingFlowSuggestionSection(
-          {},
-          Modifier.padding(horizontal = 16.dp),
+          onNavigateToMovingFlow = onNavigateToMovingFlow,
+          modifier = Modifier.padding(horizontal = 16.dp),
         )
       }
       if (uiState.crossSells.isNotEmpty()) {
@@ -321,7 +327,7 @@ private fun TerminatedContractsButton(text: String, onClick: () -> Unit, modifie
 private fun MovingFlowSuggestionSection(onNavigateToMovingFlow: () -> Unit, modifier: Modifier = Modifier) {
   Column(modifier, Arrangement.spacedBy(8.dp)) {
     HedvigText(
-      stringResource(R.string.insurances_tab_moving_flow_section_title),
+      text = stringResource(R.string.insurances_tab_moving_flow_section_title),
       style = com.hedvig.android.design.system.hedvig.HedvigTheme.typography.headlineSmall,
     )
     HedvigNotificationCard(
@@ -329,7 +335,7 @@ private fun MovingFlowSuggestionSection(onNavigateToMovingFlow: () -> Unit, modi
       priority = NotificationPriority.Campaign,
       style = InfoCardStyle.Button(
         stringResource(R.string.insurances_tab_moving_flow_info_button_title),
-        onNavigateToMovingFlow,
+        dropUnlessResumed { onNavigateToMovingFlow() },
       ),
     )
   }
@@ -369,6 +375,7 @@ private fun PreviewInsuranceScreen(
         {},
         {},
         {},
+        {},
         rememberPreviewImageLoader(),
       )
     }
@@ -391,6 +398,7 @@ private fun PreviewInsuranceDestinationAnimation() {
             onInsuranceCardClick = {},
             onCrossSellClick = {},
             navigateToCancelledInsurances = {},
+            onNavigateToMovingFlow = {},
           )
         },
       )

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenter.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenter.kt
@@ -41,6 +41,7 @@ internal data class InsuranceUiState(
   val crossSells: List<CrossSell>,
   val showNotificationBadge: Boolean,
   val quantityOfCancelledInsurances: Int,
+  val shouldSuggestMovingFlow: Boolean,
   val hasError: Boolean,
   val isLoading: Boolean,
   val isRetrying: Boolean,
@@ -51,6 +52,7 @@ internal data class InsuranceUiState(
       crossSells = listOf(),
       showNotificationBadge = false,
       quantityOfCancelledInsurances = 0,
+      shouldSuggestMovingFlow = false,
       hasError = false,
       isLoading = true,
       isRetrying = false,
@@ -129,6 +131,7 @@ internal class InsurancePresenter(
       crossSells = insuranceData.crossSells,
       showNotificationBadge = showNotificationBadge,
       quantityOfCancelledInsurances = insuranceData.quantityOfCancelledInsurances,
+      shouldSuggestMovingFlow = insuranceData.isEligibleToPerformMovingFlow,
       hasError = didFailToLoad && !isLoading && !isRetrying,
       isLoading = isLoading,
       isRetrying = isRetrying,
@@ -171,6 +174,9 @@ private suspend fun loadInsuranceData(
         contracts = insuranceCards,
         crossSells = crossSells,
         quantityOfCancelledInsurances = contracts.count(InsuranceContract::isTerminated),
+        isEligibleToPerformMovingFlow = contracts.any {
+          !it.isTerminated && it.upcomingInsuranceAgreement == null && it.supportsAddressChange
+        },
       )
     }
   }.onLeft {
@@ -184,6 +190,7 @@ private data class InsuranceData(
   val contracts: List<InsuranceContract>,
   val crossSells: List<CrossSell>,
   val quantityOfCancelledInsurances: Int,
+  val isEligibleToPerformMovingFlow: Boolean,
 ) {
   companion object {
     fun fromUiState(uiState: InsuranceUiState): InsuranceData {
@@ -191,6 +198,7 @@ private data class InsuranceData(
         contracts = uiState.contracts,
         crossSells = uiState.crossSells,
         quantityOfCancelledInsurances = uiState.quantityOfCancelledInsurances,
+        isEligibleToPerformMovingFlow = uiState.shouldSuggestMovingFlow,
       )
     }
 
@@ -198,6 +206,7 @@ private data class InsuranceData(
       contracts = listOf(),
       crossSells = listOf(),
       quantityOfCancelledInsurances = 0,
+      isEligibleToPerformMovingFlow = false,
     )
   }
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/navigation/InsuranceGraph.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/navigation/InsuranceGraph.kt
@@ -53,6 +53,7 @@ fun NavGraphBuilder.insuranceGraph(
         navigateToCancelledInsurances = {
           with(navigator) { backStackEntry.navigate(InsurancesDestinations.TerminatedInsurances) }
         },
+        onNavigateToMovingFlow = { startMovingFlow(backStackEntry) },
         imageLoader = imageLoader,
       )
     }

--- a/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
+++ b/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -37,6 +38,8 @@ import com.hedvig.android.core.designsystem.component.button.HedvigContainedSmal
 import com.hedvig.android.core.designsystem.material3.lightTypeContainer
 import com.hedvig.android.core.designsystem.material3.onLightTypeContainer
 import com.hedvig.android.core.designsystem.material3.squircleLarge
+import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.data.contract.android.CrossSell
 import com.hedvig.android.data.contract.android.iconRes
 import com.hedvig.android.placeholder.PlaceholderHighlight
@@ -46,45 +49,51 @@ import com.hedvig.android.placeholder.shimmer
 import hedvig.resources.R
 
 @Composable
-fun ColumnScope.CrossSellsSection(
+fun CrossSellsSection(
   showNotificationBadge: Boolean,
   crossSells: List<CrossSell>,
   onCrossSellClick: (String) -> Unit,
+  modifier: Modifier = Modifier,
 ) {
-  CrossSellsSubHeaderWithDivider(showNotificationBadge)
-  for ((index, crossSell) in crossSells.withIndex()) {
-    CrossSellItem(crossSell, onCrossSellClick, Modifier.padding(horizontal = 16.dp))
-    if (index != crossSells.lastIndex) {
-      Spacer(Modifier.height(16.dp))
+  Column(modifier) {
+    CrossSellsSubHeaderWithDivider(showNotificationBadge)
+    for ((index, crossSell) in crossSells.withIndex()) {
+      CrossSellItem(crossSell, onCrossSellClick, Modifier.padding(horizontal = 16.dp))
+      if (index != crossSells.lastIndex) {
+        Spacer(Modifier.height(16.dp))
+      }
     }
   }
 }
 
 @Composable
-fun ColumnScope.CrossSellItemPlaceholder() {
-  CrossSellsSubHeaderWithDivider(false)
-  CrossSellItem(
-    crossSellTitle = "HHHH",
-    crossSellSubtitle = "HHHHHHHH\nHHHHHHHHHHH",
-    storeUrl = "",
-    type = CrossSell.CrossSellType.HOME,
-    onCrossSellClick = {},
-    isLoading = true,
-    modifier = Modifier.padding(horizontal = 16.dp),
-  )
+fun CrossSellItemPlaceholder() {
+  Column {
+    CrossSellsSubHeaderWithDivider(false)
+    CrossSellItem(
+      crossSellTitle = "HHHH",
+      crossSellSubtitle = "HHHHHHHH\nHHHHHHHHHHH",
+      storeUrl = "",
+      type = CrossSell.CrossSellType.HOME,
+      onCrossSellClick = {},
+      isLoading = true,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+  }
 }
 
 @Composable
-private fun ColumnScope.CrossSellsSubHeaderWithDivider(showNotificationBadge: Boolean) {
-  Spacer(Modifier.height(32.dp))
-  NotificationSubheading(
-    text = stringResource(R.string.insurance_tab_cross_sells_title),
-    showNotification = showNotificationBadge,
-    modifier = Modifier.padding(horizontal = 16.dp),
-  )
-  Spacer(Modifier.height(16.dp))
-  HorizontalDivider(Modifier.padding(horizontal = 16.dp))
-  Spacer(Modifier.height(16.dp))
+private fun CrossSellsSubHeaderWithDivider(showNotificationBadge: Boolean) {
+  Column {
+    NotificationSubheading(
+      text = stringResource(R.string.insurance_tab_cross_sells_title),
+      showNotification = showNotificationBadge,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+    Spacer(Modifier.height(16.dp))
+    HorizontalDivider(Modifier.padding(horizontal = 16.dp))
+    Spacer(Modifier.height(16.dp))
+  }
 }
 
 @Composable
@@ -193,5 +202,19 @@ private fun NotificationSubheading(text: String, showNotification: Boolean, modi
       }
     }
     Text(text = text)
+  }
+}
+
+@HedvigPreview
+@Composable
+private fun PreviewCrossSellsSection() {
+  HedvigTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+      CrossSellsSection(
+        true,
+        List(2) { CrossSell("id", "title", "subtitle", "storeUrl", CrossSell.CrossSellType.HOME) },
+        {},
+      )
+    }
   }
 }

--- a/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
+++ b/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
+++ b/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
@@ -91,8 +91,6 @@ private fun CrossSellsSubHeaderWithDivider(showNotificationBadge: Boolean) {
       modifier = Modifier.padding(horizontal = 16.dp),
     )
     Spacer(Modifier.height(16.dp))
-    HorizontalDivider(Modifier.padding(horizontal = 16.dp))
-    Spacer(Modifier.height(16.dp))
   }
 }
 


### PR DESCRIPTION
https://www.notion.so/hedviginsurance/Insurances-info-box-for-the-moving-flow-90db1ff1bd5b4dd3b38c7f102c47cd04?p=b32af0bcf40d46c183a0a47ef377ecfe&pm=s

Turns out the notification DS component also has a one button version. I added it here!
Also, so cool to just use a DS component now, plug and play, so smooth on the call site 😊