### PR TITLE
Use the most up to date deep link URL for BankID

### DIFF
--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -134,13 +134,15 @@
   </application>
 
   <queries>
+    <!--
+    Allow querying for BankID app
+    https://developer.android.com/training/package-visibility/declaring#intent-filter-signature
+    -->
     <intent>
       <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="bankid" />
-    </intent>
-    <intent>
-      <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="https" />
+      <data
+        android:host="app.bankid.com"
+        android:scheme="https" />
     </intent>
     <intent>
       <action android:name="android.intent.action.VIEW" />

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/BankIdState.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/BankIdState.kt
@@ -1,0 +1,64 @@
+package com.hedvig.android.feature.login.swedishlogin
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.hedvig.android.logger.LogPriority
+import com.hedvig.android.logger.logcat
+
+@Stable
+internal interface BankIdState {
+  val canOpenBankId: Boolean
+
+  fun tryOpenBankId()
+}
+
+@Composable
+internal fun rememberBankIdState(bankIdUri: Uri): BankIdState {
+  val context = LocalContext.current
+  return remember(context, bankIdUri) {
+    BankIdStateImpl(bankIdUri, context).also {
+      it.initialize()
+    }
+  }
+}
+
+@Stable
+private class BankIdStateImpl(
+  val bankIdUri: Uri,
+  val context: Context,
+) : BankIdState {
+  override var canOpenBankId: Boolean by mutableStateOf(false)
+
+  override fun tryOpenBankId() {
+    if (!canOpenBankId) {
+      logcat(LogPriority.INFO) { "BankID not found, showing QR code instead" }
+      return
+    }
+    logcat(LogPriority.INFO) { "Opened BankID to handle login" }
+    context.startActivity(Intent(Intent.ACTION_VIEW, bankIdUri))
+  }
+
+  fun initialize() {
+    canOpenBankId = context.canOpenUri(bankIdUri).also {
+      logcat { "Trying to resolve BankID app with bankIdUri:$bankIdUri | result: canOpenBankId=$it" }
+    }
+  }
+
+  @SuppressLint("QueryPermissionsNeeded")
+  private fun Context.canOpenUri(uri: Uri): Boolean {
+    val resolvedActivity = Intent(Intent.ACTION_VIEW, uri).resolveActivity(packageManager)
+    if (resolvedActivity == null) {
+      logcat(LogPriority.ERROR) { "Could not resolve BankID app with bankIdUri:$uri" }
+    }
+    return resolvedActivity != null
+  }
+}

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginDestination.kt
@@ -1,10 +1,6 @@
 package com.hedvig.android.feature.login.swedishlogin
 
-import android.annotation.SuppressLint
-import android.content.Context
-import android.content.Intent
 import android.graphics.Bitmap
-import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -18,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -34,7 +29,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -57,8 +51,6 @@ import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
-import com.hedvig.android.logger.LogPriority
-import com.hedvig.android.logger.logcat
 import hedvig.resources.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -171,7 +163,7 @@ private fun SwedishLoginScreen(
       }
 
       is BankIdUiState.HandlingBankId -> {
-        val bankIdState = rememberBankIdState(uiState.autoStartToken)
+        val bankIdState = rememberBankIdState(uiState.autoStartToken.bankIdUri)
         val allowOpeningBankId = uiState.allowOpeningBankId
         LaunchedEffect(allowOpeningBankId) {
           if (!allowOpeningBankId) return@LaunchedEffect
@@ -271,47 +263,6 @@ internal fun QRCode(
     null,
     modifier.onSizeChanged { intSize = it },
   )
-}
-
-@Composable
-private fun rememberBankIdState(autoStartToken: BankIdUiState.HandlingBankId.AutoStartToken): BankIdState {
-  val context = LocalContext.current
-  return remember(context, autoStartToken) {
-    BankIdStateImpl(autoStartToken, context).also {
-      it.initialize()
-    }
-  }
-}
-
-@Stable
-private interface BankIdState {
-  val canOpenBankId: Boolean
-
-  fun tryOpenBankId()
-}
-
-@Stable
-private class BankIdStateImpl(
-  val autoStartToken: BankIdUiState.HandlingBankId.AutoStartToken,
-  val context: Context,
-) : BankIdState {
-  override var canOpenBankId: Boolean by mutableStateOf(false)
-
-  override fun tryOpenBankId() {
-    if (!canOpenBankId) {
-      logcat(LogPriority.INFO) { "BankID not found, showing QR code instead" }
-      return
-    }
-    logcat(LogPriority.INFO) { "Opened BankID to handle login" }
-    context.startActivity(Intent(Intent.ACTION_VIEW, autoStartToken.bankIdUri))
-  }
-
-  fun initialize() {
-    canOpenBankId = context.canOpenUri(autoStartToken.bankIdUri)
-  }
-
-  @SuppressLint("QueryPermissionsNeeded")
-  private fun Context.canOpenUri(uri: Uri) = Intent(Intent.ACTION_VIEW, uri).resolveActivity(packageManager) != null
 }
 
 @HedvigPreview

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginPresenter.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginPresenter.kt
@@ -220,7 +220,7 @@ internal sealed interface BankIdUiState {
     value class AutoStartToken(val token: String) {
       // The Uri which opens the BankId app while also passing in the right autoStartUrl
       val bankIdUri: Uri
-        get() = Uri.parse("bankid:///?autostarttoken=$token&redirect=null")
+        get() = Uri.parse("https://app.bankid.com/?autostarttoken=$token&redirect=null")
     }
 
     @JvmInline


### PR DESCRIPTION
Use 
`https://app.bankid.com/?autostarttoken=$token&redirect=null`
instead of 
`bankid:///?autostarttoken=$token&redirect=null`

A different one is specified in https://developer.android.com/training/package-visibility/declaring#intent-filter-signature compared to what we had before

We suspect this meant that for some people the BankID app was not properly found, so we did not show the right information on the screen

The changes in the manifest are according to the docs here https://developer.android.com/training/package-visibility/declaring#intent-filter-signature where it explains how we can explicitly ask for permission to query the information of the app which knows how to handle the `https://app.bankid.com/?autostarttoken=<INSERT AUTOSTARTTOKEN HERE>&redirect=null` link as specified [here](https://developer.android.com/training/package-visibility/declaring#intent-filter-signature)