### PR TITLE
Start potentially supporting partial gql responses

### DIFF
--- a/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCaseTest.kt
+++ b/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCaseTest.kt
@@ -5,7 +5,6 @@ import arrow.core.right
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.prop
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.testing.enqueueTestNetworkError
@@ -70,8 +69,6 @@ class GetConnectPaymentReminderUseCaseTest {
     assertThat(result)
       .isLeft()
       .isInstanceOf<ConnectPaymentReminderError.NetworkError>()
-      .prop(ConnectPaymentReminderError.NetworkError::message)
-      .isEqualTo("Network error queued in QueueTestNetworkTransport")
   }
 
   @Test

--- a/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetUpcomingRenewalRemindersUseCaseTest.kt
+++ b/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetUpcomingRenewalRemindersUseCaseTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
-import assertk.assertions.prop
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.testing.enqueueTestNetworkError
@@ -326,7 +325,5 @@ class GetUpcomingRenewalRemindersUseCaseTest {
     assertThat(result)
       .isLeft()
       .isInstanceOf<UpcomingRenewalReminderError.NetworkError>()
-      .prop(UpcomingRenewalReminderError.NetworkError::message)
-      .isEqualTo("Network error queued in QueueTestNetworkTransport")
   }
 }


### PR DESCRIPTION
Very important note here, that this is just done internally, but everything is still returned as Either, to keep the app running just as it used to. We can consider changing this at a later point. This PR is just to make it possible in the first place.

Use iorNel which instead of `Either<Error, Data>` returns `Ior<Nel<Error>, Data>`
Ior is basically an `Either` which can have *both* left and right at the same time, which is exactly what we want when we get partial responses.

This is for problems like when we've had the entire home screen error out on some members when one field failed, when we could've just had that one field be null and still showed all the rest of the data

See also articles like:
https://adambennett.dev/2024/09/using-feature-flags-in-graphql/ About how such partial responses break features and some other options for working around it. While the @include directive works for what they show there, just being able to work with partial responses properly is the more solid long-term approach without having to add @include directives everywhere.