### PR TITLE
Always show addon choice screen to allow reviewing the perils before summary

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dropdown.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dropdown.kt
@@ -265,6 +265,7 @@ private fun DropdownSelector(
             bounded = true,
             radius = 1000.dp,
           ),
+          enabled = isEnabled,
           onClick = onClick,
         ),
     ) {

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseDestination.kt
@@ -65,5 +65,4 @@ internal data class SummaryParameters(
   val quote: TravelAddonQuote,
   val activationDate: LocalDate,
   val currentTravelAddon: CurrentTravelAddon?,
-  val popCustomizeDestination: Boolean = false,
 )

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseNavGraph.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/navigation/AddonPurchaseNavGraph.kt
@@ -80,15 +80,7 @@ fun NavGraphBuilder.addonPurchaseNavGraph(
           navController.typedPopBackStack<AddonPurchaseGraphDestination>(inclusive = true)
         },
         navigateToSummary = { summaryParameters: SummaryParameters ->
-          if (summaryParameters.popCustomizeDestination) {
-            navigator.navigateUnsafe(Summary(summaryParameters)) {
-              typedPopUpTo<CustomizeAddon> {
-                inclusive = true
-              }
-            }
-          } else {
-            navigator.navigateUnsafe(Summary(summaryParameters))
-          }
+          navController.navigate(Summary(summaryParameters))
         },
         onNavigateToTravelInsurancePlusExplanation = { perilDataList: List<PerilData> ->
           navigator.navigateUnsafe(

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/customize/CustomizeTravelAddonDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/customize/CustomizeTravelAddonDestination.kt
@@ -149,18 +149,16 @@ private fun CustomizeTravelAddonScreen(
             navigateToSummary(state.summaryParamsToNavigateFurther)
           }
         }
-        if (state.summaryParamsToNavigateFurther == null) {
-          CustomizeTravelAddonScreenContent(
-            uiState = state,
-            navigateUp = navigateUp,
-            submitToSummary = submitToSummary,
-            onChooseSelectedOption = onChooseSelectedOption,
-            onChooseOptionInDialog = onChooseOptionInDialog,
-            onSetOptionBackToPreviouslyChosen = onSetOptionBackToPreviouslyChosen,
-            onNavigateToTravelInsurancePlusExplanation = onNavigateToTravelInsurancePlusExplanation,
-            popAddonFlow = popAddonFlow,
-          )
-        }
+        CustomizeTravelAddonScreenContent(
+          uiState = state,
+          navigateUp = navigateUp,
+          submitToSummary = submitToSummary,
+          onChooseSelectedOption = onChooseSelectedOption,
+          onChooseOptionInDialog = onChooseOptionInDialog,
+          onSetOptionBackToPreviouslyChosen = onSetOptionBackToPreviouslyChosen,
+          onNavigateToTravelInsurancePlusExplanation = onNavigateToTravelInsurancePlusExplanation,
+          popAddonFlow = popAddonFlow,
+        )
       }
     }
   }
@@ -317,8 +315,8 @@ private fun CustomizeTravelAddonCard(
       }
       DropdownWithDialog(
         dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+        // Locked option if there is nothing else to chose from
         isEnabled = uiState.travelAddonOffer.addonOptions.size > 1,
-        // we shouldn't get to this destination if this list size <=1 at all tbh
         style = Label(
           label = stringResource(R.string.ADDON_FLOW_SELECT_DAYS_PLACEHOLDER),
           items = addonSimpleItems,
@@ -531,6 +529,7 @@ internal class CustomizeTravelAddonPreviewProvider :
         travelAddonOffer = fakeTravelAddon,
         currentlyChosenOption = fakeTravelAddonQuote1,
         currentlyChosenOptionInDialog = fakeTravelAddonQuote1,
+        summaryParamsToNavigateFurther = null,
       ),
       CustomizeTravelAddonState.Failure("Ooops"),
     ),

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/customize/CustomizeTravelAddonViewModel.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/customize/CustomizeTravelAddonViewModel.kt
@@ -93,23 +93,12 @@ internal class CustomizeTravelAddonPresenter(
           currentState = CustomizeTravelAddonState.Failure(error.message)
         },
         ifRight = { offer ->
-          val summaryParams = if (offer.addonOptions.size == 1) {
-            SummaryParameters(
-              offer.title,
-              offer.addonOptions[0],
-              offer.activationDate,
-              currentTravelAddon = offer.currentTravelAddon,
-              popCustomizeDestination = true,
-            )
-          } else {
-            null
-          }
           selectedOptionInDialog = offer.addonOptions[0]
           currentState = CustomizeTravelAddonState.Success(
             travelAddonOffer = offer,
             currentlyChosenOption = offer.addonOptions[0],
             currentlyChosenOptionInDialog = selectedOptionInDialog,
-            summaryParamsToNavigateFurther = summaryParams,
+            summaryParamsToNavigateFurther = null,
           )
         },
       )
@@ -132,7 +121,7 @@ internal sealed interface CustomizeTravelAddonState {
     val travelAddonOffer: TravelAddonOffer,
     val currentlyChosenOption: TravelAddonQuote,
     val currentlyChosenOptionInDialog: TravelAddonQuote?,
-    val summaryParamsToNavigateFurther: SummaryParameters? = null,
+    val summaryParamsToNavigateFurther: SummaryParameters?,
   ) : CustomizeTravelAddonState
 
   data class Failure(val errorMessage: String? = null) : CustomizeTravelAddonState

--- a/app/feature/feature-addon-purchase/src/test/kotlin/ui/AddonSummaryPresenterTest.kt
+++ b/app/feature/feature-addon-purchase/src/test/kotlin/ui/AddonSummaryPresenterTest.kt
@@ -169,7 +169,6 @@ private val testSummaryParametersWithCurrentAddon = SummaryParameters(
   quote = newQuote,
   activationDate = LocalDate(2024, 12, 30),
   currentTravelAddon = currentAddon,
-  popCustomizeDestination = true,
 )
 
 private val testSummaryParametersWithMoreExpensiveCurrentAddon = SummaryParameters(
@@ -177,7 +176,6 @@ private val testSummaryParametersWithMoreExpensiveCurrentAddon = SummaryParamete
   quote = newQuote2,
   activationDate = LocalDate(2024, 12, 30),
   currentTravelAddon = moreExpensiveCurrentAddon,
-  popCustomizeDestination = true,
 )
 
 private val testSummaryParametersNoCurrentAddon = SummaryParameters(
@@ -185,5 +183,4 @@ private val testSummaryParametersNoCurrentAddon = SummaryParameters(
   quote = newQuote,
   activationDate = LocalDate(2024, 12, 30),
   currentTravelAddon = null,
-  popCustomizeDestination = true,
 )

--- a/app/feature/feature-addon-purchase/src/test/kotlin/ui/CustomizeTravelAddonPresenterTest.kt
+++ b/app/feature/feature-addon-purchase/src/test/kotlin/ui/CustomizeTravelAddonPresenterTest.kt
@@ -18,7 +18,6 @@ import com.hedvig.android.data.productvariant.InsuranceVariantDocument
 import com.hedvig.android.feature.addon.purchase.data.Addon.TravelAddonOffer
 import com.hedvig.android.feature.addon.purchase.data.GetTravelAddonOfferUseCase
 import com.hedvig.android.feature.addon.purchase.data.TravelAddonQuote
-import com.hedvig.android.feature.addon.purchase.navigation.SummaryParameters
 import com.hedvig.android.feature.addon.purchase.ui.customize.CustomizeTravelAddonEvent
 import com.hedvig.android.feature.addon.purchase.ui.customize.CustomizeTravelAddonPresenter
 import com.hedvig.android.feature.addon.purchase.ui.customize.CustomizeTravelAddonState
@@ -68,34 +67,6 @@ class CustomizeTravelAddonPresenterTest {
       skipItems(1)
       useCase.turbine.add(ErrorMessage().left())
       expectNoEvents()
-    }
-  }
-
-  @Test
-  fun `if receive good response but only one addon redirect to next screen and pop this destination`() = runTest {
-    val useCase = FakeGetTravelAddonOfferUseCase()
-    val presenter = CustomizeTravelAddonPresenter(
-      getTravelAddonOfferUseCase = useCase,
-      insuranceId = insuranceId,
-    )
-    presenter.test(
-      CustomizeTravelAddonState.Loading,
-    ) {
-      skipItems(1)
-      useCase.turbine.add(fakeTravelOfferOnlyOneOption.right())
-      val state = awaitItem()
-      assertThat(state).isInstanceOf(CustomizeTravelAddonState.Success::class)
-        .apply {
-          prop(CustomizeTravelAddonState.Success::summaryParamsToNavigateFurther)
-            .isEqualTo(
-              SummaryParameters(
-                offerDisplayName = fakeTravelOfferOnlyOneOption.title,
-                quote = fakeTravelOfferOnlyOneOption.addonOptions[0],
-                activationDate = fakeTravelOfferOnlyOneOption.activationDate,
-                currentTravelAddon = fakeTravelOfferOnlyOneOption.currentTravelAddon,
-              ),
-            )
-        }
     }
   }
 

--- a/app/feature/feature-addon-purchase/src/test/kotlin/ui/CustomizeTravelAddonPresenterTest.kt
+++ b/app/feature/feature-addon-purchase/src/test/kotlin/ui/CustomizeTravelAddonPresenterTest.kt
@@ -7,9 +7,7 @@ import arrow.core.nonEmptyListOf
 import arrow.core.right
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import com.hedvig.android.core.common.ErrorMessage
@@ -64,6 +62,7 @@ class CustomizeTravelAddonPresenterTest {
         travelAddonOffer = fakeTravelOfferTwoOptions,
         currentlyChosenOption = fakeTravelAddonQuote1,
         currentlyChosenOptionInDialog = fakeTravelAddonQuote1,
+        summaryParamsToNavigateFurther = null,
       ),
     ) {
       skipItems(1)
@@ -94,7 +93,6 @@ class CustomizeTravelAddonPresenterTest {
                 quote = fakeTravelOfferOnlyOneOption.addonOptions[0],
                 activationDate = fakeTravelOfferOnlyOneOption.activationDate,
                 currentTravelAddon = fakeTravelOfferOnlyOneOption.currentTravelAddon,
-                popCustomizeDestination = true,
               ),
             )
         }
@@ -174,36 +172,6 @@ class CustomizeTravelAddonPresenterTest {
       useCase.turbine.add(fakeTravelOfferTwoOptions.right())
       skipItems(1)
       assertThat(awaitItem()).isInstanceOf(CustomizeTravelAddonState.Success::class)
-    }
-  }
-
-  @Test
-  fun `on submit navigate further with currently chosen option and do not pop this destination`() = runTest {
-    val useCase = FakeGetTravelAddonOfferUseCase()
-    val presenter = CustomizeTravelAddonPresenter(
-      getTravelAddonOfferUseCase = useCase,
-      insuranceId = insuranceId,
-    )
-    presenter.test(
-      CustomizeTravelAddonState.Loading,
-    ) {
-      useCase.turbine.add(fakeTravelOfferTwoOptions.right())
-      skipItems(2)
-      sendEvent(CustomizeTravelAddonEvent.ChooseOptionInDialog(fakeTravelOfferTwoOptions.addonOptions[1]))
-      sendEvent(CustomizeTravelAddonEvent.ChooseSelectedOption)
-      skipItems(2)
-      sendEvent(CustomizeTravelAddonEvent.SubmitSelected)
-      assertThat(awaitItem()).isInstanceOf(CustomizeTravelAddonState.Success::class)
-        .apply {
-          prop(CustomizeTravelAddonState.Success::summaryParamsToNavigateFurther)
-            .isNotNull().apply {
-              prop(SummaryParameters::popCustomizeDestination).isFalse()
-              prop(SummaryParameters::quote).isEqualTo(fakeTravelOfferTwoOptions.addonOptions[1])
-              prop(SummaryParameters::currentTravelAddon).isEqualTo(fakeTravelOfferTwoOptions.currentTravelAddon)
-              prop(SummaryParameters::activationDate).isEqualTo(fakeTravelOfferTwoOptions.activationDate)
-              prop(SummaryParameters::offerDisplayName).isEqualTo(fakeTravelOfferTwoOptions.title)
-            }
-        }
     }
   }
 }


### PR DESCRIPTION
We no longer want to skip it, even if there is only 1 option.
That option must be pre-selected, the dropdown must be disabled, and the
member now has the option to learn more about the option before moving
forward.

Context: https://hedviginsurance.slack.com/archives/C087K3U2EDU/p1737466488102509?thread_ts=1737387896.103079&cid=C087K3U2EDU