### PR TITLE
Clear the backstack of all top level graphs on logout

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/IsTopLevelGraphInHierarchy.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/IsTopLevelGraphInHierarchy.kt
@@ -7,6 +7,7 @@ import com.hedvig.android.feature.home.home.navigation.HomeDestination
 import com.hedvig.android.feature.insurances.navigation.InsurancesDestination
 import com.hedvig.android.feature.payments.navigation.PaymentsDestination
 import com.hedvig.android.feature.profile.navigation.ProfileDestination
+import com.hedvig.android.navigation.common.Destination
 import com.hedvig.android.navigation.compose.typedHasRoute
 import com.hedvig.android.navigation.core.TopLevelGraph
 
@@ -15,14 +16,16 @@ import com.hedvig.android.navigation.core.TopLevelGraph
  */
 internal fun NavDestination?.isTopLevelGraphInHierarchy(topLevelGraph: TopLevelGraph): Boolean {
   val hierarchy = this?.hierarchy ?: return false
-  val topLevelGraphRelatedRoute = when (topLevelGraph) {
-    TopLevelGraph.Home -> HomeDestination.Graph::class
-    TopLevelGraph.Insurances -> InsurancesDestination.Graph::class
-    TopLevelGraph.Forever -> ForeverDestination.Graph::class
-    TopLevelGraph.Payments -> PaymentsDestination.Graph::class
-    TopLevelGraph.Profile -> ProfileDestination.Graph::class
-  }
   return hierarchy.any { navDestination ->
-    navDestination.typedHasRoute(topLevelGraphRelatedRoute)
+    navDestination.typedHasRoute(topLevelGraph.destination::class)
   }
 }
+
+internal val TopLevelGraph.destination: Destination
+  get() = when (this) {
+    TopLevelGraph.Home -> HomeDestination.Graph
+    TopLevelGraph.Insurances -> InsurancesDestination.Graph
+    TopLevelGraph.Forever -> ForeverDestination.Graph
+    TopLevelGraph.Payments -> PaymentsDestination.Graph
+    TopLevelGraph.Profile -> ProfileDestination.Graph
+  }

--- a/app/navigation/navigation-compose/src/main/kotlin/com/hedvig/android/navigation/compose/TypedAlternatives.kt
+++ b/app/navigation/navigation-compose/src/main/kotlin/com/hedvig/android/navigation/compose/TypedAlternatives.kt
@@ -13,6 +13,12 @@ inline fun <reified T : Destination> NavController.typedPopBackStack(
   saveState: Boolean = false,
 ): Boolean = popBackStack<T>(inclusive, saveState)
 
+fun <T : Destination> NavController.typedPopBackStack(
+  destination: KClass<T>,
+  inclusive: Boolean,
+  saveState: Boolean = false,
+): Boolean = popBackStack(destination, inclusive, saveState)
+
 inline fun <reified T : Destination> NavOptionsBuilder.typedPopUpTo(
   noinline popUpToBuilder: PopUpToBuilder.() -> Unit = {},
 ) = popUpTo<T>(popUpToBuilder)
@@ -20,3 +26,7 @@ inline fun <reified T : Destination> NavOptionsBuilder.typedPopUpTo(
 inline fun <reified T : Destination> NavDestination.typedHasRoute() = hasRoute<T>()
 
 fun <T : Destination> NavDestination.typedHasRoute(route: KClass<T>) = hasRoute(route)
+
+fun <T : Destination> NavController.typedClearBackStack(route: T): Boolean = clearBackStack(route)
+
+


### PR DESCRIPTION
Clearing the backstack does not by itself clear the saved stack on the
top level graphs. Trying to navigate back to them with 
`restoreState = true` still does try to reset the backstack and as a
consequence the ViewModels as well.
This has the unfortunate side effect that for a moment the old UI state
is shown which could be the information for the wrong member.
It only happens for a frame or two, but we might as well fix this this
way for now
