### PR TITLE
check if there is not already a change of Tier in the upcoming agreement

### DIFF
--- a/app/feature/feature-changeaddress/src/test/kotlin/com/hedvig/android/feature/changeaddress/destination/TestFakes.kt
+++ b/app/feature/feature-changeaddress/src/test/kotlin/com/hedvig/android/feature/changeaddress/destination/TestFakes.kt
@@ -120,7 +120,7 @@ internal val fakeMoveQuote = MoveQuote(
     ),
     documents = listOf(),
     displayTierName = "Standard",
-    tierDescription = "Our standard coverage"
+    tierDescription = "Our standard coverage",
   ),
   displayItems = listOf(),
 )

--- a/app/feature/feature-choose-tier/src/main/graphql/AgreementFragment.graphql
+++ b/app/feature/feature-choose-tier/src/main/graphql/AgreementFragment.graphql
@@ -1,0 +1,20 @@
+fragment GeneralAgreementFragment on Agreement {
+  displayItems {
+    displaySubtitle
+    displayTitle
+    displayValue
+  }
+  premium {
+    ...MoneyFragment
+  }
+  deductible {
+    displayText
+    percentage
+    amount {
+      ...MoneyFragment
+    }
+  }
+  productVariant {
+    ...ProductVariantFragment
+  }
+}

--- a/app/feature/feature-choose-tier/src/main/graphql/CurrentContractQuery.graphql
+++ b/app/feature/feature-choose-tier/src/main/graphql/CurrentContractQuery.graphql
@@ -4,44 +4,10 @@ query CurrentContractsForTierChange {
       id
       exposureDisplayName
       upcomingChangedAgreement {
-        displayItems {
-          displaySubtitle
-          displayTitle
-          displayValue
-        }
-        premium {
-          ...MoneyFragment
-        }
-        deductible {
-          displayText
-          percentage
-          amount {
-            ...MoneyFragment
-          }
-        }
-        productVariant {
-          ...ProductVariantFragment
-        }
+        ...GeneralAgreementFragment
       }
       currentAgreement {
-        displayItems {
-          displaySubtitle
-          displayTitle
-          displayValue
-        }
-        premium {
-          ...MoneyFragment
-        }
-        deductible {
-          displayText
-          percentage
-          amount {
-            ...MoneyFragment
-          }
-        }
-        productVariant {
-          ...ProductVariantFragment
-        }
+        ...GeneralAgreementFragment
       }
     }
   }

--- a/app/feature/feature-choose-tier/src/main/graphql/CurrentContractQuery.graphql
+++ b/app/feature/feature-choose-tier/src/main/graphql/CurrentContractQuery.graphql
@@ -3,7 +3,32 @@ query CurrentContractsForTierChange {
     activeContracts {
       id
       exposureDisplayName
+      upcomingChangedAgreement {
+        displayItems {
+          displaySubtitle
+          displayTitle
+          displayValue
+        }
+        premium {
+          ...MoneyFragment
+        }
+        deductible {
+          displayText
+          percentage
+          amount {
+            ...MoneyFragment
+          }
+        }
+        productVariant {
+          ...ProductVariantFragment
+        }
+      }
       currentAgreement {
+        displayItems {
+          displaySubtitle
+          displayTitle
+          displayValue
+        }
         premium {
           ...MoneyFragment
         }

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/data/GetCurrentContractDataUseCase.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/data/GetCurrentContractDataUseCase.kt
@@ -16,6 +16,7 @@ import com.hedvig.android.logger.LogPriority.ERROR
 import com.hedvig.android.logger.logcat
 import kotlinx.coroutines.flow.first
 import octopus.CurrentContractsForTierChangeQuery
+import octopus.fragment.GeneralAgreementFragment
 
 internal interface GetCurrentContractDataUseCase {
   suspend fun invoke(insuranceId: String): Either<ErrorMessage, CurrentContractData>
@@ -45,52 +46,35 @@ internal class GetCurrentContractDataUseCaseImpl(
         logcat(ERROR) { "Tried to start Change Tier flow but got null active contract" }
         raise(ErrorMessage("Tried to start Change Tier flow but got null active contract"))
       } else {
-        if (dataResult.upcomingChangedAgreement!=null) {
-          val deductible = dataResult.upcomingChangedAgreement.deductible?.let {
-            Deductible(
-              deductibleAmount = UiMoney.fromMoneyFragment(it.amount),
-              deductiblePercentage = it.percentage,
-              description = it.displayText,
-            )
-          }
-          CurrentContractData(
-            currentExposureName = dataResult.exposureDisplayName,
-            currentDisplayPremium = UiMoney.fromMoneyFragment(dataResult.upcomingChangedAgreement.premium),
-            deductible = deductible,
-            productVariant = dataResult.upcomingChangedAgreement.productVariant.toProductVariant(),
-            displayItems = dataResult.upcomingChangedAgreement.displayItems.map {
-              ChangeTierDeductibleDisplayItem(
-                displayTitle = it.displayTitle,
-                displaySubtitle = it.displaySubtitle,
-                displayValue = it.displayValue,
-              )
-            }
-          )
-        } else {
-          val deductible = dataResult.currentAgreement.deductible?.let {
-            Deductible(
-              deductibleAmount = UiMoney.fromMoneyFragment(it.amount),
-              deductiblePercentage = it.percentage,
-              description = it.displayText,
-            )
-          }
-          CurrentContractData(
-            currentExposureName = dataResult.exposureDisplayName,
-            currentDisplayPremium = UiMoney.fromMoneyFragment(dataResult.currentAgreement.premium),
-            deductible = deductible,
-            productVariant = dataResult.currentAgreement.productVariant.toProductVariant(),
-            displayItems = dataResult.currentAgreement.displayItems.map {
-              ChangeTierDeductibleDisplayItem(
-                displayTitle = it.displayTitle,
-                displaySubtitle = it.displaySubtitle,
-                displayValue = it.displayValue,
-              )
-            }
-          )
-        }
+        val agreement = dataResult.upcomingChangedAgreement?.toCurrentContractData(dataResult.exposureDisplayName)
+          ?: dataResult.currentAgreement.toCurrentContractData(dataResult.exposureDisplayName)
+        agreement
       }
     }
   }
+}
+
+private fun GeneralAgreementFragment.toCurrentContractData(exposureDisplayName: String): CurrentContractData {
+  val deductible = this.deductible?.let {
+    Deductible(
+      deductibleAmount = UiMoney.fromMoneyFragment(it.amount),
+      deductiblePercentage = it.percentage,
+      description = it.displayText,
+    )
+  }
+  return CurrentContractData(
+    currentExposureName = exposureDisplayName,
+    currentDisplayPremium = UiMoney.fromMoneyFragment(this.premium),
+    deductible = deductible,
+    productVariant = this.productVariant.toProductVariant(),
+    displayItems = this.displayItems.map {
+      ChangeTierDeductibleDisplayItem(
+        displayTitle = it.displayTitle,
+        displaySubtitle = it.displaySubtitle,
+        displayValue = it.displayValue,
+      )
+    },
+  )
 }
 
 data class CurrentContractData(
@@ -98,5 +82,5 @@ data class CurrentContractData(
   val currentDisplayPremium: UiMoney,
   val deductible: Deductible?,
   val productVariant: ProductVariant,
-  val displayItems: List<ChangeTierDeductibleDisplayItem>
+  val displayItems: List<ChangeTierDeductibleDisplayItem>,
 )

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/data/GetCurrentContractDataUseCase.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/data/GetCurrentContractDataUseCase.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.changetier.data.ChangeTierDeductibleDisplayItem
 import com.hedvig.android.data.changetier.data.Deductible
 import com.hedvig.android.data.productVariant.android.toProductVariant
 import com.hedvig.android.data.productvariant.ProductVariant
@@ -44,19 +45,49 @@ internal class GetCurrentContractDataUseCaseImpl(
         logcat(ERROR) { "Tried to start Change Tier flow but got null active contract" }
         raise(ErrorMessage("Tried to start Change Tier flow but got null active contract"))
       } else {
-        val deductible = dataResult.currentAgreement.deductible?.let {
-          Deductible(
-            deductibleAmount = UiMoney.fromMoneyFragment(it.amount),
-            deductiblePercentage = it.percentage,
-            description = it.displayText,
+        if (dataResult.upcomingChangedAgreement!=null) {
+          val deductible = dataResult.upcomingChangedAgreement.deductible?.let {
+            Deductible(
+              deductibleAmount = UiMoney.fromMoneyFragment(it.amount),
+              deductiblePercentage = it.percentage,
+              description = it.displayText,
+            )
+          }
+          CurrentContractData(
+            currentExposureName = dataResult.exposureDisplayName,
+            currentDisplayPremium = UiMoney.fromMoneyFragment(dataResult.upcomingChangedAgreement.premium),
+            deductible = deductible,
+            productVariant = dataResult.upcomingChangedAgreement.productVariant.toProductVariant(),
+            displayItems = dataResult.upcomingChangedAgreement.displayItems.map {
+              ChangeTierDeductibleDisplayItem(
+                displayTitle = it.displayTitle,
+                displaySubtitle = it.displaySubtitle,
+                displayValue = it.displayValue,
+              )
+            }
+          )
+        } else {
+          val deductible = dataResult.currentAgreement.deductible?.let {
+            Deductible(
+              deductibleAmount = UiMoney.fromMoneyFragment(it.amount),
+              deductiblePercentage = it.percentage,
+              description = it.displayText,
+            )
+          }
+          CurrentContractData(
+            currentExposureName = dataResult.exposureDisplayName,
+            currentDisplayPremium = UiMoney.fromMoneyFragment(dataResult.currentAgreement.premium),
+            deductible = deductible,
+            productVariant = dataResult.currentAgreement.productVariant.toProductVariant(),
+            displayItems = dataResult.currentAgreement.displayItems.map {
+              ChangeTierDeductibleDisplayItem(
+                displayTitle = it.displayTitle,
+                displaySubtitle = it.displaySubtitle,
+                displayValue = it.displayValue,
+              )
+            }
           )
         }
-        CurrentContractData(
-          currentExposureName = dataResult.exposureDisplayName,
-          currentDisplayPremium = UiMoney.fromMoneyFragment(dataResult.currentAgreement.premium),
-          deductible = deductible,
-          productVariant = dataResult.currentAgreement.productVariant.toProductVariant(),
-        )
       }
     }
   }
@@ -67,4 +98,5 @@ data class CurrentContractData(
   val currentDisplayPremium: UiMoney,
   val deductible: Deductible?,
   val productVariant: ProductVariant,
+  val displayItems: List<ChangeTierDeductibleDisplayItem>
 )

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepcustomize/SelectCoverageViewModel.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepcustomize/SelectCoverageViewModel.kt
@@ -162,13 +162,13 @@ private class SelectCoveragePresenter(
                     id = CURRENT_ID,
                     deductible = currentContractData.deductible,
                     tier = Tier(
-                      tierName = params.currentTierName, // todo: HERE edge case. If we have already changed
+                      tierName = params.currentTierName,
                       tierLevel = params.currentTierLevel,
                       tierDescription = currentContractData.productVariant.tierDescription,
                       tierDisplayName = currentContractData.productVariant.displayTierName,
                     ),
                     productVariant = currentContractData.productVariant,
-                    displayItems = listOf(), // todo: here too!
+                    displayItems = currentContractData.displayItems,
                     premium = currentContractData.currentDisplayPremium,
                   )
                 } else {

--- a/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenterTest.kt
+++ b/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenterTest.kt
@@ -57,7 +57,7 @@ internal class InsurancePresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -71,7 +71,7 @@ internal class InsurancePresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     ),
     InsuranceContract(
       id = "contractId#2",
@@ -92,7 +92,7 @@ internal class InsurancePresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -106,7 +106,7 @@ internal class InsurancePresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     ),
   )
   private val terminatedContracts: List<InsuranceContract> = listOf(
@@ -129,7 +129,7 @@ internal class InsurancePresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -143,7 +143,7 @@ internal class InsurancePresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     ),
     InsuranceContract(
       id = "contractId#4",
@@ -164,7 +164,7 @@ internal class InsurancePresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -178,7 +178,7 @@ internal class InsurancePresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     ),
   )
   private val validCrossSells: List<CrossSellsQuery.Data.CurrentMember.CrossSell> = listOf(

--- a/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailPresenterTest.kt
+++ b/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailPresenterTest.kt
@@ -259,7 +259,7 @@ class ContractDetailPresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -273,7 +273,7 @@ class ContractDetailPresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     )
 
     private val insuranceWithTerminationDate = InsuranceContract(
@@ -295,7 +295,7 @@ class ContractDetailPresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -309,7 +309,7 @@ class ContractDetailPresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     )
 
     private val responseTurbine = Turbine<Either<GetContractForContractIdError, InsuranceContract>>()

--- a/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsPresenterTest.kt
+++ b/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsPresenterTest.kt
@@ -203,7 +203,7 @@ class TerminatedContractsPresenterTest {
             insurableLimits = listOf(),
             documents = listOf(),
             displayTierName = "Standard",
-            tierDescription = "Our standard coverage"
+            tierDescription = "Our standard coverage",
           ),
           certificateUrl = null,
           coInsured = listOf(),
@@ -217,7 +217,7 @@ class TerminatedContractsPresenterTest {
         contractHolderSSN = "",
         contractHolderDisplayName = "",
         supportsTierChange = true,
-        tierName = "STANDARD"
+        tierName = "STANDARD",
       ),
       InsuranceContract(
         "contractId2",
@@ -238,7 +238,7 @@ class TerminatedContractsPresenterTest {
             insurableLimits = listOf(),
             documents = listOf(),
             displayTierName = "Standard",
-            tierDescription = "Our standard coverage"
+            tierDescription = "Our standard coverage",
           ),
           certificateUrl = null,
           coInsured = listOf(),
@@ -252,7 +252,7 @@ class TerminatedContractsPresenterTest {
         contractHolderSSN = "",
         contractHolderDisplayName = "",
         supportsTierChange = true,
-        tierName = "STANDARD"
+        tierName = "STANDARD",
       ),
     )
 
@@ -275,7 +275,7 @@ class TerminatedContractsPresenterTest {
           insurableLimits = listOf(),
           documents = listOf(),
           displayTierName = "Standard",
-          tierDescription = "Our standard coverage"
+          tierDescription = "Our standard coverage",
         ),
         certificateUrl = null,
         coInsured = listOf(),
@@ -289,7 +289,7 @@ class TerminatedContractsPresenterTest {
       contractHolderSSN = "",
       contractHolderDisplayName = "",
       supportsTierChange = true,
-      tierName = "STANDARD"
+      tierName = "STANDARD",
     )
 
     private val activeInsurances = listOf(
@@ -312,7 +312,7 @@ class TerminatedContractsPresenterTest {
             insurableLimits = listOf(),
             documents = listOf(),
             displayTierName = "Standard",
-            tierDescription = "Our standard coverage"
+            tierDescription = "Our standard coverage",
           ),
           certificateUrl = null,
           coInsured = listOf(),
@@ -326,7 +326,7 @@ class TerminatedContractsPresenterTest {
         contractHolderSSN = "",
         contractHolderDisplayName = "",
         supportsTierChange = true,
-        tierName = "STANDARD"
+        tierName = "STANDARD",
       ),
       InsuranceContract(
         "contractId4",
@@ -347,7 +347,7 @@ class TerminatedContractsPresenterTest {
             insurableLimits = listOf(),
             documents = listOf(),
             displayTierName = "Standard",
-            tierDescription = "Our standard coverage"
+            tierDescription = "Our standard coverage",
           ),
           certificateUrl = null,
           coInsured = listOf(),
@@ -361,7 +361,7 @@ class TerminatedContractsPresenterTest {
         contractHolderSSN = "",
         contractHolderDisplayName = "",
         supportsTierChange = true,
-        tierName = "STANDARD"
+        tierName = "STANDARD",
       ),
     )
   }


### PR DESCRIPTION
We display current tier/deductible by default. Now I've changed a little bit what this"current" is: if we have the upcoming change (for example, we have already gone through Tier change flow, now we want to do it again, while the first change is not yet activated), the current will be the tier and deductible for the upcoming agreement (because it's what BE counts as the base to give us available tiers/ deductibles).

Converting it to draft now; discussing possible API change