### PR TITLE
GEN-3228 Feature/coinsured deeplink

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -345,7 +345,7 @@ internal fun HedvigNavHost(
       onNavigateToNewConversation = ::navigateToNewConversation,
       hedvigDeepLinkContainer = hedvigDeepLinkContainer,
     )
-    editCoInsuredGraph(navigator)
+    editCoInsuredGraph(navigator, hedvigDeepLinkContainer = hedvigDeepLinkContainer)
     helpCenterGraph(
       hedvigDeepLinkContainer = hedvigDeepLinkContainer,
       navigator = navigator,

--- a/app/feature/feature-edit-coinsured/src/main/graphql/QueryEligibleContractsForEditCoInsured.graphql
+++ b/app/feature/feature-edit-coinsured/src/main/graphql/QueryEligibleContractsForEditCoInsured.graphql
@@ -1,0 +1,17 @@
+query EligibleContractsForEditCoInsured {
+  currentMember {
+    activeContracts {
+      id
+      exposureDisplayName
+      currentAgreement {
+        productVariant {
+          displayName
+        }
+      }
+      supportsCoInsured
+      coInsured {
+        hasMissingInfo
+      }
+    }
+  }
+}

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetInsurancesForEditCoInsuredUseCase.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetInsurancesForEditCoInsuredUseCase.kt
@@ -58,5 +58,5 @@ internal data class InsuranceForEditOrAddCoInsured(
 
 internal enum class EditCoInsuredDestination {
   MISSING_INFO,
-  ADD_OR_REMOVE
+  ADD_OR_REMOVE,
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetInsurancesForEditCoInsuredUseCase.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetInsurancesForEditCoInsuredUseCase.kt
@@ -28,22 +28,18 @@ internal class GetInsurancesForEditCoInsuredUseCaseImpl(
         .activeContracts
       val filtered = contracts
         .filter { it.supportsCoInsured }
-      buildList {
-        filtered.forEach { contract ->
-          val destination = if (contract.coInsured?.any { it.hasMissingInfo } == true) {
-            EditCoInsuredDestination.MISSING_INFO
-          } else {
-            EditCoInsuredDestination.ADD_OR_REMOVE
-          }
-          add(
-            InsuranceForEditOrAddCoInsured(
-              destination = destination,
-              displayName = contract.currentAgreement.productVariant.displayName,
-              exposureName = contract.exposureDisplayName,
-              id = contract.id,
-            ),
-          )
+      filtered.map { contract ->
+        val destination = if (contract.coInsured?.any { it.hasMissingInfo } == true) {
+          EditCoInsuredDestination.MISSING_INFO
+        } else {
+          EditCoInsuredDestination.ADD_OR_REMOVE
         }
+        InsuranceForEditOrAddCoInsured(
+          destination = destination,
+          displayName = contract.currentAgreement.productVariant.displayName,
+          exposureName = contract.exposureDisplayName,
+          id = contract.id,
+        )
       }
     }
   }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetInsurancesForEditCoInsuredUseCase.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetInsurancesForEditCoInsuredUseCase.kt
@@ -1,0 +1,62 @@
+package com.hedvig.android.feature.editcoinsured.data
+
+import arrow.core.Either
+import arrow.core.raise.either
+import com.apollographql.apollo.ApolloClient
+import com.hedvig.android.apollo.ErrorMessage
+import com.hedvig.android.apollo.safeExecute
+import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.logger.LogPriority
+import com.hedvig.android.logger.logcat
+import octopus.EligibleContractsForEditCoInsuredQuery
+
+internal interface GetInsurancesForEditCoInsuredUseCase {
+  suspend fun invoke(): Either<ErrorMessage, List<InsuranceForEditOrAddCoInsured>>
+}
+
+internal class GetInsurancesForEditCoInsuredUseCaseImpl(
+  private val apolloClient: ApolloClient,
+) :
+  GetInsurancesForEditCoInsuredUseCase {
+  override suspend fun invoke(): Either<ErrorMessage, List<InsuranceForEditOrAddCoInsured>> {
+    return either {
+      val contracts = apolloClient.query(EligibleContractsForEditCoInsuredQuery())
+        .safeExecute(::ErrorMessage)
+        .onLeft { logcat(LogPriority.ERROR) { "Could not fetch contracts ${it.message}" } }
+        .bind()
+        .currentMember
+        .activeContracts
+      val filtered = contracts
+        .filter { it.supportsCoInsured }
+      buildList {
+        filtered.forEach { contract ->
+          val destination = if (contract.coInsured?.any { it.hasMissingInfo } == true) {
+            EditCoInsuredDestination.MISSING_INFO
+          } else {
+            EditCoInsuredDestination.ADD_OR_REMOVE
+          }
+          add(
+            InsuranceForEditOrAddCoInsured(
+              destination = destination,
+              displayName = contract.currentAgreement.productVariant.displayName,
+              exposureName = contract.exposureDisplayName,
+              id = contract.id,
+            ),
+          )
+        }
+      }
+    }
+  }
+}
+
+internal data class InsuranceForEditOrAddCoInsured(
+  val id: String,
+  val destination: EditCoInsuredDestination,
+  val displayName: String,
+  val exposureName: String,
+)
+
+internal enum class EditCoInsuredDestination {
+  MISSING_INFO,
+  ADD_OR_REMOVE
+}

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/di/EditCoInsuredModule.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/di/EditCoInsuredModule.kt
@@ -11,6 +11,8 @@ import com.hedvig.android.feature.editcoinsured.data.FetchCoInsuredPersonalInfor
 import com.hedvig.android.feature.editcoinsured.data.FetchCoInsuredPersonalInformationUseCaseImpl
 import com.hedvig.android.feature.editcoinsured.data.GetCoInsuredUseCase
 import com.hedvig.android.feature.editcoinsured.data.GetCoInsuredUseCaseImpl
+import com.hedvig.android.feature.editcoinsured.data.GetInsurancesForEditCoInsuredUseCase
+import com.hedvig.android.feature.editcoinsured.data.GetInsurancesForEditCoInsuredUseCaseImpl
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -26,6 +28,11 @@ val editCoInsuredModule = module {
     FetchCoInsuredPersonalInformationUseCaseImpl(
       get<ApolloClient>(),
     )
+  }
+
+  single<GetInsurancesForEditCoInsuredUseCase> {
+    GetInsurancesForEditCoInsuredUseCaseImpl(get<ApolloClient>(),
+      )
   }
 
   single<CreateMidtermChangeUseCase> {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/di/EditCoInsuredModule.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/di/EditCoInsuredModule.kt
@@ -14,6 +14,7 @@ import com.hedvig.android.feature.editcoinsured.data.GetCoInsuredUseCaseImpl
 import com.hedvig.android.feature.editcoinsured.data.GetInsurancesForEditCoInsuredUseCase
 import com.hedvig.android.feature.editcoinsured.data.GetInsurancesForEditCoInsuredUseCaseImpl
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredViewModel
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
@@ -31,8 +32,9 @@ val editCoInsuredModule = module {
   }
 
   single<GetInsurancesForEditCoInsuredUseCase> {
-    GetInsurancesForEditCoInsuredUseCaseImpl(get<ApolloClient>(),
-      )
+    GetInsurancesForEditCoInsuredUseCaseImpl(
+      get<ApolloClient>(),
+    )
   }
 
   single<CreateMidtermChangeUseCase> {
@@ -56,6 +58,13 @@ val editCoInsuredModule = module {
       get<FetchCoInsuredPersonalInformationUseCase>(),
       get<CreateMidtermChangeUseCase>(),
       get<CommitMidtermChangeUseCase>(),
+    )
+  }
+
+  viewModel<EditCoInsuredTriageViewModel> { (contractId: String?) ->
+    EditCoInsuredTriageViewModel(
+      get<GetInsurancesForEditCoInsuredUseCase>(),
+      contractId,
     )
   }
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredDestinations.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredDestinations.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.feature.editcoinsured.navigation
 
-import androidx.annotation.Keep
 import com.hedvig.android.navigation.common.Destination
 import com.hedvig.android.navigation.common.DestinationNavTypeAware
 import kotlin.reflect.KType
@@ -8,11 +7,6 @@ import kotlin.reflect.typeOf
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-
-// Workaround for https://issuetracker.google.com/issues/353898971
-@Keep
-@Serializable
-data object EditCoInsuredGraphDestination : Destination
 
 sealed interface EditCoInsuredDestination : Destination {
   @Serializable

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredDestinations.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredDestinations.kt
@@ -6,6 +6,7 @@ import com.hedvig.android.navigation.common.DestinationNavTypeAware
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlinx.datetime.LocalDate
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 // Workaround for https://issuetracker.google.com/issues/353898971
@@ -19,6 +20,12 @@ sealed interface EditCoInsuredDestination : Destination {
 
   @Serializable
   data class CoInsuredAddOrRemove(val contractId: String) : Destination
+
+  @Serializable
+  data class EditCoInsuredTriage(
+    @SerialName("contractId")
+    val contractId: String? = null,
+  ) : Destination
 
   @Serializable
   data class Success(val date: LocalDate) : Destination {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredGraph.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredGraph.kt
@@ -1,20 +1,51 @@
 package com.hedvig.android.feature.editcoinsured.navigation
 
 import androidx.navigation.NavGraphBuilder
+import com.hedvig.android.feature.editcoinsured.navigation.EditCoInsuredDestination.EditCoInsuredTriage
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredAddMissingInfoDestination
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredAddOrRemoveDestination
 import com.hedvig.android.feature.editcoinsured.ui.EditCoInsuredSuccessDestination
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageDestination
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageViewModel
+import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
 import com.hedvig.android.navigation.compose.navgraph
 import com.hedvig.android.navigation.compose.typedPopUpTo
+import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.navigation.core.Navigator
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
-fun NavGraphBuilder.editCoInsuredGraph(navigator: Navigator) {
+fun NavGraphBuilder.editCoInsuredGraph(navigator: Navigator, hedvigDeepLinkContainer: HedvigDeepLinkContainer) {
   navgraph<EditCoInsuredGraphDestination>(
-    startDestination = EditCoInsuredDestination.CoInsuredAddOrRemove::class,
+    startDestination = EditCoInsuredDestination.EditCoInsuredTriage::class,
   ) {
+    navdestination<EditCoInsuredTriage>(
+      deepLinks = navDeepLinks(
+        hedvigDeepLinkContainer.editCoInsured,
+        hedvigDeepLinkContainer.editCoInsuredWithoutContractId,
+      ),
+    ) {
+      val viewModel: EditCoInsuredTriageViewModel = koinViewModel { parametersOf(contractId) }
+      EditCoInsuredTriageDestination(
+        viewModel = viewModel,
+        navigateUp = navigator::navigateUp,
+        navigateToAddMissingInfo = { contractId: String ->
+          navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddInfo(contractId)) {
+            typedPopUpTo<EditCoInsuredGraphDestination> {
+              inclusive = true
+            }
+          }
+        },
+        navigateToAddOrRemoveCoInsured = { contractId: String ->
+          navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddOrRemove(contractId)) {
+            typedPopUpTo<EditCoInsuredGraphDestination> {
+              inclusive = true
+            }
+          }
+        },
+      )
+    }
     navdestination<EditCoInsuredDestination.CoInsuredAddInfo> {
       EditCoInsuredAddMissingInfoDestination(
         viewModel = koinViewModel { parametersOf(contractId) },

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredGraph.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/navigation/EditCoInsuredGraph.kt
@@ -9,7 +9,6 @@ import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageDes
 import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageViewModel
 import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
-import com.hedvig.android.navigation.compose.navgraph
 import com.hedvig.android.navigation.compose.typedPopUpTo
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.navigation.core.Navigator
@@ -17,68 +16,65 @@ import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
 fun NavGraphBuilder.editCoInsuredGraph(navigator: Navigator, hedvigDeepLinkContainer: HedvigDeepLinkContainer) {
-  navgraph<EditCoInsuredGraphDestination>(
-    startDestination = EditCoInsuredDestination.EditCoInsuredTriage::class,
+  navdestination<EditCoInsuredTriage>(
+    deepLinks = navDeepLinks(
+      hedvigDeepLinkContainer.editCoInsured,
+      hedvigDeepLinkContainer.editCoInsuredWithoutContractId,
+    ),
   ) {
-    navdestination<EditCoInsuredTriage>(
-      deepLinks = navDeepLinks(
-        hedvigDeepLinkContainer.editCoInsured,
-        hedvigDeepLinkContainer.editCoInsuredWithoutContractId,
-      ),
-    ) {
-      val viewModel: EditCoInsuredTriageViewModel = koinViewModel { parametersOf(contractId) }
-      EditCoInsuredTriageDestination(
-        viewModel = viewModel,
-        navigateUp = navigator::navigateUp,
-        navigateToAddMissingInfo = { contractId: String ->
-          navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddInfo(contractId)) {
-            typedPopUpTo<EditCoInsuredGraphDestination> {
-              inclusive = true
-            }
+    val viewModel: EditCoInsuredTriageViewModel = koinViewModel { parametersOf(contractId) }
+    EditCoInsuredTriageDestination(
+      viewModel = viewModel,
+      navigateUp = navigator::navigateUp,
+      navigateToAddMissingInfo = { contractId: String ->
+        navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddInfo(contractId)) {
+          typedPopUpTo<EditCoInsuredTriage> {
+            inclusive = true
           }
-        },
-        navigateToAddOrRemoveCoInsured = { contractId: String ->
-          navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddOrRemove(contractId)) {
-            typedPopUpTo<EditCoInsuredGraphDestination> {
-              inclusive = true
-            }
+        }
+      },
+      navigateToAddOrRemoveCoInsured = { contractId: String ->
+        navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddOrRemove(contractId)) {
+          typedPopUpTo<EditCoInsuredTriage> {
+            inclusive = true
           }
-        },
-      )
-    }
-    navdestination<EditCoInsuredDestination.CoInsuredAddInfo> {
-      EditCoInsuredAddMissingInfoDestination(
-        viewModel = koinViewModel { parametersOf(contractId) },
-        navigateToSuccessScreen = {
-          navigator.navigateUnsafe(EditCoInsuredDestination.Success(it)) {
-            typedPopUpTo<EditCoInsuredGraphDestination> {
-              inclusive = true
-            }
+        }
+      },
+    )
+  }
+
+  navdestination<EditCoInsuredDestination.CoInsuredAddInfo> {
+    EditCoInsuredAddMissingInfoDestination(
+      viewModel = koinViewModel { parametersOf(contractId) },
+      navigateToSuccessScreen = {
+        navigator.navigateUnsafe(EditCoInsuredDestination.Success(it)) {
+          typedPopUpTo<EditCoInsuredDestination.CoInsuredAddInfo> {
+            inclusive = true
           }
-        },
-        navigateUp = navigator::navigateUp,
-      )
-    }
-    navdestination<EditCoInsuredDestination.CoInsuredAddOrRemove> {
-      EditCoInsuredAddOrRemoveDestination(
-        koinViewModel { parametersOf(contractId) },
-        navigateToSuccessScreen = {
-          navigator.navigateUnsafe(EditCoInsuredDestination.Success(it)) {
-            typedPopUpTo<EditCoInsuredGraphDestination> {
-              inclusive = true
-            }
+        }
+      },
+      navigateUp = navigator::navigateUp,
+    )
+  }
+  navdestination<EditCoInsuredDestination.CoInsuredAddOrRemove> {
+    EditCoInsuredAddOrRemoveDestination(
+      koinViewModel { parametersOf(contractId) },
+      navigateToSuccessScreen = {
+        navigator.navigateUnsafe(EditCoInsuredDestination.Success(it)) {
+          typedPopUpTo<EditCoInsuredDestination.CoInsuredAddOrRemove> {
+            inclusive = true
           }
-        },
-        navigateUp = navigator::navigateUp,
-      )
-    }
-    navdestination<EditCoInsuredDestination.Success>(
-      EditCoInsuredDestination.Success,
-    ) {
-      EditCoInsuredSuccessDestination(
-        date = date,
-        popBackstack = navigator::popBackStack,
-      )
-    }
+        }
+      },
+      navigateUp = navigator::navigateUp,
+    )
+  }
+  navdestination<EditCoInsuredDestination.Success>(
+    EditCoInsuredDestination.Success,
+  ) {
+    EditCoInsuredSuccessDestination(
+      date = date,
+      popBackstack = navigator::popBackStack,
+    )
   }
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageDestination.kt
@@ -1,9 +1,189 @@
 package com.hedvig.android.feature.editcoinsured.ui.triage
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.LineBreak
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hedvig.android.design.system.hedvig.ChosenState.Chosen
+import com.hedvig.android.design.system.hedvig.ChosenState.NotChosen
+import com.hedvig.android.design.system.hedvig.HedvigButton
+import com.hedvig.android.design.system.hedvig.HedvigErrorSection
+import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgress
+import com.hedvig.android.design.system.hedvig.HedvigScaffold
+import com.hedvig.android.design.system.hedvig.HedvigText
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.Icon
+import com.hedvig.android.design.system.hedvig.IconButton
+import com.hedvig.android.design.system.hedvig.RadioGroup
+import com.hedvig.android.design.system.hedvig.RadioGroupDefaults.RadioGroupSize
+import com.hedvig.android.design.system.hedvig.RadioGroupDefaults.RadioGroupStyle
+import com.hedvig.android.design.system.hedvig.RadioOptionData
+import com.hedvig.android.design.system.hedvig.RadioOptionGroupData.RadioOptionGroupDataWithLabel
+import com.hedvig.android.design.system.hedvig.icon.Close
+import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
+import com.hedvig.android.feature.editcoinsured.data.InsuranceForEditOrAddCoInsured
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageUiState.Failure
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageUiState.Loading
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageUiState.Success
+import hedvig.resources.R
 
 @Composable
 internal fun EditCoInsuredTriageDestination(
-  viewModel: EditCoInsuredTriageViewModel) {
+  viewModel: EditCoInsuredTriageViewModel,
+  navigateUp: () -> Unit,
+  navigateToAddMissingInfo: (String) -> Unit,
+  navigateToAddOrRemoveCoInsured: (String) -> Unit,
+) {
+  val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+  EditCoInsuredTriageScreen(
+    uiState = uiState,
+    navigateUp = navigateUp,
+    reload = {
+      viewModel.emit(EditCoInsuredTriageEvent.Reload)
+    },
+    submitSelectedInsurance = {
+      viewModel.emit(EditCoInsuredTriageEvent.OnContinueWithSelected)
+    },
+    selectInsurance = {
+      viewModel.emit(EditCoInsuredTriageEvent.SelectInsurance(it))
+    },
+    clearNavigation = {
+      viewModel.emit(EditCoInsuredTriageEvent.ClearNavigation)
+    },
+    navigateToAddMissingInfo = navigateToAddMissingInfo,
+    navigateToAddOrRemoveCoInsured = navigateToAddOrRemoveCoInsured,
+  )
+}
 
+@Composable
+private fun EditCoInsuredTriageScreen(
+  uiState: EditCoInsuredTriageUiState,
+  navigateUp: () -> Unit,
+  reload: () -> Unit,
+  navigateToAddMissingInfo: (String) -> Unit,
+  navigateToAddOrRemoveCoInsured: (String) -> Unit,
+  submitSelectedInsurance: () -> Unit,
+  selectInsurance: (id: String) -> Unit,
+  clearNavigation: () -> Unit,
+) {
+  when (uiState) {
+    Failure -> HedvigScaffold(
+      navigateUp = navigateUp,
+    ) {
+      HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f))
+    }
+
+    Loading -> HedvigFullScreenCenterAlignedProgress()
+    is Success -> {
+      LaunchedEffect(uiState.idToNavigateToAddOrRemoveCoInsured) {
+        if (uiState.idToNavigateToAddOrRemoveCoInsured != null) {
+          clearNavigation()
+          navigateToAddOrRemoveCoInsured(uiState.idToNavigateToAddOrRemoveCoInsured)
+        }
+      }
+      LaunchedEffect(uiState.idToNavigateToAddMissingInfo) {
+        if (uiState.idToNavigateToAddMissingInfo != null) {
+          clearNavigation()
+          navigateToAddMissingInfo(uiState.idToNavigateToAddMissingInfo)
+        }
+      }
+      if (uiState.idToNavigateToAddMissingInfo == null && uiState.idToNavigateToAddOrRemoveCoInsured == null) {
+        SuccessScreen(
+          uiState = uiState,
+          navigateUp = navigateUp,
+          submitSelectedInsurance = submitSelectedInsurance,
+          selectInsurance = selectInsurance,
+        )
+      } else {
+        HedvigFullScreenCenterAlignedProgress()
+      }
+    }
+  }
+}
+
+@Composable
+private fun SuccessScreen(
+  uiState: Success,
+  navigateUp: () -> Unit,
+  submitSelectedInsurance: () -> Unit,
+  selectInsurance: (id: String) -> Unit,
+) {
+  HedvigScaffold(
+    navigateUp = navigateUp,
+    topAppBarText = "",
+    topAppBarActions = {
+      IconButton(
+        modifier = Modifier.size(24.dp),
+        onClick = { navigateUp() },
+        content = {
+          Icon(
+            imageVector = HedvigIcons.Close,
+            contentDescription = null,
+          )
+        },
+      )
+    },
+  ) {
+    Spacer(modifier = Modifier.height(8.dp))
+    HedvigText(
+      text = stringResource(R.string.HC_QUICK_ACTIONS_EDIT_COINSURED),
+      style = HedvigTheme.typography.headlineMedium,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    HedvigText(
+      style = HedvigTheme.typography.headlineMedium.copy(
+        lineBreak = LineBreak.Heading,
+        color = HedvigTheme.colorScheme.textSecondary,
+      ),
+      text = stringResource(R.string.HC_QUICK_ACTIONS_CO_INSURED_SUBTITLE),
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(16.dp))
+    val radioOptionData = mapToListOfDataWithLabel(uiState.list, uiState.selected)
+    RadioGroup(
+      onOptionClick = { insuranceId -> selectInsurance(insuranceId) },
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+      radioGroupSize = RadioGroupSize.Medium,
+      radioGroupStyle = RadioGroupStyle.Vertical.Label(radioOptionData),
+    )
+    Spacer(Modifier.height(12.dp))
+    HedvigButton(
+      stringResource(id = R.string.general_continue_button),
+      enabled = uiState.selected != null,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+      onClick = submitSelectedInsurance,
+    )
+    Spacer(Modifier.height(16.dp))
+  }
+}
+
+private fun mapToListOfDataWithLabel(
+  list: List<InsuranceForEditOrAddCoInsured>,
+  selectedInsurance: InsuranceForEditOrAddCoInsured?,
+): List<RadioOptionGroupDataWithLabel> {
+  return list.map { insurance ->
+    RadioOptionGroupDataWithLabel(
+      RadioOptionData(
+        id = insurance.id,
+        optionText = insurance.displayName,
+        chosenState = if (selectedInsurance == insurance) Chosen else NotChosen,
+      ),
+      labelText = insurance.exposureName,
+    )
+  }
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageDestination.kt
@@ -1,0 +1,9 @@
+package com.hedvig.android.feature.editcoinsured.ui.triage
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun EditCoInsuredTriageDestination(
+  viewModel: EditCoInsuredTriageViewModel) {
+
+}

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageViewModel.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageViewModel.kt
@@ -1,0 +1,4 @@
+package com.hedvig.android.feature.editcoinsured.ui.triage
+
+class EditCoInsuredTriageViewModel {
+}

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageViewModel.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageViewModel.kt
@@ -1,4 +1,127 @@
 package com.hedvig.android.feature.editcoinsured.ui.triage
 
-class EditCoInsuredTriageViewModel {
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import com.hedvig.android.feature.editcoinsured.data.EditCoInsuredDestination
+import com.hedvig.android.feature.editcoinsured.data.GetInsurancesForEditCoInsuredUseCase
+import com.hedvig.android.feature.editcoinsured.data.InsuranceForEditOrAddCoInsured
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageEvent.OnContinueWithSelected
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageUiState.Failure
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageUiState.Loading
+import com.hedvig.android.feature.editcoinsured.ui.triage.EditCoInsuredTriageUiState.Success
+import com.hedvig.android.molecule.android.MoleculeViewModel
+import com.hedvig.android.molecule.public.MoleculePresenter
+import com.hedvig.android.molecule.public.MoleculePresenterScope
+
+
+internal class EditCoInsuredTriageViewModel(
+  getInsuranceForEditCoInsuredUseCase: GetInsurancesForEditCoInsuredUseCase,
+  insuranceId: String?
+) : MoleculeViewModel<
+  EditCoInsuredTriageEvent,
+  EditCoInsuredTriageUiState,
+  >(
+  initialState = Loading,
+  presenter = EditCoInsuredTriagePresenter(getInsuranceForEditCoInsuredUseCase, insuranceId),
+)
+
+internal class EditCoInsuredTriagePresenter(
+  private val getInsuranceForEditCoInsuredUseCase: GetInsurancesForEditCoInsuredUseCase,
+  private val insuranceId: String?
+) : MoleculePresenter<
+  EditCoInsuredTriageEvent,
+  EditCoInsuredTriageUiState,
+  > {
+  @Composable
+  override fun MoleculePresenterScope<EditCoInsuredTriageEvent>.present(
+    lastState: EditCoInsuredTriageUiState,
+  ): EditCoInsuredTriageUiState {
+    var loadIteration by remember { mutableIntStateOf(0) }
+    var currentState by remember { mutableStateOf(lastState) }
+    var selected by remember {
+      mutableStateOf((currentState as? Success)?.selected) }
+    CollectEvents { event ->
+      when (event) {
+        is OnContinueWithSelected -> {
+          val currentStateValue = currentState as? Success ?: return@CollectEvents
+          selected?.let {
+            currentState = when (it.destination) {
+              EditCoInsuredDestination.MISSING_INFO -> currentStateValue.copy(
+                idToNavigateToAddMissingInfo = it.id
+              )
+              EditCoInsuredDestination.ADD_OR_REMOVE -> currentStateValue.copy(
+                idToNavigateToAddOrRemoveCoInsured = it.id
+              )
+            }
+          }
+        }
+        EditCoInsuredTriageEvent.Reload -> loadIteration++
+        EditCoInsuredTriageEvent.ClearNavigation -> {
+          val currentStateValue = currentState as? Success ?: return@CollectEvents
+          currentState = currentStateValue.copy(idToNavigateToAddMissingInfo = null,
+            idToNavigateToAddOrRemoveCoInsured = null)
+        }
+        is EditCoInsuredTriageEvent.SelectInsurance -> {
+          val currentStateValue = currentState as? Success ?: return@CollectEvents
+          val selectedInsurance = currentStateValue.list.first { it.id == event.id }
+          selected = selectedInsurance
+        }
+      }
+    }
+    LaunchedEffect(loadIteration) {
+      currentState = Loading
+      getInsuranceForEditCoInsuredUseCase.invoke().fold(
+        ifLeft = {
+          currentState = Failure
+        },
+        ifRight = { data ->
+          val preselected = if (insuranceId!=null) {
+            data.firstOrNull { it.id==insuranceId }
+          } else null
+          currentState = Success(
+            list = data,
+            selected = preselected,
+            idToNavigateToAddMissingInfo =
+            if (preselected?.destination==EditCoInsuredDestination.MISSING_INFO) insuranceId else null,
+            idToNavigateToAddOrRemoveCoInsured =
+            if (preselected?.destination==EditCoInsuredDestination.ADD_OR_REMOVE) insuranceId else null,
+          )
+        },
+      )
+    }
+    val currentStateValue = currentState
+    return when (currentStateValue) {
+      Failure -> Failure
+      Loading -> Loading
+      is Success -> currentStateValue.copy(selected = selected)
+    }
+  }
+}
+
+internal sealed interface EditCoInsuredTriageEvent {
+  data object OnContinueWithSelected : EditCoInsuredTriageEvent
+
+  data object Reload : EditCoInsuredTriageEvent
+
+  data class SelectInsurance(val id: String) : EditCoInsuredTriageEvent
+
+  data object ClearNavigation : EditCoInsuredTriageEvent
+}
+
+internal sealed interface EditCoInsuredTriageUiState {
+  data object Loading : EditCoInsuredTriageUiState
+
+  data object Failure : EditCoInsuredTriageUiState
+
+  data class Success(
+    val list: List<InsuranceForEditOrAddCoInsured>,
+    val selected: InsuranceForEditOrAddCoInsured?,
+    val idToNavigateToAddMissingInfo: String? = null,
+    val idToNavigateToAddOrRemoveCoInsured: String? = null,
+  ) : EditCoInsuredTriageUiState
 }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageViewModel.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/triage/EditCoInsuredTriageViewModel.kt
@@ -2,10 +2,10 @@ package com.hedvig.android.feature.editcoinsured.ui.triage
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import com.hedvig.android.feature.editcoinsured.data.EditCoInsuredDestination
 import com.hedvig.android.feature.editcoinsured.data.GetInsurancesForEditCoInsuredUseCase
@@ -18,24 +18,23 @@ import com.hedvig.android.molecule.android.MoleculeViewModel
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 
-
 internal class EditCoInsuredTriageViewModel(
   getInsuranceForEditCoInsuredUseCase: GetInsurancesForEditCoInsuredUseCase,
-  insuranceId: String?
+  insuranceId: String?,
 ) : MoleculeViewModel<
-  EditCoInsuredTriageEvent,
-  EditCoInsuredTriageUiState,
+    EditCoInsuredTriageEvent,
+    EditCoInsuredTriageUiState,
   >(
-  initialState = Loading,
-  presenter = EditCoInsuredTriagePresenter(getInsuranceForEditCoInsuredUseCase, insuranceId),
-)
+    initialState = Loading,
+    presenter = EditCoInsuredTriagePresenter(getInsuranceForEditCoInsuredUseCase, insuranceId),
+  )
 
 internal class EditCoInsuredTriagePresenter(
   private val getInsuranceForEditCoInsuredUseCase: GetInsurancesForEditCoInsuredUseCase,
-  private val insuranceId: String?
+  private val insuranceId: String?,
 ) : MoleculePresenter<
-  EditCoInsuredTriageEvent,
-  EditCoInsuredTriageUiState,
+    EditCoInsuredTriageEvent,
+    EditCoInsuredTriageUiState,
   > {
   @Composable
   override fun MoleculePresenterScope<EditCoInsuredTriageEvent>.present(
@@ -44,7 +43,8 @@ internal class EditCoInsuredTriagePresenter(
     var loadIteration by remember { mutableIntStateOf(0) }
     var currentState by remember { mutableStateOf(lastState) }
     var selected by remember {
-      mutableStateOf((currentState as? Success)?.selected) }
+      mutableStateOf((currentState as? Success)?.selected)
+    }
     CollectEvents { event ->
       when (event) {
         is OnContinueWithSelected -> {
@@ -52,10 +52,10 @@ internal class EditCoInsuredTriagePresenter(
           selected?.let {
             currentState = when (it.destination) {
               EditCoInsuredDestination.MISSING_INFO -> currentStateValue.copy(
-                idToNavigateToAddMissingInfo = it.id
+                idToNavigateToAddMissingInfo = it.id,
               )
               EditCoInsuredDestination.ADD_OR_REMOVE -> currentStateValue.copy(
-                idToNavigateToAddOrRemoveCoInsured = it.id
+                idToNavigateToAddOrRemoveCoInsured = it.id,
               )
             }
           }
@@ -63,8 +63,10 @@ internal class EditCoInsuredTriagePresenter(
         EditCoInsuredTriageEvent.Reload -> loadIteration++
         EditCoInsuredTriageEvent.ClearNavigation -> {
           val currentStateValue = currentState as? Success ?: return@CollectEvents
-          currentState = currentStateValue.copy(idToNavigateToAddMissingInfo = null,
-            idToNavigateToAddOrRemoveCoInsured = null)
+          currentState = currentStateValue.copy(
+            idToNavigateToAddMissingInfo = null,
+            idToNavigateToAddOrRemoveCoInsured = null,
+          )
         }
         is EditCoInsuredTriageEvent.SelectInsurance -> {
           val currentStateValue = currentState as? Success ?: return@CollectEvents
@@ -80,17 +82,22 @@ internal class EditCoInsuredTriagePresenter(
           currentState = Failure
         },
         ifRight = { data ->
-          val preselected = if (insuranceId!=null) {
-            data.firstOrNull { it.id==insuranceId }
-          } else null
-          currentState = Success(
+          val preselected = if (insuranceId != null) {
+            data.firstOrNull { it.id == insuranceId }
+          } else if (data.size == 1) {
+            data[0]
+          } else {
+            null
+          }
+          val success = Success(
             list = data,
             selected = preselected,
             idToNavigateToAddMissingInfo =
-            if (preselected?.destination==EditCoInsuredDestination.MISSING_INFO) insuranceId else null,
+              if (preselected?.destination == EditCoInsuredDestination.MISSING_INFO) preselected.id else null,
             idToNavigateToAddOrRemoveCoInsured =
-            if (preselected?.destination==EditCoInsuredDestination.ADD_OR_REMOVE) insuranceId else null,
+              if (preselected?.destination == EditCoInsuredDestination.ADD_OR_REMOVE) preselected.id else null,
           )
+          currentState = success
         },
       )
     }

--- a/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/HelpCenterGraph.kt
+++ b/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/HelpCenterGraph.kt
@@ -81,6 +81,7 @@ fun NavGraphBuilder.helpCenterGraph(
                   with(navigator) {
                     backStackEntry.navigate(
                       ChooseInsuranceToEditCoInsured,
+                      //todo: change to EditCoinsuredTriage!
                     )
                   }
                 }

--- a/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/HelpCenterGraph.kt
+++ b/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/HelpCenterGraph.kt
@@ -81,7 +81,7 @@ fun NavGraphBuilder.helpCenterGraph(
                   with(navigator) {
                     backStackEntry.navigate(
                       ChooseInsuranceToEditCoInsured,
-                      //todo: change to EditCoinsuredTriage!
+                      // todo: change to EditCoinsuredTriage!
                     )
                   }
                 }

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
@@ -20,6 +20,12 @@ interface HedvigDeepLinkContainer {
   // A specific contract destination with a contractId. If none match, an empty screen is shown
   val contract: List<String>
 
+  //No contractId, either a screen with a list or redirect further
+  val editCoInsuredWithoutContractId: List<String>
+
+  // A specific destination  for editing co-insured with a contractId. If none match, an error screen is shown
+  val editCoInsured: List<String>
+
   val terminateInsurance: List<String> // The screen with a list of insurances eligible for self-service cancellation
 
   val forever: List<String> // The forever/referrals destination, showing the existing discount and the unique code
@@ -71,7 +77,13 @@ internal class HedvigDeepLinkContainerImpl(
   override val contract: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
     "$baseDeepLinkDomain/contract?contractId={contractId}"
   }
+  override val editCoInsuredWithoutContractId: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
+    "$baseDeepLinkDomain/edit-coinsured"
+  }
 
+  override val editCoInsured: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
+    "$baseDeepLinkDomain/edit-coinsured?contractId={contractId}"
+  }
   override val terminateInsurance: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
     "$baseDeepLinkDomain/terminate-contract?contractId={contractId}"
   }
@@ -112,6 +124,8 @@ val HedvigDeepLinkContainer.allDeepLinkUriPatterns: List<String>
     insurances.first(),
     contract.first(),
     contractWithoutContractId.first(),
+    editCoInsured.first(),
+    editCoInsuredWithoutContractId.first(),
     terminateInsurance.first(),
     forever.first(),
     profile.first(),

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
@@ -20,7 +20,7 @@ interface HedvigDeepLinkContainer {
   // A specific contract destination with a contractId. If none match, an empty screen is shown
   val contract: List<String>
 
-  //No contractId, either a screen with a list or redirect further
+  // No contractId, either a screen with a list or redirect further
   val editCoInsuredWithoutContractId: List<String>
 
   // A specific destination  for editing co-insured with a contractId. If none match, an error screen is shown


### PR DESCRIPTION
Deeplink to edit coInsured, with and without arguments.

Not sure what to do with navigation here, again. if I move triage into the graph and make it graph's startDestination, scaffold back Icon drom missinginfo/addOrRemove destination recreates the startDestination, so I have to press button twice; if I move outside the graph, set startDestination back to AddMissingInfo and get there by deeplink with no arguments, it crashes bc it tries to recreate graph with no argument in the start destination.