### PR TITLE
Align all always-dark-mode cards in deflect screens

### DIFF
--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectGlassDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectGlassDamageDestination.kt
@@ -112,8 +112,8 @@ private fun DeflectGlassDamageScreen(
             .fillMaxWidth(),
         ) {
           Surface(
-            color = HedvigTheme.colorScheme.fillBlack.copy(0.95f).compositeOver(HedvigTheme.colorScheme.fillWhite),
-            contentColor = HedvigTheme.colorScheme.fillNegative,
+            color = HedvigTheme.colorScheme.backgroundPrimary.copy(0.95f).compositeOver(HedvigTheme.colorScheme.fillWhite),
+            contentColor = HedvigTheme.colorScheme.fillPrimary,
           ) {
             Column(Modifier.padding(16.dp)) {
               AsyncImage(
@@ -130,7 +130,6 @@ private fun DeflectGlassDamageScreen(
               HedvigText(
                 text = stringResource(R.string.SUBMIT_CLAIM_GLASS_DAMAGE_ONLINE_BOOKING_LABEL),
                 textAlign = TextAlign.Center,
-                color = HedvigTheme.colorScheme.textWhite,
                 modifier = Modifier.fillMaxWidth(),
               )
               Spacer(Modifier.height(16.dp))

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectPestsDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectPestsDestination.kt
@@ -23,7 +23,6 @@ import com.hedvig.android.data.claimflow.DeflectPartner
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Medium
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Small
 import com.hedvig.android.design.system.hedvig.HedvigButton
-import com.hedvig.android.design.system.hedvig.HedvigCard
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
@@ -94,57 +93,55 @@ private fun DeflectPestsScreen(
         Spacer(Modifier.height(8.dp))
       }
       HedvigTheme(darkTheme = true) {
-        HedvigCard(
+        Surface(
+          color = HedvigTheme.colorScheme.backgroundPrimary.copy(0.95f)
+            .compositeOver(HedvigTheme.colorScheme.fillWhite),
+          contentColor = HedvigTheme.colorScheme.fillPrimary,
+          shape = HedvigTheme.shapes.cornerXLarge,
           modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
         ) {
-          Surface(
-            color = HedvigTheme.colorScheme.fillBlack.copy(0.95f).compositeOver(HedvigTheme.colorScheme.fillWhite),
-            contentColor = HedvigTheme.colorScheme.fillNegative,
-          ) {
-            Column(Modifier.padding(16.dp)) {
-              AsyncImage(
-                model = partner.imageUrl,
-                contentDescription = null,
-                imageLoader = imageLoader,
-                placeholder = rememberShapedColorPainter(HedvigTheme.colorScheme.surfacePrimary),
-                modifier = Modifier
-                  .padding(16.dp)
-                  .fillMaxWidth()
-                  .height(40.dp),
-              )
-              Spacer(Modifier.height(8.dp))
-              HedvigText(
-                text = stringResource(R.string.SUBMIT_CLAIM_PESTS_CUSTOMER_SERVICE_LABEL),
-                textAlign = TextAlign.Center,
-                style = LocalTextStyle.current.copy(
-                  lineBreak = LineBreak.Heading,
-                ),
-                color = HedvigTheme.colorScheme.textWhite,
-                modifier = Modifier.fillMaxWidth(),
-              )
-              Spacer(Modifier.height(16.dp))
-              HedvigButton(
-                text = stringResource(R.string.SUBMIT_CLAIM_PESTS_CUSTOMER_SERVICE_BUTTON),
-                enabled = true,
-                buttonSize = Medium,
-                onClick = dropUnlessResumed {
-                  val url = partner.url
-                  if (url != null) {
-                    openUrl(url)
-                  } else {
-                    logcat(ERROR) {
-                      """
+          Column(Modifier.padding(16.dp)) {
+            AsyncImage(
+              model = partner.imageUrl,
+              contentDescription = null,
+              imageLoader = imageLoader,
+              placeholder = rememberShapedColorPainter(HedvigTheme.colorScheme.surfacePrimary),
+              modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+                .height(40.dp),
+            )
+            Spacer(Modifier.height(8.dp))
+            HedvigText(
+              text = stringResource(R.string.SUBMIT_CLAIM_PESTS_CUSTOMER_SERVICE_LABEL),
+              textAlign = TextAlign.Center,
+              style = LocalTextStyle.current.copy(
+                lineBreak = LineBreak.Heading,
+              ),
+              modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(16.dp))
+            HedvigButton(
+              text = stringResource(R.string.SUBMIT_CLAIM_PESTS_CUSTOMER_SERVICE_BUTTON),
+              enabled = true,
+              buttonSize = Medium,
+              onClick = dropUnlessResumed {
+                val url = partner.url
+                if (url != null) {
+                  openUrl(url)
+                } else {
+                  logcat(ERROR) {
+                    """
                   |Partner URL was null for DeflectPestsDestination! Deflect partner:[$this]. 
                   |This is problematic because the UI offers no real help to the member, the CTA button does nothing.
                       """.trimMargin()
-                    }
                   }
-                },
-                modifier = Modifier.fillMaxWidth(),
-              )
-            }
+                }
+              },
+              modifier = Modifier.fillMaxWidth(),
+            )
           }
         }
       }

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectTowingDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectTowingDestination.kt
@@ -37,7 +37,6 @@ import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Medium
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Small
 import com.hedvig.android.design.system.hedvig.ExpandablePlusCard
 import com.hedvig.android.design.system.hedvig.HedvigButton
-import com.hedvig.android.design.system.hedvig.HedvigCard
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
@@ -105,62 +104,61 @@ private fun DeflectTowingScreen(
         Spacer(Modifier.height(8.dp))
       }
       HedvigTheme(darkTheme = true) {
-        HedvigCard(
+        Surface(
+          color = HedvigTheme.colorScheme.backgroundPrimary.copy(0.95f)
+            .compositeOver(HedvigTheme.colorScheme.fillWhite),
+          contentColor = HedvigTheme.colorScheme.fillPrimary,
+          shape = HedvigTheme.shapes.cornerXLarge,
           modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
-        ) {
-          Surface(
-            color = HedvigTheme.colorScheme.fillBlack.copy(0.95f).compositeOver(HedvigTheme.colorScheme.fillWhite),
-            contentColor = HedvigTheme.colorScheme.fillPrimary,
           ) {
-            Column(Modifier.padding(16.dp)) {
-              AsyncImage(
-                model = partner.imageUrl,
-                contentDescription = null,
-                imageLoader = imageLoader,
-                placeholder = rememberShapedColorPainter(HedvigTheme.colorScheme.surfacePrimary),
-                modifier = Modifier
-                  .padding(16.dp)
-                  .fillMaxWidth()
-                  .height(40.dp),
-              )
-              Spacer(Modifier.height(16.dp))
-              HedvigText(
-                text = stringResource(id = R.string.SUBMIT_CLAIM_TOWING_ONLINE_BOOKING_LABEL),
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-              )
-              Spacer(Modifier.height(16.dp))
-              val context = LocalContext.current
-              HedvigButton(
-                text = stringResource(id = R.string.SUBMIT_CLAIM_TOWING_ONLINE_BOOKING_BUTTON),
-                enabled = true,
-                buttonSize = Medium,
-                onClick = dropUnlessResumed {
-                  val phoneNumber = partner.phoneNumber
-                  if (phoneNumber != null) {
-                    try {
-                      context.startActivity(
-                        Intent(
-                          Intent.ACTION_DIAL,
-                          Uri.parse("tel:$phoneNumber"),
-                        ),
-                      )
-                    } catch (exception: Throwable) {
-                      logcat(ERROR, exception) {
-                        "Could not open dial activity in deflect towing destination"
-                      }
-                    }
-                  } else {
-                    logcat(ERROR) {
-                      "Partner phone number was null for DeflectTowingDestination! Deflect partner: $partner."
+          Column(Modifier.padding(16.dp)) {
+            AsyncImage(
+              model = partner.imageUrl,
+              contentDescription = null,
+              imageLoader = imageLoader,
+              placeholder = rememberShapedColorPainter(HedvigTheme.colorScheme.surfacePrimary),
+              modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+                .height(40.dp),
+            )
+            Spacer(Modifier.height(16.dp))
+            HedvigText(
+              text = stringResource(id = R.string.SUBMIT_CLAIM_TOWING_ONLINE_BOOKING_LABEL),
+              textAlign = TextAlign.Center,
+              modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(16.dp))
+            val context = LocalContext.current
+            HedvigButton(
+              text = stringResource(id = R.string.SUBMIT_CLAIM_TOWING_ONLINE_BOOKING_BUTTON),
+              enabled = true,
+              buttonSize = Medium,
+              onClick = dropUnlessResumed {
+                val phoneNumber = partner.phoneNumber
+                if (phoneNumber != null) {
+                  try {
+                    context.startActivity(
+                      Intent(
+                        Intent.ACTION_DIAL,
+                        Uri.parse("tel:$phoneNumber"),
+                      ),
+                    )
+                  } catch (exception: Throwable) {
+                    logcat(ERROR, exception) {
+                      "Could not open dial activity in deflect towing destination"
                     }
                   }
-                },
-                modifier = Modifier.fillMaxWidth(),
-              )
-            }
+                } else {
+                  logcat(ERROR) {
+                    "Partner phone number was null for DeflectTowingDestination! Deflect partner: $partner."
+                  }
+                }
+              },
+              modifier = Modifier.fillMaxWidth(),
+            )
           }
         }
       }

--- a/app/ui/ui-emergency/src/main/kotlin/com/hedvig/android/ui/emergency/EmergencyScreen.kt
+++ b/app/ui/ui-emergency/src/main/kotlin/com/hedvig/android/ui/emergency/EmergencyScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.LineBreak
@@ -21,6 +22,7 @@ import com.hedvig.android.design.system.hedvig.AccordionList
 import com.hedvig.android.design.system.hedvig.ButtonDefaults
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
+import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
@@ -58,8 +60,10 @@ fun EmergencyScreen(
         priority = NotificationDefaults.NotificationPriority.Attention,
       )
       Spacer(Modifier.height(8.dp))
-      HedvigTheme(true) {
+      HedvigTheme(darkTheme = true) {
         Surface(
+          color = HedvigTheme.colorScheme.backgroundPrimary.copy(0.95f).compositeOver(HedvigTheme.colorScheme.fillWhite),
+          contentColor = HedvigTheme.colorScheme.fillPrimary,
           shape = HedvigTheme.shapes.cornerXLarge,
           modifier = Modifier
             .padding(horizontal = 16.dp)
@@ -85,7 +89,7 @@ fun EmergencyScreen(
             HedvigText(
               text = stringResource(R.string.SUBMIT_CLAIM_EMERGENCY_GLOBAL_ASSISTANCE_LABEL),
               textAlign = TextAlign.Center,
-              color = HedvigTheme.colorScheme.textTertiary,
+              color = HedvigTheme.colorScheme.textSecondary,
               style = HedvigTheme.typography.bodySmall.copy(
                 lineBreak = LineBreak.Heading,
               ),
@@ -144,7 +148,7 @@ fun EmergencyScreen(
               text = stringResource(R.string.SUBMIT_CLAIM_GLOBAL_ASSISTANCE_FOOTNOTE),
               textAlign = TextAlign.Center,
               modifier = Modifier.fillMaxWidth(),
-              color = HedvigTheme.colorScheme.textTertiary,
+              color = HedvigTheme.colorScheme.textSecondary,
               style = HedvigTheme.typography.finePrint,
             )
             Spacer(Modifier.height(8.dp))
@@ -201,7 +205,7 @@ private fun mapToAccordionData(list: List<Pair<String, String>>): List<Accordion
   }
 }
 
-@Preview
+@HedvigPreview
 @Composable
 private fun PreviewEmergencyScreen() {
   HedvigTheme {


### PR DESCRIPTION
Made them all do `backgroundPrimary` with the 0.95f alpha trick as surface color, and `fillPrimary` as the content color.
They are all wrapped in the forced dark theme wrapper, so it's always the right color in the background, which then allows for items using the normal `surfacePrimary` color to still be visible on top of them (simmer card does this), and the content remains readable and properly accessible this way.
It also makes sure that all such cards across the screens look the same, as opposed to the emergency screens which were using the surfacePrimary color which was a little bit different.