### PR TITLE
Fix documents UI according to Figma specs

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Typography.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Typography.kt
@@ -12,7 +12,7 @@ import com.hedvig.android.design.system.hedvig.tokens.TypographyTokens
 data class Typography(
   val bodyLarge: TextStyle = TypographyTokens.BodyLarge,
   val bodyMedium: TextStyle = TypographyTokens.BodyMedium,
-  val bodySmall: TextStyle = TypographyTokens.BodySmall,
+  val bodySmall: TextStyle = TypographyTokens.BodySmall, // The default typography of the app
   val displayLarge: TextStyle = TypographyTokens.DisplayLarge,
   val displayMedium: TextStyle = TypographyTokens.DisplayMedium,
   val displaySmall: TextStyle = TypographyTokens.DisplaySmall,

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/TypographyTokens.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/TypographyTokens.kt
@@ -19,6 +19,8 @@ internal object TypographyTokens {
     lineHeight = TypeScaleTokens.BodyMediumLineHeight,
     letterSpacing = TypeScaleTokens.BodyMediumTracking,
   )
+
+  // The default typography of the app
   val BodySmall = DefaultTextStyle.copy(
     fontFamily = TypeScaleTokens.BodySmallFont,
     fontWeight = TypeScaleTokens.BodySmallWeight,

--- a/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
+++ b/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
@@ -23,12 +23,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hedvig.android.compose.ui.LayoutWithoutPlacement
 import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.data.contract.ContractGroup.DOG
 import com.hedvig.android.data.contract.ContractType.SE_HOUSE
@@ -166,28 +169,45 @@ private fun QuoteCard(
             if (productVariant.documents.isNotEmpty()) {
               Column {
                 HedvigText(stringResource(R.string.TIER_FLOW_SUMMARY_DOCUMENTS_SUBTITLE))
-                for (document in productVariant.documents) {
-                  val uriHandler = LocalUriHandler.current
-                  Row(
-                    modifier = Modifier
-                      .fillMaxWidth()
-                      .clip(HedvigTheme.shapes.cornerExtraSmall)
-                      .clickable {
-                        uriHandler.openUri(document.url)
-                      },
-                  ) {
-                    HedvigText(
-                      text = document.displayName,
-                      color = HedvigTheme.colorScheme.textSecondary,
-                      modifier = Modifier.weight(1f),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Icon(
-                      imageVector = HedvigIcons.ArrowNorthEast,
-                      contentDescription = null,
-                      tint = HedvigTheme.colorScheme.fillPrimary,
-                      modifier = Modifier.wrapContentWidth(),
-                    )
+                Column(
+                  verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                  for (document in productVariant.documents) {
+                    val uriHandler = LocalUriHandler.current
+                    Row(
+                      modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(HedvigTheme.shapes.cornerExtraSmall)
+                        .clickable {
+                          uriHandler.openUri(document.url)
+                        },
+                    ) {
+                      HedvigText(
+                        text = document.displayName,
+                        style = HedvigTheme.typography.bodySmall,
+                        color = HedvigTheme.colorScheme.textSecondary,
+                        modifier = Modifier.weight(1f),
+                      )
+                      Spacer(Modifier.width(8.dp))
+                      LayoutWithoutPlacement(
+                        sizeAdjustingContent = {
+                          HedvigText(
+                            "H",
+                            style = HedvigTheme.typography.bodySmall,
+                          )
+                        },
+                      ) {
+                        val density = LocalDensity.current
+                        Icon(
+                          imageVector = HedvigIcons.ArrowNorthEast,
+                          contentDescription = null,
+                          tint = HedvigTheme.colorScheme.fillPrimary,
+                          modifier = Modifier
+                            .then(with(density) { Modifier.size(16.sp.toDp()) })
+                            .align(Alignment.Center),
+                        )
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Issue: https://www.notion.so/hedviginsurance/130c3f71cb0a80249219eb8a7589a637?v=130c3f71cb0a81d6bc17000c33cc9b68&p=130c3f71cb0a80e0bc0be32d4a4b202b&pm=s

After discussion here:
https://www.notion.so/hedviginsurance/It-looks-quite-compact-between-the-different-documents-hard-to-differentiate-them-Even-without-wie-130c3f71cb0a80ff877dfa94074ef806?d=131c3f71cb0a8073a6a2001c5f3676e1
And:
https://www.notion.so/hedviginsurance/Arrow-Icons-are-a-bit-off-not-aligned-with-text-on-Show-details-11cc3f71cb0a80ce8b1cdaedf3c4d158?d=11cc3f71cb0a8074a6c2001cf7f90322
regarding how the spacing works in this area, especially due to the close proximity of many clickable items together