### PR TITLE
Disable generating androidResources for 50+ android library modules

### DIFF
--- a/app/core/core-design-system/build.gradle.kts
+++ b/app/core/core-design-system/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 hedvig {
+  androidResources()
   compose()
 }
 

--- a/app/core/core-resources/build.gradle.kts
+++ b/app/core/core-resources/build.gradle.kts
@@ -7,10 +7,13 @@ plugins {
   id("hedvig.android.lokalise")
 }
 
-val lokaliseProperties = Properties()
-lokaliseProperties.load(FileInputStream(rootProject.file("lokalise.properties")))
+hedvig {
+  androidResources()
+}
 
 lokalise {
+  val lokaliseProperties = Properties()
+  lokaliseProperties.load(FileInputStream(rootProject.file("lokalise.properties")))
   lokaliseProjectId.set(lokaliseProperties.getProperty("id"))
   lokaliseToken.set(lokaliseProperties.getProperty("token"))
   outputDirectory.set(file("src/main/res"))

--- a/app/data/data-contract/data-contract-android/build.gradle.kts
+++ b/app/data/data-contract/data-contract-android/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
   id("hedvig.android.library")
 }
 
+hedvig {
+  androidResources()
+}
+
 dependencies {
   implementation(projects.coreResources)
   implementation(projects.dataContractPublic)

--- a/app/feature/feature-changeaddress/build.gradle.kts
+++ b/app/feature/feature-changeaddress/build.gradle.kts
@@ -4,9 +4,10 @@ plugins {
 }
 
 hedvig {
+  androidResources()
   apollo("octopus")
-  serialization()
   compose()
+  serialization()
 }
 
 android {

--- a/app/feature/feature-help-center/build.gradle.kts
+++ b/app/feature/feature-help-center/build.gradle.kts
@@ -4,9 +4,10 @@ plugins {
 }
 
 hedvig {
+  androidResources()
   apollo("octopus")
-  serialization()
   compose()
+  serialization()
 }
 
 dependencies {

--- a/app/feature/feature-login/build.gradle.kts
+++ b/app/feature/feature-login/build.gradle.kts
@@ -4,8 +4,9 @@ plugins {
 }
 
 hedvig {
-  serialization()
+  androidResources()
   compose()
+  serialization()
 }
 
 android {

--- a/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
@@ -27,6 +27,7 @@ class LibraryConventionPlugin : Plugin<Project> {
         buildFeatures {
           resValues = false
           shaders = false
+          androidResources = false
         }
       }
     }

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/HedvigGradlePluginExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/HedvigGradlePluginExtension.kt
@@ -22,10 +22,12 @@ abstract class HedvigGradlePluginExtension @Inject constructor(
   private val libs: LibrariesForLibs,
   private val pluginManager: PluginManager,
 ) {
-  internal val apolloSchemaHandler: ApolloSchemaHandler =
+  private val apolloSchemaHandler: ApolloSchemaHandler =
     project.objects.newInstance<ApolloSchemaHandler>()
-  internal val composeHandler: ComposeHandler =
+  private val composeHandler: ComposeHandler =
     project.objects.newInstance<ComposeHandler>()
+  private val androidResHandler: AndroidResHandler =
+    project.objects.newInstance<AndroidResHandler>()
 
   fun apolloSchema(apolloServiceAction: Action<com.apollographql.apollo.gradle.api.Service>) {
     apolloSchemaHandler.configure(project, apolloServiceAction)
@@ -54,6 +56,10 @@ abstract class HedvigGradlePluginExtension @Inject constructor(
     pluginManager.apply(libs.plugins.serialization.get().pluginId)
   }
 
+  fun androidResources() {
+    androidResHandler.configure(project)
+  }
+
   companion object {
     internal fun Project.configureHedvigPlugin(): HedvigGradlePluginExtension {
       return extensions.create<HedvigGradlePluginExtension>(
@@ -66,7 +72,7 @@ abstract class HedvigGradlePluginExtension @Inject constructor(
   }
 }
 
-internal abstract class ApolloSchemaHandler {
+private abstract class ApolloSchemaHandler {
   fun configure(project: Project, apolloServiceAction: Action<com.apollographql.apollo.gradle.api.Service>) {
     with(project) {
       pluginManager.apply(the<LibrariesForLibs>().plugins.apollo.get().pluginId)
@@ -134,7 +140,7 @@ internal abstract class ApolloSchemaHandler {
   }
 }
 
-internal abstract class ComposeHandler {
+private abstract class ComposeHandler {
   fun configure(project: Project) {
     val libs = project.the<LibrariesForLibs>()
     project.pluginManager.apply(libs.plugins.composeCompilerGradlePlugin.get().pluginId)
@@ -167,6 +173,16 @@ internal abstract class ComposeHandler {
   private fun AndroidCommonExtension.configureComposeAndroidBuildFeature() {
     buildFeatures {
       compose = true
+    }
+  }
+}
+
+private abstract class AndroidResHandler {
+  fun configure(project: Project) {
+    project.extensions.configure<LibraryExtension> {
+      buildFeatures {
+        androidResources = true
+      }
     }
   }
 }


### PR DESCRIPTION
Keep it on only for the select few that have any resources in them We go from `gw build --dry-run --console=plain | grep SKIPPED | wc -l` returning 1765 tasks to now returning only 1490 tasks! Reference:
https://github.com/cashapp/redwood/pull/1326

In scans:
Before: https://scans.gradle.com/s/iga2y7d7nj322
1740 tasks, 904 transforms executed in 107 projects in 2m 50s

After: https://scans.gradle.com/s/mje5wlkusb3ay
1465 tasks, 904 transforms executed in 107 projects in 2m 4s

Don't focus too much on the time taken, since that one fluctuates for other reasons too, but removing ~300 tasks is just a great net benefit for changing nothing in functionality.
The android libraries that do have a `res` directory now need to opt-in to get their resources generated, but luckily that's just 4 modules for us.

EDIT:
Plus 2 more modules which were referencing resources from their tests. It looks like those also need this setting to be flipped on for them to be able to succeed.