### PR TITLE
Fix bottom sheet universal inset handling

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.design.system.hedvig
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -194,7 +195,13 @@ private fun InternalHedvigBottomSheet(
     onSystemBack = onSystemBack,
     shape = bottomSheetShape.shape,
   ) {
-    Box(modifier) {
+    // [ModalSheet] automatically requests focus on appearance. This means that if there is a focusable child available,
+    // it gets focus immediately. This commonly is a TextField, which also brings the keyboard up. The keyboard ends up
+    // coming up way too early, before the sheet manages to show, which results in a very awkward and janky animation
+    // where the keyboard and the sheet are coming up in different timings, hiding each other while the insets are not
+    // quick enough to catch up to make them go up in sync.
+    // Making this box focusable means that it itself grabs the focus instead, not showing the keyboard on appearance.
+    Box(Modifier.consumeWindowInsets(sheetPadding).focusable()) {
       Column(
         modifier = Modifier
           .then(

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.WindowInsetsSides.Companion
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
@@ -52,7 +53,6 @@ fun HedvigBottomSheet(
   isVisible: Boolean,
   onVisibleChange: (Boolean) -> Unit,
   onSystemBack: (() -> Unit)? = { onVisibleChange(false) },
-  sheetPadding: PaddingValues? = null,
   contentPadding: PaddingValues? = null,
   cancelable: Boolean = true,
   content: @Composable ColumnScope.() -> Unit,
@@ -61,42 +61,10 @@ fun HedvigBottomSheet(
     isVisible = isVisible,
     onVisibleChange = onVisibleChange,
     onSystemBack = onSystemBack,
-    sheetPadding = sheetPadding,
     contentPadding = contentPadding,
     cancelable = cancelable,
     content = content,
   )
-}
-
-@OptIn(ExperimentalSheetApi::class)
-@Composable
-fun HedvigBottomSheet(
-  isVisible: Boolean,
-  onVisibleChange: (Boolean) -> Unit,
-  bottomButtonText: String,
-  onSystemBack: (() -> Unit)? = { onVisibleChange(false) },
-  onBottomButtonClick: () -> Unit = { onVisibleChange(false) },
-  sheetPadding: PaddingValues? = null,
-  cancelable: Boolean = true,
-  content: @Composable ColumnScope.() -> Unit,
-) {
-  InternalHedvigBottomSheet(
-    isVisible = isVisible,
-    onVisibleChange = onVisibleChange,
-    onSystemBack = onSystemBack,
-    sheetPadding = sheetPadding,
-    cancelable = cancelable,
-  ) {
-    content()
-    HedvigButton(
-      onClick = onBottomButtonClick,
-      text = bottomButtonText,
-      enabled = true,
-      buttonStyle = Ghost,
-      modifier = Modifier.fillMaxWidth(),
-    )
-    Spacer(modifier = Modifier.height(32.dp))
-  }
 }
 
 @Composable
@@ -138,8 +106,6 @@ private class HedvigBottomSheetStateImpl<T>() : HedvigBottomSheetState<T> {
 @Composable
 fun <T> HedvigBottomSheet(
   hedvigBottomSheetState: HedvigBottomSheetState<T>,
-  modifier: Modifier = Modifier,
-  sheetPadding: PaddingValues? = null,
   contentPadding: PaddingValues? = null,
   content: @Composable ColumnScope.(T) -> Unit,
 ) {
@@ -154,8 +120,6 @@ fun <T> HedvigBottomSheet(
       hedvigBottomSheetState.dismiss()
     },
     contentPadding = contentPadding,
-    sheetPadding = sheetPadding,
-    modifier = modifier,
   ) {
     if (hedvigBottomSheetState.data != null) {
       content(hedvigBottomSheetState.data!!)
@@ -168,9 +132,7 @@ fun <T> HedvigBottomSheet(
 private fun InternalHedvigBottomSheet(
   isVisible: Boolean,
   onVisibleChange: (Boolean) -> Unit,
-  modifier: Modifier = Modifier,
   onSystemBack: (() -> Unit)? = { onVisibleChange(false) },
-  sheetPadding: PaddingValues? = null,
   contentPadding: PaddingValues? = null,
   cancelable: Boolean = true,
   content: @Composable ColumnScope.() -> Unit,
@@ -182,8 +144,7 @@ private fun InternalHedvigBottomSheet(
       scrollState.animateScrollTo(scrollState.maxValue)
     }
   }
-  val finalSheetPadding =
-    sheetPadding ?: WindowInsets.safeDrawing.only(WindowInsetsSides.Top + Companion.Horizontal).asPaddingValues()
+  val sheetPadding = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + Companion.Horizontal).asPaddingValues()
   ModalSheet(
     visible = isVisible,
     onVisibleChange = onVisibleChange,
@@ -191,7 +152,7 @@ private fun InternalHedvigBottomSheet(
     scrimColor = bottomSheetColors.scrimColor,
     backgroundColor = bottomSheetColors.bottomSheetBackgroundColor,
     contentColor = bottomSheetColors.contentColor,
-    sheetPadding = finalSheetPadding,
+    sheetPadding = sheetPadding,
     onSystemBack = onSystemBack,
     shape = bottomSheetShape.shape,
   ) {

--- a/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/extrabuildings/ExtraBuildingBottomSheet.kt
+++ b/app/feature/feature-changeaddress/src/main/kotlin/com/hedvig/android/feature/changeaddress/ui/extrabuildings/ExtraBuildingBottomSheet.kt
@@ -2,8 +2,11 @@ package com.hedvig.android.feature.changeaddress.ui.extrabuildings
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -21,7 +24,9 @@ import com.hedvig.android.core.designsystem.component.button.HedvigContainedButt
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
 import com.hedvig.android.core.ui.clearFocusOnTap
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Ghost
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
+import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.feature.changeaddress.data.ExtraBuilding
 import com.hedvig.android.feature.changeaddress.data.ExtraBuildingType
 import com.hedvig.android.feature.changeaddress.data.ExtraBuildingType.CARPORT
@@ -45,10 +50,6 @@ internal fun ExtraBuildingBottomSheet(
   HedvigBottomSheet(
     isVisible = isVisible,
     onVisibleChange = onVisibleChange,
-    bottomButtonText = stringResource(id = R.string.general_cancel_button),
-    onBottomButtonClick = {
-      onDismiss()
-    },
   ) {
     Column(
       modifier = Modifier.clearFocusOnTap(),
@@ -106,7 +107,15 @@ internal fun ExtraBuildingBottomSheet(
           }
         },
       )
+      HedvigButton(
+        onClick = onDismiss,
+        text = stringResource(R.string.general_cancel_button),
+        enabled = true,
+        buttonStyle = Ghost,
+        modifier = Modifier.fillMaxWidth(),
+      )
       Spacer(Modifier.height(8.dp))
+      Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
     }
   }
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -57,6 +60,8 @@ import com.hedvig.android.core.ui.infocard.VectorWarningCard
 import com.hedvig.android.core.ui.rememberHedvigDateTimeFormatter
 import com.hedvig.android.core.ui.text.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.core.ui.text.WarningTextWithIconForInput
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Ghost
+import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.AddBottomSheetState
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredState.Loaded.InfoFromSsn
@@ -73,6 +78,7 @@ internal fun AddCoInsuredBottomSheetContent(
   bottomSheetState: AddBottomSheetState,
   onSsnChanged: (String) -> Unit,
   onContinue: () -> Unit,
+  onDismiss: () -> Unit,
   onManualInputSwitchChanged: (Boolean) -> Unit,
   onBirthDateChanged: (LocalDate) -> Unit,
   onFirstNameChanged: (String) -> Unit,
@@ -166,6 +172,15 @@ internal fun AddCoInsuredBottomSheetContent(
       isLoading = bottomSheetState.isLoading,
     )
     Spacer(Modifier.height(8.dp))
+    HedvigButton(
+      onClick = onDismiss,
+      text = stringResource(R.string.general_cancel_button),
+      enabled = true,
+      buttonStyle = Ghost,
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }
 
@@ -200,9 +215,9 @@ private fun SelectableHedvigCard(text: String, isSelected: Boolean, onClick: () 
     Row(
       verticalAlignment = Alignment.CenterVertically,
       modifier = Modifier
-        .heightIn(72.dp)
-        .fillMaxWidth()
-        .padding(horizontal = 16.dp, vertical = 10.dp),
+          .heightIn(72.dp)
+          .fillMaxWidth()
+          .padding(horizontal = 16.dp, vertical = 10.dp),
     ) {
       Text(
         text = text,
@@ -497,6 +512,7 @@ private fun AddCoInsuredBottomSheetContentPreview() {
         ),
         onSsnChanged = {},
         onContinue = {},
+        onDismiss = {},
         onManualInputSwitchChanged = {},
         onBirthDateChanged = {},
         onFirstNameChanged = {},
@@ -525,6 +541,7 @@ private fun AddCoInsuredBottomSheetContentWithCoInsuredPreview() {
         ),
         onSsnChanged = {},
         onContinue = {},
+        onDismiss = {},
         onManualInputSwitchChanged = {},
         onBirthDateChanged = {},
         onFirstNameChanged = {},

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -140,6 +140,7 @@ private fun EditCoInsuredScreen(
               onResetAddBottomSheetState()
             }
           },
+          sheetPadding = WindowInsets.safeDrawing.asPaddingValues(),
           bottomButtonText = stringResource(id = R.string.general_cancel_button),
         ) {
           AddCoInsuredBottomSheetContent(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -140,12 +140,11 @@ private fun EditCoInsuredScreen(
               onResetAddBottomSheetState()
             }
           },
-          sheetPadding = WindowInsets.safeDrawing.asPaddingValues(),
-          bottomButtonText = stringResource(id = R.string.general_cancel_button),
         ) {
           AddCoInsuredBottomSheetContent(
             bottomSheetState = uiState.addBottomSheetState,
             onContinue = onBottomSheetContinue,
+            onDismiss = onResetAddBottomSheetState,
             onSsnChanged = onSsnChanged,
             onFirstNameChanged = onFirstNameChanged,
             onLastNameChanged = onLastNameChanged,
@@ -199,7 +198,7 @@ private fun EditCoInsuredScreen(
           Spacer(Modifier.height(8.dp))
           HedvigTextButton(
             onClick = navigateUp,
-            text = stringResource(id = R.string.general_cancel_button),
+            text = stringResource(R.string.general_cancel_button),
             modifier = Modifier.padding(horizontal = 16.dp),
           )
           Spacer(Modifier.height(16.dp))

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -169,6 +169,7 @@ private fun EditCoInsuredScreen(
             }
           }
           HedvigBottomSheet(
+            sheetPadding = WindowInsets.safeDrawing.asPaddingValues(),
             bottomButtonText = stringResource(id = R.string.general_cancel_button),
             isVisible = uiState.addBottomSheetState.show,
             onVisibleChange = { isVisible ->

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -169,8 +169,6 @@ private fun EditCoInsuredScreen(
             }
           }
           HedvigBottomSheet(
-            sheetPadding = WindowInsets.safeDrawing.asPaddingValues(),
-            bottomButtonText = stringResource(id = R.string.general_cancel_button),
             isVisible = uiState.addBottomSheetState.show,
             onVisibleChange = { isVisible ->
               if (!isVisible) {
@@ -181,6 +179,7 @@ private fun EditCoInsuredScreen(
             AddCoInsuredBottomSheetContent(
               bottomSheetState = uiState.addBottomSheetState,
               onContinue = onSave,
+              onDismiss = onResetAddBottomSheetState,
               onSsnChanged = onSsnChanged,
               onFirstNameChanged = onFirstNameChanged,
               onLastNameChanged = onLastNameChanged,
@@ -192,7 +191,6 @@ private fun EditCoInsuredScreen(
           }
 
           HedvigBottomSheet(
-            bottomButtonText = stringResource(R.string.general_cancel_button),
             isVisible = uiState.removeBottomSheetState.show && uiState.removeBottomSheetState.coInsured != null,
             onVisibleChange = { isVisible ->
               if (!isVisible) {
@@ -202,6 +200,7 @@ private fun EditCoInsuredScreen(
           ) {
             if (uiState.removeBottomSheetState.coInsured != null) {
               RemoveCoInsuredBottomSheetContent(
+                onDismiss = onResetRemoveBottomSheetState,
                 onRemove = { onRemoveCoInsured(it) },
                 isLoading = uiState.removeBottomSheetState.isLoading,
                 coInsured = uiState.removeBottomSheetState.coInsured,
@@ -242,7 +241,7 @@ private fun EditCoInsuredScreen(
             Spacer(Modifier.height(8.dp))
             HedvigTextButton(
               onClick = navigateUp,
-              text = stringResource(id = R.string.general_cancel_button),
+              text = stringResource(R.string.general_cancel_button),
               modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
@@ -2,7 +2,11 @@ package com.hedvig.android.feature.editcoinsured.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -15,11 +19,14 @@ import androidx.compose.ui.unit.dp
 import com.hedvig.android.core.designsystem.component.button.HedvigContainedButton
 import com.hedvig.android.core.designsystem.preview.HedvigPreview
 import com.hedvig.android.core.designsystem.theme.HedvigTheme
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Ghost
+import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import hedvig.resources.R
 
 @Composable
 internal fun RemoveCoInsuredBottomSheetContent(
+  onDismiss: () -> Unit,
   onRemove: (CoInsured) -> Unit,
   isLoading: Boolean,
   errorMessage: String?,
@@ -49,6 +56,15 @@ internal fun RemoveCoInsuredBottomSheetContent(
       isLoading = isLoading,
     )
     Spacer(Modifier.height(8.dp))
+    HedvigButton(
+      onClick = onDismiss,
+      text = stringResource(R.string.general_cancel_button),
+      enabled = true,
+      buttonStyle = Ghost,
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }
 
@@ -58,6 +74,7 @@ private fun RemoveCoInsuredBottomSheetContentPreview() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       RemoveCoInsuredBottomSheetContent(
+        onDismiss = {},
         onRemove = {},
         isLoading = false,
         coInsured = CoInsured(
@@ -79,6 +96,7 @@ private fun RemoveCoInsuredBottomSheetContentWithCoInsuredPreview() {
   HedvigTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
       RemoveCoInsuredBottomSheetContent(
+        onDismiss = {},
         onRemove = {},
         isLoading = false,
         coInsured = CoInsured(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -591,7 +591,7 @@ private fun CrossSellBottomSheet(
         crossSells = crossSells,
         onCrossSellClick = onCrossSellClick,
       )
-      Spacer(Modifier.height(16.dp))
+      Spacer(Modifier.height(8.dp))
       Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
     },
   )

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
@@ -66,7 +66,7 @@ internal fun CoverageTab(
       onClick = { bottomSheetState.dismiss() },
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(8.dp))
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
@@ -129,12 +129,12 @@ internal fun EditInsuranceBottomSheetContent(
     )
     Spacer(modifier = Modifier.height(8.dp))
     HedvigTextButton(
-      text = stringResource(id = R.string.general_cancel_button),
+      text = stringResource(R.string.general_cancel_button),
       buttonSize = Large,
       onClick = onDismiss,
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(8.dp))
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/UpcomingChangesBottomSheetContent.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/UpcomingChangesBottomSheetContent.kt
@@ -62,7 +62,7 @@ internal fun UpcomingChangesBottomSheetContent(
       onClick = onDismiss,
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(8.dp))
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
@@ -103,7 +103,6 @@ private fun MarketingScreen(
   HedvigBottomSheet(
     isVisible = (showPreferencesSheet && uiState is MarketingUiState.Success),
     onVisibleChange = { showPreferencesSheet = it },
-    sheetPadding = PaddingValues(0.dp),
     contentPadding = PaddingValues(0.dp),
   ) {
     if (uiState is MarketingUiState.Success) {
@@ -296,7 +295,7 @@ private fun ColumnScope.PreferencesSheetContent(
       .fillMaxWidth()
       .padding(horizontal = 16.dp),
   )
-  Spacer(Modifier.height(16.dp))
+  Spacer(Modifier.height(8.dp))
   Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
 }
 

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationScaffold.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/ui/TerminationScaffold.kt
@@ -2,11 +2,14 @@ package com.hedvig.android.feature.terminateinsurance.ui
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,7 +20,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.design.system.hedvig.AccordionData
 import com.hedvig.android.design.system.hedvig.AccordionList
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Ghost
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
+import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigText
@@ -126,7 +131,6 @@ private fun ExplanationBottomSheet(onDismiss: () -> Unit, text: String, isVisibl
         onDismiss()
       }
     },
-    bottomButtonText = stringResource(id = R.string.general_close_button),
     isVisible = isVisible,
   ) {
     HedvigText(
@@ -143,7 +147,15 @@ private fun ExplanationBottomSheet(onDismiss: () -> Unit, text: String, isVisibl
         .fillMaxWidth()
         .padding(horizontal = 24.dp),
     )
-    Spacer(Modifier.height(32.dp))
+    HedvigButton(
+      onClick = onDismiss,
+      text = stringResource(id = R.string.general_close_button),
+      enabled = true,
+      buttonStyle = Ghost,
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }
 

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/ui/EditCodeBottomSheet.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/ui/EditCodeBottomSheet.kt
@@ -2,14 +2,8 @@ package com.hedvig.android.shared.foreverui.ui.ui
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.runtime.Composable
@@ -52,17 +46,11 @@ internal fun EditCodeBottomSheet(
   onSubmitCode: (code: String) -> Unit,
   isLoading: Boolean,
 ) {
-  val insetsAroundSheet = WindowInsets
-    .safeDrawing
-    .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
-    .add(WindowInsets.ime)
   DismissSheetOnSuccessfulCodeChangeEffect(sheetState, referralCodeSuccessfullyChanged)
   ClearErrorOnSheetDismissedEffect(sheetState, showedReferralCodeSubmissionError)
   HedvigBottomSheet(
     hedvigBottomSheetState = sheetState,
-    sheetPadding = insetsAroundSheet.asPaddingValues(),
     contentPadding = null,
-    modifier = Modifier.consumeWindowInsets(insetsAroundSheet),
   ) { initialCode ->
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
@@ -95,8 +83,8 @@ internal fun EditCodeBottomSheet(
         )
       },
       modifier = Modifier
-        .focusRequester(focusRequester)
-        .fillMaxWidth(),
+          .focusRequester(focusRequester)
+          .fillMaxWidth(),
     )
     Spacer(Modifier.height(8.dp))
     HedvigButton(
@@ -117,7 +105,7 @@ internal fun EditCodeBottomSheet(
       buttonSize = ButtonDefaults.ButtonSize.Large,
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(8.dp))
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/ui/ForeverExplanationBottomSheet.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/ui/ForeverExplanationBottomSheet.kt
@@ -41,7 +41,7 @@ internal fun ForeverExplanationBottomSheet(sheetState: HedvigBottomSheetState<Ui
       onClick = { sheetState.dismiss() },
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(8.dp))
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -132,7 +132,6 @@ fun ComparisonDestination(viewModel: ComparisonViewModel, navigateUp: () -> Unit
 private fun ComparisonScreen(uiState: Success, navigateUp: () -> Unit) {
   var bottomSheetRow by remember { mutableStateOf<ComparisonRow?>(null) }
   HedvigBottomSheet(
-    sheetPadding = PaddingValues(0.dp),
     isVisible = bottomSheetRow != null,
     onVisibleChange = { isVisible ->
       if (!isVisible) {
@@ -157,7 +156,7 @@ private fun ComparisonScreen(uiState: Success, navigateUp: () -> Unit) {
           color = HedvigTheme.colorScheme.textSecondary,
         )
       }
-      Spacer(Modifier.height(16.dp))
+      Spacer(Modifier.height(8.dp))
       Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
     }
   }


### PR DESCRIPTION
Make sure that modal bottom sheets don't give focus on appearance

Due to how he modal sheet is implemented
https://github.com/oleksandrbalan/modalsheet/blob/519938d25af1b9f41a409c5514f36a6cce0f4cb0/modalsheet/src/main/java/eu/wewox/modalsheet/FullscreenPopup.kt#L135
[ModalSheet] automatically requests focus on appearance. This means that if there is a focusable child available,
it gets focus immediately. This commonly is a TextField, which also brings the keyboard up. The keyboard ends up
coming up way too early, before the sheet manages to show, which results in a very awkward and janky animation
where the keyboard and the sheet are coming up in different timings, hiding each other while the insets are not
quick enough to catch up to make them go up in sync.
Making this box focusable means that it itself grabs the focus instead, not showing the keyboard on appearance.
@[StylianosGakis](https://github.com/HedvigInsurance/android/commits?author=StylianosGakis)
StylianosGakis committed 2 hours ago


Remove overload with a built-in bottom button

This ended up making it harder to work with insets, since any insets
added on the content slot would end up showing *above* that button,
which is not what we expect here.
Remove the `sheetPadding` parameter for everyone, since we do not want
to inset the sheet itself anything other than around the top and
horizontally, as we want the sheet to always go all the way to the
bottom of the screen.

Update all callers accordingly

Also just change all callers to have a 8.dp bottom space instead of 16, for some consistency between the sheets.
There may be room for embedding part of this logic in the sheet itself, but I am hesitant to do that as we're probably gonna at some point in the near future try to use the m3 sheet and I wanna make sure it'd work there too.
So for now, 8.dp + bottom insets are added on each caller individually, and we do not let callers change the insets of the sheet itself, since we never want the sheet to clip its contents at the bottom, yet we always want it to be inset at all other sides so that the sheet does not go "out of bounds" of the entire screen