### PR TITLE
Retain the "Unathenticated" information even after merging all errors

### DIFF
--- a/app/data/data-conversations/src/main/kotlin/com/hedvig/android/data/conversations/HasAnyActiveConversationUseCase.kt
+++ b/app/data/data-conversations/src/main/kotlin/com/hedvig/android/data/conversations/HasAnyActiveConversationUseCase.kt
@@ -25,10 +25,12 @@ class HasAnyActiveConversationUseCase(
       .map { result ->
         either {
           val data = result
-            .onLeft { apolloOperationError ->
-              if (apolloOperationError is ApolloOperationError.OperationError.Unathenticated) return@onLeft
-              logcat(LogPriority.ERROR, apolloOperationError.throwable) {
-                "isEligibleToShowTheChatIcon cant determine if the chat icon should be shown. $apolloOperationError"
+            .onLeft { error ->
+              if ((error as? ApolloOperationError.OperationError)?.containsUnauthenticatedError == true) {
+                return@onLeft
+              }
+              logcat(LogPriority.ERROR, error.throwable) {
+                "isEligibleToShowTheChatIcon cant determine if the chat icon should be shown. $error"
               }
             }
             .bind()


### PR DESCRIPTION
This stops logging "isEligibleToShowTheChatIcon cant determine if the chat icon should be shown" for real this time when we are just not logged in yet