### PR TITLE
GEN-2638 nullify coinsured info

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -40,7 +39,7 @@ import com.hedvig.android.design.system.hedvig.tokens.BottomSheetTokens
 import eu.wewox.modalsheet.ExperimentalSheetApi
 import eu.wewox.modalsheet.ModalSheet
 
-@OptIn(ExperimentalSheetApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalSheetApi::class)
 @Composable
 fun HedvigBottomSheet(
   isVisible: Boolean,

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/RadioGroup.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/RadioGroup.kt
@@ -259,7 +259,6 @@ private fun HorizontalWithLabelRadioOption(
         indication = ripple(
           bounded = false,
           radius = 50.dp,
-          // todo: pls check out this ripple. I like this one, but maybe it's too much
         ),
       ) {
         if (enabled) {

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -37,9 +37,6 @@ import com.hedvig.android.compose.ui.preview.TripleCase
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.error.HedvigErrorSection
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
-import com.hedvig.android.core.designsystem.material3.infoContainer
-import com.hedvig.android.core.designsystem.material3.onInfoContainer
-import com.hedvig.android.core.designsystem.material3.squircleExtraSmall
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
 import com.hedvig.android.core.ui.getLocale

--- a/app/feature/feature-edit-coinsured/build.gradle.kts
+++ b/app/feature/feature-edit-coinsured/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   implementation(projects.navigationCompose)
   implementation(projects.navigationComposeTyped)
   implementation(projects.navigationCore)
+  implementation(projects.designSystemHedvig)
 
   testImplementation(libs.apollo.testingSupport)
   testImplementation(libs.assertK)

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -62,6 +62,8 @@ import com.hedvig.android.core.ui.text.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.core.ui.text.WarningTextWithIconForInput
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.AddBottomSheetState
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.InfoFromSsn
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.ManualInfo
 import hedvig.resources.R
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
@@ -103,7 +105,7 @@ internal fun AddCoInsuredBottomSheetContent(
     } else {
       AnimatedVisibility(visible = bottomSheetState.showManualInput) {
         ManualInputFields(
-          birthDate = bottomSheetState.birthDate,
+          birthDate = bottomSheetState.manualInfo.birthDate,
           errorMessage = bottomSheetState.errorMessage,
           onBirthDateChanged = onBirthDateChanged,
           onFirstNameChanged = onFirstNameChanged,
@@ -460,6 +462,8 @@ private fun AddCoInsuredBottomSheetContentPreview() {
       AddCoInsuredBottomSheetContent(
         bottomSheetState = AddBottomSheetState(
           errorMessage = "Error",
+          manualInfo = ManualInfo(),
+          infoFromSsn = InfoFromSsn(),
           selectableCoInsured = listOf(
             CoInsured(
               "Test",
@@ -501,8 +505,9 @@ private fun AddCoInsuredBottomSheetContentWithCoInsuredPreview() {
           errorMessage = "errorMessage",
           showUnderAgedInfo = true,
           showManualInput = true,
-          birthDate = LocalDate(2016, 7, 28),
-        ),
+          infoFromSsn = InfoFromSsn(),
+          manualInfo = ManualInfo(birthDate = LocalDate(2016, 7, 28),
+        )),
         onSsnChanged = {},
         onContinue = {},
         onManualInputSwitchChanged = {},

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -7,14 +7,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -77,16 +72,13 @@ internal fun AddCoInsuredBottomSheetContent(
   onSsnChanged: (String) -> Unit,
   onContinue: () -> Unit,
   onManualInputSwitchChanged: (Boolean) -> Unit,
-  onDismiss: () -> Unit,
   onBirthDateChanged: (LocalDate) -> Unit,
   onFirstNameChanged: (String) -> Unit,
   onLastNameChanged: (String) -> Unit,
   onAddNewCoInsured: () -> Unit,
   onCoInsuredSelected: (CoInsured) -> Unit,
 ) {
-  Column(
-    modifier = Modifier.padding(horizontal = 16.dp),
-  ) {
+  Column {
     Spacer(Modifier.height(16.dp))
     Text(
       text = stringResource(id = R.string.CONTRACT_ADD_COINSURED),
@@ -106,6 +98,8 @@ internal fun AddCoInsuredBottomSheetContent(
       AnimatedVisibility(visible = bottomSheetState.showManualInput) {
         ManualInputFields(
           birthDate = bottomSheetState.manualInfo.birthDate,
+          firstName = bottomSheetState.manualInfo.firstName,
+          lastName = bottomSheetState.manualInfo.lastName,
           errorMessage = bottomSheetState.errorMessage,
           onBirthDateChanged = onBirthDateChanged,
           onFirstNameChanged = onFirstNameChanged,
@@ -115,6 +109,7 @@ internal fun AddCoInsuredBottomSheetContent(
       AnimatedVisibility(visible = !bottomSheetState.showManualInput) {
         FetchFromSsnFields(
           displayName = bottomSheetState.displayName,
+          ssn = bottomSheetState.infoFromSsn.ssn,
           errorMessage = bottomSheetState.errorMessage,
           onSsnChanged = onSsnChanged,
           onContinue = onContinue,
@@ -169,13 +164,6 @@ internal fun AddCoInsuredBottomSheetContent(
       isLoading = bottomSheetState.isLoading,
     )
     Spacer(Modifier.height(8.dp))
-    HedvigTextButton(
-      onClick = onDismiss,
-      text = stringResource(id = R.string.general_cancel_button),
-      modifier = Modifier.fillMaxWidth(),
-    )
-    Spacer(Modifier.height(16.dp))
-    Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)))
   }
 }
 
@@ -206,12 +194,13 @@ internal fun SelectableCoInsuredList(
 
 @Composable
 private fun FetchFromSsnFields(
+  ssn: String?,
   displayName: String,
   errorMessage: String?,
   onSsnChanged: (String) -> Unit,
   onContinue: () -> Unit,
 ) {
-  var ssnInput by remember { mutableStateOf("") }
+  var ssnInput by remember { mutableStateOf(ssn ?: "") }
   val mask = stringResource(id = R.string.edit_coinsured_ssn_placeholder)
   val maskColor = MaterialTheme.colorScheme.onSurfaceVariant
   Column {
@@ -298,13 +287,15 @@ private class PersonalNumberVisualTransformation(
 @Composable
 private fun ManualInputFields(
   birthDate: LocalDate?,
+  firstName: String?,
+  lastName: String?,
   onBirthDateChanged: (LocalDate) -> Unit,
   onFirstNameChanged: (String) -> Unit,
   onLastNameChanged: (String) -> Unit,
   errorMessage: String?,
 ) {
-  var firstNameInput by remember { mutableStateOf("") }
-  var lastNameInput by remember { mutableStateOf("") }
+  var firstNameInput by remember { mutableStateOf(firstName ?: "") }
+  var lastNameInput by remember { mutableStateOf(lastName ?: "") }
 
   Column {
     DatePickerWithDialog(
@@ -484,7 +475,6 @@ private fun AddCoInsuredBottomSheetContentPreview() {
         onSsnChanged = {},
         onContinue = {},
         onManualInputSwitchChanged = {},
-        onDismiss = {},
         onBirthDateChanged = {},
         onFirstNameChanged = {},
         onLastNameChanged = {},
@@ -506,12 +496,13 @@ private fun AddCoInsuredBottomSheetContentWithCoInsuredPreview() {
           showUnderAgedInfo = true,
           showManualInput = true,
           infoFromSsn = InfoFromSsn(),
-          manualInfo = ManualInfo(birthDate = LocalDate(2016, 7, 28),
-        )),
+          manualInfo = ManualInfo(
+            birthDate = LocalDate(2016, 7, 28),
+          ),
+        ),
         onSsnChanged = {},
         onContinue = {},
         onManualInputSwitchChanged = {},
-        onDismiss = {},
         onBirthDateChanged = {},
         onFirstNameChanged = {},
         onLastNameChanged = {},

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.editcoinsured.ui
 
+import android.icu.text.IDNA.Info
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -38,6 +39,8 @@ import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import com.hedvig.android.feature.editcoinsured.data.Member
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.InfoFromSsn
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.ManualInfo
 import hedvig.resources.R
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
@@ -281,6 +284,8 @@ private fun EditCoInsuredScreenEditablePreview() {
           ),
           addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
             isLoading = false,
+            manualInfo = ManualInfo(),
+            infoFromSsn = InfoFromSsn()
           ),
           removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
         ),
@@ -336,6 +341,8 @@ private fun EditCoInsuredScreenNonEditablePreview() {
           ),
           addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
             isLoading = false,
+            infoFromSsn = InfoFromSsn(),
+            manualInfo = ManualInfo()
           ),
           removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
         ),

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -23,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
@@ -154,7 +157,11 @@ private fun EditCoInsuredScreen(
 
         Column(
           modifier = Modifier
-            .weight(1f)
+            .fillMaxSize()
+            .padding(
+              WindowInsets
+                .safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues(),
+            )
             .verticalScroll(state = rememberScrollState()),
         ) {
           CoInsuredList(
@@ -162,6 +169,7 @@ private fun EditCoInsuredScreen(
             onRemove = {},
             onEdit = onCoInsuredClicked,
             allowEdit = true,
+            modifier = Modifier.padding(horizontal = 16.dp),
           )
           Spacer(Modifier.height(8.dp))
 
@@ -170,23 +178,23 @@ private fun EditCoInsuredScreen(
               text = stringResource(
                 id = R.string.CONTRACT_ADD_COINSURED_REVIEW_INFO,
               ),
-              modifier = Modifier.padding(horizontal = 16.dp),
-            )
-          }
-        }
-
-        Column {
-          if (uiState.listState.priceInfo != null && uiState.listState.hasMadeChanges()) {
-            Spacer(Modifier.height(8.dp))
-            HedvigContainedButton(
-              text = stringResource(id = R.string.GENERAL_SAVE_CHANGES_BUTTON),
-              onClick = onCommitChanges,
-              enabled = true,
-              isLoading = uiState.listState.isCommittingUpdate,
-              modifier = Modifier.padding(horizontal = 16.dp),
+              modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
             )
           }
 
+          Spacer(Modifier.weight(1f))
+          Column {
+            if (uiState.listState.priceInfo != null && uiState.listState.hasMadeChanges()) {
+              Spacer(Modifier.height(8.dp))
+              HedvigContainedButton(
+                text = stringResource(id = R.string.GENERAL_SAVE_CHANGES_BUTTON),
+                onClick = onCommitChanges,
+                enabled = true,
+                isLoading = uiState.listState.isCommittingUpdate,
+                modifier = Modifier.padding(horizontal = 16.dp),
+              )
+            }
+          }
           Spacer(Modifier.height(8.dp))
           HedvigTextButton(
             onClick = navigateUp,
@@ -194,8 +202,8 @@ private fun EditCoInsuredScreen(
             modifier = Modifier.padding(horizontal = 16.dp),
           )
           Spacer(Modifier.height(16.dp))
+          Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)))
         }
-        Spacer(Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)))
       }
 
       EditCoInsuredState.Loading -> HedvigFullScreenCenterAlignedProgressDebounced()
@@ -204,7 +212,7 @@ private fun EditCoInsuredScreen(
 }
 
 @Composable
-@HedvigPreview
+@HedvigMultiScreenPreview
 private fun EditCoInsuredScreenEditablePreview() {
   HedvigTheme {
     Surface {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.feature.editcoinsured.ui
 
-import android.icu.text.IDNA.Info
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -13,15 +12,10 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -29,7 +23,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
-import com.hedvig.android.core.designsystem.material3.squircleLargeTop
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
@@ -37,12 +30,12 @@ import com.hedvig.android.core.ui.dialog.ErrorDialog
 import com.hedvig.android.core.ui.infocard.VectorWarningCard
 import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import com.hedvig.android.feature.editcoinsured.data.Member
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.InfoFromSsn
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.ManualInfo
 import hedvig.resources.R
-import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 
 @Composable
@@ -132,43 +125,31 @@ private fun EditCoInsuredScreen(
       }
 
       is EditCoInsuredState.Loaded -> {
-        val coroutineScope = rememberCoroutineScope()
-
         LaunchedEffect(uiState.contractUpdateDate) {
           if (uiState.contractUpdateDate != null) {
             onCompleted(uiState.contractUpdateDate)
           }
         }
-
-        if (uiState.addBottomSheetState.show) {
-          val sheetState = rememberModalBottomSheetState(true)
-          ModalBottomSheet(
-            containerColor = MaterialTheme.colorScheme.background,
-            onDismissRequest = onResetAddBottomSheetState,
-            shape = MaterialTheme.shapes.squircleLargeTop,
-            sheetState = sheetState,
-            tonalElevation = 0.dp,
-            contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Top) },
-          ) {
-            AddCoInsuredBottomSheetContent(
-              bottomSheetState = uiState.addBottomSheetState,
-              onContinue = onBottomSheetContinue,
-              onSsnChanged = onSsnChanged,
-              onFirstNameChanged = onFirstNameChanged,
-              onLastNameChanged = onLastNameChanged,
-              onBirthDateChanged = onBirthDateChanged,
-              onManualInputSwitchChanged = onManualInputSwitchChanged,
-              onAddNewCoInsured = onAddNewCoInsured,
-              onCoInsuredSelected = onCoInsuredSelected,
-              onDismiss = {
-                coroutineScope.launch {
-                  sheetState.hide()
-                }.invokeOnCompletion {
-                  onResetAddBottomSheetState()
-                }
-              },
-            )
-          }
+        HedvigBottomSheet(
+          isVisible = uiState.addBottomSheetState.show,
+          onVisibleChange = { isVisible ->
+            if (!isVisible) {
+              onResetAddBottomSheetState()
+            }
+          },
+          bottomButtonText = stringResource(id = R.string.general_cancel_button),
+        ) {
+          AddCoInsuredBottomSheetContent(
+            bottomSheetState = uiState.addBottomSheetState,
+            onContinue = onBottomSheetContinue,
+            onSsnChanged = onSsnChanged,
+            onFirstNameChanged = onFirstNameChanged,
+            onLastNameChanged = onLastNameChanged,
+            onBirthDateChanged = onBirthDateChanged,
+            onManualInputSwitchChanged = onManualInputSwitchChanged,
+            onAddNewCoInsured = onAddNewCoInsured,
+            onCoInsuredSelected = onCoInsuredSelected,
+          )
         }
 
         Column(
@@ -285,7 +266,7 @@ private fun EditCoInsuredScreenEditablePreview() {
           addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
             isLoading = false,
             manualInfo = ManualInfo(),
-            infoFromSsn = InfoFromSsn()
+            infoFromSsn = InfoFromSsn(),
           ),
           removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
         ),
@@ -342,7 +323,7 @@ private fun EditCoInsuredScreenNonEditablePreview() {
           addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
             isLoading = false,
             infoFromSsn = InfoFromSsn(),
-            manualInfo = ManualInfo()
+            manualInfo = ManualInfo(),
           ),
           removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
         ),

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -48,6 +48,8 @@ import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import com.hedvig.android.feature.editcoinsured.data.Member
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.InfoFromSsn
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.ManualInfo
 import hedvig.resources.R
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
@@ -360,6 +362,8 @@ private fun EditCoInsuredScreenEditablePreview() {
           ),
           addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
             isLoading = false,
+            manualInfo = ManualInfo(),
+            infoFromSsn = InfoFromSsn()
           ),
           removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
         ),
@@ -418,6 +422,8 @@ private fun EditCoInsuredScreenNonEditablePreview() {
           ),
           addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
             isLoading = false,
+            manualInfo = ManualInfo(),
+            infoFromSsn = InfoFromSsn()
           ),
           removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
         ),

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -23,7 +23,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -33,6 +36,7 @@ import com.hedvig.android.core.designsystem.component.button.HedvigContainedButt
 import com.hedvig.android.core.designsystem.component.button.HedvigSecondaryContainedButton
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
@@ -149,62 +153,67 @@ private fun EditCoInsuredScreen(
       }
 
       is EditCoInsuredState.Loaded -> {
-        LaunchedEffect(uiState.contractUpdateDate) {
-          if (uiState.contractUpdateDate != null) {
-            onCompleted(uiState.contractUpdateDate)
-          }
-        }
-        HedvigBottomSheet(
-          bottomButtonText = stringResource(id = R.string.general_cancel_button),
-          isVisible = uiState.addBottomSheetState.show,
-          onVisibleChange = { isVisible ->
-            if (!isVisible) {
-              onResetAddBottomSheetState()
-            }
-          },
-        ) {
-          AddCoInsuredBottomSheetContent(
-            bottomSheetState = uiState.addBottomSheetState,
-            onContinue = onSave,
-            onSsnChanged = onSsnChanged,
-            onFirstNameChanged = onFirstNameChanged,
-            onLastNameChanged = onLastNameChanged,
-            onBirthDateChanged = onBirthDateChanged,
-            onManualInputSwitchChanged = onManualInputSwitchChanged,
-            onAddNewCoInsured = onAddNewCoInsured,
-            onCoInsuredSelected = onCoInsuredSelected,
-          )
-        }
-
-        HedvigBottomSheet(
-          bottomButtonText = stringResource(R.string.general_cancel_button),
-          isVisible = uiState.removeBottomSheetState.show && uiState.removeBottomSheetState.coInsured != null,
-          onVisibleChange = { isVisible ->
-            if (!isVisible) {
-              onResetRemoveBottomSheetState()
-            }
-          },
-        ) {
-          if (uiState.removeBottomSheetState.coInsured != null) {
-            RemoveCoInsuredBottomSheetContent(
-              onRemove = { onRemoveCoInsured(it) },
-              isLoading = uiState.removeBottomSheetState.isLoading,
-              coInsured = uiState.removeBottomSheetState.coInsured,
-              errorMessage = uiState.removeBottomSheetState.errorMessage,
-            )
-          }
-        }
-
         Column(
-          modifier = Modifier
-            .weight(1f)
+          Modifier
+            .fillMaxSize()
+            .padding(
+              WindowInsets
+                .safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues(),
+            )
+            .nestedScroll(remember { object : NestedScrollConnection {} })
             .verticalScroll(state = rememberScrollState()),
         ) {
+          LaunchedEffect(uiState.contractUpdateDate) {
+            if (uiState.contractUpdateDate != null) {
+              onCompleted(uiState.contractUpdateDate)
+            }
+          }
+          HedvigBottomSheet(
+            bottomButtonText = stringResource(id = R.string.general_cancel_button),
+            isVisible = uiState.addBottomSheetState.show,
+            onVisibleChange = { isVisible ->
+              if (!isVisible) {
+                onResetAddBottomSheetState()
+              }
+            },
+          ) {
+            AddCoInsuredBottomSheetContent(
+              bottomSheetState = uiState.addBottomSheetState,
+              onContinue = onSave,
+              onSsnChanged = onSsnChanged,
+              onFirstNameChanged = onFirstNameChanged,
+              onLastNameChanged = onLastNameChanged,
+              onBirthDateChanged = onBirthDateChanged,
+              onManualInputSwitchChanged = onManualInputSwitchChanged,
+              onAddNewCoInsured = onAddNewCoInsured,
+              onCoInsuredSelected = onCoInsuredSelected,
+            )
+          }
+
+          HedvigBottomSheet(
+            bottomButtonText = stringResource(R.string.general_cancel_button),
+            isVisible = uiState.removeBottomSheetState.show && uiState.removeBottomSheetState.coInsured != null,
+            onVisibleChange = { isVisible ->
+              if (!isVisible) {
+                onResetRemoveBottomSheetState()
+              }
+            },
+          ) {
+            if (uiState.removeBottomSheetState.coInsured != null) {
+              RemoveCoInsuredBottomSheetContent(
+                onRemove = { onRemoveCoInsured(it) },
+                isLoading = uiState.removeBottomSheetState.isLoading,
+                coInsured = uiState.removeBottomSheetState.coInsured,
+                errorMessage = uiState.removeBottomSheetState.errorMessage,
+              )
+            }
+          }
           CoInsuredList(
             uiState = uiState.listState,
             onRemove = onRemoveCoInsuredClicked,
             onEdit = {},
             allowEdit = false,
+            modifier = Modifier.padding(horizontal = 16.dp),
           )
 
           Spacer(Modifier.height(8.dp))
@@ -215,35 +224,36 @@ private fun EditCoInsuredScreen(
               modifier = Modifier.padding(horizontal = 16.dp),
             )
           }
-        }
 
-        Column {
-          if (uiState.listState.priceInfo != null && uiState.listState.hasMadeChanges()) {
+          Spacer(Modifier.weight(1f))
+          Column {
+            if (uiState.listState.priceInfo != null && uiState.listState.hasMadeChanges()) {
+              Spacer(Modifier.height(8.dp))
+              PriceInfo(uiState.listState.priceInfo)
+              HedvigContainedButton(
+                text = stringResource(id = R.string.CONTRACT_ADD_COINSURED_CONFIRM_CHANGES),
+                onClick = onCommitChanges,
+                isLoading = uiState.listState.isCommittingUpdate,
+                modifier = Modifier.padding(horizontal = 16.dp),
+              )
+            }
+
             Spacer(Modifier.height(8.dp))
-            PriceInfo(uiState.listState.priceInfo)
-            HedvigContainedButton(
-              text = stringResource(id = R.string.CONTRACT_ADD_COINSURED_CONFIRM_CHANGES),
-              onClick = onCommitChanges,
-              isLoading = uiState.listState.isCommittingUpdate,
-              modifier = Modifier.padding(horizontal = 16.dp),
+            HedvigTextButton(
+              onClick = navigateUp,
+              text = stringResource(id = R.string.general_cancel_button),
+              modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            )
+            Spacer(Modifier.height(16.dp))
+            Spacer(
+              Modifier.padding(
+                WindowInsets.safeDrawing
+                  .only(WindowInsetsSides.Bottom).asPaddingValues(),
+              ),
             )
           }
-
-          Spacer(Modifier.height(8.dp))
-          HedvigTextButton(
-            onClick = navigateUp,
-            text = stringResource(id = R.string.general_cancel_button),
-            modifier = Modifier
-              .fillMaxWidth()
-              .padding(horizontal = 16.dp),
-          )
-          Spacer(Modifier.height(16.dp))
-          Spacer(
-            Modifier.padding(
-              WindowInsets.safeDrawing
-                .only(WindowInsetsSides.Bottom).asPaddingValues(),
-            ),
-          )
         }
       }
 
@@ -367,7 +377,7 @@ private fun EditCoInsuredScreenEditablePreview() {
 }
 
 @Composable
-@HedvigPreview
+@HedvigMultiScreenPreview
 private fun EditCoInsuredScreenNonEditablePreview() {
   HedvigTheme {
     Surface {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
@@ -49,10 +49,12 @@ internal class EditCoInsuredPresenter(
     }
     var addBottomSheetState by remember {
       val lastBottomSheetState = lastState.safeCast<Loaded>()?.addBottomSheetState
-      mutableStateOf(lastBottomSheetState ?: Loaded.AddBottomSheetState(
-        manualInfo = ManualInfo(),
-        infoFromSsn = InfoFromSsn()
-      ))
+      mutableStateOf(
+        lastBottomSheetState ?: Loaded.AddBottomSheetState(
+          manualInfo = ManualInfo(),
+          infoFromSsn = InfoFromSsn(),
+        ),
+      )
     }
     var removeBottomSheetState by remember {
       val lastBottomSheetState = lastState.safeCast<Loaded>()?.removeBottomSheetState
@@ -122,8 +124,11 @@ internal class EditCoInsuredPresenter(
           if (event.ssn.length <= 12) {
             addBottomSheetState = addBottomSheetState.copy(
               manualInfo = ManualInfo(),
-              infoFromSsn = InfoFromSsn(ssn = event.ssn,firstName = null,
-                lastName = null, ),
+              infoFromSsn = InfoFromSsn(
+                ssn = event.ssn,
+                firstName = null,
+                lastName = null,
+              ),
               errorMessage = null,
             )
           }
@@ -131,26 +136,29 @@ internal class EditCoInsuredPresenter(
         is EditCoInsuredEvent.OnBirthDateChanged ->
           addBottomSheetState =
             addBottomSheetState.copy(
-              manualInfo = addBottomSheetState.manualInfo.copy(birthDate = event.birthDate), errorMessage = null)
+              manualInfo = addBottomSheetState.manualInfo.copy(birthDate = event.birthDate),
+              errorMessage = null,
+            )
 
         is EditCoInsuredEvent.OnFirstNameChanged ->
           addBottomSheetState =
             addBottomSheetState.copy(
               manualInfo = addBottomSheetState.manualInfo.copy(firstName = event.firstName),
-              errorMessage = null)
+              errorMessage = null,
+            )
 
         is EditCoInsuredEvent.OnLastNameChanged ->
           addBottomSheetState =
             addBottomSheetState.copy(
-              manualInfo = addBottomSheetState.manualInfo.copy(lastName = event.lastName), errorMessage = null)
+              manualInfo = addBottomSheetState.manualInfo.copy(lastName = event.lastName),
+              errorMessage = null,
+            )
 
         is EditCoInsuredEvent.OnManualInputSwitchChanged -> {
           addBottomSheetState = addBottomSheetState.copy(
             showManualInput = event.show,
-//            ssn = null,
-//            birthDate = null,
-//            firstName = null,
-//            lastName = null
+            errorMessage = null,
+            showUnderAgedInfo = false,
           )
         }
 
@@ -160,7 +168,8 @@ internal class EditCoInsuredPresenter(
             manualInfo = ManualInfo(
               firstName = event.coInsured.firstName,
               lastName = event.coInsured.lastName,
-              birthDate = event.coInsured.birthDate),
+              birthDate = event.coInsured.birthDate,
+            ),
             infoFromSsn = InfoFromSsn(
               firstName = event.coInsured.firstName,
               lastName = event.coInsured.lastName,
@@ -194,7 +203,7 @@ internal class EditCoInsuredPresenter(
         ResetAddBottomSheetState -> {
           addBottomSheetState = Loaded.AddBottomSheetState(
             infoFromSsn = InfoFromSsn(),
-            manualInfo = ManualInfo()
+            manualInfo = ManualInfo(),
           )
         }
 
@@ -213,9 +222,11 @@ internal class EditCoInsuredPresenter(
           when (result) {
             is CoInsuredPersonalInformation.FullInfo -> {
               addBottomSheetState = addBottomSheetState.copy(
-                infoFromSsn = InfoFromSsn( firstName = result.firstName,
+                infoFromSsn = InfoFromSsn(
+                  firstName = result.firstName,
                   lastName = result.lastName,
-                  ssn = ssn,),
+                  ssn = ssn,
+                ),
                 errorMessage = null,
               )
             }
@@ -225,7 +236,7 @@ internal class EditCoInsuredPresenter(
                 Loaded.AddBottomSheetState(
                   showManualInput = true,
                   show = true,
-                  manualInfo = ManualInfo(null,null, birthDate = result.dateOfBirth),
+                  manualInfo = ManualInfo(null, null, birthDate = result.dateOfBirth),
                   infoFromSsn = InfoFromSsn(),
                   showUnderAgedInfo = true,
                 )
@@ -273,8 +284,9 @@ internal class EditCoInsuredPresenter(
                 selectedCoInsuredId = null
                 addBottomSheetState = Loaded.AddBottomSheetState(
                   show = false,
-                  manualInfo = ManualInfo(null,null, birthDate = null),
-                  infoFromSsn = InfoFromSsn(null,null,null),)
+                  manualInfo = ManualInfo(null, null, birthDate = null),
+                  infoFromSsn = InfoFromSsn(null, null, null),
+                )
                 removeBottomSheetState = Loaded.RemoveBottomSheetState(show = false)
                 editedCoInsuredList = null
               }
@@ -436,7 +448,6 @@ internal sealed interface EditCoInsuredState {
       val validFrom: LocalDate,
     )
 
-
     data class ManualInfo(
       val firstName: String? = null,
       val lastName: String? = null,
@@ -448,7 +459,6 @@ internal sealed interface EditCoInsuredState {
       val lastName: String? = null,
       val ssn: String? = null,
     )
-
 
     data class AddBottomSheetState(
       val infoFromSsn: InfoFromSsn,

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
@@ -136,7 +136,12 @@ internal class EditCoInsuredPresenter(
             addBottomSheetState.copy(lastName = event.lastName, errorMessage = null)
 
         is EditCoInsuredEvent.OnManualInputSwitchChanged -> {
-          addBottomSheetState = addBottomSheetState.copy(showManualInput = event.show)
+          addBottomSheetState = addBottomSheetState.copy(
+            showManualInput = event.show,
+            ssn = null,
+            birthDate = null,
+            firstName = null,
+            lastName = null)
         }
 
         is EditCoInsuredEvent.OnEditCoInsuredClicked -> {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoinsuredSuccessDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoinsuredSuccessDestination.kt
@@ -1,11 +1,11 @@
 package com.hedvig.android.feature.editcoinsured.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -17,40 +17,44 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.component.success.HedvigSuccessSection
-import com.hedvig.android.core.designsystem.preview.HedvigPreview
+import com.hedvig.android.core.designsystem.preview.HedvigMultiScreenPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.getLocale
 import com.hedvig.android.core.ui.hedvigDateTimeFormatter
-import com.hedvig.android.core.ui.plus
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
 
 @Composable
 internal fun EditCoInsuredSuccessDestination(date: LocalDate?, popBackstack: () -> Unit) {
-  Box(
-    modifier = Modifier.fillMaxSize(),
+  Column(
+    Modifier.padding(WindowInsets.safeDrawing.asPaddingValues()),
   ) {
-    HedvigSuccessSection(
-      title = stringResource(id = hedvig.resources.R.string.CONTRACT_ADD_COINSURED_UPDATED_TITLE),
-      subTitle = stringResource(
-        id = hedvig.resources.R.string.CONTRACT_ADD_COINSURED_UPDATED_LABEL,
-        date?.toJavaLocalDate()?.format(hedvigDateTimeFormatter(getLocale())) ?: "-",
-      ),
-      modifier = Modifier.align(Alignment.Center),
-    )
-    val padding = WindowInsets.safeDrawing.asPaddingValues() + PaddingValues(vertical = 32.dp, horizontal = 16.dp)
+    Spacer(Modifier.height(8.dp))
+    Box(
+      modifier = Modifier.weight(1f),
+    ) {
+      HedvigSuccessSection(
+        title = stringResource(id = hedvig.resources.R.string.CONTRACT_ADD_COINSURED_UPDATED_TITLE),
+        subTitle = stringResource(
+          id = hedvig.resources.R.string.CONTRACT_ADD_COINSURED_UPDATED_LABEL,
+          date?.toJavaLocalDate()?.format(hedvigDateTimeFormatter(getLocale())) ?: "-",
+        ),
+        modifier = Modifier.align(Alignment.Center),
+      )
+    }
+    Spacer(Modifier.height(8.dp))
+    val padding = PaddingValues(start = 16.dp, end = 16.dp)
     HedvigTextButton(
       text = stringResource(id = hedvig.resources.R.string.general_done_button),
       onClick = popBackstack,
       modifier = Modifier
-        .align(Alignment.BottomStart)
         .padding(padding),
     )
     Spacer(Modifier.height(16.dp))
   }
 }
 
-@HedvigPreview
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewChangeAddressResultDestination() {
   HedvigTheme {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoinsuredSuccessDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoinsuredSuccessDestination.kt
@@ -1,8 +1,14 @@
 package com.hedvig.android.feature.editcoinsured.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,6 +21,7 @@ import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.getLocale
 import com.hedvig.android.core.ui.hedvigDateTimeFormatter
+import com.hedvig.android.core.ui.plus
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
 
@@ -31,13 +38,15 @@ internal fun EditCoInsuredSuccessDestination(date: LocalDate?, popBackstack: () 
       ),
       modifier = Modifier.align(Alignment.Center),
     )
+    val padding = WindowInsets.safeDrawing.asPaddingValues() + PaddingValues(vertical = 32.dp, horizontal = 16.dp)
     HedvigTextButton(
       text = stringResource(id = hedvig.resources.R.string.general_done_button),
       onClick = popBackstack,
       modifier = Modifier
         .align(Alignment.BottomStart)
-        .padding(vertical = 32.dp, horizontal = 16.dp),
+        .padding(padding),
     )
+    Spacer(Modifier.height(16.dp))
   }
 }
 

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/InsuredRow.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/InsuredRow.kt
@@ -96,8 +96,7 @@ internal fun InsuredRow(
         } else {
           onRemove()
         }
-      }
-      .padding(horizontal = 16.dp),
+      },
   )
 }
 

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
@@ -2,9 +2,7 @@ package com.hedvig.android.feature.editcoinsured.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -15,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
-import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
@@ -24,14 +21,12 @@ import hedvig.resources.R
 @Composable
 internal fun RemoveCoInsuredBottomSheetContent(
   onRemove: (CoInsured) -> Unit,
-  onDismiss: () -> Unit,
   isLoading: Boolean,
-  errorMessage: String?,
+  errorMessage: String?, // todo: not used??
   coInsured: CoInsured,
 ) {
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,
-    modifier = Modifier.padding(horizontal = 16.dp),
   ) {
     Spacer(Modifier.height(16.dp))
     Text(stringResource(id = R.string.CONTRACT_REMOVE_COINSURED_CONFIRMATION))
@@ -54,12 +49,6 @@ internal fun RemoveCoInsuredBottomSheetContent(
       isLoading = isLoading,
     )
     Spacer(Modifier.height(8.dp))
-    HedvigTextButton(
-      onClick = onDismiss,
-      text = stringResource(id = R.string.general_cancel_button),
-      modifier = Modifier.fillMaxWidth(),
-    )
-    Spacer(Modifier.height(32.dp))
   }
 }
 
@@ -70,7 +59,6 @@ private fun RemoveCoInsuredBottomSheetContentPreview() {
     Surface(color = MaterialTheme.colorScheme.background) {
       RemoveCoInsuredBottomSheetContent(
         onRemove = {},
-        onDismiss = {},
         isLoading = false,
         coInsured = CoInsured(
           "Tester",
@@ -92,7 +80,6 @@ private fun RemoveCoInsuredBottomSheetContentWithCoInsuredPreview() {
     Surface(color = MaterialTheme.colorScheme.background) {
       RemoveCoInsuredBottomSheetContent(
         onRemove = {},
-        onDismiss = {},
         isLoading = false,
         coInsured = CoInsured(
           "Tester",

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
@@ -22,7 +22,7 @@ import hedvig.resources.R
 internal fun RemoveCoInsuredBottomSheetContent(
   onRemove: (CoInsured) -> Unit,
   isLoading: Boolean,
-  errorMessage: String?, // todo: not used??
+  errorMessage: String?,
   coInsured: CoInsured,
 ) {
   Column(

--- a/app/feature/feature-edit-coinsured/src/test/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenterTest.kt
+++ b/app/feature/feature-edit-coinsured/src/test/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenterTest.kt
@@ -3,11 +3,11 @@ package com.hedvig.android.feature.editcoinsured.ui
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isTrue
-import assertk.assertions.prop
 import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.feature.editcoinsured.data.CoInsuredResult
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.InfoFromSsn
+import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.ManualInfo
 import com.hedvig.android.feature.editcoinsured.ui.data.TestCommitMidtermChangeUseCase
 import com.hedvig.android.feature.editcoinsured.ui.data.TestCreateMidTermChangeUseCase
 import com.hedvig.android.feature.editcoinsured.ui.data.TestFetchCoInsuredPersonalInformationUseCase
@@ -78,7 +78,10 @@ internal class EditCoInsuredPresenterTest {
           member = testMember,
           allCoInsured = listOf(),
         ),
-        addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(),
+        addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
+          infoFromSsn = InfoFromSsn(),
+          manualInfo = ManualInfo(),
+        ),
         removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
       ),
     ) {
@@ -90,16 +93,16 @@ internal class EditCoInsuredPresenterTest {
       assertThat(item).isInstanceOf<EditCoInsuredState.Loaded>()
       val uiState = item as EditCoInsuredState.Loaded
 
-      assertThat(uiState.addBottomSheetState.firstName).isEqualTo(coInsuredTestList[0].firstName)
-      assertThat(uiState.addBottomSheetState.lastName).isEqualTo(coInsuredTestList[0].lastName)
-      assertThat(uiState.addBottomSheetState.ssn).isEqualTo(coInsuredTestList[0].ssn)
-      assertThat(uiState.addBottomSheetState.birthDate).isEqualTo(coInsuredTestList[0].birthDate)
+      assertThat(uiState.addBottomSheetState.manualInfo.firstName).isEqualTo(coInsuredTestList[0].firstName)
+      assertThat(uiState.addBottomSheetState.manualInfo.lastName).isEqualTo(coInsuredTestList[0].lastName)
+      assertThat(uiState.addBottomSheetState.infoFromSsn.ssn).isEqualTo(coInsuredTestList[0].ssn)
+      assertThat(uiState.addBottomSheetState.manualInfo.birthDate).isEqualTo(coInsuredTestList[0].birthDate)
       assertThat(uiState.addBottomSheetState.show).isEqualTo(true)
     }
   }
 
   @Test
-  fun `should update co-insured when saving from bottom sheet`() = runTest {
+  fun `should update co-insured from the right mode, manual or ssn fetch, when saving from bottom sheet`() = runTest {
     val testGetCoInsuredUseCase = TestGetCoInsuredUseCase()
     val testFetchCoInsuredPersonalInformationUseCase = TestFetchCoInsuredPersonalInformationUseCase()
     val testCreateMidTermChangeUseCase = TestCreateMidTermChangeUseCase()
@@ -120,38 +123,38 @@ internal class EditCoInsuredPresenterTest {
           member = testMember,
           allCoInsured = listOf(),
         ),
-        addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(),
+        addBottomSheetState = EditCoInsuredState.Loaded.AddBottomSheetState(
+          showManualInput = false,
+          infoFromSsn = InfoFromSsn(),
+          manualInfo = ManualInfo(),
+        ),
         removeBottomSheetState = EditCoInsuredState.Loaded.RemoveBottomSheetState(),
       ),
     ) {
       skipItems(1)
       sendEvent(EditCoInsuredEvent.OnEditCoInsuredClicked(coInsuredTestList[2]))
       skipItems(1)
+      sendEvent(EditCoInsuredEvent.OnSsnChanged("5555"))
+      skipItems(1)
       sendEvent(EditCoInsuredEvent.OnManualInputSwitchChanged(show = true))
       skipItems(1)
-      sendEvent(EditCoInsuredEvent.OnSsnChanged("4321"))
-      skipItems(1)
+      sendEvent(EditCoInsuredEvent.OnLastNameChanged("New last name manual"))
+      val state2 = awaitItem()
+      assertThat((state2 as EditCoInsuredState.Loaded).addBottomSheetState.manualInfo.lastName).isEqualTo("New last name manual")
       sendEvent(EditCoInsuredEvent.OnBottomSheetContinue)
-
-      val state = awaitItem()
-      assertThat(state).isInstanceOf<EditCoInsuredState.Loaded>().run {
-        prop(EditCoInsuredState.Loaded::addBottomSheetState)
-          .prop(EditCoInsuredState.Loaded.AddBottomSheetState::isLoading)
-          .isTrue()
-      }
-
+      skipItems(1)
       testCreateMidTermChangeUseCase.addCreateMidtermChangeResult(
         "test",
         currentPremium = UiMoney(300.0, UiCurrencyCode.SEK),
         newPremium = UiMoney(400.0, UiCurrencyCode.SEK),
         activatedDate = LocalDate.fromEpochDays(400),
       )
-
       val item = awaitItem()
       assertThat(item).isInstanceOf<EditCoInsuredState.Loaded>()
       val uiState = item as EditCoInsuredState.Loaded
-
-      assertThat(uiState.listState.coInsured[2].ssn).isEqualTo("4321")
+      assertThat(uiState.addBottomSheetState.manualInfo).isEqualTo(ManualInfo())
+      assertThat(uiState.listState.coInsured[2].ssn).isEqualTo(null)
+      assertThat(uiState.listState.coInsured[2].lastName).isEqualTo("New last name manual")
     }
   }
 }

--- a/app/feature/feature-edit-coinsured/src/test/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenterTest.kt
+++ b/app/feature/feature-edit-coinsured/src/test/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenterTest.kt
@@ -140,7 +140,9 @@ internal class EditCoInsuredPresenterTest {
       skipItems(1)
       sendEvent(EditCoInsuredEvent.OnLastNameChanged("New last name manual"))
       val state2 = awaitItem()
-      assertThat((state2 as EditCoInsuredState.Loaded).addBottomSheetState.manualInfo.lastName).isEqualTo("New last name manual")
+      assertThat(
+        (state2 as EditCoInsuredState.Loaded).addBottomSheetState.manualInfo.lastName,
+      ).isEqualTo("New last name manual")
       sendEvent(EditCoInsuredEvent.OnBottomSheetContinue)
       skipItems(1)
       testCreateMidTermChangeUseCase.addCreateMidtermChangeResult(


### PR DESCRIPTION
That bug affects not only the ssn, name also stays if you switch back from manual. I added some if-else at first, but then it seems that the most reliable thing to do would be just to clean the state ssn, birthday and name entirely. Tell me wdyt:)