### PR TITLE
Fix: Excluded addons should stay shrinked and non-interactive

### DIFF
--- a/app/apollo/apollo-octopus-public/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/AddonVariantFragment.graphql
+++ b/app/apollo/apollo-octopus-public/src/main/graphql/com/hedvig/android/apollo/octopus/graphql/AddonVariantFragment.graphql
@@ -10,11 +10,6 @@ fragment AddonVariantFragment on AddonVariant {
     exceptions
     colorCode
   }
-  insurableLimits {
-    label
-    limit
-    description
-  }
   documents {
     displayName
     url

--- a/app/compose/compose-ui/src/main/kotlin/com/hedvig/android/compose/ui/SharedElements.kt
+++ b/app/compose/compose-ui/src/main/kotlin/com/hedvig/android/compose/ui/SharedElements.kt
@@ -19,7 +19,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Modifier

--- a/app/data/data-product-variant/data-product-variant-public/src/main/kotlin/com/hedvig/android/data/productvariant/AddonVariant.kt
+++ b/app/data/data-product-variant/data-product-variant-public/src/main/kotlin/com/hedvig/android/data/productvariant/AddonVariant.kt
@@ -9,8 +9,7 @@ data class AddonVariant(
   val displayName: String,
   val product: String,
   val documents: List<InsuranceVariantDocument>,
-  val perils: List<ProductVariantPeril>,
-  val insurableLimits: List<InsurableLimit>,
+  val perils: List<ProductVariantPeril>
 )
 
 fun AddonVariantFragment.toAddonVariant() = AddonVariant(
@@ -33,12 +32,5 @@ fun AddonVariantFragment.toAddonVariant() = AddonVariant(
       exceptions = peril.exceptions,
       colorCode = peril.colorCode,
     )
-  },
-  insurableLimits = this.insurableLimits.map { insurableLimit ->
-    InsurableLimit(
-      label = insurableLimit.label,
-      limit = insurableLimit.limit,
-      description = insurableLimit.description,
-    )
-  },
+  }
 )

--- a/app/data/data-product-variant/data-product-variant-public/src/main/kotlin/com/hedvig/android/data/productvariant/AddonVariant.kt
+++ b/app/data/data-product-variant/data-product-variant-public/src/main/kotlin/com/hedvig/android/data/productvariant/AddonVariant.kt
@@ -9,7 +9,7 @@ data class AddonVariant(
   val displayName: String,
   val product: String,
   val documents: List<InsuranceVariantDocument>,
-  val perils: List<ProductVariantPeril>
+  val perils: List<ProductVariantPeril>,
 )
 
 fun AddonVariantFragment.toAddonVariant() = AddonVariant(
@@ -32,5 +32,5 @@ fun AddonVariantFragment.toAddonVariant() = AddonVariant(
       exceptions = peril.exceptions,
       colorCode = peril.colorCode,
     )
-  }
+  },
 )

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsBottomHeight

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigScaffold.kt
@@ -3,12 +3,15 @@ package com.hedvig.android.design.system.hedvig
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -51,13 +54,10 @@ fun HedvigScaffold(
           .fillMaxSize()
           .verticalScroll(rememberScrollState())
           .consumeWindowInsets(topAppbarInsets.only(WindowInsetsSides.Top))
-          .windowInsetsPadding(
-            // todo remove this bottom insets padding from Scaffold, as it forces the callers to clip the bottom bar
-            //  insets if they happen to want to have their own scrollable state
-            WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
-          ),
+          .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
       ) {
         content()
+        Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
       }
     }
   }

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/customize/CustomizeTravelAddonDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/customize/CustomizeTravelAddonDestination.kt
@@ -546,7 +546,6 @@ private val fakeTravelAddonQuote1 = TravelAddonQuote(
     perils = listOf(),
     displayName = "45 days",
     product = "",
-    insurableLimits = listOf(),
   ),
   price = UiMoney(
     49.0,
@@ -564,7 +563,6 @@ private val fakeTravelAddonQuote2 = TravelAddonQuote(
     perils = listOf(),
     displayName = "60 days",
     product = "",
-    insurableLimits = listOf(),
   ),
   price = UiMoney(
     60.0,

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/summary/AddonSummaryDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/summary/AddonSummaryDestination.kt
@@ -353,7 +353,7 @@ private class ChooseInsuranceForAddonUiStateProvider :
             documents = listOf(),
             perils = listOf(),
             displayName = "45 days",
-            product = ""
+            product = "",
           ),
           price = UiMoney(
             60.0,

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/summary/AddonSummaryDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/summary/AddonSummaryDestination.kt
@@ -353,8 +353,7 @@ private class ChooseInsuranceForAddonUiStateProvider :
             documents = listOf(),
             perils = listOf(),
             displayName = "45 days",
-            product = "",
-            insurableLimits = listOf(),
+            product = ""
           ),
           price = UiMoney(
             60.0,

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/travelinsuranceplusexplanation/TravelInsurancePlusExplanationDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/travelinsuranceplusexplanation/TravelInsurancePlusExplanationDestination.kt
@@ -1,12 +1,9 @@
 package com.hedvig.android.feature.addon.purchase.ui.travelinsuranceplusexplanation
 
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/travelinsuranceplusexplanation/TravelInsurancePlusExplanationDestination.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/ui/travelinsuranceplusexplanation/TravelInsurancePlusExplanationDestination.kt
@@ -1,27 +1,19 @@
 package com.hedvig.android.feature.addon.purchase.ui.travelinsuranceplusexplanation
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HighlightLabel
@@ -32,8 +24,6 @@ import com.hedvig.android.design.system.hedvig.PerilData
 import com.hedvig.android.design.system.hedvig.PerilDefaults.PerilSize.Small
 import com.hedvig.android.design.system.hedvig.PerilList
 import com.hedvig.android.design.system.hedvig.Surface
-import com.hedvig.android.design.system.hedvig.TopAppBar
-import com.hedvig.android.design.system.hedvig.TopAppBarActionType.BACK
 import com.hedvig.android.feature.addon.purchase.navigation.AddonPurchaseDestination.TravelInsurancePlusExplanation.TravelPerilData
 import hedvig.resources.R
 
@@ -56,53 +46,31 @@ internal fun TravelInsurancePlusExplanationDestination(travelPerilData: List<Tra
 
 @Composable
 private fun TravelInsurancePlusExplanationScreen(perilData: List<PerilData>, navigateUp: () -> Unit) {
-  Surface(
-    color = HedvigTheme.colorScheme.backgroundPrimary,
-    modifier = Modifier.fillMaxSize(),
-  ) {
-    Column {
-      val topAppbarInsets =
-        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
-      TopAppBar(
-        title = "",
-        actionType = BACK,
-        windowInsets = topAppbarInsets,
-        onActionClick = dropUnlessResumed(block = navigateUp),
-      )
-      Column(
-        modifier = Modifier
-          .fillMaxSize()
-          .verticalScroll(rememberScrollState())
-          .consumeWindowInsets(topAppbarInsets.only(WindowInsetsSides.Top))
-          .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
-      ) {
-        HedvigText(
-          text = stringResource(R.string.ADDON_FLOW_TRAVEL_INFORMATION_TITLE),
-          style = HedvigTheme.typography.bodyMedium,
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 18.dp),
-        )
-        HedvigText(
-          text = stringResource(R.string.ADDON_FLOW_TRAVEL_INFORMATION_DESCRIPTION),
-          color = HedvigTheme.colorScheme.textSecondary,
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 18.dp),
-        )
-        Spacer(Modifier.height(32.dp))
-        HighlightLabel(
-          labelText = stringResource(R.string.ADDON_LEARN_MORE_LABEL),
-          size = Medium,
-          color = Blue(LIGHT),
-          modifier = Modifier.padding(horizontal = 16.dp),
-        )
-        Spacer(Modifier.height(16.dp))
-        PerilList(perilData, Small, Modifier.fillMaxWidth().padding(horizontal = 16.dp))
-        Spacer(Modifier.height(16.dp))
-        Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
-      }
-    }
+  HedvigScaffold(navigateUp) {
+    HedvigText(
+      text = stringResource(R.string.ADDON_FLOW_TRAVEL_INFORMATION_TITLE),
+      style = HedvigTheme.typography.bodyMedium,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 18.dp),
+    )
+    HedvigText(
+      text = stringResource(R.string.ADDON_FLOW_TRAVEL_INFORMATION_DESCRIPTION),
+      color = HedvigTheme.colorScheme.textSecondary,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 18.dp),
+    )
+    Spacer(Modifier.height(32.dp))
+    HighlightLabel(
+      labelText = stringResource(R.string.ADDON_LEARN_MORE_LABEL),
+      size = Medium,
+      color = Blue(LIGHT),
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+    Spacer(Modifier.height(16.dp))
+    PerilList(perilData, Small, Modifier.fillMaxWidth().padding(horizontal = 16.dp))
+    Spacer(Modifier.height(16.dp))
   }
 }
 

--- a/app/feature/feature-addon-purchase/src/test/kotlin/data/GetTravelAddonOfferUseCaseImplTest.kt
+++ b/app/feature/feature-addon-purchase/src/test/kotlin/data/GetTravelAddonOfferUseCaseImplTest.kt
@@ -317,7 +317,6 @@ private val mockWithoutUpgrade = TravelAddonOffer(
         displayName = "45 days",
         product = "",
         perils = listOf(),
-        insurableLimits = listOf(),
       ),
       price = UiMoney(
         49.0,
@@ -335,7 +334,6 @@ private val mockWithoutUpgrade = TravelAddonOffer(
         displayName = "60 days",
         product = "",
         perils = listOf(),
-        insurableLimits = listOf(),
       ),
       price = UiMoney(
         60.0,
@@ -362,7 +360,6 @@ private val mockWithUpgrade = TravelAddonOffer(
         displayName = "45 days",
         product = "",
         perils = listOf(),
-        insurableLimits = listOf(),
       ),
       price = UiMoney(
         60.0,

--- a/app/feature/feature-addon-purchase/src/test/kotlin/ui/AddonSummaryPresenterTest.kt
+++ b/app/feature/feature-addon-purchase/src/test/kotlin/ui/AddonSummaryPresenterTest.kt
@@ -111,7 +111,6 @@ private val newQuote = TravelAddonQuote(
     displayName = "45 days",
     product = "",
     perils = listOf(),
-    insurableLimits = listOf(),
     documents = listOf(
       InsuranceVariantDocument(
         "Terms and Conditions",
@@ -139,7 +138,6 @@ private val newQuote2 = TravelAddonQuote(
     displayName = "60 days",
     product = "",
     perils = listOf(),
-    insurableLimits = listOf(),
     documents = listOf(
       InsuranceVariantDocument(
         "Terms and Conditions",

--- a/app/feature/feature-addon-purchase/src/test/kotlin/ui/CustomizeTravelAddonPresenterTest.kt
+++ b/app/feature/feature-addon-purchase/src/test/kotlin/ui/CustomizeTravelAddonPresenterTest.kt
@@ -165,7 +165,6 @@ private val fakeTravelAddonQuote1 = TravelAddonQuote(
     displayName = "45 days",
     product = "",
     perils = listOf(),
-    insurableLimits = listOf(),
     documents = listOf(
       InsuranceVariantDocument(
         "Terms and Conditions",
@@ -188,7 +187,6 @@ private val fakeTravelAddonQuote2 = TravelAddonQuote(
     displayName = "60 days",
     product = "",
     perils = listOf(),
-    insurableLimits = listOf(),
     documents = listOf(
       InsuranceVariantDocument(
         "Terms and Conditions",

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
@@ -64,6 +64,7 @@ import com.hedvig.android.feature.change.tier.ui.stepsummary.SummaryState.Making
 import com.hedvig.android.feature.change.tier.ui.stepsummary.SummaryState.Success
 import com.hedvig.android.tiersandaddons.QuoteCard
 import com.hedvig.android.tiersandaddons.QuoteDisplayItem
+import com.hedvig.android.tiersandaddons.rememberQuoteCardState
 import hedvig.resources.R
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
@@ -320,6 +321,7 @@ private fun AddonCard(
   val startDate = formatStartDate(activationDate)
   val subtitle = stringResource(R.string.CHANGE_ADDRESS_ACTIVATION_DATE, startDate)
   QuoteCard(
+    quoteCardState = rememberQuoteCardState(),
     displayName = addonQuote.addonVariant.displayName,
     contractGroup = null,
     insurableLimits = emptyList(),

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
@@ -442,7 +442,6 @@ private class ChooseInsuranceUiStateProvider :
               addonVariant = AddonVariant(
                 displayName = "Addon Name",
                 perils = listOf(),
-                insurableLimits = listOf(),
                 documents = listOf(
                   InsuranceVariantDocument(
                     "Document name",

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -400,7 +400,6 @@ private fun PreviewContractDetailScreen() {
                       ),
                     ),
                     perils = listOf(),
-                    insurableLimits = listOf(),
                   ),
                 ),
               ),

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
@@ -241,7 +241,7 @@ private val fakeAddonVariant = AddonVariant(
     ),
   ),
   displayName = "Travel Insurance Plus",
-  product = ""
+  product = "",
 )
 
 private val previewInsurableLimits: List<InsurableLimit> = listOf(

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/coverage/CoverageTab.kt
@@ -241,8 +241,7 @@ private val fakeAddonVariant = AddonVariant(
     ),
   ),
   displayName = "Travel Insurance Plus",
-  product = "",
-  insurableLimits = listOf(),
+  product = ""
 )
 
 private val previewInsurableLimits: List<InsurableLimit> = listOf(

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
@@ -159,7 +159,6 @@ private fun PreviewDocumentsScreen() {
                   InsuranceVariantDocument.InsuranceDocumentType.GENERAL_TERMS,
                 ),
               ),
-              insurableLimits = listOf(),
             ),
           ),
         ),

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -360,7 +360,7 @@ private fun AddonQuoteCard(
           visible = canExcludeAddons && state.showDetails && !quote.isExcludedByUser,
           enter = expandVertically(expandFrom = Alignment.Top),
           exit = shrinkVertically(shrinkTowards = Alignment.Top),
-          modifier = Modifier.padding(bottom = 8.dp),
+          modifier = Modifier.padding(top = 8.dp),
         ) {
           HedvigButton(
             text = stringResource(R.string.GENERAL_REMOVE),
@@ -427,7 +427,6 @@ private fun AddonQuoteCard(
     displayName = quote.addonVariant.displayName,
     contractGroup = null,
     insurableLimits = emptyList(),
-    // todo: here we don't want to show insurable limits for addons, that may change later
     documents = quote.addonVariant.documents,
     subtitle = subtitle,
     premium = quote.premium.toString(),
@@ -551,8 +550,7 @@ private class SummaryUiStateProvider : PreviewParameterProvider<SummaryUiState> 
         type = CERTIFICATE,
       ),
     ),
-    perils = listOf(),
-    insurableLimits = listOf(),
+    perils = listOf()
   )
   val startDate = LocalDate.parse("2025-01-01")
 

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -356,11 +356,11 @@ private fun AddonQuoteCard(
     modifier = modifier,
     underDetailsContent = { state ->
       Column {
+        Spacer(Modifier.height(16.dp))
         AnimatedVisibility(
           visible = canExcludeAddons && state.showDetails && !quote.isExcludedByUser,
           enter = expandVertically(expandFrom = Alignment.Top),
           exit = shrinkVertically(shrinkTowards = Alignment.Top),
-          modifier = Modifier.padding(top = 8.dp),
         ) {
           HedvigButton(
             text = stringResource(R.string.GENERAL_REMOVE),
@@ -369,7 +369,7 @@ private fun AddonQuoteCard(
             buttonStyle = Ghost,
             buttonSize = Medium,
             border = HedvigTheme.colorScheme.borderPrimary,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
           )
         }
         if (quote.isExcludedByUser) {
@@ -379,12 +379,21 @@ private fun AddonQuoteCard(
             enabled = true,
             buttonStyle = Secondary,
             buttonSize = Medium,
-            modifier = Modifier
-              .fillMaxWidth()
-              .padding(top = 16.dp),
+            modifier = Modifier.fillMaxWidth()
           )
         } else {
-          QuoteCardDefaults.UnderDetailsContent(state)
+          HedvigButton(
+            text = if (state.showDetails) {
+              stringResource(R.string.TIER_FLOW_SUMMARY_HIDE_DETAILS_BUTTON)
+            } else {
+              stringResource(R.string.TIER_FLOW_SUMMARY_SHOW_DETAILS)
+            },
+            onClick = state::toggleState,
+            enabled = true,
+            buttonStyle = Secondary,
+            buttonSize = Medium,
+            modifier = Modifier.fillMaxWidth()
+          )
         }
       }
     },

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -95,6 +95,7 @@ import com.hedvig.android.tiersandaddons.QuoteCard
 import com.hedvig.android.tiersandaddons.QuoteCardDefaults
 import com.hedvig.android.tiersandaddons.QuoteCardState
 import com.hedvig.android.tiersandaddons.QuoteDisplayItem
+import com.hedvig.android.tiersandaddons.rememberQuoteCardState
 import hedvig.resources.R
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
@@ -378,7 +379,9 @@ private fun AddonQuoteCard(
             enabled = true,
             buttonStyle = Secondary,
             buttonSize = Medium,
-            modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(top = 16.dp),
           )
         } else {
           QuoteCardDefaults.UnderDetailsContent(state)
@@ -409,7 +412,18 @@ private fun AddonQuoteCard(
   } else {
     stringResource(R.string.CHANGE_ADDRESS_ACTIVATION_DATE, startDate)
   }
+  val quoteCardState = rememberQuoteCardState()
   QuoteCard(
+    quoteCardState = object : QuoteCardState {
+      override var showDetails: Boolean
+        get() = if (quote is HomeAddonQuote && quote.isExcludedByUser) false else quoteCardState.showDetails
+        set(value) {
+          if (quote is HomeAddonQuote && quote.isExcludedByUser) return
+          quoteCardState.showDetails = value
+        }
+      override val isEnabled: Boolean
+        get() = if (quote is HomeAddonQuote && quote.isExcludedByUser) false else quoteCardState.isEnabled
+    },
     displayName = quote.addonVariant.displayName,
     contractGroup = null,
     insurableLimits = emptyList(),

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -355,6 +355,11 @@ private fun AddonQuoteCard(
     quote = quote,
     modifier = modifier,
     underDetailsContent = { state ->
+      LaunchedEffect(quote.isExcludedByUser) {
+        if (quote.isExcludedByUser) {
+          state.showDetails = false
+        }
+      }
       Column {
         Spacer(Modifier.height(16.dp))
         AnimatedVisibility(
@@ -369,7 +374,9 @@ private fun AddonQuoteCard(
             buttonStyle = Ghost,
             buttonSize = Medium,
             border = HedvigTheme.colorScheme.borderPrimary,
-            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(bottom = 8.dp),
           )
         }
         if (quote.isExcludedByUser) {
@@ -379,7 +386,7 @@ private fun AddonQuoteCard(
             enabled = true,
             buttonStyle = Secondary,
             buttonSize = Medium,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
           )
         } else {
           HedvigButton(
@@ -392,7 +399,7 @@ private fun AddonQuoteCard(
             enabled = true,
             buttonStyle = Secondary,
             buttonSize = Medium,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
           )
         }
       }
@@ -559,7 +566,7 @@ private class SummaryUiStateProvider : PreviewParameterProvider<SummaryUiState> 
         type = CERTIFICATE,
       ),
     ),
-    perils = listOf()
+    perils = listOf(),
   )
   val startDate = LocalDate.parse("2025-01-01")
 

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/selectcontract/SelectContractDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/selectcontract/SelectContractDestination.kt
@@ -18,14 +18,19 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.data.claimflow.ClaimFlowStep
 import com.hedvig.android.data.claimflow.LocalContractContractOption
+import com.hedvig.android.design.system.hedvig.ChosenState
 import com.hedvig.android.design.system.hedvig.ErrorSnackbarState
 import com.hedvig.android.design.system.hedvig.HedvigButton
-import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.LockedState.NotLocked
+import com.hedvig.android.design.system.hedvig.RadioGroup
+import com.hedvig.android.design.system.hedvig.RadioGroupDefaults
+import com.hedvig.android.design.system.hedvig.RadioOptionData
+import com.hedvig.android.design.system.hedvig.RadioOptionGroupData
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.calculateForPreview
-import com.hedvig.android.feature.odyssey.ui.ContractOptionWithDialog
 import com.hedvig.android.ui.claimflow.ClaimFlowScaffold
 import hedvig.resources.R
 
@@ -59,7 +64,7 @@ internal fun SelectContractDestination(
 private fun SelectContractScreen(
   uiState: SelectContractUiState,
   windowSizeClass: WindowSizeClass,
-  selectLocation: (LocalContractContractOption) -> Unit,
+  selectLocation: (String) -> Unit,
   submitLocation: () -> Unit,
   showedError: () -> Unit,
   navigateUp: () -> Unit,
@@ -82,12 +87,24 @@ private fun SelectContractScreen(
     )
     Spacer(Modifier.height(32.dp))
     Spacer(Modifier.weight(1f))
-    ContractOptionWithDialog(
-      locationOptions = uiState.contractOptions,
-      selectedLocation = uiState.selectedContract,
-      selectLocationOption = selectLocation,
-      enabled = !uiState.isLoading,
+    RadioGroup(
+      radioGroupSize = RadioGroupDefaults.RadioGroupSize.Medium,
+      radioGroupStyle = RadioGroupDefaults.RadioGroupStyle.Vertical.Default(
+        dataList = uiState.contractOptions.map { option ->
+          RadioOptionGroupData.RadioOptionGroupDataSimple(
+            RadioOptionData(
+              id = option.id,
+              optionText = option.displayName,
+              chosenState = if (option == uiState.selectedContract) ChosenState.Chosen else ChosenState.NotChosen,
+            ),
+          )
+        },
+      ),
+      onOptionClick = { id ->
+        selectLocation(id)
+      },
       modifier = sideSpacingModifier.fillMaxWidth(),
+      groupLockedState = NotLocked,
     )
     Spacer(Modifier.height(16.dp))
     HedvigButton(
@@ -102,7 +119,7 @@ private fun SelectContractScreen(
   }
 }
 
-@HedvigPreview
+@HedvigMultiScreenPreview
 @Composable
 private fun PreviewLocationScreen() {
   HedvigTheme {

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/selectcontract/SelectContractViewModel.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/selectcontract/SelectContractViewModel.kt
@@ -13,15 +13,16 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal class SelectContractViewModel(
-  private val selectContract: ClaimFlowDestination.SelectContract,
+  selectContract: ClaimFlowDestination.SelectContract,
   private val claimFlowRepository: ClaimFlowRepository,
 ) : ViewModel() {
   private val _uiState = MutableStateFlow(SelectContractUiState.fromInitialSelection(selectContract.options))
   val uiState: StateFlow<SelectContractUiState> = _uiState.asStateFlow()
 
-  fun selectContractOption(selectedContract: LocalContractContractOption) {
+  fun selectContractOption(selectedContractId: String) {
     _uiState.update { oldUiState ->
-      oldUiState.copy(selectedContract = selectedContract)
+      val selected = oldUiState.contractOptions.first { it.id == selectedContractId }
+      oldUiState.copy(selectedContract = selected)
     }
   }
 

--- a/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
+++ b/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -25,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -45,7 +45,6 @@ import androidx.compose.ui.unit.sp
 import com.hedvig.android.compose.ui.LayoutWithoutPlacement
 import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.stringWithShiftedLabel
-import com.hedvig.android.compose.ui.withoutPlacement
 import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.ContractGroup.DOG
 import com.hedvig.android.data.contract.android.toPillow
@@ -122,7 +121,9 @@ object QuoteCardDefaults {
       enabled = true,
       buttonStyle = Secondary,
       buttonSize = Medium,
-      modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(top = 16.dp),
     )
   }
 }
@@ -172,7 +173,7 @@ fun QuoteCard(
   underDetailsContent: @Composable (QuoteCardState) -> Unit = { state ->
     QuoteCardDefaults.UnderDetailsContent(state)
   },
-  ) {
+) {
   QuoteCard(
     quoteCardState = quoteCardState,
     subtitle = subtitle,
@@ -355,40 +356,41 @@ private fun QuoteCard(
     indication = ripple(bounded = true, radius = 1000.dp),
   ) {
     Column(modifier = Modifier.padding(16.dp)) {
-      HorizontalItemsWithMaximumSpaceTaken(
-        startSlot = {
-          Row {
-            if (contractGroup != null) {
-              Image(
-                painter = painterResource(contractGroup.toPillow()),
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
+      Row {
+        if (contractGroup != null) {
+          Image(
+            painter = painterResource(contractGroup.toPillow()),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+          )
+          Spacer(modifier = Modifier.width(12.dp))
+        }
+        Column(Modifier.weight(1f)) {
+          HorizontalItemsWithMaximumSpaceTaken(
+            startSlot = { HedvigText(displayName) },
+            endSlot = { titleEndSlot() },
+            spaceBetween = 8.dp,
+          )
+          AnimatedContent(
+            targetState = subtitle,
+            transitionSpec = {
+              (fadeIn() + expandVertically(expandFrom = Alignment.Top))
+                .togetherWith(fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top))
+            },
+            modifier = Modifier.fillMaxWidth(),
+          ) { subtitle ->
+            if (subtitle != null) {
+              HedvigText(
+                text = subtitle,
+                color = HedvigTheme.colorScheme.textSecondary,
+                modifier = Modifier.fillMaxWidth(),
               )
-              Spacer(modifier = Modifier.width(12.dp))
-            }
-            Column {
-              HedvigText(displayName)
-              val lastKnownSubtitle by remember { mutableStateOf(subtitle) }.apply {
-                value = subtitle ?: value
-              }
-              AnimatedContent(
-                targetState = subtitle,
-                transitionSpec = { fadeIn() togetherWith fadeOut() },
-              ) { subtitle ->
-                HedvigText(
-                  text = subtitle ?: lastKnownSubtitle ?: "",
-                  color = HedvigTheme.colorScheme.textSecondary,
-                  modifier = if (subtitle == null) Modifier.withoutPlacement() else Modifier,
-                )
-              }
+            } else {
+              Box(Modifier.fillMaxWidth()/*.height(1.dp)*/)
             }
           }
-        },
-        endSlot = {
-          titleEndSlot()
-        },
-        spaceBetween = 8.dp,
-      )
+        }
+      }
       Spacer(Modifier.height(16.dp))
       HorizontalItemsWithMaximumSpaceTaken(
         startSlot = {

--- a/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
+++ b/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
@@ -386,7 +386,7 @@ private fun QuoteCard(
                 modifier = Modifier.fillMaxWidth(),
               )
             } else {
-              Box(Modifier.fillMaxWidth()/*.height(1.dp)*/)
+              Box(Modifier.fillMaxWidth())
             }
           }
         }

--- a/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
+++ b/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
@@ -158,6 +158,7 @@ fun QuoteCard(
 
 @Composable
 fun QuoteCard(
+  quoteCardState: QuoteCardState,
   displayName: String,
   contractGroup: ContractGroup?,
   insurableLimits: List<InsurableLimit>,
@@ -171,9 +172,9 @@ fun QuoteCard(
   underDetailsContent: @Composable (QuoteCardState) -> Unit = { state ->
     QuoteCardDefaults.UnderDetailsContent(state)
   },
-) {
+  ) {
   QuoteCard(
-    quoteCardState = rememberQuoteCardState(),
+    quoteCardState = quoteCardState,
     subtitle = subtitle,
     premium = premium,
     isExcluded = isExcluded,
@@ -349,6 +350,7 @@ private fun QuoteCard(
   HedvigCard(
     modifier = modifier,
     onClick = quoteCardState::toggleState,
+    enabled = quoteCardState.isEnabled,
     interactionSource = null,
     indication = ripple(bounded = true, radius = 1000.dp),
   ) {


### PR DESCRIPTION
https://hedviginsurance.slack.com/archives/C07MM6F0DK2/p1737638802028819?thread_ts=1737038997.141969&cid=C07MM6F0DK2

This also has https://github.com/HedvigInsurance/android/pull/2388 merged since it contains a fix for the padding of the button in there