### PR TITLE
Make shared element APIs a no-op when the locals are not set

### DIFF
--- a/app/navigation/navigation-compose/src/main/kotlin/com/hedvig/android/navigation/compose/LocalNavAnimatedVisibilityScope.kt
+++ b/app/navigation/navigation-compose/src/main/kotlin/com/hedvig/android/navigation/compose/LocalNavAnimatedVisibilityScope.kt
@@ -9,6 +9,6 @@ import androidx.navigation.NavGraphBuilder
  * A local which contains the AnimatedVisibilityScope tied to the current navigation's destination.
  * See [NavGraphBuilder.navdestination] for how it's provided.
  */
-val LocalNavAnimatedVisibilityScope: ProvidableCompositionLocal<AnimatedVisibilityScope> = compositionLocalOf {
-  error("Must be under a compose `navdestination`")
+val LocalNavAnimatedVisibilityScope: ProvidableCompositionLocal<AnimatedVisibilityScope?> = compositionLocalOf {
+  null
 }


### PR DESCRIPTION
This makes previews easier to work with as they don't need to know about those locals nor set them up in any way.