### PR TITLE
Fix top level navigation crash

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppState.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigAppState.kt
@@ -198,17 +198,17 @@ internal class HedvigAppState(
   fun navigateToTopLevelGraph(topLevelGraph: TopLevelGraph) {
     val popToStartOfGraph = navController.currentDestination?.isTopLevelGraphInHierarchy(topLevelGraph) == true
     if (popToStartOfGraph) {
-      navController.typedPopBackStack(topLevelGraph.destination::class, false)
+      navController.typedPopBackStack(destination = topLevelGraph.startDestination, inclusive = false)
     } else {
       navController.navigate(
-          route = topLevelGraph.destination,
-          navOptions = navOptions {
-              popUpTo(navController.graph.findStartDestination().id) {
-                  saveState = true
-              }
-              launchSingleTop = true
-              restoreState = true
-          },
+        route = topLevelGraph.destination,
+        navOptions = navOptions {
+          popUpTo(navController.graph.findStartDestination().id) {
+            saveState = true
+          }
+          launchSingleTop = true
+          restoreState = true
+        },
       )
     }
   }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/IsTopLevelGraphInHierarchy.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/IsTopLevelGraphInHierarchy.kt
@@ -29,3 +29,12 @@ internal val TopLevelGraph.destination: Destination
     TopLevelGraph.Payments -> PaymentsDestination.Graph
     TopLevelGraph.Profile -> ProfileDestination.Graph
   }
+
+internal val TopLevelGraph.startDestination: Destination
+  get() = when (this) {
+    TopLevelGraph.Home -> HomeDestination.Home
+    TopLevelGraph.Insurances -> InsurancesDestination.Insurances
+    TopLevelGraph.Forever -> ForeverDestination.Forever
+    TopLevelGraph.Payments -> PaymentsDestination.Payments
+    TopLevelGraph.Profile -> ProfileDestination.Profile
+  }

--- a/app/navigation/navigation-compose/src/main/kotlin/com/hedvig/android/navigation/compose/TypedAlternatives.kt
+++ b/app/navigation/navigation-compose/src/main/kotlin/com/hedvig/android/navigation/compose/TypedAlternatives.kt
@@ -14,7 +14,7 @@ inline fun <reified T : Destination> NavController.typedPopBackStack(
 ): Boolean = popBackStack<T>(inclusive, saveState)
 
 fun <T : Destination> NavController.typedPopBackStack(
-  destination: KClass<T>,
+  destination: T,
   inclusive: Boolean,
   saveState: Boolean = false,
 ): Boolean = popBackStack(destination, inclusive, saveState)


### PR DESCRIPTION
This now seems to work. I was wrongly passing a KClass as the type of the destination, where I should've been using the real instance of the destination instead.