### PR TITLE
Fix/table

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/NavigationBar.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/NavigationBar.kt
@@ -205,7 +205,7 @@ private fun NavigationItem(
     Offset((itemWidthPx - indicatorWidth).toFloat() / 2, itemPaddings.calculateTopPadding().toPx())
   }
   val offsetInteractionSource = remember(interactionSource, deltaOffset) {
-    MappedInteractionSource(interactionSource, deltaOffset)
+    MappedInteractionSource(interactionSource, { -deltaOffset })
   }
   val indicatorShape = HedvigTheme.shapes.cornerLarge
   Column(

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/internal/MappedInteractionSource.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/internal/MappedInteractionSource.kt
@@ -1,16 +1,20 @@
 package com.hedvig.android.design.system.hedvig.internal
 
 import androidx.compose.foundation.interaction.Interaction
-import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.ui.geometry.Offset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-internal class MappedInteractionSource(
-  underlyingInteractionSource: InteractionSource,
-  private val delta: Offset,
-) : InteractionSource {
+/**
+ * [delta] is the [Offset] of how far away the source coming from [underlyingInteractionSource] is, relevant to the
+ * returned [MutableInteractionSource].
+ */
+class MappedInteractionSource(
+  private val underlyingInteractionSource: MutableInteractionSource,
+  private val delta: () -> Offset,
+) : MutableInteractionSource {
   private val mappedPresses = mutableMapOf<PressInteraction.Press, PressInteraction.Press>()
 
   override val interactions: Flow<Interaction> = underlyingInteractionSource.interactions.map { interaction ->
@@ -43,7 +47,15 @@ internal class MappedInteractionSource(
     }
   }
 
+  override suspend fun emit(interaction: Interaction) {
+    underlyingInteractionSource.emit(interaction)
+  }
+
+  override fun tryEmit(interaction: Interaction): Boolean {
+    return underlyingInteractionSource.tryEmit(interaction)
+  }
+
   private fun mapPress(press: PressInteraction.Press): PressInteraction.Press {
-    return PressInteraction.Press((press.pressPosition - delta))
+    return PressInteraction.Press((press.pressPosition + delta()))
   }
 }

--- a/app/shared/tier-comparison/build.gradle.kts
+++ b/app/shared/tier-comparison/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("hedvig.gradle.plugin")
   id("hedvig.android.library")
-  id("kotlin-parcelize")
 }
 
 hedvig {

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -309,7 +308,6 @@ private fun Table(
       }
   }
   val fixedCellWidth: Dp = remember(uiState.comparisonData.columns, textStyle) {
-    val totalHorizontalPadding = 16.dp
     with(density) {
       uiState.comparisonData.columns.map { it.title }.filterNotNull().maxOf { title ->
         textMeasurer.measure(
@@ -319,7 +317,7 @@ private fun Table(
           softWrap = false,
           maxLines = 1,
         ).size.width
-      }.toDp() + totalHorizontalPadding
+      }.toDp() + CellTitleHorizontalPadding
     }
   }
   val numberOfCells = remember(uiState.comparisonData.columns) {
@@ -631,6 +629,7 @@ private fun ComparisonScreenPreview() {
 }
 
 private val CellEndPadding = 16.dp
+private val CellTitleHorizontalPadding = 16.dp
 private val ColumnTextStartPadding = 16.dp
 private val ColumnTextEndPadding = 6.dp
 private val MaxSizeRatioForFixedColumn = 0.4f

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -79,6 +79,7 @@ import com.hedvig.android.design.system.hedvig.icon.Checkmark
 import com.hedvig.android.design.system.hedvig.icon.Close
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.Minus
+import com.hedvig.android.design.system.hedvig.internal.MappedInteractionSource
 import com.hedvig.android.shared.tier.comparison.data.ComparisonCell
 import com.hedvig.android.shared.tier.comparison.data.ComparisonData
 import com.hedvig.android.shared.tier.comparison.data.ComparisonRow
@@ -353,6 +354,7 @@ private fun Table(uiState: Success, selectComparisonRow: (ComparisonRow) -> Unit
         maxWidth = remainingWidthCoercedToAtLeastTheMinimumScreenPercentage,
       )
     }
+    overlaidIndicationState.fixedColumnWidth = columnConstraints.maxWidth
     val fixSizedComparisonDataColumnPlaceable = fixSizedComparisonDataColumn.measure(columnConstraints)
     val spaceRemainingForCells = constraints.maxWidth - fixSizedComparisonDataColumnPlaceable.width
     val remainingWidthForCellSection = cellSectionFullWidth.coerceAtMost(spaceRemainingForCells)
@@ -492,14 +494,19 @@ private fun ScrollableTableSection(
     }
     Column {
       comparisonData.rows.forEachIndexed { rowIndex, comparisonRow ->
-        val interactionSource = remember { MutableInteractionSource() }
+        val mappedInteractionSource = remember {
+          MappedInteractionSource(
+            MutableInteractionSource(),
+            { Offset(overlaidIndicationState.fixedColumnWidth.toFloat(), 0f) },
+          )
+        }
         val borderColor = HedvigTheme.colorScheme.borderSecondary
         Row(
           verticalAlignment = Alignment.CenterVertically,
           modifier = Modifier
-            .overlaidIndicationConnection(overlaidIndicationState, interactionSource)
+            .overlaidIndicationConnection(overlaidIndicationState, mappedInteractionSource)
             .clickable(
-              interactionSource = interactionSource,
+              interactionSource = mappedInteractionSource,
               indication = null,
               onClick = { onRowClick(comparisonRow) },
             )

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -261,7 +261,9 @@ private fun IndicateScrollableTableEffect(scrollState: ScrollState) {
 private fun Table(uiState: Success, selectComparisonRow: (ComparisonRow) -> Unit, modifier: Modifier = Modifier) {
   val density = LocalDensity.current
   val textStyle = LocalTextStyle.current
-  val textMeasurer = rememberTextMeasurer()
+  val textMeasurer = rememberTextMeasurer(
+    cacheSize = uiState.comparisonData.columns.count() + uiState.comparisonData.rows.count() + 1,
+  )
   val maxWidthRequiredForFixedColumnTexts = remember(textMeasurer, uiState.comparisonData.rows, textStyle) {
     uiState
       .comparisonData
@@ -580,10 +582,9 @@ private fun Cell(
   textMeasurer: TextMeasurer,
   fixedWidth: Dp? = null,
   modifier: Modifier = Modifier,
-  customText: String? = null,
   content: @Composable () -> Unit = {},
 ) {
-  val fixedHeight = calculateCellHeight(textMeasurer, customText)
+  val fixedHeight = calculateCellHeight(textMeasurer)
   Box(
     modifier = modifier
       .then(
@@ -601,13 +602,13 @@ private fun Cell(
 }
 
 @Composable
-private fun calculateCellHeight(textMeasurer: TextMeasurer, customText: String? = null): Dp {
+private fun calculateCellHeight(textMeasurer: TextMeasurer): Dp {
   val textStyle = LocalTextStyle.current
   val density = LocalDensity.current
-  return remember(textMeasurer, customText) {
+  return remember(textMeasurer) {
     with(density) {
       textMeasurer.measure(
-        text = customText ?: "H",
+        text = ConstantLetterUsedAsMeasurementPlaceholder,
         style = textStyle,
         softWrap = false,
         maxLines = 1,
@@ -629,7 +630,10 @@ private fun ComparisonScreenPreview() {
     ) {
       ComparisonScreen(
         Success(
-          mockComparisonData,
+          mockComparisonData.copy(
+            rows = mockComparisonData.rows,
+            columns = mockComparisonData.columns,
+          ),
           1,
         ),
         {},
@@ -638,6 +642,7 @@ private fun ComparisonScreenPreview() {
   }
 }
 
+private val ConstantLetterUsedAsMeasurementPlaceholder = "H"
 private val CellEndPadding = 16.dp
 private val CellVerticalPadding = 8.dp
 private val CellTitleHorizontalPadding = 16.dp

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -55,11 +55,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.design.system.hedvig.HedvigCircularProgressIndicator
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
@@ -622,7 +624,24 @@ private fun calculateCellHeight(textMeasurer: TextMeasurer): Dp {
 @PreviewFontScale
 @Preview
 @Composable
-private fun ComparisonScreenPreview() {
+private fun ComparisonScreenPreview(
+  @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) withExtraData: Boolean,
+) {
+  val comparisonData = if (withExtraData) {
+    val rows = mockComparisonData.rows.map {
+      it.copy(
+        title = it.title.repeat(2),
+        cells = it.cells + it.cells,
+      )
+    }
+    val columns = (mockComparisonData.columns + mockComparisonData.columns)
+    mockComparisonData.copy(
+      rows = rows + rows,
+      columns = columns,
+    )
+  } else {
+    mockComparisonData
+  }
   HedvigTheme {
     Surface(
       modifier = Modifier.fillMaxSize(),
@@ -630,10 +649,7 @@ private fun ComparisonScreenPreview() {
     ) {
       ComparisonScreen(
         Success(
-          mockComparisonData.copy(
-            rows = mockComparisonData.rows,
-            columns = mockComparisonData.columns,
-          ),
+          comparisonData,
           1,
         ),
         {},

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/OverlaidIndicationState.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/OverlaidIndicationState.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -16,11 +17,15 @@ internal fun rememberOverlaidIndicationState(): OverlaidIndicationState {
 
 @Stable
 internal interface OverlaidIndicationState {
+  // Used to be able to offset the interactions coming from the cell rows by this much, so that they match the physical
+  // position of the origin of the interaction
+  var fixedColumnWidth: Int
   var offset: IntOffset
   val interactionSource: MutableInteractionSource
 }
 
 private class OverlaidIndicationStateImpl() : OverlaidIndicationState {
+  override var fixedColumnWidth by mutableIntStateOf(0)
   override var offset by mutableStateOf(IntOffset(0, 0))
   override val interactionSource: MutableInteractionSource = MutableInteractionSource()
 }


### PR DESCRIPTION
Surely this time is the last time
![image](https://github.com/user-attachments/assets/52d22578-fe45-41bc-9916-a901e15078bc)

I caved and just made a custom layout for the table + cells + overlay to have full control of what goes where.

Basically with the implementation before, the left column would cap at 40% of the screen, even if the cells did not actually need the rest 60% of the screen, which was very common for wider screens/landscape mode.

This makes use of textMeasurer to calculate all the widths eagerly (textMeasurer has an internal cache, so we only measure each text exactly once), and we can make more well informed decisions about the table.

That way we have all the information we need in order to
achieve all of our requirements at the same time:
* If there is enough space for everything, render everything without
clipping any text
* If there is not enough space for everything, place the row titles
first and then the cells right next to them
* If the row titles end up being smaller than 40% of the screen, do
nothing else about it, and give the rest of the screen to the cells
* If the row titles were to try to take more than 40% of the screen,
force them to take 40% of the screen instead, and then give the cells
the rest of the screen

This also makes sure that since the interaction source of the cells comes from a different X axis compared to where the overlay sits in, that we offset the interaction source `pressPosition` by exactly the width of the left column width.