### PR TITLE
Go full width/height in some places where we did not

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
@@ -2,11 +2,10 @@ package com.hedvig.android.design.system.hedvig
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,13 +21,13 @@ fun HedvigErrorSection(
   title: String = stringResource(R.string.something_went_wrong),
   subTitle: String? = stringResource(R.string.GENERAL_ERROR_BODY),
   buttonText: String = stringResource(R.string.GENERAL_RETRY),
-  contentPadding: PaddingValues = WindowInsets.safeDrawing.asPaddingValues(),
+  windowInsets: WindowInsets = WindowInsets.safeDrawing,
 ) {
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
     modifier = modifier
-      .padding(contentPadding)
+      .windowInsetsPadding(windowInsets)
       .padding(horizontal = 16.dp),
   ) {
     EmptyState(

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
@@ -34,18 +35,20 @@ fun HedvigScaffold(
     modifier = modifier,
   ) {
     Column {
+      val topAppbarInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
       TopAppBar(
         title = topAppBarText ?: "",
         actionType = topAppBarActionType,
         onActionClick = dropUnlessResumed(block = navigateUp),
         topAppBarActions = topAppBarActions,
-        windowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+        windowInsets = topAppbarInsets,
       )
       Column(
         horizontalAlignment = itemsColumnHorizontalAlignment,
         modifier = Modifier
           .fillMaxSize()
           .verticalScroll(rememberScrollState())
+          .consumeWindowInsets(topAppbarInsets)
           .windowInsetsPadding(
             // todo remove this bottom insets padding from Scaffold, as it forces the callers to clip the bottom bar
             //  insets if they happen to want to have their own scrollable state

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
@@ -48,7 +48,7 @@ fun HedvigScaffold(
         modifier = Modifier
           .fillMaxSize()
           .verticalScroll(rememberScrollState())
-          .consumeWindowInsets(topAppbarInsets)
+          .consumeWindowInsets(topAppbarInsets.only(WindowInsetsSides.Top))
           .windowInsetsPadding(
             // todo remove this bottom insets padding from Scaffold, as it forces the callers to clip the bottom bar
             //  insets if they happen to want to have their own scrollable state

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -91,7 +92,7 @@ private fun InboxScreen(
         InboxUiState.Loading -> HedvigFullScreenCenterAlignedProgressDebounced()
         InboxUiState.Failure -> HedvigErrorSection(
           onButtonClick = reload,
-          modifier = Modifier.weight(1f),
+          modifier = Modifier.weight(1f).fillMaxWidth(),
         )
 
         is InboxUiState.Success -> InboxSuccessScreen(

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/addhouseinformation/AddHouseInformationDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/addhouseinformation/AddHouseInformationDestination.kt
@@ -145,6 +145,7 @@ private fun AddHouseInformationScreen(
         onButtonClick = popBackStack,
         subTitle = null,
         buttonText = stringResource(R.string.app_info_submit_bug_go_back),
+        modifier = Modifier.fillMaxWidth(),
       )
 
       is Content -> AddHouseInformationScreen(uiState, dismissSubmissionError, onSubmit, Modifier.weight(1f))
@@ -244,6 +245,7 @@ private fun AddHouseInformationScreen(
       HedvigNotificationCard(
         message = stringResource(R.string.CHANGE_ADDRESS_COVERAGE_INFO_TEXT),
         priority = Info,
+        modifier = Modifier.fillMaxWidth(),
       )
       Spacer(Modifier.height(16.dp))
       HedvigButton(

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/successfulmove/SuccessfulMoveDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/successfulmove/SuccessfulMoveDestination.kt
@@ -1,17 +1,18 @@
 package com.hedvig.android.feature.movingflow.ui.successfulmove
 
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Large
 import com.hedvig.android.design.system.hedvig.EmptyState
 import com.hedvig.android.design.system.hedvig.EmptyStateDefaults.EmptyStateIconStyle.SUCCESS
-import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
 import com.hedvig.android.design.system.hedvig.HedvigTheme
@@ -29,13 +30,16 @@ internal fun SuccessfulMoveDestination(moveDate: LocalDate, navigateUp: () -> Un
     HedvigDateTimeFormatterDefaults.dateMonthAndYear(locale).format(moveDate.toJavaLocalDate())
   }
   HedvigScaffold(navigateUp) {
-    Spacer(Modifier.weight(1f))
     EmptyState(
       text = stringResource(R.string.TIER_FLOW_COMMIT_PROCESSING_TITLE),
       description = stringResource(R.string.TIER_FLOW_COMMIT_PROCESSING_DESCRIPTION, formattedDate),
       iconStyle = SUCCESS,
+      modifier = Modifier
+        .fillMaxWidth()
+        .weight(1f)
+        .wrapContentHeight(Alignment.CenterVertically)
+        .padding(horizontal = 16.dp),
     )
-    Spacer(Modifier.weight(1f))
     HedvigTextButton(
       text = stringResource(id = R.string.general_close_button),
       onClick = { popBackStack() },
@@ -48,7 +52,7 @@ internal fun SuccessfulMoveDestination(moveDate: LocalDate, navigateUp: () -> Un
   }
 }
 
-@HedvigPreview
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewSuccessfulMoveDestination() {
   HedvigTheme {

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -33,6 +35,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.core.uidata.UiCurrencyCode.SEK
@@ -124,11 +128,12 @@ private fun SummaryScreen(
     modifier = Modifier.fillMaxSize(),
   ) {
     when (uiState) {
-      Loading -> HedvigFullScreenCenterAlignedProgress()
+      Loading -> HedvigFullScreenCenterAlignedProgress(Modifier.weight(1f).fillMaxWidth())
       SummaryUiState.Error -> HedvigErrorSection(
         onButtonClick = navigateBack,
         subTitle = null,
         buttonText = stringResource(R.string.general_back_button),
+        modifier = Modifier.weight(1f).fillMaxWidth(),
       )
 
       is Content -> SummaryScreen(
@@ -408,79 +413,13 @@ private fun QuestionsAndAnswers(modifier: Modifier = Modifier) {
 @HedvigPreview
 @Preview(device = "spec:width=1080px,height=3800px,dpi=440")
 @Composable
-private fun PreviewSummaryScreen() {
+private fun PreviewSummaryScreen(
+  @PreviewParameter(SummaryUiStateProvider::class) summaryUiState: SummaryUiState,
+) {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
-      val productVariant = ProductVariant(
-        displayName = "Variant",
-        contractGroup = ContractGroup.RENTAL,
-        contractType = ContractType.SE_APARTMENT_RENT,
-        partner = null,
-        perils = listOf(
-          ProductVariantPeril(
-            "id",
-            "peril title",
-            "peril description",
-            emptyList(),
-            emptyList(),
-            null,
-          ),
-        ),
-        insurableLimits = listOf(
-          InsurableLimit(
-            label = "insurable limit label",
-            limit = "insurable limit limit",
-            description = "insurable limit description",
-            type = BIKE,
-          ),
-        ),
-        documents = listOf(
-          InsuranceVariantDocument(
-            displayName = "displayName",
-            url = "url",
-            type = CERTIFICATE,
-          ),
-        ),
-        displayTierName = "tierDescription",
-        tierDescription = "displayNameTier",
-      )
-      val startDate = LocalDate.parse("2025-01-01")
       SummaryScreen(
-        uiState = SummaryUiState.Content(
-          summaryInfo = SummaryInfo(
-            moveHomeQuote = MoveHomeQuote(
-              id = "id",
-              premium = UiMoney(99.0, SEK),
-              startDate = startDate,
-              displayItems = listOf(
-                DisplayItem(
-                  title = "display title",
-                  subtitle = "display subtitle",
-                  value = "display value",
-                ),
-              ),
-              exposureName = "exposureName",
-              productVariant = productVariant,
-              tierName = "tierName",
-              tierLevel = 1,
-              tierDescription = "tierDescription",
-              deductible = Deductible(UiMoney(1500.0, SEK), null, "displayText"),
-              defaultChoice = false,
-            ),
-            moveMtaQuotes = listOf(
-              MoveMtaQuote(
-                premium = UiMoney(49.0, SEK),
-                exposureName = "exposureName",
-                productVariant = productVariant,
-                startDate = startDate,
-                displayItems = emptyList(),
-              ),
-            ),
-          ),
-          false,
-          null,
-          null,
-        ),
+        uiState = summaryUiState,
         navigateUp = {},
         navigateBack = {},
         onNavigateToNewConversation = {},
@@ -489,4 +428,81 @@ private fun PreviewSummaryScreen() {
       )
     }
   }
+}
+
+private class SummaryUiStateProvider : PreviewParameterProvider<SummaryUiState> {
+  private val productVariant = ProductVariant(
+    displayName = "Variant",
+    contractGroup = ContractGroup.RENTAL,
+    contractType = ContractType.SE_APARTMENT_RENT,
+    partner = null,
+    perils = listOf(
+      ProductVariantPeril(
+        "id",
+        "peril title",
+        "peril description",
+        emptyList(),
+        emptyList(),
+        null,
+      ),
+    ),
+    insurableLimits = listOf(
+      InsurableLimit(
+        label = "insurable limit label",
+        limit = "insurable limit limit",
+        description = "insurable limit description",
+        type = BIKE,
+      ),
+    ),
+    documents = listOf(
+      InsuranceVariantDocument(
+        displayName = "displayName",
+        url = "url",
+        type = CERTIFICATE,
+      ),
+    ),
+    displayTierName = "tierDescription",
+    tierDescription = "displayNameTier",
+  )
+  val startDate = LocalDate.parse("2025-01-01")
+
+  override val values: Sequence<SummaryUiState> = sequenceOf(
+    SummaryUiState.Loading,
+    SummaryUiState.Error,
+    SummaryUiState.Content(
+      summaryInfo = SummaryInfo(
+        moveHomeQuote = MoveHomeQuote(
+          id = "id",
+          premium = UiMoney(99.0, SEK),
+          startDate = startDate,
+          displayItems = listOf(
+            DisplayItem(
+              title = "display title",
+              subtitle = "display subtitle",
+              value = "display value",
+            ),
+          ),
+          exposureName = "exposureName",
+          productVariant = productVariant,
+          tierName = "tierName",
+          tierLevel = 1,
+          tierDescription = "tierDescription",
+          deductible = Deductible(UiMoney(1500.0, SEK), null, "displayText"),
+          defaultChoice = false,
+        ),
+        moveMtaQuotes = listOf(
+          MoveMtaQuote(
+            premium = UiMoney(49.0, SEK),
+            exposureName = "exposureName",
+            productVariant = productVariant,
+            startDate = startDate,
+            displayItems = emptyList(),
+          ),
+        ),
+      ),
+      false,
+      null,
+      null,
+    ),
+  )
 }


### PR DESCRIPTION
https://www.notion.so/hedviginsurance/130c3f71cb0a80249219eb8a7589a637?v=130c3f71cb0a81d6bc17000c33cc9b68&p=130c3f71cb0a8028b114de7c4bdd05f1&pm=s

Also fix some bugs with how we were consuming or not consuming some window insets in this process.

The reason this is often something we miss is that the error text message is long enough that in normal-sized screens it requires the entire width of the screen already, and it looks correct. Given bigger screens (or landscape mode), us missing a `fillMaxWidth()` becomes obvious.

It's possible we've missed this in more places, but we can fix those as they surface.