### PR TITLE
Always show details in addon purchase

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigCard.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigCard.kt
@@ -45,6 +45,7 @@ import com.hedvig.android.placeholder.PlaceholderHighlight
 fun HedvigCard(
   modifier: Modifier = Modifier,
   onClick: (() -> Unit)? = null,
+  enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = null,
   shape: Shape = HedvigTheme.shapes.cornerXLarge,
@@ -54,6 +55,7 @@ fun HedvigCard(
     Surface(
       shape = shape,
       onClick = onClick,
+      enabled = enabled,
       interactionSource = interactionSource,
       indication = indication,
       modifier = modifier,

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/summary/AddonSummaryDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/summary/AddonSummaryDestination.kt
@@ -46,6 +46,7 @@ import com.hedvig.android.feature.addon.purchase.data.TravelAddonQuote
 import com.hedvig.android.feature.addon.purchase.ui.summary.AddonSummaryState.Content
 import com.hedvig.android.feature.addon.purchase.ui.summary.AddonSummaryState.Loading
 import com.hedvig.android.tiersandaddons.QuoteCard
+import com.hedvig.android.tiersandaddons.QuoteCardState
 import hedvig.resources.R
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
@@ -218,6 +219,10 @@ private fun SummaryCard(uiState: Content, modifier: Modifier = Modifier) {
     ).format(uiState.activationDate.toJavaLocalDate())
   }
   QuoteCard(
+    quoteCardState = object : QuoteCardState {
+      override var showDetails: Boolean = true
+      override val isEnabled: Boolean = false
+    },
     subtitle = stringResource(R.string.ADDON_FLOW_SUMMARY_ACTIVE_FROM, formattedDate),
     premium = {
       Row(horizontalArrangement = Arrangement.End) {
@@ -254,12 +259,13 @@ private fun SummaryCard(uiState: Content, modifier: Modifier = Modifier) {
     } else {
       null
     },
-    underTitleContent = {},
-    modifier = modifier,
     displayName = uiState.offerDisplayName,
     contractGroup = null,
     insurableLimits = null,
     documents = uiState.quote.addonVariant.documents,
+    modifier = modifier,
+    underTitleContent = {},
+    underDetailsContent = {},
   )
 }
 

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -93,7 +93,7 @@ import com.hedvig.android.feature.movingflow.ui.summary.SummaryUiState.Content.S
 import com.hedvig.android.feature.movingflow.ui.summary.SummaryUiState.Loading
 import com.hedvig.android.tiersandaddons.QuoteCard
 import com.hedvig.android.tiersandaddons.QuoteCardDefaults
-import com.hedvig.android.tiersandaddons.QuoteCardDefaults.UnderDetailsContentState
+import com.hedvig.android.tiersandaddons.QuoteCardState
 import com.hedvig.android.tiersandaddons.QuoteDisplayItem
 import hedvig.resources.R
 import kotlinx.datetime.LocalDate
@@ -378,7 +378,7 @@ private fun AddonQuoteCard(
             enabled = true,
             buttonStyle = Secondary,
             buttonSize = Medium,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
           )
         } else {
           QuoteCardDefaults.UnderDetailsContent(state)
@@ -401,7 +401,7 @@ private fun AddonQuoteCard(quote: MovingFlowQuotes.AddonQuote.MtaAddonQuote, mod
 private fun AddonQuoteCard(
   quote: MovingFlowQuotes.AddonQuote,
   modifier: Modifier = Modifier,
-  underDetailsContent: (@Composable (UnderDetailsContentState) -> Unit)?,
+  underDetailsContent: (@Composable (QuoteCardState) -> Unit)?,
 ) {
   val startDate = formatStartDate(quote.startDate)
   val subtitle = if (quote is HomeAddonQuote && quote.isExcludedByUser) {


### PR DESCRIPTION
The diff in QuoteCard.kt is ugly but comes mostly from moving things around.
The important part is exposing `QuoteCardState` so that the summary screen is allowed to force the card to always show. It also uses `underDetailsContent`
 to not show the "show details" button at all

Context:
https://hedviginsurance.slack.com/archives/C087K3U2EDU/p1737467303293259?thread_ts=1737387896.103079&cid=C087K3U2EDU

<img width="523" alt="image" src="https://github.com/user-attachments/assets/d72eaf87-bae9-403c-babd-810e1e70abd6" />
