### PR TITLE
Fix/cbm related fixes

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -52,6 +52,7 @@ import com.hedvig.android.navigation.activity.ExternalNavigator
 import com.hedvig.android.navigation.compose.Destination
 import com.hedvig.android.navigation.compose.typedPopUpTo
 import com.hedvig.android.navigation.core.AppDestination
+import com.hedvig.android.navigation.core.AppDestination.ClaimDetails
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.navigation.core.Navigator
 
@@ -265,6 +266,9 @@ internal fun HedvigNavHost(
       hedvigBuildConstants = hedvigBuildConstants,
       imageLoader = imageLoader,
       openUrl = openUrl,
+      onNavigateToClaimDetails = { claimId ->
+        hedvigAppState.navController.navigate(ClaimDetails(claimId))
+      },
       navigator = navigator,
     )
     connectPaymentGraph(

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -47,6 +47,7 @@ import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuran
 import com.hedvig.android.feature.terminateinsurance.navigation.terminateInsuranceGraph
 import com.hedvig.android.feature.travelcertificate.navigation.travelCertificateGraph
 import com.hedvig.android.language.LanguageService
+import com.hedvig.android.logger.logcat
 import com.hedvig.android.market.Market
 import com.hedvig.android.navigation.activity.ExternalNavigator
 import com.hedvig.android.navigation.compose.Destination
@@ -267,6 +268,7 @@ internal fun HedvigNavHost(
       imageLoader = imageLoader,
       openUrl = openUrl,
       onNavigateToClaimDetails = { claimId ->
+        logcat { "Navigating to claim details from chat" }
         hedvigAppState.navController.navigate(ClaimDetails(claimId))
       },
       navigator = navigator,

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Scaffold.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Scaffold.kt
@@ -1,36 +1,19 @@
 package com.hedvig.android.design.system.hedvig
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.union
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import com.hedvig.android.design.system.hedvig.TopAppBarDefaults.windowInsets
-import com.hedvig.android.design.system.hedvig.icon.ArrowLeft
-import com.hedvig.android.design.system.hedvig.icon.Close
-import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.tokens.ScaffoldTokens
 
 @Composable
@@ -53,8 +36,8 @@ fun Scaffold(
     ) {
       TopAppBar(
         title = topAppBarText ?: "",
-        onClick = navigateUp,
         actionType = topAppBarActionType,
+        onActionClick = navigateUp,
         topAppBarActions = topAppBarActions,
       )
       Column(
@@ -71,112 +54,6 @@ fun Scaffold(
         content()
       }
     }
-  }
-}
-
-@Composable
-fun TopAppBarLayoutForActions(modifier: Modifier = Modifier, actions: @Composable RowScope.() -> Unit = {}) {
-  Row(
-    horizontalArrangement = Arrangement.End,
-    verticalAlignment = Alignment.CenterVertically,
-    modifier = modifier
-      .windowInsetsPadding(windowInsets)
-      .height(ScaffoldTokens.TopAppBarHeight)
-      .fillMaxWidth()
-      .padding(horizontal = ScaffoldTokens.TopAppBarHorizontalPadding),
-  ) {
-    actions()
-  }
-}
-
-@Composable
-fun TopAppBarWithBack(
-  title: String,
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
-) {
-  TopAppBar(
-    title = title,
-    onClick = onClick,
-    actionType = TopAppBarActionType.BACK,
-    modifier = modifier,
-    windowInsets = windowInsets,
-  )
-}
-
-enum class TopAppBarActionType {
-  BACK,
-  CLOSE,
-}
-
-internal object TopAppBarDefaults {
-  val windowInsets: WindowInsets
-    @Composable
-    get() = WindowInsets.systemBars
-      .union(WindowInsets.displayCutout)
-      .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
-}
-
-@Composable
-fun TopAppBar(
-  title: String,
-  onClick: () -> Unit,
-  actionType: TopAppBarActionType,
-  modifier: Modifier = Modifier,
-  topAppBarActions: @Composable (RowScope.() -> Unit)? = null,
-  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
-) {
-  Row(
-    verticalAlignment = Alignment.CenterVertically,
-    modifier =
-      modifier
-        .windowInsetsPadding(windowInsets)
-        .height(ScaffoldTokens.TopAppBarHeight)
-        .fillMaxWidth()
-        .padding(horizontal = ScaffoldTokens.TopAppBarHorizontalPadding),
-  ) {
-    HorizontalItemsWithMaximumSpaceTaken(
-      startSlot = {
-        Row(
-          horizontalArrangement = Arrangement.Start,
-          verticalAlignment = Alignment.CenterVertically,
-        ) {
-          IconButton(
-            onClick = { onClick() },
-            modifier = Modifier.size(24.dp),
-            content = {
-              Icon(
-                imageVector = when (actionType) {
-                  TopAppBarActionType.BACK -> HedvigIcons.ArrowLeft
-                  TopAppBarActionType.CLOSE -> HedvigIcons.Close
-                },
-                contentDescription = null,
-              )
-            },
-          )
-          Spacer(Modifier.width(8.dp))
-          HedvigText(
-            text = title,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(top = 10.dp, bottom = 10.dp),
-            style = ScaffoldTokens.TopAppBarTextStyle.value,
-          )
-        }
-      },
-      endSlot = {
-        if (topAppBarActions != null) {
-          Row(
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
-          ) {
-            topAppBarActions()
-          }
-        }
-      },
-      spaceBetween = 8.dp,
-    )
   }
 }
 

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/TopAppBar.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/TopAppBar.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.design.system.hedvig
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -23,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.design.system.hedvig.TopAppBarDefaults.windowInsets

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/TopAppBar.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/TopAppBar.kt
@@ -1,0 +1,192 @@
+package com.hedvig.android.design.system.hedvig
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.design.system.hedvig.TopAppBarDefaults.windowInsets
+import com.hedvig.android.design.system.hedvig.icon.ArrowLeft
+import com.hedvig.android.design.system.hedvig.icon.Close
+import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
+import com.hedvig.android.design.system.hedvig.tokens.TopAppBarTokens
+
+@Composable
+fun TopAppBar(
+  actionType: TopAppBarActionType,
+  onActionClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+  content: @Composable () -> Unit,
+) {
+  Surface(
+    color = TopAppBarTokens.ContainerColor.value,
+    contentColor = TopAppBarTokens.ContentColor.value,
+    modifier = modifier.fillMaxWidth(),
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = modifier
+        .windowInsetsPadding(windowInsets)
+        .height(TopAppBarTokens.ContainerHeight)
+        .padding(horizontal = TopAppBarTokens.ContentHorizontalPadding),
+    ) {
+      IconButton(
+        onClick = onActionClick,
+        content = {
+          Icon(
+            imageVector = when (actionType) {
+              TopAppBarActionType.BACK -> HedvigIcons.ArrowLeft
+              TopAppBarActionType.CLOSE -> HedvigIcons.Close
+            },
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+          )
+        },
+      )
+      Spacer(Modifier.width(8.dp))
+      CompositionLocalProvider(LocalTextStyle provides TopAppBarTokens.TextStyle.value) {
+        Box(
+          Modifier
+            .weight(1f)
+            .fillMaxHeight(),
+          propagateMinConstraints = true,
+        ) {
+          content()
+        }
+      }
+    }
+  }
+}
+
+@Composable
+fun TopAppBar(
+  title: String,
+  actionType: TopAppBarActionType,
+  onActionClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  topAppBarActions: @Composable (RowScope.() -> Unit)? = null,
+  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+) {
+  Surface(
+    color = TopAppBarTokens.ContainerColor.value,
+    contentColor = TopAppBarTokens.ContentColor.value,
+    modifier = modifier
+      .fillMaxWidth()
+      .height(TopAppBarTokens.ContainerHeight),
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier
+        .windowInsetsPadding(windowInsets)
+        .padding(horizontal = TopAppBarTokens.ContentHorizontalPadding),
+    ) {
+      HorizontalItemsWithMaximumSpaceTaken(
+        startSlot = {
+          Row(
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            IconButton(
+              onClick = onActionClick,
+              modifier = Modifier.size(24.dp),
+              content = {
+                Icon(
+                  imageVector = when (actionType) {
+                    TopAppBarActionType.BACK -> HedvigIcons.ArrowLeft
+                    TopAppBarActionType.CLOSE -> HedvigIcons.Close
+                  },
+                  contentDescription = null,
+                )
+              },
+            )
+            Spacer(Modifier.width(8.dp))
+            HedvigText(
+              text = title,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+              modifier = Modifier.padding(top = 10.dp, bottom = 10.dp),
+              style = TopAppBarTokens.TextStyle.value,
+            )
+          }
+        },
+        endSlot = {
+          if (topAppBarActions != null) {
+            Row(
+              horizontalArrangement = Arrangement.End,
+              verticalAlignment = Alignment.CenterVertically,
+            ) {
+              topAppBarActions()
+            }
+          }
+        },
+        spaceBetween = 8.dp,
+      )
+    }
+  }
+}
+
+@Composable
+internal fun TopAppBarLayoutForActions(modifier: Modifier = Modifier, actions: @Composable RowScope.() -> Unit = {}) {
+  Row(
+    horizontalArrangement = Arrangement.End,
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier
+      .windowInsetsPadding(windowInsets)
+      .height(TopAppBarTokens.ContainerHeight)
+      .fillMaxWidth()
+      .padding(horizontal = TopAppBarTokens.ContentHorizontalPadding),
+  ) {
+    actions()
+  }
+}
+
+@Composable
+internal fun TopAppBarWithBack(
+  title: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+) {
+  TopAppBar(
+    title = title,
+    actionType = TopAppBarActionType.BACK,
+    onActionClick = onClick,
+    modifier = modifier,
+    windowInsets = windowInsets,
+  )
+}
+
+enum class TopAppBarActionType {
+  BACK,
+  CLOSE,
+}
+
+internal object TopAppBarDefaults {
+  val windowInsets: WindowInsets
+    @Composable
+    get() = WindowInsets.systemBars
+      .union(WindowInsets.displayCutout)
+      .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
+}

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/ScaffoldTokens.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/ScaffoldTokens.kt
@@ -1,10 +1,5 @@
 package com.hedvig.android.design.system.hedvig.tokens
 
-import androidx.compose.ui.unit.dp
-
 internal object ScaffoldTokens {
   val BackgroundColor = ColorSchemeKeyTokens.BackgroundPrimary
-  val TopAppBarHeight = 64.dp
-  val TopAppBarHorizontalPadding = 16.dp
-  val TopAppBarTextStyle = TypographyKeyTokens.HeadlineSmall
 }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/TopAppBarTokens.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/TopAppBarTokens.kt
@@ -1,0 +1,11 @@
+package com.hedvig.android.design.system.hedvig.tokens
+
+import androidx.compose.ui.unit.dp
+
+internal object TopAppBarTokens {
+  val ContainerColor = ColorSchemeKeyTokens.BackgroundPrimary
+  val ContentColor = ColorSchemeKeyTokens.TextPrimary
+  val ContainerHeight = 64.dp
+  val ContentHorizontalPadding = 16.dp
+  val TextStyle = TypographyKeyTokens.HeadlineSmall
+}

--- a/app/feature/feature-chat/src/main/graphql/FragmentConversationInfo.graphql
+++ b/app/feature/feature-chat/src/main/graphql/FragmentConversationInfo.graphql
@@ -3,6 +3,7 @@ fragment ConversationInfo on Conversation {
   createdAt
   isLegacy
   claim {
+    id
     claimType
   }
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/CbmChatViewModel.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/CbmChatViewModel.kt
@@ -285,6 +285,10 @@ internal sealed interface CbmChatUiState {
         }
       }
     }
+    val claimId: String? = when (backendConversationInfo) {
+      NoConversation -> null
+      is Info -> backendConversationInfo.claimInfo?.claimId
+    }
 
     data class LatestChatMessage(
       val id: Uuid,

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatDestination.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.chat
 
 import android.net.Uri
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -8,20 +9,16 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -29,19 +26,19 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.dropUnlessResumed
 import coil.ImageLoader
 import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.core.designsystem.component.error.HedvigErrorSection
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
-import com.hedvig.android.core.icons.Hedvig
-import com.hedvig.android.core.icons.hedvig.normal.ArrowBack
 import com.hedvig.android.core.ui.HedvigDateTimeFormatterDefaults
 import com.hedvig.android.core.ui.getLocale
 import com.hedvig.android.core.ui.preview.rememberPreviewImageLoader
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
-import com.hedvig.android.design.system.hedvig.LocalTextStyle
+import com.hedvig.android.design.system.hedvig.TopAppBar
+import com.hedvig.android.design.system.hedvig.TopAppBarActionType
 import com.hedvig.android.feature.chat.CbmChatUiState.Error
 import com.hedvig.android.feature.chat.CbmChatUiState.Initializing
 import com.hedvig.android.feature.chat.CbmChatUiState.Loaded
@@ -62,6 +59,7 @@ internal fun CbmChatDestination(
   imageLoader: ImageLoader,
   appPackageId: String,
   openUrl: (String) -> Unit,
+  onNavigateToClaimDetails: (String) -> Unit,
   onNavigateUp: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -72,6 +70,7 @@ internal fun CbmChatDestination(
     openUrl = openUrl,
     onBannerLinkClicked = openUrl,
     onNavigateUp = onNavigateUp,
+    onNavigateToClaimDetails = onNavigateToClaimDetails,
     onSendMessage = { message: String ->
       viewModel.emit(CbmChatEvent.SendTextMessage(message))
     },
@@ -101,6 +100,7 @@ private fun ChatScreen(
   openUrl: (String) -> Unit,
   onBannerLinkClicked: (String) -> Unit,
   onNavigateUp: () -> Unit,
+  onNavigateToClaimDetails: (String) -> Unit,
   onSendMessage: (String) -> Unit,
   onSendPhoto: (Uri) -> Unit,
   onSendMedia: (Uri) -> Unit,
@@ -118,7 +118,7 @@ private fun ChatScreen(
       ChatTopAppBar(
         uiState = uiState,
         onNavigateUp = onNavigateUp,
-        topAppBarScrollBehavior = topAppBarScrollBehavior,
+        onNavigateToClaimDetails = onNavigateToClaimDetails,
         modifier = Modifier.onSizeChanged {
           with(density) { topAppBarHeight = it.height.toDp() }
         },
@@ -144,7 +144,6 @@ private fun ChatScreen(
               uiState = uiState,
               imageLoader = imageLoader,
               appPackageId = appPackageId,
-              topAppBarScrollBehavior = topAppBarScrollBehavior,
               openUrl = openUrl,
               onBannerLinkClicked = onBannerLinkClicked,
               onRetrySendChatMessage = onRetrySendChatMessage,
@@ -163,61 +162,61 @@ private fun ChatScreen(
 private fun ChatTopAppBar(
   uiState: CbmChatUiState,
   onNavigateUp: () -> Unit,
-  topAppBarScrollBehavior: TopAppBarScrollBehavior,
+  onNavigateToClaimDetails: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   TopAppBar(
-    modifier = modifier.fillMaxWidth(),
-    title = {
-      CompositionLocalProvider(LocalTextStyle provides HedvigTheme.typography.headlineSmall) {
-        when (uiState) {
-          is Loaded -> {
-            when (val topAppBarText = uiState.topAppBarText) {
-              Legacy -> HedvigText(stringResource(R.string.CHAT_CONVERSATION_HISTORY_TITLE))
-              NewConversation -> {
-                Column {
-                  HedvigText(stringResource(R.string.CHAT_NEW_CONVERSATION_TITLE))
-                  HedvigText(
-                    stringResource(R.string.CHAT_NEW_CONVERSATION_SUBTITLE),
-                    color = HedvigTheme.colorScheme.textSecondary,
-                  )
-                }
+    TopAppBarActionType.BACK,
+    onNavigateUp,
+    modifier,
+  ) {
+    Box(
+      Modifier
+        .then(
+          if (uiState is Loaded && uiState.claimId != null) {
+            Modifier.clickable(onClick = dropUnlessResumed { onNavigateToClaimDetails(uiState.claimId) })
+          } else {
+            Modifier
+          },
+        )
+        .wrapContentHeight(Alignment.CenterVertically),
+    ) {
+      when (uiState) {
+        is Loaded -> {
+          when (val topAppBarText = uiState.topAppBarText) {
+            Legacy -> HedvigText(stringResource(R.string.CHAT_CONVERSATION_HISTORY_TITLE))
+            NewConversation -> {
+              Column {
+                HedvigText(stringResource(R.string.CHAT_NEW_CONVERSATION_TITLE))
+                HedvigText(
+                  stringResource(R.string.CHAT_NEW_CONVERSATION_SUBTITLE),
+                  color = HedvigTheme.colorScheme.textSecondary,
+                )
               }
+            }
 
-              is ClaimConversation -> {
-                Column {
-                  HedvigText(topAppBarText.claimType ?: stringResource(R.string.home_claim_card_pill_claim))
-                  val subtitle = chatTopAppBarFormattedSubtitle(topAppBarText.createdAt)
-                  HedvigText(subtitle, color = HedvigTheme.colorScheme.textSecondary)
-                }
+            is ClaimConversation -> {
+              Column {
+                HedvigText(topAppBarText.claimType ?: stringResource(R.string.home_claim_card_pill_claim))
+                val subtitle = chatTopAppBarFormattedSubtitle(topAppBarText.createdAt)
+                HedvigText(subtitle, color = HedvigTheme.colorScheme.textSecondary)
               }
+            }
 
-              is ServiceConversation -> {
-                Column {
-                  HedvigText(stringResource(R.string.CHAT_CONVERSATION_QUESTION_TITLE))
-                  val subtitle = chatTopAppBarFormattedSubtitle(topAppBarText.createdAt)
-                  HedvigText(subtitle, color = HedvigTheme.colorScheme.textSecondary)
-                }
+            is ServiceConversation -> {
+              Column {
+                HedvigText(stringResource(R.string.CHAT_CONVERSATION_QUESTION_TITLE))
+                val subtitle = chatTopAppBarFormattedSubtitle(topAppBarText.createdAt)
+                HedvigText(subtitle, color = HedvigTheme.colorScheme.textSecondary)
               }
             }
           }
-
-          else -> HedvigText(stringResource(R.string.CHAT_TITLE))
         }
+
+        else -> HedvigText(stringResource(R.string.CHAT_TITLE))
       }
-    },
-    navigationIcon = {
-      IconButton(
-        onClick = onNavigateUp,
-        content = { Icon(imageVector = Icons.Hedvig.ArrowBack, contentDescription = null) },
-      )
-    },
-    colors = TopAppBarDefaults.topAppBarColors(
-      containerColor = MaterialTheme.colorScheme.background,
-      scrolledContainerColor = MaterialTheme.colorScheme.surface,
-    ),
-    scrollBehavior = topAppBarScrollBehavior,
-  )
+    }
+  }
 }
 
 @Composable
@@ -253,6 +252,7 @@ private fun PreviewChatScreen(
             appPackageId = "",
             openUrl = {},
             onBannerLinkClicked = {},
+            onNavigateToClaimDetails = {},
             onNavigateUp = {},
             onSendMessage = {},
             onSendPhoto = {},

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
@@ -40,8 +40,6 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -66,7 +64,6 @@ import androidx.compose.ui.graphics.vector.RenderVectorGroup
 import androidx.compose.ui.graphics.vector.VectorConfig
 import androidx.compose.ui.graphics.vector.VectorProperty
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -140,7 +137,6 @@ internal fun CbmChatLoadedScreen(
   uiState: CbmChatUiState.Loaded,
   imageLoader: ImageLoader,
   appPackageId: String,
-  topAppBarScrollBehavior: TopAppBarScrollBehavior,
   openUrl: (String) -> Unit,
   onBannerLinkClicked: (String) -> Unit,
   onRetrySendChatMessage: (messageId: String) -> Unit,
@@ -159,7 +155,6 @@ internal fun CbmChatLoadedScreen(
     uiState = uiState,
     lazyListState = lazyListState,
     imageLoader = imageLoader,
-    topAppBarScrollBehavior = topAppBarScrollBehavior,
     openUrl = openUrl,
     onBannerLinkClicked = onBannerLinkClicked,
     onRetrySendChatMessage = onRetrySendChatMessage,
@@ -190,7 +185,6 @@ private fun ChatLoadedScreen(
   uiState: CbmChatUiState.Loaded,
   lazyListState: LazyListState,
   imageLoader: ImageLoader,
-  topAppBarScrollBehavior: TopAppBarScrollBehavior,
   openUrl: (String) -> Unit,
   onBannerLinkClicked: (String) -> Unit,
   onRetrySendChatMessage: (messageId: String) -> Unit,
@@ -208,8 +202,7 @@ private fun ChatLoadedScreen(
         modifier = Modifier
           .fillMaxWidth()
           .weight(1f)
-          .clearFocusOnTap()
-          .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+          .clearFocusOnTap(),
       )
       if (uiState.bannerText != null) {
         AnimatedVisibility(
@@ -750,7 +743,7 @@ private fun PreviewChatLoadedScreen() {
             uiState = Loaded(
               backendConversationInfo = ConversationInfo.Info(
                 "1",
-                ClaimInfo("claimType"),
+                ClaimInfo("id", "claimType"),
                 Instant.parse("2024-05-01T00:00:00Z"),
                 false,
               ),
@@ -760,7 +753,6 @@ private fun PreviewChatLoadedScreen() {
             ),
             lazyListState = rememberLazyListState(),
             imageLoader = rememberPreviewImageLoader(),
-            topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
             openUrl = {},
             onBannerLinkClicked = {},
             onRetrySendChatMessage = {},

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -339,7 +339,10 @@ internal sealed interface ConversationInfo {
     val createdAt: Instant,
     val isLegacy: Boolean,
   ) : ConversationInfo {
-    data class ClaimInfo(val claimType: String?)
+    data class ClaimInfo(
+      val claimId: String,
+      val claimType: String?,
+    )
   }
 }
 
@@ -357,7 +360,10 @@ private fun octopus.fragment.ConversationInfo.toConversationInfo(): Conversation
     createdAt = createdAt,
     isLegacy = isLegacy,
     claimInfo = claim?.let {
-      ConversationInfo.Info.ClaimInfo(it.claimType)
+      ConversationInfo.Info.ClaimInfo(
+        it.id,
+        it.claimType,
+      )
     },
   )
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/GetAllConversationsUseCase.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/GetAllConversationsUseCase.kt
@@ -64,7 +64,7 @@ internal class GetAllConversationsUseCaseImpl(
 }
 
 private fun List<InboxConversation>.sortByLastMessageTimestamp(): List<InboxConversation> {
-  return this.sortedBy { it.latestMessage?.sentAt ?: it.createdAt }
+  return this.sortedByDescending { it.latestMessage?.sentAt ?: it.createdAt }
 }
 
 private fun ConversationFragment.toInboxConversation(isLegacy: Boolean): InboxConversation {

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -37,9 +37,6 @@ import com.hedvig.android.compose.ui.preview.TripleCase
 import com.hedvig.android.core.designsystem.component.card.HedvigCard
 import com.hedvig.android.core.designsystem.component.error.HedvigErrorSection
 import com.hedvig.android.core.designsystem.component.progress.HedvigFullScreenCenterAlignedProgressDebounced
-import com.hedvig.android.core.designsystem.material3.infoContainer
-import com.hedvig.android.core.designsystem.material3.onInfoContainer
-import com.hedvig.android.core.designsystem.material3.squircleExtraSmall
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.ui.appbar.m3.TopAppBarWithBack
 import com.hedvig.android.core.ui.getLocale

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/CbmChatGraph.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/CbmChatGraph.kt
@@ -20,6 +20,7 @@ fun NavGraphBuilder.cbmChatGraph(
   hedvigBuildConstants: HedvigBuildConstants,
   imageLoader: ImageLoader,
   openUrl: (String) -> Unit,
+  onNavigateToClaimDetails: (claimId: String) -> Unit,
   navigator: Navigator,
 ) {
   navgraph<ChatDestination>(
@@ -53,6 +54,7 @@ fun NavGraphBuilder.cbmChatGraph(
         imageLoader = imageLoader,
         appPackageId = hedvigBuildConstants.appId,
         openUrl = openUrl,
+        onNavigateToClaimDetails = onNavigateToClaimDetails,
         onNavigateUp = navigator::navigateUp,
       )
     }

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/navigation/ClaimFlowGraph.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/navigation/ClaimFlowGraph.kt
@@ -369,7 +369,6 @@ fun NavGraphBuilder.terminalClaimFlowStepDestinations(
   }
   navdestination<ClaimFlowDestination.ClaimSuccess> { backStackEntry ->
     ClaimSuccessDestination(
-      onNavigateToNewConversation = { onNavigateToNewConversation(backStackEntry) },
       closeSuccessScreen = navigator::popBackStack,
     )
   }

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/success/ClaimSuccessDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/success/ClaimSuccessDestination.kt
@@ -25,22 +25,18 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.component.button.HedvigTextButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import hedvig.resources.R
 
 @Composable
-internal fun ClaimSuccessDestination(onNavigateToNewConversation: () -> Unit, closeSuccessScreen: () -> Unit) {
-  ClaimSuccessScreen(
-    onNavigateToNewConversation = onNavigateToNewConversation,
-    closeSuccessScreen = closeSuccessScreen,
-  )
+internal fun ClaimSuccessDestination(closeSuccessScreen: () -> Unit) {
+  ClaimSuccessScreen(closeSuccessScreen = closeSuccessScreen)
 }
 
 @Composable
-private fun ClaimSuccessScreen(onNavigateToNewConversation: () -> Unit, closeSuccessScreen: () -> Unit) {
+private fun ClaimSuccessScreen(closeSuccessScreen: () -> Unit) {
   Surface(
     color = MaterialTheme.colorScheme.background,
     modifier = Modifier.fillMaxSize(),
@@ -79,14 +75,6 @@ private fun ClaimSuccessScreen(onNavigateToNewConversation: () -> Unit, closeSuc
         }
       }
       Spacer(Modifier.height(16.dp))
-      HedvigContainedButton(
-        text = stringResource(R.string.open_chat),
-        onClick = onNavigateToNewConversation,
-        modifier = Modifier
-          .padding(horizontal = 16.dp)
-          .fillMaxWidth(),
-      )
-      Spacer(Modifier.height(8.dp))
       HedvigTextButton(
         onClick = closeSuccessScreen,
         text = stringResource(R.string.general_close_button),
@@ -105,7 +93,7 @@ private fun ClaimSuccessScreen(onNavigateToNewConversation: () -> Unit, closeSuc
 fun PreviewClaimSuccessScreen() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-      ClaimSuccessScreen({}, {})
+      ClaimSuccessScreen({})
     }
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/topbar/TopAppBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/topbar/TopAppBar.kt
@@ -61,7 +61,8 @@ fun TopAppBarShowcase() {
       },
     ) {
       Column(
-        modifier = Modifier.fillMaxSize().border(1.dp, Color.Red)
+        modifier = Modifier
+          .fillMaxSize()
           .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/topbar/TopAppBar.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/topbar/TopAppBar.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hedvig.android.design.system.hedvig.HedvigButton


### PR DESCRIPTION
Add a way to go to claim details from claim conversation.
Context: https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1726215771897049?thread_ts=1726214710.558449&cid=C03U9C6Q7TP

---

Remove "open chat" button from the last step of the claim flow when it has succeeded.
Context: This way they won't create a new unrelated conversation. Instead they will see the claim card in the home screen and should hopefully start getting more familiar with that one and how one can go to the chat through there instead.

---

Fix the inbox ordering problem where I changed the code and did not add `sortedByDescending` again, but did `sorted` instead.
I did not notice since we had the test session yesterday and I unsigned my member with 128472 conversations 😂