### PR TITLE
add pdf decoder

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -53,6 +53,7 @@ import com.hedvig.android.database.di.databaseModule
 import com.hedvig.android.datadog.core.addDatadogConfiguration
 import com.hedvig.android.datadog.core.di.datadogModule
 import com.hedvig.android.datadog.demo.tracking.di.datadogDemoTrackingModule
+import com.hedvig.android.design.system.hedvig.pdfrenderer.PdfDecoder
 import com.hedvig.android.feature.addon.purchase.di.addonPurchaseModule
 import com.hedvig.android.feature.change.tier.di.chooseTierModule
 import com.hedvig.android.feature.chat.di.chatModule
@@ -285,6 +286,7 @@ private val coilModule = module {
         } else {
           add(GifDecoder.Factory())
         }
+        add(PdfDecoder.Factory())
       }.memoryCache {
         MemoryCache.Builder(applicationContext).build()
       }.diskCache {

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/pdfrenderer/PdfDecoder.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/pdfrenderer/PdfDecoder.kt
@@ -1,0 +1,55 @@
+package com.hedvig.android.design.system.hedvig.pdfrenderer
+
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import androidx.core.graphics.drawable.toDrawable
+import coil.ImageLoader
+import coil.decode.DecodeResult
+import coil.decode.Decoder
+import coil.decode.ImageSource
+import coil.fetch.SourceResult
+import coil.request.Options
+
+class PdfDecoder(
+  private val source: ImageSource,
+  private val options: Options,
+) : Decoder {
+  override suspend fun decode(): DecodeResult {
+    val context = options.context
+    val pdfRenderer = PdfRenderer(
+      ParcelFileDescriptor.open(
+        source.file().toFile(),
+        ParcelFileDescriptor.MODE_READ_ONLY,
+      ),
+    )
+    val page = pdfRenderer.openPage(0)
+
+    val bitmap = Bitmap.createBitmap(
+      page.width * 2,
+      page.height * 2,
+      Bitmap.Config.ARGB_8888,
+    )
+    page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+    page.close()
+    pdfRenderer.close()
+
+    return DecodeResult(
+      drawable = bitmap.toDrawable(context.resources),
+      isSampled = false,
+    )
+  }
+
+  class Factory : Decoder.Factory {
+    override fun create(result: SourceResult, options: Options, imageLoader: ImageLoader): Decoder? {
+      if (!isApplicable(result)) return null
+      return PdfDecoder(result.source, options)
+    }
+
+    private fun isApplicable(result: SourceResult): Boolean = result.mimeType == MIME_TYPE_PDF
+  }
+
+  companion object {
+    private const val MIME_TYPE_PDF = "application/pdf"
+  }
+}

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
@@ -448,7 +448,17 @@ private fun ChatBubble(
               )
             }
 
-            CbmChatMessage.ChatMessageFile.MimeType.PDF, // todo chat: consider rendering PDFs inline in the chat
+            CbmChatMessage.ChatMessageFile.MimeType.PDF -> {
+              ChatAsyncImage(
+                model = chatMessage.url,
+                imageLoader = imageLoader,
+                cacheKey = chatMessage.id,
+                modifier = Modifier.clickable {
+                  openUrl(chatMessage.url)
+                },
+              )
+            }
+
             CbmChatMessage.ChatMessageFile.MimeType.MP4, // todo chat: consider rendering videos inline in the chat
             CbmChatMessage.ChatMessageFile.MimeType.OTHER,
             -> {
@@ -458,7 +468,11 @@ private fun ChatBubble(
         }
 
         is CbmChatMessage.ChatMessageGif -> {
-          ChatAsyncImage(model = chatMessage.gifUrl, imageLoader = imageLoader, cacheKey = chatMessage.gifUrl)
+          ChatAsyncImage(
+            model = chatMessage.gifUrl,
+            imageLoader = imageLoader,
+            cacheKey = chatMessage.gifUrl,
+          )
         }
 
         is CbmChatMessage.FailedToBeSent -> {


### PR DESCRIPTION
I first started to implement a bigger solution where we actually rendered a pdf file inside the app on a separate screen as a lazy list of pages, but then I thought that we maybe need just a preview of the pdf file in the chat itself for better readability, and the actual pdf opening is probably better in the browser for the same reasons you mentioned when we talked about opening image in browser. Then a decoder for coil (first page of the pdf) would already suffice for this purpose. 
Pls let me know if you agree, if not - I'll continue with separate screen whole file rendering :)