### PR TITLE
show "change address" in insurance detail only if it allowed

### DIFF
--- a/app/feature/feature-insurances/src/main/graphql/QueryInsuranceContracts.graphql
+++ b/app/feature/feature-insurances/src/main/graphql/QueryInsuranceContracts.graphql
@@ -1,5 +1,8 @@
 query InsuranceContracts {
   currentMember {
+    memberActions {
+      isMovingEnabled
+    }
     firstName
     lastName
     ssn

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCase.kt
@@ -36,19 +36,19 @@ internal class GetInsuranceContractsUseCaseImpl(
       featureManager.isFeatureEnabled(Feature.EDIT_COINSURED),
       featureManager.isFeatureEnabled(Feature.MOVING_FLOW),
       featureManager.isFeatureEnabled(Feature.TIER),
-    ) { insuranceQueryResponse, isEditCoInsuredEnabled, isMovingFlowEnabled, isTierEnabled ->
+    ) { insuranceQueryResponse, isEditCoInsuredEnabled, isMovingFlowFlagEnabled, isTierEnabled ->
       either {
         val insuranceQueryData = insuranceQueryResponse.bind()
         val contractHolderDisplayName = insuranceQueryData.getContractHolderDisplayName()
         val contractHolderSSN = insuranceQueryData.currentMember.ssn?.let { formatSsn(it) }
-
+        val isMovingEnabledForMember = insuranceQueryData.currentMember.memberActions?.isMovingEnabled ?: false
         val terminatedContracts = insuranceQueryData.currentMember.terminatedContracts.map {
           it.toContract(
             isTerminated = true,
             contractHolderDisplayName = contractHolderDisplayName,
             contractHolderSSN = contractHolderSSN,
             isEditCoInsuredEnabled = isEditCoInsuredEnabled,
-            isMovingFlowEnabled = isMovingFlowEnabled,
+            isMovingFlowEnabled = isMovingFlowFlagEnabled && isMovingEnabledForMember,
             isTierFlagEnabled = isTierEnabled,
           )
         }
@@ -59,7 +59,7 @@ internal class GetInsuranceContractsUseCaseImpl(
             contractHolderDisplayName = contractHolderDisplayName,
             contractHolderSSN = contractHolderSSN,
             isEditCoInsuredEnabled = isEditCoInsuredEnabled,
-            isMovingFlowEnabled = isMovingFlowEnabled,
+            isMovingFlowEnabled = isMovingFlowFlagEnabled && isMovingEnabledForMember,
             isTierFlagEnabled = isTierEnabled,
           )
         }


### PR DESCRIPTION
Check for memberAction isMovingAllowed before showing the "change address" button.
So if member has >1 home insurance they won't be able to start moving flow at all, both from HC and from ins.detail.