### PR TITLE
Feature/videoplayer oom

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -96,6 +96,7 @@ import com.hedvig.android.tracking.datadog.di.trackingDatadogModule
 import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import java.io.File
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -109,6 +110,8 @@ private val networkModule = module {
     val languageService = get<LanguageService>()
     val builder: OkHttpClient.Builder = OkHttpClient
       .Builder()
+      .connectTimeout(240, TimeUnit.SECONDS)
+
       .addDatadogConfiguration(get<HedvigBuildConstants>())
       .addInterceptor { chain ->
         chain.proceed(

--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -110,8 +110,6 @@ private val networkModule = module {
     val languageService = get<LanguageService>()
     val builder: OkHttpClient.Builder = OkHttpClient
       .Builder()
-      .connectTimeout(240, TimeUnit.SECONDS)
-
       .addDatadogConfiguration(get<HedvigBuildConstants>())
       .addInterceptor { chain ->
         chain.proceed(

--- a/app/app/src/main/kotlin/com/hedvig/android/app/logginginterceptor/HedvigLoggingInterceptor.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/logginginterceptor/HedvigLoggingInterceptor.kt
@@ -20,13 +20,14 @@ import okio.GzipSource
 private const val MAX_LOG_SIZE = 100 * 1024
 
 class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
-  private val logger: Logger = Logger.DEFAULT
+  private val logger: Logger = Logger.DEFAULT,
 ) : Interceptor {
-
-  @Volatile private var headersToRedact = emptySet<String>()
+  @Volatile
+  private var headersToRedact = emptySet<String>()
 
   @set:JvmName("level")
-  @Volatile var level = Level.NONE
+  @Volatile
+  var level = Level.NONE
 
   enum class Level {
     /** No logs. */
@@ -84,7 +85,7 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
      * <-- END HTTP
      * ```
      */
-    BODY
+    BODY,
   }
 
   fun interface Logger {
@@ -94,6 +95,7 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
       /** A [Logger] defaults output appropriate for the current platform. */
       @JvmField
       val DEFAULT: Logger = DefaultLogger()
+
       private class DefaultLogger : Logger {
         override fun log(message: String) {
           Platform.get().log(message)
@@ -124,7 +126,7 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
   @Deprecated(
     message = "moved to var",
     replaceWith = ReplaceWith(expression = "level"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.ERROR,
   )
   fun getLevel(): Level = level
 
@@ -195,11 +197,13 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
             logger.log("--> END ${request.method} (${requestBody.contentLength()}-byte body)")
           } else {
             logger.log(
-              "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)")
+              "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)",
+            )
           }
         } catch (e: OutOfMemoryError) {
           logger.log(
-          "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted) with OutOfMemoryError: $e")
+            "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted) with OutOfMemoryError: $e",
+          )
         }
       }
     }
@@ -219,7 +223,8 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
     val contentLength = responseBody.contentLength()
     val bodySize = if (contentLength != -1L) "$contentLength-byte" else "unknown-length"
     logger.log(
-      "<-- ${response.code}${if (response.message.isEmpty()) "" else ' ' + response.message} ${response.request.url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
+      "<-- ${response.code}${if (response.message.isEmpty()) "" else ' ' + response.message} ${response.request.url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})",
+    )
 
     if (logHeaders) {
       val headers = response.headers
@@ -283,7 +288,6 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
       !contentEncoding.equals("gzip", ignoreCase = true)
   }
 }
-
 
 internal fun Buffer.isProbablyUtf8(): Boolean {
   try {

--- a/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
+++ b/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
@@ -1,29 +1,16 @@
 package com.hedvig.android.core.fileupload
 
 import android.content.ContentResolver
-import android.content.Context
 import android.net.Uri
-import android.os.Build
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
-import androidx.annotation.RequiresApi
 import com.hedvig.android.logger.logcat
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.lang.IllegalStateException
-import java.nio.channels.FileChannel
-
-
 import java.util.Locale
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.BufferedSink
-import okio.IOException
-import okio.buffer
-import okio.source
 
 class FileService(
   private val contentResolver: ContentResolver,
@@ -37,9 +24,7 @@ class FileService(
       }
 
       override fun writeTo(sink: BufferedSink) {
-        val size = getFileSize(contentResolver, uri)
-        val maxMemory = Runtime.getRuntime().maxMemory()
-        if (size< maxMemory) {
+        if (fileDoesNotExceedMemory(uri)) {
           contentResolver.openInputStream(uri)?.use { inputStream ->
             val buffer = ByteArray(4 * 1024)
             var bytesRead: Int
@@ -51,17 +36,15 @@ class FileService(
               }
             } catch (e: OutOfMemoryError) {
               System.gc()
-              throw OutOfMemoryError("Could not open input stream for uri:$uri with OutOfMemoryError: $e")
+              error("Could not open input stream for uri:$uri with OutOfMemoryError: $e")
             }
           } ?: error("Could not open input stream for uri:$uri")
         } else {
-          throw OutOfMemoryError("Could not open input stream for uri:$uri not enough memory")
+          error("Could not open input stream for uri:$uri with OutOfMemoryError")
         }
       }
     },
   )
-
-
 
   fun getFileName(uri: Uri): String? {
     if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
@@ -105,10 +88,19 @@ class FileService(
   }
 
   private fun getFileExtension(path: String): String = MimeTypeMap.getFileExtensionFromUrl(path)
+
+  fun fileDoesNotExceedMemory(uri: Uri): Boolean {
+    val size = getFileSize(contentResolver, uri)
+    val maxMemory = Runtime.getRuntime().maxMemory()
+    logcat {
+      "Mariia: size of the file: ${size / 1024 / 1024} Mb, " +
+        "maxMemory: ${maxMemory / 1024 / 1024} Mb"
+    }
+    return size < maxMemory
+  }
 }
 
-
-fun getFileSize(contentResolver: ContentResolver, uri: Uri): Long {
+private fun getFileSize(contentResolver: ContentResolver, uri: Uri): Long {
   return contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.SIZE), null, null, null)?.use { cursor ->
     val sizeIndex = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
     if (cursor.moveToFirst()) cursor.getLong(sizeIndex) else -1

--- a/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
+++ b/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
@@ -1,15 +1,28 @@
 package com.hedvig.android.core.fileupload
 
 import android.content.ContentResolver
+import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
+import androidx.annotation.RequiresApi
+import com.hedvig.android.logger.logcat
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.lang.IllegalStateException
+import java.nio.channels.FileChannel
+
+
 import java.util.Locale
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.BufferedSink
+import okio.IOException
+import okio.buffer
 import okio.source
 
 class FileService(
@@ -24,12 +37,31 @@ class FileService(
       }
 
       override fun writeTo(sink: BufferedSink) {
-        contentResolver.openInputStream(uri)?.use { inputStream ->
-          sink.writeAll(inputStream.source())
-        } ?: error("Could not open input stream for uri:$uri")
+        val size = getFileSize(contentResolver, uri)
+        val maxMemory = Runtime.getRuntime().maxMemory()
+        if (size< maxMemory) {
+          contentResolver.openInputStream(uri)?.use { inputStream ->
+            val buffer = ByteArray(4 * 1024)
+            var bytesRead: Int
+            val outputStream = sink.outputStream()
+            try {
+              while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                outputStream.write(buffer, 0, bytesRead)
+                outputStream.flush()
+              }
+            } catch (e: OutOfMemoryError) {
+              System.gc()
+              throw OutOfMemoryError("Could not open input stream for uri:$uri with OutOfMemoryError: $e")
+            }
+          } ?: error("Could not open input stream for uri:$uri")
+        } else {
+          throw OutOfMemoryError("Could not open input stream for uri:$uri not enough memory")
+        }
       }
     },
   )
+
+
 
   fun getFileName(uri: Uri): String? {
     if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
@@ -73,4 +105,12 @@ class FileService(
   }
 
   private fun getFileExtension(path: String): String = MimeTypeMap.getFileExtensionFromUrl(path)
+}
+
+
+fun getFileSize(contentResolver: ContentResolver, uri: Uri): Long {
+  return contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+    val sizeIndex = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
+    if (cursor.moveToFirst()) cursor.getLong(sizeIndex) else -1
+  } ?: -1
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -340,7 +340,7 @@ internal class CbmChatRepositoryImpl(
       .onLeft {
       }.mapLeft {
         val errorMessage = "Failed to upload file with path:${file.absolutePath}. Error:$it"
-        logcat(LogPriority.ERROR) { errorMessage }
+        logcat(ERROR) { errorMessage }
         it.toErrorMessage().message ?: errorMessage
       }.bind()
       .firstOrNull()
@@ -351,18 +351,23 @@ internal class CbmChatRepositoryImpl(
   }
 
   private suspend fun Raise<String>.uploadMediaToBotService(uri: Uri): String {
-    val uploadToken = botServiceService
-      .uploadFile(fileService.createFormData(uri))
-      .mapLeft {
-        val errorMessage = "Failed to upload media with uri:$uri. Error:$it"
-        logcat(LogPriority.ERROR) { errorMessage }
-        it.toErrorMessage().message ?: errorMessage
-      }.bind()
-      .firstOrNull()
-      ?.uploadToken
-    ensureNotNull(uploadToken) { "No upload token" }
-    logcat { "Uploaded file with uri:$uri. UploadToken:$uploadToken" }
-    return uploadToken
+    val fileDoesNotExceedMemory = fileService.fileDoesNotExceedMemory(uri)
+    if (fileDoesNotExceedMemory) {
+      val uploadToken = botServiceService
+        .uploadFile(fileService.createFormData(uri))
+        .mapLeft {
+          val errorMessage = "Failed to upload media with uri:$uri. Error:$it"
+          logcat(ERROR) { errorMessage }
+          it.toErrorMessage().message ?: errorMessage
+        }.bind()
+        .firstOrNull()
+        ?.uploadToken
+      ensureNotNull(uploadToken) { "No upload token" }
+      logcat { "Uploaded file with uri:$uri. UploadToken:$uploadToken" }
+      return uploadToken
+    } else {
+      raise("Failed to upload media with uri:$uri with Out Of Memory error.")
+    }
   }
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/model/Sender.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/model/Sender.kt
@@ -12,6 +12,7 @@ internal fun ChatMessageSender.toSender(): Sender = when (this) {
   ChatMessageSender.MEMBER -> Sender.MEMBER
   ChatMessageSender.HEDVIG -> Sender.HEDVIG
   ChatMessageSender.UNKNOWN__ -> Sender.HEDVIG
+  ChatMessageSender.AUTOMATION -> Sender.HEDVIG
 }
 
 internal fun ChatMessageEntity.Sender.toSender(): Sender {


### PR DESCRIPTION
As far as I understand, what happens here is that if we try to upload a too big file that exceeds the whole app JVM memory (maybe we even should use `getRuntime().totalMemory()` instead of `.maxMemory()` here - not sure), 
then (despite that I tried as you see to buffer writing in the fileService - it does not help, I'm not sure if I should revert it as it was or is it still better than writing it all in the sink in one go?) the system starts urgently shutdown everything, and we can't even catch this OOM error bc there's nothing left that can catch it, so to speak :) 
So here I'm making this file size check before we even start.

Combined with this [user-friendly file size limit PR](https://github.com/HedvigInsurance/android/pull/2416) I think we're probably good. That linked PR has temporary hard-coded limitation according to our current BE requirements + user-friendly error handling.