### PR TITLE
Filter out cancellation exceptions for RUM errors

### DIFF
--- a/app/datadog/datadog-android/src/main/kotlin/com/hedvig/android/datadog/core/DatadogInitializer.kt
+++ b/app/datadog/datadog-android/src/main/kotlin/com/hedvig/android/datadog/core/DatadogInitializer.kt
@@ -6,12 +6,15 @@ import androidx.startup.Initializer
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.event.EventMapper
 import com.datadog.android.log.Logger
 import com.datadog.android.log.Logs
 import com.datadog.android.log.LogsConfiguration
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ErrorEvent.Category.EXCEPTION
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.Trace
@@ -55,6 +58,7 @@ abstract class DatadogInitializer : Initializer<Unit>, KoinComponent {
     val rumConfig = RumConfiguration.Builder(applicationId)
       .trackLongTasks()
       .trackFrustrations(true)
+      .setErrorEventMapper(cancellationFilteringErrorEventMapper)
       .useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
       .build()
     Rum.enable(rumConfig, sdkCore)
@@ -88,5 +92,25 @@ abstract class DatadogInitializer : Initializer<Unit>, KoinComponent {
       .build()
 
     Timber.plant(DatadogLoggingTree(logger))
+  }
+}
+
+/**
+ * Filters out errors that originate from a network request throwing an error when the exception is explicitly an
+ * IOException with the message "cancelled". These "errors" are just part of the normal app behavior, where we may leave
+ * a screen which was in the middle of a network request, and in the process of leaving we cancel the coroutineScope in
+ * which that work was being done in.
+ */
+private val cancellationFilteringErrorEventMapper = EventMapper<ErrorEvent> { errorEvent ->
+  val wasCancellationException = with(errorEvent.error) {
+    category == EXCEPTION &&
+      isCrash == false &&
+      type == "java.io.IOException" &&
+      stack?.startsWith("java.io.IOException: Canceled") == true
+  }
+  if (wasCancellationException) {
+    null
+  } else {
+    errorEvent
   }
 }


### PR DESCRIPTION
Context:
https://github.com/DataDog/dd-sdk-android/issues/2426#issuecomment-2527646874

Tested by adding an interceptor which cancels all requests
```
    val okHttpBuilder = get<OkHttpClient.Builder>().addInterceptor(get<AuthTokenRefreshingInterceptor>())
      .addInterceptor {
        it.call().cancel()
        it.proceed(it.request())
      }
```
and seeing what that error looks like for the event mapper.
Then we simply drop the error event as suggested in the linked discussion