### PR TITLE
Make travel addon banner fetch from network

### DIFF
--- a/app/data/data-addons/build.gradle.kts
+++ b/app/data/data-addons/build.gradle.kts
@@ -11,6 +11,7 @@ hedvig {
 dependencies {
   implementation(libs.androidx.datastore.core)
   implementation(libs.androidx.datastore.preferencesCore)
+  implementation(libs.apollo.normalizedCache)
   implementation(libs.apollo.runtime)
   implementation(libs.arrow.core)
   implementation(libs.koin.core)

--- a/app/data/data-addons/src/main/kotlin/com/hedvig/android/data/addons/data/GetTravelAddonBannerInfoUseCase.kt
+++ b/app/data/data-addons/src/main/kotlin/com/hedvig/android/data/addons/data/GetTravelAddonBannerInfoUseCase.kt
@@ -6,66 +6,78 @@ import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.cache.normalized.FetchPolicy.CacheAndNetwork
+import com.apollographql.apollo.cache.normalized.FetchPolicy.NetworkFirst
+import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
+import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import kotlin.String
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import octopus.TravelAddonBannerQuery
 import octopus.type.UpsellTravelAddonFlow
 
 interface GetTravelAddonBannerInfoUseCase {
-  suspend fun invoke(source: TravelAddonBannerSource): Either<ErrorMessage, TravelAddonBannerInfo?>
+  fun invoke(source: TravelAddonBannerSource): Flow<Either<ErrorMessage, TravelAddonBannerInfo?>>
 }
 
 internal class GetTravelAddonBannerInfoUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val featureManager: FeatureManager,
 ) : GetTravelAddonBannerInfoUseCase {
-  override suspend fun invoke(source: TravelAddonBannerSource): Either<ErrorMessage, TravelAddonBannerInfo?> {
-    return either {
-      val isAddonFlagOn = featureManager.isFeatureEnabled(Feature.TRAVEL_ADDON).first()
-      if (!isAddonFlagOn) {
-        logcat(LogPriority.INFO) {
-          "Tried to get TravelAddonBannerInfo but addon feature flag is off"
-        }
-        return@either null
-      }
-      val mappedSource = when (source) {
-        TravelAddonBannerSource.TRAVEL_CERTIFICATES -> UpsellTravelAddonFlow.APP_UPSELL_UPGRADE
-        TravelAddonBannerSource.INSURANCES_TAB -> UpsellTravelAddonFlow.APP_ONLY_UPSALE
-      }
-      val result = apolloClient
+  override fun invoke(source: TravelAddonBannerSource): Flow<Either<ErrorMessage, TravelAddonBannerInfo?>> {
+    val mappedSource = when (source) {
+      TravelAddonBannerSource.TRAVEL_CERTIFICATES -> UpsellTravelAddonFlow.APP_UPSELL_UPGRADE
+      TravelAddonBannerSource.INSURANCES_TAB -> UpsellTravelAddonFlow.APP_ONLY_UPSALE
+    }
+    return combine(
+      featureManager.isFeatureEnabled(Feature.TRAVEL_ADDON),
+      apolloClient
         .query(TravelAddonBannerQuery(mappedSource))
-        .safeExecute()
-        .mapLeft { error ->
-          logcat(LogPriority.ERROR) { "Error from travelAddonBannerQuery from source: $mappedSource: $error" }
-          ErrorMessage()
+        .fetchPolicy(CacheAndNetwork)
+        .safeFlow()
+        .map {
+          it.mapLeft { error ->
+            logcat(LogPriority.ERROR) { "Error from travelAddonBannerQuery from source: $mappedSource: $error" }
+            ErrorMessage()
+          }
+        },
+    ) { isAddonFlagOn, travelAddonBannerQueryResult ->
+      either {
+        if (!isAddonFlagOn) {
+          logcat(LogPriority.INFO) {
+            "Tried to get TravelAddonBannerInfo but addon feature flag is off"
+          }
+          return@either null
         }
-        .bind()
-      val bannerData = result.currentMember.upsellTravelAddonBanner
-      if (bannerData == null) {
-        logcat(LogPriority.DEBUG) { "Got null response from TravelAddonBannerQuery" }
-        return@either null
-      }
-      val nonEmptyContracts = bannerData.contractIds.toNonEmptyListOrNull()
-      if (nonEmptyContracts.isNullOrEmpty()) {
-        logcat(LogPriority.ERROR) {
-          "Got non null response from TravelAddonBannerQuery from source: " +
-            "$mappedSource, but contractIds are empty"
+        val bannerData = travelAddonBannerQueryResult.bind().currentMember.upsellTravelAddonBanner
+        if (bannerData == null) {
+          logcat(LogPriority.DEBUG) { "Got null response from TravelAddonBannerQuery" }
+          return@either null
         }
-        return@either null
+        val nonEmptyContracts = bannerData.contractIds.toNonEmptyListOrNull()
+        if (nonEmptyContracts == null) {
+          logcat(LogPriority.ERROR) {
+            "Got non null response from TravelAddonBannerQuery from source: " +
+              "$mappedSource, but contractIds are empty"
+          }
+          return@either null
+        }
+        TravelAddonBannerInfo(
+          title = bannerData.titleDisplayName,
+          description = bannerData.descriptionDisplayName,
+          labels = bannerData.badges,
+          eligibleInsurancesIds = nonEmptyContracts,
+          bannerSource = mappedSource,
+        )
       }
-      TravelAddonBannerInfo(
-        title = bannerData.titleDisplayName,
-        description = bannerData.descriptionDisplayName,
-        labels = bannerData.badges,
-        eligibleInsurancesIds = nonEmptyContracts,
-        bannerSource = mappedSource,
-      )
     }
   }
 }

--- a/app/data/data-addons/src/test/kotlin/GetTravelAddonBannerInfoUseCaseImplTest.kt
+++ b/app/data/data-addons/src/test/kotlin/GetTravelAddonBannerInfoUseCaseImplTest.kt
@@ -1,5 +1,6 @@
 import arrow.core.nonEmptyListOf
-import arrow.core.raise.either
+import arrow.core.right
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -13,9 +14,13 @@ import com.hedvig.android.apollo.test.TestNetworkTransportType
 import com.hedvig.android.data.addons.data.GetTravelAddonBannerInfoUseCaseImpl
 import com.hedvig.android.data.addons.data.TravelAddonBannerInfo
 import com.hedvig.android.data.addons.data.TravelAddonBannerSource
+import com.hedvig.android.data.addons.data.TravelAddonBannerSource.INSURANCES_TAB
+import com.hedvig.android.data.addons.data.TravelAddonBannerSource.TRAVEL_CERTIFICATES
 import com.hedvig.android.featureflags.flags.Feature
+import com.hedvig.android.featureflags.flags.Feature.TRAVEL_ADDON
 import com.hedvig.android.featureflags.test.FakeFeatureManager2
 import com.hedvig.android.logger.TestLogcatLoggingRule
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import octopus.TravelAddonBannerQuery
 import octopus.type.UpsellTravelAddonFlow
@@ -127,14 +132,14 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
 
   @Test
   fun `if FF for addons is off return null`() = runTest {
-    val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to false))
+    val featureManager = FakeFeatureManager2(fixedMap = mapOf(TRAVEL_ADDON to false))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithFullBannerData, featureManager)
-    val resultFromInsurances = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES)
-    assertk.assertThat(resultFromInsurances)
-      .isEqualTo(either { null })
-    val resultFromTravel = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES)
-    assertk.assertThat(resultFromTravel)
-      .isEqualTo(either { null })
+    val resultFromInsurances = sut.invoke(INSURANCES_TAB).first()
+    assertThat(resultFromInsurances)
+      .isEqualTo(null.right())
+    val resultFromTravel = sut.invoke(TRAVEL_CERTIFICATES).first()
+    assertThat(resultFromTravel)
+      .isEqualTo(null.right())
   }
 
   @Test
@@ -143,16 +148,16 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithNullBannerData, featureManager)
     val result = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES)
     assertk.assertThat(result)
-      .isEqualTo(either { null })
+      .isEqualTo(null.right())
   }
 
   @Test
   fun `the source is mapped to the correct flow for the query`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to true))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithTwoFlows, featureManager)
-    val resultFromTravelCertificates = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).getOrNull()
+    val resultFromTravelCertificates = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).first().getOrNull()
     assertk.assertThat(resultFromTravelCertificates).isNotNull()
-    val resultFromInsurances = sut.invoke(TravelAddonBannerSource.INSURANCES_TAB).getOrNull()
+    val resultFromInsurances = sut.invoke(TravelAddonBannerSource.INSURANCES_TAB).first().getOrNull()
     assertk.assertThat(resultFromInsurances).isNull()
   }
 
@@ -162,14 +167,14 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithEmptyContracts, featureManager)
     val result = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES)
     assertk.assertThat(result)
-      .isEqualTo(either { null })
+      .isEqualTo(null.right())
   }
 
   @Test
   fun `if get error from BE return ErrorMessage`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to true))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithError, featureManager)
-    val resultFromTravels = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).isLeft()
+    val resultFromTravels = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).first().isLeft()
     assertk.assertThat(resultFromTravels)
       .isTrue()
   }
@@ -178,7 +183,7 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
   fun `if get full banner data from BE return TravelAddonBannerInfo`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to true))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithFullBannerData, featureManager)
-    val resultFromTravel = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).getOrNull()
+    val resultFromTravel = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).first().getOrNull()
     assertk.assertThat(resultFromTravel)
       .isNotNull()
   }
@@ -187,7 +192,7 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
   fun `the received data is passed correctly and in full`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to true))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithFullBannerData, featureManager)
-    val resultFromTravel = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).getOrNull()
+    val resultFromTravel = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).first().getOrNull()
     assertk.assertThat(resultFromTravel)
       .isEqualTo(
         TravelAddonBannerInfo(

--- a/app/data/data-addons/src/test/kotlin/GetTravelAddonBannerInfoUseCaseImplTest.kt
+++ b/app/data/data-addons/src/test/kotlin/GetTravelAddonBannerInfoUseCaseImplTest.kt
@@ -133,7 +133,7 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
   @Test
   fun `if FF for addons is off return null`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(TRAVEL_ADDON to false))
-    val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithFullBannerData, featureManager)
+    val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithTwoFlows, featureManager)
     val resultFromInsurances = sut.invoke(INSURANCES_TAB).first()
     assertThat(resultFromInsurances)
       .isEqualTo(null.right())
@@ -146,7 +146,7 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
   fun `if get null bannerData from BE return null`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to true))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithNullBannerData, featureManager)
-    val result = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES)
+    val result = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).first()
     assertk.assertThat(result)
       .isEqualTo(null.right())
   }
@@ -165,7 +165,7 @@ class GetTravelAddonBannerInfoUseCaseImplTest {
   fun `if get bannerData from BE is not null but contractIds are empty return null`() = runTest {
     val featureManager = FakeFeatureManager2(fixedMap = mapOf(Feature.TRAVEL_ADDON to true))
     val sut = GetTravelAddonBannerInfoUseCaseImpl(apolloClientWithEmptyContracts, featureManager)
-    val result = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES)
+    val result = sut.invoke(TravelAddonBannerSource.TRAVEL_CERTIFICATES).first()
     assertk.assertThat(result)
       .isEqualTo(null.right())
   }

--- a/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenterTest.kt
+++ b/app/feature/feature-insurances/src/test/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsurancePresenterTest.kt
@@ -28,7 +28,9 @@ import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.notification.badge.data.crosssell.card.FakeCrossSellCardNotificationBadgeService
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import octopus.CrossSellsQuery
@@ -259,6 +261,7 @@ internal class InsurancePresenterTest {
 
       getInsuranceContractsUseCase.contracts.add(validContracts)
       getCrossSellsUseCase.errorMessages.add(ErrorMessage())
+      getTravelAddonBannerInfoUseCase.turbine.add(either { fakeTravelAddon })
       awaitItem().also { uiState ->
         assertThat(uiState.hasError).isTrue()
         assertThat(uiState.isLoading).isFalse()
@@ -286,6 +289,7 @@ internal class InsurancePresenterTest {
       getInsuranceContractsUseCase.errorMessages.add(ErrorMessage())
       expectNoEvents() // No events while we're still waiting for all backend calls to finish
       getCrossSellsUseCase.errorMessages.add(ErrorMessage())
+      getTravelAddonBannerInfoUseCase.turbine.add(either { fakeTravelAddon })
       awaitItem().also { uiState ->
         assertThat(uiState.hasError).isTrue()
         assertThat(uiState.isLoading).isFalse()
@@ -538,8 +542,8 @@ internal class InsurancePresenterTest {
   private class FakeGetTravelAddonBannerInfoUseCase : GetTravelAddonBannerInfoUseCase {
     val turbine = Turbine<Either<ErrorMessage, TravelAddonBannerInfo?>>()
 
-    override suspend fun invoke(source: TravelAddonBannerSource): Either<ErrorMessage, TravelAddonBannerInfo?> {
-      return turbine.awaitItem()
+    override fun invoke(source: TravelAddonBannerSource): Flow<Either<ErrorMessage, TravelAddonBannerInfo?>> {
+      return turbine.asChannel().receiveAsFlow()
     }
   }
 


### PR DESCRIPTION
Prevents old cache persisting the banner despite having already signed up for the addon
Adjust the callers to work on the reactive data instead of the one shot call


From: https://www.notion.so/hedviginsurance/Travel-Addon-17cc3f71cb0a8043ba45cc9d7d6006a5?p=17dc3f71cb0a8092863fd7383dea306f&pm=s
And: https://hedviginsurance.slack.com/archives/C03HT2JRDPG/p1736943683086899