### PR TITLE
Add travel plus explanation screen

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Peril.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Peril.kt
@@ -148,7 +148,7 @@ private fun parseColorString(colorString: String?): Color = with(HedvigTheme.col
     try {
       Color(parseColor(colorString))
     } catch (e: Exception) {
-      logcat(priority = LogPriority.ERROR) { "Parsing color resulted in an error" }
+      logcat(priority = LogPriority.ERROR) { "Parsing color with colorString:$colorString resulted in an error" }
       fromToken(TextPrimary)
     }
   }

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseDestination.kt
@@ -20,6 +20,24 @@ internal sealed interface AddonPurchaseDestination {
   data class CustomizeAddon(val insuranceId: String) : AddonPurchaseDestination, Destination
 
   @Serializable
+  data class TravelInsurancePlusExplanation(
+    val perilData: List<TravelPerilData>,
+  ) : AddonPurchaseDestination, Destination {
+    @Serializable
+    data class TravelPerilData(
+      val title: String,
+      val description: String,
+      val covered: List<String>,
+      val colorCode: String?,
+      val isEnabled: Boolean = true,
+    )
+
+    companion object : DestinationNavTypeAware {
+      override val typeList: List<KType> = listOf(typeOf<List<TravelPerilData>>())
+    }
+  }
+
+  @Serializable
   data class Summary(
     val params: SummaryParameters,
   ) : AddonPurchaseDestination, Destination {

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseNavGraph.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseNavGraph.kt
@@ -4,11 +4,15 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.toRoute
+import com.hedvig.android.design.system.hedvig.PerilData
 import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.ChooseInsuranceToAddAddonDestination
 import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.CustomizeAddon
 import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.SubmitFailure
 import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.SubmitSuccess
 import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.Summary
+import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.TravelInsurancePlusExplanation
+import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.TravelInsurancePlusExplanation.TravelPerilData
 import com.hedvig.android.feature.addon.purchase.ui.customize.CustomizeTravelAddonDestination
 import com.hedvig.android.feature.addon.purchase.ui.customize.CustomizeTravelAddonViewModel
 import com.hedvig.android.feature.addon.purchase.ui.selectinsurance.SelectInsuranceForAddonDestination
@@ -17,6 +21,7 @@ import com.hedvig.android.feature.addon.purchase.ui.success.SubmitAddonFailureSc
 import com.hedvig.android.feature.addon.purchase.ui.success.SubmitAddonSuccessScreen
 import com.hedvig.android.feature.addon.purchase.ui.summary.AddonSummaryDestination
 import com.hedvig.android.feature.addon.purchase.ui.summary.AddonSummaryViewModel
+import com.hedvig.android.feature.addon.purchase.ui.travelinsuranceplusexplanation.TravelInsurancePlusExplanationDestination
 import com.hedvig.android.navigation.compose.navdestination
 import com.hedvig.android.navigation.compose.navgraph
 import com.hedvig.android.navigation.compose.typed.getRouteFromBackStack
@@ -42,9 +47,9 @@ fun NavGraphBuilder.addonPurchaseNavGraph(
         .getRouteFromBackStack<AddonPurchaseGraphDestination>(backStackEntry)
       if (addonPurchaseGraphDestination.insuranceIds.size == 1) {
         LaunchedEffect(Unit) {
-          navigator.navigateUnsafe(CustomizeAddon(addonPurchaseGraphDestination.insuranceIds[0]), {
+          navigator.navigateUnsafe(CustomizeAddon(addonPurchaseGraphDestination.insuranceIds[0])) {
             typedPopUpTo<ChooseInsuranceToAddAddonDestination>({ inclusive = true })
-          })
+          }
         }
       } else {
         val viewModel: SelectInsuranceForAddonViewModel = koinViewModel {
@@ -85,10 +90,33 @@ fun NavGraphBuilder.addonPurchaseNavGraph(
             navigator.navigateUnsafe(Summary(summaryParameters))
           }
         },
+        onNavigateToTravelInsurancePlusExplanation = { perilDataList: List<PerilData> ->
+          navigator.navigateUnsafe(
+            TravelInsurancePlusExplanation(
+              perilDataList.map { perilData ->
+                TravelPerilData(
+                  title = perilData.title,
+                  description = perilData.description,
+                  covered = perilData.covered,
+                  colorCode = perilData.colorCode,
+                  isEnabled = perilData.isEnabled,
+                )
+              },
+            ),
+          )
+        },
         onNavigateToNewConversation = {
           navController.typedPopBackStack<AddonPurchaseGraphDestination>(inclusive = true)
           onNavigateToNewConversation(backStackEntry)
         },
+      )
+    }
+
+    navdestination<TravelInsurancePlusExplanation>(TravelInsurancePlusExplanation) { backStackEntry ->
+      val perilData = backStackEntry.toRoute<TravelInsurancePlusExplanation>().perilData
+      TravelInsurancePlusExplanationDestination(
+        travelPerilData = perilData,
+        navigateUp = navController::navigateUp,
       )
     }
 

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/travelinsuranceplusexplanation/TravelInsurancePlusExplanationDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/travelinsuranceplusexplanation/TravelInsurancePlusExplanationDestination.kt
@@ -1,0 +1,116 @@
+package com.hedvig.android.feature.addon.purchase.ui.travelinsuranceplusexplanation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigText
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.PerilData
+import com.hedvig.android.design.system.hedvig.PerilDefaults.PerilSize.Small
+import com.hedvig.android.design.system.hedvig.PerilList
+import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.design.system.hedvig.TopAppBar
+import com.hedvig.android.design.system.hedvig.TopAppBarActionType.BACK
+import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.TravelInsurancePlusExplanation.TravelPerilData
+import hedvig.resources.R
+
+@Composable
+internal fun TravelInsurancePlusExplanationDestination(travelPerilData: List<TravelPerilData>, navigateUp: () -> Unit) {
+  TravelInsurancePlusExplanationScreen(
+    perilData = remember(travelPerilData) {
+      travelPerilData.map {
+        PerilData(
+          title = it.title,
+          description = it.description,
+          covered = it.covered,
+          colorCode = it.colorCode,
+        )
+      }
+    },
+    navigateUp = navigateUp,
+  )
+}
+
+@Composable
+private fun TravelInsurancePlusExplanationScreen(perilData: List<PerilData>, navigateUp: () -> Unit) {
+  Surface(
+    color = HedvigTheme.colorScheme.backgroundPrimary,
+    modifier = Modifier.fillMaxSize(),
+  ) {
+    Column {
+      val topAppbarInsets =
+        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
+      TopAppBar(
+        title = "",
+        actionType = BACK,
+        windowInsets = topAppbarInsets,
+        onActionClick = dropUnlessResumed(block = navigateUp),
+      )
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState())
+          .consumeWindowInsets(topAppbarInsets.only(WindowInsetsSides.Top))
+          .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
+      ) {
+        HedvigText(
+          text = stringResource(R.string.ADDON_FLOW_TRAVEL_INFORMATION_TITLE),
+          style = HedvigTheme.typography.bodyMedium,
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp),
+        )
+        HedvigText(
+          text = stringResource(R.string.ADDON_FLOW_TRAVEL_INFORMATION_DESCRIPTION),
+          color = HedvigTheme.colorScheme.textSecondary,
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        PerilList(perilData, Small, Modifier.fillMaxWidth().padding(horizontal = 16.dp))
+        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
+      }
+    }
+  }
+}
+
+@HedvigPreview
+@Composable
+private fun PreviewTravelInsurancePlusExplanationScreen() {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      TravelInsurancePlusExplanationScreen(
+        perilData = List(4) { index ->
+          PerilData(
+            title = "Title$index",
+            description = "Description$index",
+            covered = listOf("Covered#$index", "Also covered#$index"),
+            colorCode = "#FFD0ECFB",
+          )
+        },
+        navigateUp = {},
+      )
+    }
+  }
+}


### PR DESCRIPTION
The "learn more" button now takes you to a screen where we render all the peril information instead of showing a simpler text about it. The perils are picked up from the currently selected addon in the dropdown

| entrypoint | extra screen |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/05f6aa40-abf1-49b5-8ff9-ea59660242b1) | ![image](https://github.com/user-attachments/assets/68917430-feb9-475f-9cef-8c9cfd0bcc90) |