### PR TITLE
Fix/chat persist scroll position when coming back to it

### DIFF
--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/CbmChatViewModel.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/CbmChatViewModel.kt
@@ -68,16 +68,24 @@ internal class CbmChatViewModel(
   remoteKeyDao: RemoteKeyDao,
   chatRepository: Provider<CbmChatRepository>,
   clock: Clock,
-  scope: CoroutineScope = CoroutineScope(SupervisorJob() + AndroidUiDispatcher.Main),
+  coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + AndroidUiDispatcher.Main),
 ) : MoleculeViewModel<CbmChatEvent, CbmChatUiState>(
     initialState = CbmChatUiState.Initializing,
     presenter = CbmChatPresenter(
-      Uuid.fromString(conversationId),
-      cbmChatPresenterPagingData(conversationId, database, chatDao, remoteKeyDao, chatRepository, clock, scope),
-      chatDao,
-      chatRepository,
+      conversationId = Uuid.fromString(conversationId),
+      pagingData = cbmChatPresenterPagingData(
+        conversationId = conversationId,
+        database = database,
+        chatDao = chatDao,
+        remoteKeyDao = remoteKeyDao,
+        chatRepository = chatRepository,
+        clock = clock,
+        scope = coroutineScope,
+      ),
+      chatDao = chatDao,
+      chatRepository = chatRepository,
     ),
-    coroutineScope = scope,
+    coroutineScope = coroutineScope,
   )
 
 @OptIn(ExperimentalPagingApi::class)

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/ChatLoadedScreen.kt
@@ -153,6 +153,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -308,6 +309,7 @@ private fun ScrollToBottomEffect(
     snapshotFlow { updatedLatestChatMessage }
       .filterNotNull()
       .distinctUntilChangedBy(LatestChatMessage::id)
+      .drop(1)
       .collectLatest { chatMessage ->
         val idToScrollTo = chatMessage.id
         withTimeout(1.seconds) {

--- a/app/molecule/molecule-android/src/main/kotlin/com/hedvig/android/molecule/android/MoleculeViewModel.kt
+++ b/app/molecule/molecule-android/src/main/kotlin/com/hedvig/android/molecule/android/MoleculeViewModel.kt
@@ -9,6 +9,7 @@ import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -23,9 +24,8 @@ abstract class MoleculeViewModel<Event, State>(
   initialState: State,
   presenter: MoleculePresenter<Event, State>,
   sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(5.seconds),
-) : ViewModel() {
-  private val scope = CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
-
+  coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + AndroidUiDispatcher.Main),
+) : ViewModel(coroutineScope) {
   /**
    * Events have a capacity large enough to handle simultaneous UI events, but small enough to surface issues if they
    * get backed up for some reason.
@@ -54,7 +54,7 @@ abstract class MoleculeViewModel<Event, State>(
   }.onEach { newState: State ->
     lastState = newState
   }.stateIn(
-    scope = scope,
+    scope = viewModelScope,
     started = sharingStarted,
     initialValue = lastState,
   )


### PR DESCRIPTION
### Fix chat resetting the scroll position when navigating back to it

By moving the flow creation and caching (through cachedIn) to the
ViewModel instance, the data is persisted in a way that it is available
on the first frame. This, in combination with the LazyListState
restoring its scroll position results in everything working as expected.

---

### Allow overriding the CoroutineScope passed into MoleculeViewModel

This makes use of the new(ish) constructor of ViewModel which accepts a
a CoroutineScope which can then later be accessed through the
`ViewModel.viewModelScope` extension function

---

### Stop scrolling to the bottom of the chat on the first frame

We simply drop the first ever "latest message" as it is the one which
appears on the first time any messages are rendered on the screen.
In the cases where we just came to this screen, we will have been at the
beginning of the list regardless. And in the scenarios where we come
back to this screen which has existed before we instead want to stay at
the scroll position we had in the past