### PR TITLE
Migrate from the deprecated constructors

### DIFF
--- a/app/datadog/datadog-android/src/main/kotlin/com/hedvig/android/datadog/core/OkHttpDatadogUtil.kt
+++ b/app/datadog/datadog-android/src/main/kotlin/com/hedvig/android/datadog/core/OkHttpDatadogUtil.kt
@@ -12,17 +12,13 @@ fun OkHttpClient.Builder.addDatadogConfiguration(hedvigBuildConstants: HedvigBui
   return this
     .eventListenerFactory(DatadogEventListener.Factory())
     .addInterceptor(
-      DatadogInterceptor(
-        sdkInstanceName = null,
-        firstPartyHosts = tracedHosts,
-        traceSampler = RateBasedSampler(sampleRate = 100f),
-      ),
+      DatadogInterceptor.Builder(tracedHosts)
+        .setTraceSampler(RateBasedSampler(sampleRate = 100f))
+        .build(),
     )
     .addNetworkInterceptor(
-      TracingInterceptor(
-        sdkInstanceName = null,
-        tracedHosts = tracedHosts,
-        traceSampler = RateBasedSampler(sampleRate = 100f),
-      ),
+      TracingInterceptor.Builder(tracedHosts)
+        .setTraceSampler(RateBasedSampler(sampleRate = 100f))
+        .build(),
     )
 }


### PR DESCRIPTION
So since there was nothing to do in the code itself, I at least took the time to remove two constructors we were using which were deprecated in the latest versions. They migrated to use builders instead.