### PR TITLE
GEN-2988: T&A in moving flow summary screen

### DIFF
--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/data/MovingFlowQuotes.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/data/MovingFlowQuotes.kt
@@ -38,6 +38,7 @@ internal data class MovingFlowQuotes(
     val tierDescription: String?,
     val deductible: Deductible?,
     val defaultChoice: Boolean,
+    val relatedAddonQuotes: List<AddonQuote>,
   ) : Quote {
     val tierDisplayName = productVariant.displayTierName ?: tierName
 
@@ -56,6 +57,15 @@ internal data class MovingFlowQuotes(
     override val productVariant: ProductVariant,
     override val startDate: LocalDate,
     override val displayItems: List<DisplayItem>,
+  ) : Quote
+
+  @Serializable
+  data class AddonQuote(
+    override val premium: UiMoney,
+    override val startDate: LocalDate,
+    override val displayItems: List<DisplayItem>,
+    override val exposureName: String,
+    override val productVariant: ProductVariant,
   ) : Quote
 
   @Serializable
@@ -87,6 +97,7 @@ internal fun MoveIntentQuotesFragment.toMovingFlowQuotes(): MovingFlowQuotes {
           )
         },
         defaultChoice = houseQuote.defaultChoice,
+        relatedAddonQuotes = emptyList(), // todo tier & addons: populate the related addons when backend returns them
       )
     },
     mtaQuotes = (mtaQuotes ?: emptyList()).map { mtaQuote ->

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/chosecoveragelevelanddeductible/ChoseCoverageLevelAndDeductibleDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/chosecoveragelevelanddeductible/ChoseCoverageLevelAndDeductibleDestination.kt
@@ -562,6 +562,7 @@ fun PreviewChoseCoverageLevelAndDeductibleScreen() {
       tierDescription = "tierDescription#$it",
       deductible = null,
       defaultChoice = false,
+      relatedAddonQuotes = emptyList(),
     )
   }
   ChoseCoverageLevelAndDeductibleScreen(


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/a67eb386-894c-4cdc-9199-c780e874240a) | ![image](https://github.com/user-attachments/assets/3cf0dd62-fb12-4ecf-ad35-d76aa24dae36) |

I re-used most of what was there to make it easier to work with.
When backend exists for this, we can populate this list.
If it turns out that what we get from backend does not match the shape of a `Quote` that can change.
If it turns out that it needs additional information, they can be added to `AddonQuote` as needed.
I made sure to use the QuoteCard overload where I pass in a null `contractGroup` so that the pillow image does not show.

All the saving/restoring from Datastore still should work since we take the object and store it as a Json, and the new addon is also @Serializable as it should.

The order in which they appear is also persistent since the list of addons are added to the quote itself, so they go right after the home quote itself, and before any other unrelated quotes.