### PR TITLE
Fix Android <= 8.1 not rendering clipped content properly

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -192,6 +192,7 @@ private val buildConstantsModule = module {
       override val isDebug: Boolean = BuildConfig.DEBUG
       override val isProduction: Boolean =
         BuildConfig.BUILD_TYPE == "release" && BuildConfig.APPLICATION_ID == "com.hedvig.app"
+      override val buildApiVersion: Int = Build.VERSION.SDK_INT
     }
   }
 }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -22,6 +22,7 @@ import com.hedvig.android.app.urihandler.DeepLinkFirstUriHandler
 import com.hedvig.android.app.urihandler.SafeAndroidUriHandler
 import com.hedvig.android.auth.AuthStatus
 import com.hedvig.android.auth.AuthTokenService
+import com.hedvig.android.compose.ui.UseSimplerShapesForOldAndroidVersions
 import com.hedvig.android.core.appreview.WaitUntilAppReviewDialogShouldBeOpenedUseCase
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
 import com.hedvig.android.core.demomode.DemoManager
@@ -99,7 +100,10 @@ internal fun HedvigApp(
         navController = hedvigAppState.navController,
         delegate = SafeAndroidUriHandler(LocalContext.current),
       )
-      CompositionLocalProvider(LocalUriHandler provides deepLinkFirstUriHandler) {
+      CompositionLocalProvider(
+        LocalUriHandler provides deepLinkFirstUriHandler,
+        UseSimplerShapesForOldAndroidVersions provides (hedvigBuildConstants.buildApiVersion <= 27),
+      ) {
         HedvigAppUi(
           hedvigAppState = hedvigAppState,
           hedvigDeepLinkContainer = hedvigDeepLinkContainer,

--- a/app/compose/compose-ui/src/main/kotlin/com/hedvig/android/compose/ui/UseSimplerShapesForOldAndroidVersions.kt
+++ b/app/compose/compose-ui/src/main/kotlin/com/hedvig/android/compose/ui/UseSimplerShapesForOldAndroidVersions.kt
@@ -1,0 +1,10 @@
+package com.hedvig.android.compose.ui
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * https://issuetracker.google.com/issues/347031392
+ * In API versions 27 and lower, we default to a rounded corner shape instead of the more intricate shape since there
+ * is a bug with nothing rendering at all for all UI clipped with any generic shape.
+ */
+val UseSimplerShapesForOldAndroidVersions = staticCompositionLocalOf { false }

--- a/app/core/core-build-constants/src/main/kotlin/com/hedvig/android/core/buildconstants/HedvigBuildConstants.kt
+++ b/app/core/core-build-constants/src/main/kotlin/com/hedvig/android/core/buildconstants/HedvigBuildConstants.kt
@@ -60,4 +60,9 @@ interface HedvigBuildConstants {
    * do sometimes want to know the difference.
    */
   val isProduction: Boolean
+
+  /**
+   * The Android SDK version we are currently running on
+   */
+  val buildApiVersion: Int
 }

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/bottomsheet/HedvigBottomSheet.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/bottomsheet/HedvigBottomSheet.kt
@@ -71,7 +71,7 @@ fun HedvigBottomSheet(
     sheetState = sheetState,
     tonalElevation = 0.dp,
     shape = MaterialTheme.shapes.squircleLargeTop,
-    windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+    contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
   ) {
     Column(
       modifier = Modifier.verticalScroll(rememberScrollState()),

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/card/HedvigCard.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/card/HedvigCard.kt
@@ -110,7 +110,6 @@ private fun Card(
     shape = shape,
     color = colors.containerColor(enabled = true),
     contentColor = colors.contentColor(enabled = true),
-    tonalElevation = elevation.tonalElevation(enabled = true),
     shadowElevation = elevation.shadowElevation(enabled = true, interactionSource = null).value,
     border = border,
   ) {
@@ -141,7 +140,6 @@ private fun Card(
     shape = shape,
     color = colors.containerColor(enabled),
     contentColor = colors.contentColor(enabled),
-    tonalElevation = elevation.tonalElevation(enabled),
     shadowElevation = elevation.shadowElevation(enabled, interactionSource).value,
     border = border,
     interactionSource = interactionSource,

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/tokens/HedvigShapeKeyTokens.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/component/tokens/HedvigShapeKeyTokens.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Shape
+import com.hedvig.android.compose.ui.UseSimplerShapesForOldAndroidVersions
 import com.hedvig.android.core.designsystem.material3.fromToken
 
 @Suppress("unused")
@@ -23,4 +24,4 @@ internal enum class HedvigShapeKeyTokens {
 internal val HedvigShapeKeyTokens.value: Shape
   @Composable
   @ReadOnlyComposable
-  get() = MaterialTheme.shapes.fromToken(this)
+  get() = MaterialTheme.shapes.fromToken(this, UseSimplerShapesForOldAndroidVersions.current)

--- a/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigShapes.kt
+++ b/app/core/core-design-system/src/main/kotlin/com/hedvig/android/core/designsystem/material3/HedvigShapes.kt
@@ -4,6 +4,7 @@ package com.hedvig.android.core.designsystem.material3
 
 import androidx.annotation.FloatRange
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.CornerRounding
 import androidx.graphics.shapes.RoundedPolygon
 import androidx.graphics.shapes.toPath
+import com.hedvig.android.compose.ui.UseSimplerShapesForOldAndroidVersions
 import com.hedvig.android.core.designsystem.component.tokens.HedvigShapeKeyTokens
 
 // Take shapes from existing theme setup
@@ -76,21 +78,38 @@ private val SquircleExtraSmall = FigmaShape(8.dp)
 private val SquircleExtraSmallTop = FigmaShape(8.dp).top()
 private val SquircleSmall = FigmaShape(10.dp)
 private val SquircleMedium = FigmaShape(12.dp)
-private val SquircleMediumTop = FigmaShape(12.dp).top()
 private val SquircleLarge = FigmaShape(16.dp)
 private val SquircleLargeTop = FigmaShape(16.dp).top()
 private val SquircleExtraLarge = FigmaShape(24.dp)
 private val SquircleExtraLargeTop = FigmaShape(24.dp).top()
 
-val Shapes.squircleExtraSmall: Shape get() = SquircleExtraSmall
-val Shapes.squircleExtraSmallTop: Shape get() = SquircleExtraSmallTop
-val Shapes.squircleSmall: Shape get() = SquircleSmall
-val Shapes.squircleMedium: Shape get() = SquircleMedium
-val Shapes.squircleMediumTop: Shape get() = SquircleMediumTop
-val Shapes.squircleLarge: Shape get() = SquircleLarge
-val Shapes.squircleLargeTop: Shape get() = SquircleLargeTop
-val Shapes.squircleExtraLarge: Shape get() = SquircleExtraLarge
-val Shapes.squircleExtraLargeTop: Shape get() = SquircleExtraLargeTop
+private val RoundedSquircleExtraSmall = RoundedCornerShape(8.dp)
+private val RoundedSquircleExtraSmallTop = RoundedCornerShape(8.dp)
+  .copy(bottomStart = CornerSize(0), bottomEnd = CornerSize(0))
+private val RoundedSquircleSmall = RoundedCornerShape(10.dp)
+private val RoundedSquircleMedium = RoundedCornerShape(12.dp)
+private val RoundedSquircleLarge = RoundedCornerShape(16.dp)
+private val RoundedSquircleLargeTop = RoundedCornerShape(16.dp)
+  .copy(bottomStart = CornerSize(0), bottomEnd = CornerSize(0))
+private val RoundedSquircleExtraLarge = RoundedCornerShape(24.dp)
+private val RoundedSquircleExtraLargeTop = RoundedCornerShape(24.dp)
+  .copy(bottomStart = CornerSize(0), bottomEnd = CornerSize(0))
+
+val Shapes.squircleExtraSmall: Shape
+  @Composable
+  get() = if (UseSimplerShapesForOldAndroidVersions.current) RoundedSquircleExtraSmall else SquircleExtraSmall
+val Shapes.squircleSmall: Shape
+  @Composable
+  get() = if (UseSimplerShapesForOldAndroidVersions.current) RoundedSquircleSmall else SquircleSmall
+val Shapes.squircleMedium: Shape
+  @Composable
+  get() = if (UseSimplerShapesForOldAndroidVersions.current) RoundedSquircleMedium else SquircleMedium
+val Shapes.squircleLarge: Shape
+  @Composable
+  get() = if (UseSimplerShapesForOldAndroidVersions.current) RoundedSquircleLarge else SquircleLarge
+val Shapes.squircleLargeTop: Shape
+  @Composable
+  get() = if (UseSimplerShapesForOldAndroidVersions.current) RoundedSquircleLargeTop else SquircleLargeTop
 
 /**
  * Turns the shape into one where only the top corners apply, by combining the path with a square path at the bottom.
@@ -120,18 +139,33 @@ private fun Shape.top(): Shape = object : Shape {
  * tokens:
  * ``MaterialTheme.shapes.fromToken(FabPrimarySmallTokens.ContainerShape)``
  */
-internal fun Shapes.fromToken(value: HedvigShapeKeyTokens): Shape {
-  return when (value) {
-    HedvigShapeKeyTokens.CornerExtraLarge -> SquircleExtraLarge
-    HedvigShapeKeyTokens.CornerExtraLargeTop -> SquircleExtraLargeTop
-    HedvigShapeKeyTokens.CornerExtraSmall -> SquircleExtraSmall
-    HedvigShapeKeyTokens.CornerExtraSmallTop -> SquircleExtraSmallTop
-    HedvigShapeKeyTokens.CornerFull -> CircleShape
-    HedvigShapeKeyTokens.CornerLarge -> SquircleLarge
-    HedvigShapeKeyTokens.CornerLargeTop -> SquircleLargeTop
-    HedvigShapeKeyTokens.CornerMedium -> SquircleMedium
-    HedvigShapeKeyTokens.CornerNone -> RectangleShape
-    HedvigShapeKeyTokens.CornerSmall -> SquircleSmall
+internal fun Shapes.fromToken(token: HedvigShapeKeyTokens, useSimplerShapes: Boolean): Shape {
+  return if (useSimplerShapes) {
+    when (token) {
+      HedvigShapeKeyTokens.CornerExtraLarge -> RoundedSquircleExtraLarge
+      HedvigShapeKeyTokens.CornerExtraLargeTop -> RoundedSquircleExtraLargeTop
+      HedvigShapeKeyTokens.CornerExtraSmall -> RoundedSquircleExtraSmall
+      HedvigShapeKeyTokens.CornerExtraSmallTop -> RoundedSquircleExtraSmallTop
+      HedvigShapeKeyTokens.CornerFull -> CircleShape
+      HedvigShapeKeyTokens.CornerLarge -> RoundedSquircleLarge
+      HedvigShapeKeyTokens.CornerLargeTop -> RoundedSquircleLargeTop
+      HedvigShapeKeyTokens.CornerMedium -> RoundedSquircleMedium
+      HedvigShapeKeyTokens.CornerNone -> RectangleShape
+      HedvigShapeKeyTokens.CornerSmall -> RoundedSquircleSmall
+    }
+  } else {
+    when (token) {
+      HedvigShapeKeyTokens.CornerExtraLarge -> SquircleExtraLarge
+      HedvigShapeKeyTokens.CornerExtraLargeTop -> SquircleExtraLargeTop
+      HedvigShapeKeyTokens.CornerExtraSmall -> SquircleExtraSmall
+      HedvigShapeKeyTokens.CornerExtraSmallTop -> SquircleExtraSmallTop
+      HedvigShapeKeyTokens.CornerFull -> CircleShape
+      HedvigShapeKeyTokens.CornerLarge -> SquircleLarge
+      HedvigShapeKeyTokens.CornerLargeTop -> SquircleLargeTop
+      HedvigShapeKeyTokens.CornerMedium -> SquircleMedium
+      HedvigShapeKeyTokens.CornerNone -> RectangleShape
+      HedvigShapeKeyTokens.CornerSmall -> SquircleSmall
+    }
   }
 }
 
@@ -139,5 +173,5 @@ internal fun Shapes.fromToken(value: HedvigShapeKeyTokens): Shape {
 @Composable
 @ReadOnlyComposable
 internal fun HedvigShapeKeyTokens.toShape(): Shape {
-  return MaterialTheme.shapes.fromToken(this)
+  return MaterialTheme.shapes.fromToken(this, UseSimplerShapesForOldAndroidVersions.current)
 }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
@@ -111,9 +111,9 @@ private fun DragHandle(modifier: Modifier = Modifier) {
       .width(40.dp)
       .height(4.dp)
       .background(
-        shape = ShapeDefaults.CornerSmall,
+        shape = HedvigTheme.shapes.cornerSmall,
         color = bottomSheetColors.chipColor,
-      ).clip(ShapeDefaults.CornerSmall),
+      ).clip(HedvigTheme.shapes.cornerSmall),
   ) {}
 }
 

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Shapes.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Shapes.kt
@@ -5,47 +5,58 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Shape
+import com.hedvig.android.compose.ui.UseSimplerShapesForOldAndroidVersions
 import com.hedvig.android.design.system.hedvig.tokens.ShapeKeyTokens
 import com.hedvig.android.design.system.hedvig.tokens.ShapeTokens
 import com.hedvig.android.design.system.hedvig.tokens.ShapeTokens.CornerTopOnlyXLarge
 
 @Immutable
 data class Shapes(
-  val cornerXXLarge: Shape = ShapeDefaults.CornerXXLarge,
-  val cornerXLarge: Shape = ShapeDefaults.CornerXLarge,
-  val cornerLarge: Shape = ShapeDefaults.CornerLarge,
-  val cornerMedium: Shape = ShapeDefaults.CornerMedium,
-  val cornerSmall: Shape = ShapeDefaults.CornerSmall,
-  val cornerExtraSmall: Shape = ShapeDefaults.CornerExtraSmall,
-  val cornerNone: Shape = ShapeDefaults.CornerNone,
+  val cornerXXLarge: Shape = ShapeTokens.CornerXXLarge,
+  val cornerXLarge: Shape = ShapeTokens.CornerXLarge,
+  val cornerLarge: Shape = ShapeTokens.CornerLarge,
+  val cornerMedium: Shape = ShapeTokens.CornerMedium,
+  val cornerSmall: Shape = ShapeTokens.CornerSmall,
+  val cornerExtraSmall: Shape = ShapeTokens.CornerExtraSmall,
+  val cornerNone: Shape = ShapeTokens.CornerNone,
+  val roundedCornerXXLarge: Shape = ShapeTokens.RoundedCornerXXLarge,
+  val roundedCornerXLarge: Shape = ShapeTokens.RoundedCornerXLarge,
+  val roundedCornerLarge: Shape = ShapeTokens.RoundedCornerLarge,
+  val roundedCornerMedium: Shape = ShapeTokens.RoundedCornerMedium,
+  val roundedCornerSmall: Shape = ShapeTokens.RoundedCornerSmall,
+  val roundedCornerExtraSmall: Shape = ShapeTokens.RoundedCornerExtraSmall,
+  val roundedCornerTopOnlyXLarge: Shape = ShapeTokens.RoundedCornerTopOnlyXLarge,
 )
 
-object ShapeDefaults {
-  val CornerXXLarge: Shape = ShapeTokens.CornerXXLarge
-  val CornerXLarge: Shape = ShapeTokens.CornerXLarge
-  val CornerLarge: Shape = ShapeTokens.CornerLarge
-  val CornerMedium: Shape = ShapeTokens.CornerMedium
-  val CornerSmall: Shape = ShapeTokens.CornerSmall
-  val CornerExtraSmall: Shape = ShapeTokens.CornerExtraSmall
-  val CornerNone: Shape = ShapeTokens.CornerNone
-}
-
-internal fun Shapes.fromToken(value: ShapeKeyTokens): Shape {
-  return when (value) {
-    ShapeKeyTokens.CornerXXLarge -> cornerXXLarge
-    ShapeKeyTokens.CornerXLarge -> cornerXLarge
-    ShapeKeyTokens.CornerLarge -> cornerLarge
-    ShapeKeyTokens.CornerMedium -> cornerMedium
-    ShapeKeyTokens.CornerSmall -> cornerSmall
-    ShapeKeyTokens.CornerExtraSmall -> cornerExtraSmall
-    ShapeKeyTokens.CornerNone -> cornerNone
-    ShapeKeyTokens.CornerTopOnlyXLarge -> CornerTopOnlyXLarge
+internal fun Shapes.fromToken(token: ShapeKeyTokens, useSimplerShapes: Boolean): Shape {
+  return if (useSimplerShapes) {
+    when (token) {
+      ShapeKeyTokens.CornerXXLarge -> roundedCornerXXLarge
+      ShapeKeyTokens.CornerXLarge -> roundedCornerXLarge
+      ShapeKeyTokens.CornerLarge -> roundedCornerLarge
+      ShapeKeyTokens.CornerMedium -> roundedCornerMedium
+      ShapeKeyTokens.CornerSmall -> roundedCornerSmall
+      ShapeKeyTokens.CornerExtraSmall -> roundedCornerExtraSmall
+      ShapeKeyTokens.CornerNone -> cornerNone
+      ShapeKeyTokens.CornerTopOnlyXLarge -> roundedCornerTopOnlyXLarge
+    }
+  } else {
+    when (token) {
+      ShapeKeyTokens.CornerXXLarge -> cornerXXLarge
+      ShapeKeyTokens.CornerXLarge -> cornerXLarge
+      ShapeKeyTokens.CornerLarge -> cornerLarge
+      ShapeKeyTokens.CornerMedium -> cornerMedium
+      ShapeKeyTokens.CornerSmall -> cornerSmall
+      ShapeKeyTokens.CornerExtraSmall -> cornerExtraSmall
+      ShapeKeyTokens.CornerNone -> cornerNone
+      ShapeKeyTokens.CornerTopOnlyXLarge -> CornerTopOnlyXLarge
+    }
   }
 }
 
 internal val ShapeKeyTokens.value: Shape
   @Composable
   @ReadOnlyComposable
-  get() = HedvigTheme.shapes.fromToken(this)
+  get() = HedvigTheme.shapes.fromToken(this, UseSimplerShapesForOldAndroidVersions.current)
 
 internal val LocalShapes = staticCompositionLocalOf { Shapes() }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Toggle.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Toggle.kt
@@ -283,7 +283,7 @@ private fun ToggleBackground(
 ) {
   Surface(
     color = color,
-    shape = ShapeDefaults.CornerLarge,
+    shape = HedvigTheme.shapes.cornerLarge,
     modifier = modifier,
   ) {
     Box(

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/ShapeTokens.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/ShapeTokens.kt
@@ -1,6 +1,8 @@
 package com.hedvig.android.design.system.hedvig.tokens
 
 import androidx.annotation.FloatRange
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
@@ -24,6 +26,17 @@ internal object ShapeTokens {
   val CornerExtraSmall: Shape = FigmaShape(6.dp)
   val CornerNone: Shape = RectangleShape
   val CornerTopOnlyXLarge: Shape = SquircleTopShape(16.dp)
+
+  val RoundedCornerXXLarge: Shape = RoundedCornerShape(24.dp)
+  val RoundedCornerXLarge: Shape = RoundedCornerShape(16.dp)
+  val RoundedCornerLarge: Shape = RoundedCornerShape(12.dp)
+  val RoundedCornerMedium: Shape = RoundedCornerShape(10.dp)
+  val RoundedCornerSmall: Shape = RoundedCornerShape(8.dp)
+  val RoundedCornerExtraSmall: Shape = RoundedCornerShape(6.dp)
+  val RoundedCornerTopOnlyXLarge: Shape = RoundedCornerShape(16.dp).copy(
+    bottomStart = CornerSize(0),
+    bottomEnd = CornerSize(0),
+  )
 }
 
 private fun RoundedPolygon.Companion.squircle(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -145,7 +145,7 @@ private fun EditCoInsuredScreen(
             shape = MaterialTheme.shapes.squircleLargeTop,
             sheetState = sheetState,
             tonalElevation = 0.dp,
-            windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+            contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
           ) {
             AddCoInsuredBottomSheetContent(
               bottomSheetState = uiState.addBottomSheetState,

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -168,7 +168,7 @@ private fun EditCoInsuredScreen(
             shape = MaterialTheme.shapes.squircleLargeTop,
             sheetState = sheetState,
             tonalElevation = 0.dp,
-            windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+            contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
           ) {
             AddCoInsuredBottomSheetContent(
               bottomSheetState = uiState.addBottomSheetState,
@@ -199,7 +199,7 @@ private fun EditCoInsuredScreen(
             shape = MaterialTheme.shapes.squircleLargeTop,
             sheetState = sheetState,
             tonalElevation = 0.dp,
-            windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+            contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
           ) {
             RemoveCoInsuredBottomSheetContent(
               onRemove = { onRemoveCoInsured(it) },

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
@@ -77,7 +77,7 @@ internal fun CoverageTab(
       shape = MaterialTheme.shapes.squircleLargeTop,
       sheetState = sheetState,
       tonalElevation = 0.dp,
-      windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+      contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
     ) {
       Column(
         Modifier

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -98,7 +98,7 @@ internal fun YourInfoTab(
       shape = MaterialTheme.shapes.squircleLargeTop,
       sheetState = sheetState,
       tonalElevation = 0.dp,
-      windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+      contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
     ) {
       EditInsuranceBottomSheetContent(
         allowChangeAddress = allowChangeAddress,
@@ -148,7 +148,7 @@ internal fun YourInfoTab(
       shape = MaterialTheme.shapes.squircleLargeTop,
       sheetState = sheetState,
       tonalElevation = 0.dp,
-      windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+      contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
     ) {
       UpcomingChangesBottomSheetContent(
         infoText = stringResource(

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
@@ -105,7 +105,7 @@ private fun MarketingScreen(
           containerColor = MaterialTheme.colorScheme.background,
           onDismissRequest = { showPreferencesSheet = false },
           sheetState = sheetState,
-          windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+          contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
         ) {
           Column(Modifier.verticalScroll(rememberScrollState())) {
             PreferencesSheetContent(

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/discounts/DiscountsDestination.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/discounts/DiscountsDestination.kt
@@ -114,7 +114,7 @@ private fun DiscountsScreen(
         shape = MaterialTheme.shapes.squircleLargeTop,
         sheetState = sheetState,
         tonalElevation = 0.dp,
-        windowInsets = BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top),
+        contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
       ) {
         AddDiscountBottomSheet(
           onAddDiscount = { code ->

--- a/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/EnableNotificationsReminderManagerTest.kt
+++ b/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/EnableNotificationsReminderManagerTest.kt
@@ -131,4 +131,5 @@ private val TestHedvigBuildConstants = object : HedvigBuildConstants {
   override val appId: String = ""
   override val isDebug: Boolean = false
   override val isProduction: Boolean = true
+  override val buildApiVersion: Int = Int.MAX_VALUE
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,31 +28,31 @@ squareSortDependencies = "0.8"
 
 # Other versions sorted alphabetically
 accompanist = "0.34.0"
-androidx-activity-compose = "1.9.1"
-androidx-activity-core = "1.9.1"
+androidx-activity-compose = "1.9.2"
+androidx-activity-core = "1.9.2"
 androidx-annotation = "1.8.2"
-androidx-composeBom = "2024.08.00"
+androidx-composeBom = "2024.09.00"
 androidx-datastore = "1.1.1"
 androidx-junit = "1.2.1"
-androidx-lifecycle = "2.8.4"
-androidx-navigation = "2.8.0-rc01"
+androidx-lifecycle = "2.8.5"
+androidx-navigation = "2.8.0"
 androidx-other-appCompat = "1.7.0"
 androidx-other-browser = "1.8.0"
 androidx-other-constraintLayout = "2.1.4"
 androidx-other-core = "1.13.1"
-androidx-other-splashscreen = "1.2.0-alpha01"
+androidx-other-splashscreen = "1.2.0-alpha02"
 androidx-other-startup = "1.1.1"
 androidx-other-workManager = "2.9.1"
 androidx-profileInstaller = "1.3.1"
 androidx-test = "1.6.1"
 androidx-testRunners = "1.6.2"
-androidxGraphicsShapes = "1.0.0"
+androidxGraphicsShapes = "1.0.1"
 arrow = "1.2.4"
 assertK = "0.28.1"
 coil = "2.7.0"
 composeRichtext = "0.20.0"
 concatAdapterExtension = "1.2.1"
-coreLibraryDesugaring = "2.1.1"
+coreLibraryDesugaring = "2.1.2"
 coroutines = "1.8.1"
 datadog = "2.12.1"
 dependencyAnalysis = "2.0.1"
@@ -93,13 +93,13 @@ androidx-activity-core = { module = "androidx.activity:activity", version.ref = 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-compose-animation = { module = "androidx.compose.animation:animation-core" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-composeBom" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version = "1.7.0-rc01" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-foundationLayout = { module = "androidx.compose.foundation:foundation-layout" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-material3-windowSizeClass = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-materialIconsCore = { module = "androidx.compose.material:material-icons-core" }
 androidx-compose-materialIconsExtended = { module = "androidx.compose.material:material-icons-extended" }
-androidx-compose-materialRipple = { module = "androidx.compose.material:material-ripple", version = "1.7.0-rc01" }
+androidx-compose-materialRipple = { module = "androidx.compose.material:material-ripple" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 androidx-compose-uiCore = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
Done by a hacky composition local which is just provided by the :app module through 
`UseSimplerShapesForOldAndroidVersions provides (hedvigBuildConstants.buildApiVersion <= 27),`
Then in the token resolution path, where we still have access to composition locals we grab it and branch to the right path.

Don't love it but I hope they do just fix it anyway at some point so we can just remove this local completely.

This has some unrelated material3 changes as I bumped to latest compose BOM to make sure they didn't just fix it in the latest release anyway.