### PR TITLE
Capitalize the first letter of the address when possible

### DIFF
--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressDestination.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardCapitalization.Companion
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
@@ -194,6 +196,9 @@ private fun EnterNewAddressScreen(
             uiState.address.updateValue(it)
           },
           labelText = stringResource(R.string.CHANGE_ADDRESS_NEW_ADDRESS_LABEL),
+          keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Sentences,
+          ),
           textFieldSize = HedvigTextFieldDefaults.TextFieldSize.Medium,
           errorState = when (val validationError = uiState.address.validationError) {
             null -> HedvigTextFieldDefaults.ErrorState.NoError


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="357" alt="image" src="https://github.com/user-attachments/assets/d5db9c76-eda0-40ef-9605-5ad32a77184d"> | <img width="357" alt="image" src="https://github.com/user-attachments/assets/627f2ea3-9311-49ac-9c0f-703fea1a883e"> |

It just by default makes the first letter capital, so that if someone enters an address without explicitly thinking about it, they will get the right behavior.
