### PR TITLE
Feature/chat multiple doc and videoplayer small fixes

### DIFF
--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
@@ -415,7 +415,7 @@ private fun ChatLazyColumn(
           .fillParentMaxWidth()
           .padding(horizontal = 16.dp)
           .wrapContentWidth(alignment)
-          .fillParentMaxWidth(dynamicBubbleWidthFraction)
+          .fillMaxWidth(dynamicBubbleWidthFraction)
           .wrapContentWidth(alignment)
           .padding(bottom = 8.dp),
       )
@@ -688,10 +688,9 @@ private fun VideoMessage(
     },
   )
   val height = if (showingFullWidth) 350.dp else 220.dp
-  val updatedModifier = if (showingFullWidth) modifier.padding(horizontal = 16.dp) else modifier
   Media(
     state = state,
-    modifier = updatedModifier
+    modifier = modifier
       .height(height)
       .clip(HedvigTheme.shapes.cornerLarge)
       .background(Color.Black),


### PR DESCRIPTION
* [Make read receipt have correct padding in expanded state](https://github.com/HedvigInsurance/android/commit/a0edcec751261fabe794d53f6c6fc7b363740d0f)
* [Stop showing two retry icons on failed to be sent media](https://github.com/HedvigInsurance/android/commit/0d01d23aa38747be31691e80889819b085d247c9)