### PR TITLE
Introduce OverlaidIndication to handle the full row indication logic

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
@@ -106,7 +106,7 @@ private annotation class HedvigTabletPreview
   uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
   device = "spec:width=1280dp,height=800dp,dpi=240",
 )
-private annotation class HedvigTabletLandscapePreview
+annotation class HedvigTabletLandscapePreview
 
 @HedvigPreview
 @HedvigLandscapePreview

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/OverlaidIndicationConnection.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/OverlaidIndicationConnection.kt
@@ -1,0 +1,62 @@
+package com.hedvig.android.shared.tier.comparison.ui
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.node.LayoutAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.round
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+internal fun Modifier.overlaidIndicationConnection(
+  overlaidIndicationState: OverlaidIndicationState,
+  interactionSource: MutableInteractionSource,
+): Modifier = this then OverlaidIndicationConnectionElement(overlaidIndicationState, interactionSource)
+
+private data class OverlaidIndicationConnectionElement(
+  val overlaidIndicationState: OverlaidIndicationState,
+  val interactionSource: MutableInteractionSource,
+) : ModifierNodeElement<OverlaidIndicationConnectionNode>() {
+  override fun create(): OverlaidIndicationConnectionNode {
+    return OverlaidIndicationConnectionNode(overlaidIndicationState, interactionSource)
+  }
+
+  override fun update(node: OverlaidIndicationConnectionNode) {
+    node.update(overlaidIndicationState, interactionSource)
+  }
+}
+
+private class OverlaidIndicationConnectionNode(
+  private var overlaidIndicationState: OverlaidIndicationState,
+  private var interactionSource: MutableInteractionSource,
+) : LayoutAwareModifierNode, Modifier.Node() {
+  private var offset = IntOffset(0, 0)
+  private var collectingJob: Job? = null
+
+  override fun onAttach() {
+    startCollection()
+  }
+
+  fun update(overlaidIndicationState: OverlaidIndicationState, interactionSource: MutableInteractionSource) {
+    this.overlaidIndicationState = overlaidIndicationState
+    this.interactionSource = interactionSource
+    startCollection()
+  }
+
+  private fun startCollection() {
+    collectingJob?.cancel()
+    collectingJob = coroutineScope.launch {
+      interactionSource.interactions.collect {
+        overlaidIndicationState.offset = offset
+        overlaidIndicationState.interactionSource.tryEmit(it)
+      }
+    }
+  }
+
+  override fun onPlaced(coordinates: LayoutCoordinates) {
+    offset = coordinates.positionInParent().round()
+  }
+}

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/OverlaidIndicationState.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/OverlaidIndicationState.kt
@@ -1,0 +1,26 @@
+package com.hedvig.android.shared.tier.comparison.ui
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.IntOffset
+
+@Composable
+internal fun rememberOverlaidIndicationState(): OverlaidIndicationState {
+  return remember { OverlaidIndicationStateImpl() }
+}
+
+@Stable
+internal interface OverlaidIndicationState {
+  var offset: IntOffset
+  val interactionSource: MutableInteractionSource
+}
+
+private class OverlaidIndicationStateImpl() : OverlaidIndicationState {
+  override var offset by mutableStateOf(IntOffset(0, 0))
+  override val interactionSource: MutableInteractionSource = MutableInteractionSource()
+}


### PR DESCRIPTION
overlaidIndicationConnection serves as the modifier to be added to the
places where the source of the indication comes from, which syncs all
interactions back to the interaction source which is used in the
OverlaidIndication.
The normal `clickable` modifier is then used in the rows since that one
correctly passes all interaction events, including hover events, long
clicks etc, which are otherwise harder to do manually with a pointerInput

I basically also used this as an opportunity to learn how to work with
custom modifiers. I followed the docs here if you're curious:
https://developer.android.com/develop/ui/compose/custom-modifiers#implement_a_custom_modifier_using_modifiernode