### PR TITLE
Home screen shenanigans

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/apollo/LoggingInterceptor.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/apollo/LoggingInterceptor.kt
@@ -14,6 +14,7 @@ import com.hedvig.android.core.tracking.logError
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 
 internal class LoggingInterceptor : ApolloInterceptor {
@@ -21,8 +22,9 @@ internal class LoggingInterceptor : ApolloInterceptor {
     request: ApolloRequest<D>,
     chain: ApolloInterceptorChain,
   ): Flow<ApolloResponse<D>> {
+    logcat { "GraphQL request for ${request.operation.name()} START." }
     return chain.proceed(request).onEach { response ->
-      logcat { "GraphQL request for ${request.operation.name()} with response data: ${response.data}" }
+      logcat { "GraphQL request for ${request.operation.name()} EMISSION. Response data: ${response.data}" }
       val data = response.data
       val errors = response.errors.orEmpty().map { it.toGraphqlError() }
       if (errors.isNotEmpty() && !errors.isUnathenticated()) {
@@ -33,6 +35,8 @@ internal class LoggingInterceptor : ApolloInterceptor {
           "GraphQL exception for ${request.operation.name()}: ${response.exception}"
         }
       }
+    }.onCompletion {
+      logcat { "GraphQL request for ${request.operation.name()} END." }
     }
   }
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/apollo/LoggingInterceptor.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/apollo/LoggingInterceptor.kt
@@ -22,6 +22,7 @@ internal class LoggingInterceptor : ApolloInterceptor {
     chain: ApolloInterceptorChain,
   ): Flow<ApolloResponse<D>> {
     return chain.proceed(request).onEach { response ->
+      logcat { "GraphQL request for ${request.operation.name()} with response data: ${response.data}" }
       val data = response.data
       val errors = response.errors.orEmpty().map { it.toGraphqlError() }
       if (errors.isNotEmpty() && !errors.isUnathenticated()) {

--- a/app/feature/feature-home/src/main/graphql/QueryNumberOfChatMessages.graphql
+++ b/app/feature/feature-home/src/main/graphql/QueryNumberOfChatMessages.graphql
@@ -1,8 +1,0 @@
-query NumberOfChatMessages {
-  chat(until: null) {
-    messages {
-      id
-      sender
-    }
-  }
-}

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
@@ -2,13 +2,13 @@ package com.hedvig.android.feature.home.home.data
 
 import arrow.core.Either
 import arrow.core.right
-import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.memberreminders.MemberReminders
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 internal class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
-  override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ErrorMessage, HomeData>> = flowOf(
+  override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> = flowOf(
     HomeData(
       contractStatus = HomeData.ContractStatus.Active,
       claimStatusCardsData = null,

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
@@ -40,9 +40,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import octopus.CbmNumberOfChatMessagesQuery
 import octopus.HomeQuery
-import octopus.NumberOfChatMessagesQuery
 import octopus.type.ChatMessageSender
-import octopus.type.buildChat
 import octopus.type.buildChatMessagePage
 import octopus.type.buildChatMessageText
 import octopus.type.buildClaim
@@ -75,10 +73,6 @@ internal class GetHomeUseCaseTest {
         registerTestResponse(
           HomeQuery(),
           HomeQuery.Data(OctopusFakeResolver),
-        )
-        registerTestResponse(
-          NumberOfChatMessagesQuery(),
-          NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
         )
         apolloClient.registerTestResponse(
           CbmNumberOfChatMessagesQuery(),
@@ -123,10 +117,6 @@ internal class GetHomeUseCaseTest {
           HomeQuery(),
           HomeQuery.Data(OctopusFakeResolver),
         )
-        registerTestResponse(
-          NumberOfChatMessagesQuery(),
-          NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-        )
         apolloClient.registerTestResponse(
           CbmNumberOfChatMessagesQuery(),
           CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
@@ -170,10 +160,6 @@ internal class GetHomeUseCaseTest {
       },
     )
     apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-    )
-    apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
       CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
@@ -201,10 +187,6 @@ internal class GetHomeUseCaseTest {
           importantMessages = emptyList()
         }
       },
-    )
-    apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
     apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
@@ -239,10 +221,6 @@ internal class GetHomeUseCaseTest {
       },
     )
     apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-    )
-    apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
       CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
@@ -274,10 +252,6 @@ internal class GetHomeUseCaseTest {
       },
     )
     apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-    )
-    apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
       CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
@@ -307,10 +281,6 @@ internal class GetHomeUseCaseTest {
           )
         }
       },
-    )
-    apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
     apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
@@ -354,10 +324,6 @@ internal class GetHomeUseCaseTest {
       },
     )
     apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-    )
-    apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
       CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
@@ -399,10 +365,6 @@ internal class GetHomeUseCaseTest {
       },
     )
     apolloClient.registerTestResponse(
-      NumberOfChatMessagesQuery(),
-      NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-    )
-    apolloClient.registerTestResponse(
       CbmNumberOfChatMessagesQuery(),
       CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
     )
@@ -425,13 +387,11 @@ internal class GetHomeUseCaseTest {
   fun `showing the chat button is true when there are any messages by the member, or more than 1 by Hedvig`(
     @TestParameter hasAtLeastOneMessageByMember: Boolean,
     @TestParameter("0", "1", "2") numberOfMessagesByHedvig: Int,
-    @TestParameter isCbmEnabled: Boolean,
   ) = runTest {
     val featureManager = FakeFeatureManager2(
       mapOf(
         Feature.DISABLE_CHAT to false,
         Feature.HELP_CENTER to true,
-        Feature.ENABLE_CBM to isCbmEnabled,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -440,59 +400,33 @@ internal class GetHomeUseCaseTest {
       HomeQuery(),
       HomeQuery.Data(OctopusFakeResolver),
     )
-    if (isCbmEnabled) {
-      apolloClient.registerTestResponse(
-        CbmNumberOfChatMessagesQuery(),
-        CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver) {
-          this.currentMember = buildMember {
-            this.legacyConversation = buildConversation {
-              this.messagePage = buildChatMessagePage {
-                this.messages = buildList {
-                  if (hasAtLeastOneMessageByMember) {
-                    add(
-                      buildChatMessageText {
-                        this.sender = ChatMessageSender.MEMBER
-                      },
-                    )
-                  }
-                  addAll(
-                    List(numberOfMessagesByHedvig) {
-                      buildChatMessageText {
-                        this.sender = ChatMessageSender.HEDVIG
-                      }
+    apolloClient.registerTestResponse(
+      CbmNumberOfChatMessagesQuery(),
+      CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver) {
+        this.currentMember = buildMember {
+          this.legacyConversation = buildConversation {
+            this.messagePage = buildChatMessagePage {
+              this.messages = buildList {
+                if (hasAtLeastOneMessageByMember) {
+                  add(
+                    buildChatMessageText {
+                      this.sender = ChatMessageSender.MEMBER
                     },
                   )
                 }
-              }
-            }
-          }
-        },
-      )
-    } else {
-      apolloClient.registerTestResponse(
-        NumberOfChatMessagesQuery(),
-        NumberOfChatMessagesQuery.Data(OctopusFakeResolver) {
-          chat = buildChat {
-            messages = buildList {
-              if (hasAtLeastOneMessageByMember) {
-                add(
-                  buildChatMessageText {
-                    sender = ChatMessageSender.MEMBER
+                addAll(
+                  List(numberOfMessagesByHedvig) {
+                    buildChatMessageText {
+                      this.sender = ChatMessageSender.HEDVIG
+                    }
                   },
                 )
               }
-              addAll(
-                List(numberOfMessagesByHedvig) {
-                  buildChatMessageText {
-                    sender = ChatMessageSender.HEDVIG
-                  }
-                },
-              )
             }
           }
-        },
-      )
-    }
+        }
+      },
+    )
     val result = getHomeDataUseCase.invoke(true).first()
 
     assertThat(result)
@@ -513,13 +447,11 @@ internal class GetHomeUseCaseTest {
     @TestParameter chatIsKillSwitched: Boolean,
     @TestParameter helpCenterIsEnabled: Boolean,
     @TestParameter isEligibleToSeeTheChatButton: Boolean,
-    @TestParameter isCbmEnabled: Boolean,
   ) = runTest {
     val featureManager = FakeFeatureManager2(
       mapOf(
         Feature.DISABLE_CHAT to chatIsKillSwitched,
         Feature.HELP_CENTER to helpCenterIsEnabled,
-        Feature.ENABLE_CBM to isCbmEnabled,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -528,45 +460,26 @@ internal class GetHomeUseCaseTest {
       HomeQuery(),
       HomeQuery.Data(OctopusFakeResolver),
     )
-    if (isCbmEnabled) {
-      apolloClient.registerTestResponse(
-        CbmNumberOfChatMessagesQuery(),
-        CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver) {
-          this.currentMember = buildMember {
-            this.legacyConversation = buildConversation {
-              this.messagePage = buildChatMessagePage {
-                this.messages = if (isEligibleToSeeTheChatButton) {
-                  listOf(
-                    buildChatMessageText {
-                      sender = ChatMessageSender.MEMBER
-                    },
-                  )
-                } else {
-                  emptyList()
-                }
+    apolloClient.registerTestResponse(
+      CbmNumberOfChatMessagesQuery(),
+      CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver) {
+        this.currentMember = buildMember {
+          this.legacyConversation = buildConversation {
+            this.messagePage = buildChatMessagePage {
+              this.messages = if (isEligibleToSeeTheChatButton) {
+                listOf(
+                  buildChatMessageText {
+                    sender = ChatMessageSender.MEMBER
+                  },
+                )
+              } else {
+                emptyList()
               }
             }
           }
-        },
-      )
-    } else {
-      apolloClient.registerTestResponse(
-        NumberOfChatMessagesQuery(),
-        NumberOfChatMessagesQuery.Data(OctopusFakeResolver) {
-          chat = buildChat {
-            messages = if (isEligibleToSeeTheChatButton) {
-              listOf(
-                buildChatMessageText {
-                  sender = ChatMessageSender.MEMBER
-                },
-              )
-            } else {
-              emptyList()
-            }
-          }
-        },
-      )
-    }
+        }
+      },
+    )
     val result = getHomeDataUseCase.invoke(true).first()
 
     assertThat(result)
@@ -597,13 +510,11 @@ internal class GetHomeUseCaseTest {
   @Test
   fun `the disable help center feature flag determines if we show it or not`(
     @TestParameter helpCenterIsEnabled: Boolean,
-    @TestParameter isCbmEnabled: Boolean,
   ) = runTest {
     val featureManager = FakeFeatureManager2(
       mapOf(
         Feature.DISABLE_CHAT to true,
         Feature.HELP_CENTER to helpCenterIsEnabled,
-        Feature.ENABLE_CBM to isCbmEnabled,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -612,17 +523,10 @@ internal class GetHomeUseCaseTest {
       HomeQuery(),
       HomeQuery.Data(OctopusFakeResolver),
     )
-    if (isCbmEnabled) {
-      apolloClient.registerTestResponse(
-        CbmNumberOfChatMessagesQuery(),
-        CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-      )
-    } else {
-      apolloClient.registerTestResponse(
-        NumberOfChatMessagesQuery(),
-        NumberOfChatMessagesQuery.Data(OctopusFakeResolver),
-      )
-    }
+    apolloClient.registerTestResponse(
+      CbmNumberOfChatMessagesQuery(),
+      CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
+    )
 
     val result = getHomeDataUseCase.invoke(true).first()
 

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenterTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenterTest.kt
@@ -13,7 +13,7 @@ import assertk.assertions.isTrue
 import assertk.assertions.prop
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.data.chat.read.timestamp.FakeChatLastMessageReadRepository
 import com.hedvig.android.data.contract.android.CrossSell
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
@@ -49,14 +49,14 @@ internal class HomePresenterTest {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
       assertThat(getHomeDataUseCase.forceNetworkFetchTurbine.awaitItem()).isFalse()
 
-      getHomeDataUseCase.responseTurbine.add(ErrorMessage().left())
+      getHomeDataUseCase.responseTurbine.add(ApolloOperationError.OperationError("").left())
       assertThat(awaitItem()).isInstanceOf<HomeUiState.Error>()
 
       sendEvent(HomeEvent.RefreshData)
       assertThat(getHomeDataUseCase.forceNetworkFetchTurbine.awaitItem()).isTrue()
       assertThat(awaitItem()).isInstanceOf<HomeUiState.Loading>()
 
-      getHomeDataUseCase.responseTurbine.add(ErrorMessage().left())
+      getHomeDataUseCase.responseTurbine.add(ApolloOperationError.OperationError("").left())
       assertThat(awaitItem()).isInstanceOf<HomeUiState.Error>()
     }
   }
@@ -75,7 +75,7 @@ internal class HomePresenterTest {
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
 
-      getHomeDataUseCase.responseTurbine.add(ErrorMessage().left())
+      getHomeDataUseCase.responseTurbine.add(ApolloOperationError.OperationError("").left())
       assertThat(awaitItem()).isInstanceOf<HomeUiState.Error>()
 
       sendEvent(HomeEvent.RefreshData)
@@ -212,7 +212,7 @@ internal class HomePresenterTest {
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
 
-      getHomeDataUseCase.responseTurbine.add(ErrorMessage().left())
+      getHomeDataUseCase.responseTurbine.add(ApolloOperationError.OperationError("").left())
       assertThat(awaitItem()).isInstanceOf<HomeUiState.Error>()
 
       getHomeDataUseCase.responseTurbine.add(someIrrelevantHomeDataInstance.right())
@@ -487,9 +487,9 @@ internal class HomePresenterTest {
 
   private class TestGetHomeDataUseCase : GetHomeDataUseCase {
     val forceNetworkFetchTurbine = Turbine<Boolean>()
-    val responseTurbine = Turbine<Either<ErrorMessage, HomeData>>()
+    val responseTurbine = Turbine<Either<ApolloOperationError, HomeData>>()
 
-    override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ErrorMessage, HomeData>> {
+    override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> {
       forceNetworkFetchTurbine.add(forceNetworkFetch)
       return responseTurbine.asChannel().receiveAsFlow()
     }


### PR DESCRIPTION
Log EVERYTHING around GQL requests, and make home query keep the ApolloOperationResponse signature so when it's logged it should hopefully contain the information of what went wrong.