### PR TITLE
Get extra information only when tiers flag is on

### DIFF
--- a/app/feature/feature-terminate-insurance/src/main/graphql/FragmentTerminationFlowStepFragment.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/FragmentTerminationFlowStepFragment.graphql
@@ -62,14 +62,14 @@ fragment FlowTerminationDateStepFragment on FlowTerminationDateStep {
   id
   minDate
   maxDate
-  extraCoverage {
+  extraCoverage @include(if: $tiersEnabled) {
     ...ExtraCoverageItemFragment
   }
 }
 
 fragment FlowTerminationDeletionStepFragment on FlowTerminationDeletionStep {
   id
-  extraCoverage {
+  extraCoverage @include(if: $tiersEnabled) {
     ...ExtraCoverageItemFragment
   }
 }

--- a/app/feature/feature-terminate-insurance/src/main/graphql/FragmentTerminationFlowStepFragment.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/FragmentTerminationFlowStepFragment.graphql
@@ -62,14 +62,14 @@ fragment FlowTerminationDateStepFragment on FlowTerminationDateStep {
   id
   minDate
   maxDate
-  extraCoverage @include(if: $tiersEnabled) {
+  extraCoverage @include(if: $addonsEnabled) {
     ...ExtraCoverageItemFragment
   }
 }
 
 fragment FlowTerminationDeletionStepFragment on FlowTerminationDeletionStep {
   id
-  extraCoverage @include(if: $tiersEnabled) {
+  extraCoverage @include(if: $addonsEnabled) {
     ...ExtraCoverageItemFragment
   }
 }

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDateNext.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDateNext.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationDateNext($context: FlowContext!, $input: FlowTerminationDateInput!, $tiersEnabled: Boolean!) {
+mutation FlowTerminationDateNext($context: FlowContext!, $input: FlowTerminationDateInput!, $addonsEnabled: Boolean!) {
   flowTerminationDateNext(context: $context, input: $input) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDateNext.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDateNext.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationDateNext($context: FlowContext!, $input: FlowTerminationDateInput!) {
+mutation FlowTerminationDateNext($context: FlowContext!, $input: FlowTerminationDateInput!, $tiersEnabled: Boolean!) {
   flowTerminationDateNext(context: $context, input: $input) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDeletionNext.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDeletionNext.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationDeletionNext($context: FlowContext!) {
+mutation FlowTerminationDeletionNext($context: FlowContext!, $tiersEnabled: Boolean!) {
   flowTerminationDeletionNext(input: {confirmed: true}, context: $context) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDeletionNext.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationDeletionNext.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationDeletionNext($context: FlowContext!, $tiersEnabled: Boolean!) {
+mutation FlowTerminationDeletionNext($context: FlowContext!, $addonsEnabled: Boolean!) {
   flowTerminationDeletionNext(input: {confirmed: true}, context: $context) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationStart.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationStart.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationStart($flowTerminationStartInput : FlowTerminationStartInput!) {
+mutation FlowTerminationStart($flowTerminationStartInput : FlowTerminationStartInput!, $tiersEnabled: Boolean!) {
   flowTerminationStart(input: $flowTerminationStartInput, context: null) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationStart.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationStart.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationStart($flowTerminationStartInput : FlowTerminationStartInput!, $tiersEnabled: Boolean!) {
+mutation FlowTerminationStart($flowTerminationStartInput : FlowTerminationStartInput!, $addonsEnabled: Boolean!) {
   flowTerminationStart(input: $flowTerminationStartInput, context: null) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationSurveyNext.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationSurveyNext.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationSurveyNext($context: FlowContext!, $input:  FlowTerminationSurveyInput!) {
+mutation FlowTerminationSurveyNext($context: FlowContext!, $input:  FlowTerminationSurveyInput!, $tiersEnabled: Boolean!) {
   flowTerminationSurveyNext(context: $context, input: $input) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationSurveyNext.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/MutationFlowTerminationSurveyNext.graphql
@@ -1,4 +1,4 @@
-mutation FlowTerminationSurveyNext($context: FlowContext!, $input:  FlowTerminationSurveyInput!, $tiersEnabled: Boolean!) {
+mutation FlowTerminationSurveyNext($context: FlowContext!, $input:  FlowTerminationSurveyInput!, $addonsEnabled: Boolean!) {
   flowTerminationSurveyNext(context: $context, input: $input) {
     id
     context

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
@@ -10,6 +10,7 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.feature.terminateinsurance.InsuranceId
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature.TIER
+import com.hedvig.android.featureflags.flags.Feature.TRAVEL_ADDON
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDate
 import octopus.FlowTerminationDateNextMutation
@@ -41,8 +42,9 @@ internal class TerminateInsuranceRepositoryImpl(
   override suspend fun startTerminationFlow(insuranceId: InsuranceId): Either<ErrorMessage, TerminateInsuranceStep> {
     return either {
       val isTierEnabled = featureManager.isFeatureEnabled(TIER).first()
+      val isAddonsEnabled = featureManager.isFeatureEnabled(TRAVEL_ADDON).first()
       val result = apolloClient
-        .mutation(FlowTerminationStartMutation(FlowTerminationStartInput(insuranceId.id), isTierEnabled))
+        .mutation(FlowTerminationStartMutation(FlowTerminationStartInput(insuranceId.id), isAddonsEnabled))
         .safeExecute(::ErrorMessage)
         .bind()
         .flowTerminationStart
@@ -55,12 +57,13 @@ internal class TerminateInsuranceRepositoryImpl(
   override suspend fun setTerminationDate(terminationDate: LocalDate): Either<ErrorMessage, TerminateInsuranceStep> {
     return either {
       val isTierEnabled = featureManager.isFeatureEnabled(TIER).first()
+      val isAddonsEnabled = featureManager.isFeatureEnabled(TRAVEL_ADDON).first()
       val result = apolloClient
         .mutation(
           FlowTerminationDateNextMutation(
             context = terminationFlowContextStorage.getContext(),
             input = FlowTerminationDateInput(terminationDate),
-            tiersEnabled = isTierEnabled,
+            addonsEnabled = isAddonsEnabled,
           ),
         )
         .safeExecute(::ErrorMessage)
@@ -76,6 +79,7 @@ internal class TerminateInsuranceRepositoryImpl(
   ): Either<ErrorMessage, TerminateInsuranceStep> {
     return either {
       val isTierEnabled = featureManager.isFeatureEnabled(TIER).first()
+      val isAddonsEnabled = featureManager.isFeatureEnabled(TRAVEL_ADDON).first()
       val result = apolloClient
         .mutation(
           FlowTerminationSurveyNextMutation(
@@ -86,7 +90,7 @@ internal class TerminateInsuranceRepositoryImpl(
                 text = Optional.presentIfNotNull(reason.feedBack),
               ),
             ),
-            tiersEnabled = isTierEnabled,
+            addonsEnabled = isAddonsEnabled,
           ),
         )
         .safeExecute(::ErrorMessage)
@@ -100,8 +104,9 @@ internal class TerminateInsuranceRepositoryImpl(
   override suspend fun confirmDeletion(): Either<ErrorMessage, TerminateInsuranceStep> {
     return either {
       val isTierEnabled = featureManager.isFeatureEnabled(TIER).first()
+      val isAddonsEnabled = featureManager.isFeatureEnabled(TRAVEL_ADDON).first()
       val result = apolloClient
-        .mutation(FlowTerminationDeletionNextMutation(terminationFlowContextStorage.getContext(), isTierEnabled))
+        .mutation(FlowTerminationDeletionNextMutation(terminationFlowContextStorage.getContext(), isAddonsEnabled))
         .safeExecute(::ErrorMessage)
         .bind()
         .flowTerminationDeletionNext

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
@@ -42,7 +42,7 @@ internal class TerminateInsuranceRepositoryImpl(
     return either {
       val isTierEnabled = featureManager.isFeatureEnabled(TIER).first()
       val result = apolloClient
-        .mutation(FlowTerminationStartMutation(FlowTerminationStartInput(insuranceId.id)))
+        .mutation(FlowTerminationStartMutation(FlowTerminationStartInput(insuranceId.id), isTierEnabled))
         .safeExecute(::ErrorMessage)
         .bind()
         .flowTerminationStart
@@ -60,6 +60,7 @@ internal class TerminateInsuranceRepositoryImpl(
           FlowTerminationDateNextMutation(
             context = terminationFlowContextStorage.getContext(),
             input = FlowTerminationDateInput(terminationDate),
+            tiersEnabled = isTierEnabled,
           ),
         )
         .safeExecute(::ErrorMessage)
@@ -85,6 +86,7 @@ internal class TerminateInsuranceRepositoryImpl(
                 text = Optional.presentIfNotNull(reason.feedBack),
               ),
             ),
+            tiersEnabled = isTierEnabled,
           ),
         )
         .safeExecute(::ErrorMessage)
@@ -99,7 +101,7 @@ internal class TerminateInsuranceRepositoryImpl(
     return either {
       val isTierEnabled = featureManager.isFeatureEnabled(TIER).first()
       val result = apolloClient
-        .mutation(FlowTerminationDeletionNextMutation(terminationFlowContextStorage.getContext()))
+        .mutation(FlowTerminationDeletionNextMutation(terminationFlowContextStorage.getContext(), isTierEnabled))
         .safeExecute(::ErrorMessage)
         .bind()
         .flowTerminationDeletionNext

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceStep.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceStep.kt
@@ -229,10 +229,10 @@ internal fun TerminateInsuranceStep.toTerminateInsuranceDestination(
   }
 }
 
-private fun List<ExtraCoverageItemFragment>.toExtraCoverageItems(): List<ExtraCoverageItem> {
-  return map {
+private fun List<ExtraCoverageItemFragment>?.toExtraCoverageItems(): List<ExtraCoverageItem> {
+  return this?.map {
     ExtraCoverageItem(it.displayName, it.displayValue)
-  }
+  } ?: emptyList()
 }
 
 @Serializable

--- a/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepositoryImplTest.kt
+++ b/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepositoryImplTest.kt
@@ -59,7 +59,7 @@ class TerminateInsuranceRepositoryImplTest {
   private val apolloClientWithGoodResponse: ApolloClient
     get() = testApolloClientRule.apolloClient.apply {
       registerTestResponse(
-        operation = FlowTerminationStartMutation(FlowTerminationStartInput(testId)),
+        operation = FlowTerminationStartMutation(FlowTerminationStartInput(testId), false),
         data = FlowTerminationStartMutation.Data(OctopusFakeResolver) {
           flowTerminationStart = buildFlow {
             id = "flowId"
@@ -136,7 +136,12 @@ class TerminateInsuranceRepositoryImplTest {
   @Test
   fun `when response is ok but FF is off options with tier-related subOptions should be mapped without subOptions but with required feedback`() =
     runTest {
-      val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TIER to false))
+      val featureManager = FakeFeatureManager2(
+        fixedMap = mapOf(
+          Feature.TIER to false,
+          Feature.TRAVEL_ADDON to false,
+        )
+      )
 
       val repo = TerminateInsuranceRepositoryImpl(
         apolloClient = apolloClientWithGoodResponse,
@@ -176,7 +181,12 @@ class TerminateInsuranceRepositoryImplTest {
   @Test
   fun `when response is ok and FF is on options with tier-related subOptions should have subOptions and no required feedback`() =
     runTest {
-      val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TIER to true))
+      val featureManager = FakeFeatureManager2(
+        fixedMap = mapOf(
+          Feature.TIER to true,
+          Feature.TRAVEL_ADDON to false,
+        )
+      )
 
       val repo = TerminateInsuranceRepositoryImpl(
         apolloClient = apolloClientWithGoodResponse,
@@ -216,7 +226,12 @@ class TerminateInsuranceRepositoryImplTest {
   @Test
   fun `when response is ok but FF is off options with tier actions should have their action mapped to UnknownAction and have required feedback`() =
     runTest {
-      val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TIER to false))
+      val featureManager = FakeFeatureManager2(
+        fixedMap = mapOf(
+          Feature.TIER to false,
+          Feature.TRAVEL_ADDON to false,
+        )
+      )
 
       val repo = TerminateInsuranceRepositoryImpl(
         apolloClient = apolloClientWithGoodResponse,
@@ -242,7 +257,12 @@ class TerminateInsuranceRepositoryImplTest {
   @Test
   fun `when response is ok and FF is on options with tier actions should have corresponding action and have no feedback`() =
     runTest {
-      val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TIER to true))
+      val featureManager = FakeFeatureManager2(
+        fixedMap = mapOf(
+          Feature.TIER to true,
+          Feature.TRAVEL_ADDON to false,
+        )
+      )
 
       val repo = TerminateInsuranceRepositoryImpl(
         apolloClient = apolloClientWithGoodResponse,


### PR DESCRIPTION
The `$tiersEnabled` field is automagically propagated down in the fragments, even though we don't quite get autocompletion for it. But this works :D 