### PR TITLE
Feature travel certificates history deep link

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Density
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
@@ -147,7 +146,6 @@ internal fun HedvigNavHost(
     homeGraph(
       nestedGraphs = {
         nestedHomeGraphs(
-          density = density,
           hedvigAppState = hedvigAppState,
           hedvigBuildConstants = hedvigBuildConstants,
           hedvigDeepLinkContainer = hedvigDeepLinkContainer,
@@ -386,7 +384,6 @@ internal fun HedvigNavHost(
 }
 
 private fun NavGraphBuilder.nestedHomeGraphs(
-  density: Density,
   hedvigAppState: HedvigAppState,
   hedvigBuildConstants: HedvigBuildConstants,
   hedvigDeepLinkContainer: HedvigDeepLinkContainer,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -150,6 +150,7 @@ internal fun HedvigNavHost(
           density = density,
           hedvigAppState = hedvigAppState,
           hedvigBuildConstants = hedvigBuildConstants,
+          hedvigDeepLinkContainer = hedvigDeepLinkContainer,
           navigator = navigator,
           shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale,
           externalNavigator = externalNavigator,
@@ -388,6 +389,7 @@ private fun NavGraphBuilder.nestedHomeGraphs(
   density: Density,
   hedvigAppState: HedvigAppState,
   hedvigBuildConstants: HedvigBuildConstants,
+  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
   navigator: Navigator,
   shouldShowRequestPermissionRationale: (String) -> Boolean,
   externalNavigator: ExternalNavigator,
@@ -410,9 +412,9 @@ private fun NavGraphBuilder.nestedHomeGraphs(
     applicationId = hedvigBuildConstants.appId,
   )
   travelCertificateGraph(
-    density = density,
     navigator = navigator,
     applicationId = hedvigBuildConstants.appId,
+    hedvigDeepLinkContainer = hedvigDeepLinkContainer,
     onNavigateToCoInsuredAddInfo = { contractId ->
       navigator.navigateUnsafe(EditCoInsuredDestination.CoInsuredAddInfo(contractId))
     },

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/navigation/TravelCertificateGraph.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/navigation/TravelCertificateGraph.kt
@@ -1,7 +1,6 @@
 package com.hedvig.android.feature.travelcertificate.navigation
 
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.Density
 import androidx.navigation.NavGraphBuilder
 import com.hedvig.android.core.common.android.sharePDF
 import com.hedvig.android.feature.travelcertificate.ui.choose.ChooseContractForCertificateDestination
@@ -15,24 +14,28 @@ import com.hedvig.android.feature.travelcertificate.ui.history.CertificateHistor
 import com.hedvig.android.feature.travelcertificate.ui.history.TravelCertificateHistoryDestination
 import com.hedvig.android.feature.travelcertificate.ui.overview.TravelCertificateOverviewDestination
 import com.hedvig.android.feature.travelcertificate.ui.overview.TravelCertificateOverviewViewModel
+import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
 import com.hedvig.android.navigation.compose.navgraph
 import com.hedvig.android.navigation.compose.typedPopUpTo
+import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.navigation.core.Navigator
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
 fun NavGraphBuilder.travelCertificateGraph(
-  density: Density,
   navigator: Navigator,
   applicationId: String,
+  hedvigDeepLinkContainer: HedvigDeepLinkContainer,
   onNavigateToCoInsuredAddInfo: (String) -> Unit,
   onNavigateToAddonPurchaseFlow: (List<String>) -> Unit,
 ) {
   navgraph<TravelCertificateGraphDestination>(
     startDestination = TravelCertificateDestination.TravelCertificateHistory::class,
   ) {
-    navdestination<TravelCertificateDestination.TravelCertificateHistory> { navBackStackEntry ->
+    navdestination<TravelCertificateDestination.TravelCertificateHistory>(
+      deepLinks = navDeepLinks(hedvigDeepLinkContainer.travelCertificate)
+    ) { navBackStackEntry ->
       val viewModel: CertificateHistoryViewModel = koinViewModel()
       val localContext = LocalContext.current
       TravelCertificateHistoryDestination(

--- a/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
+++ b/app/navigation/navigation-core/src/main/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
@@ -48,6 +48,7 @@ interface HedvigDeepLinkContainer {
 
   // Travel addon purchase flow
   val travelAddon: List<String>
+  val travelCertificate: List<String> // The screen which shows existing and allows creating new travel certificates
 }
 
 internal class HedvigDeepLinkContainerImpl(
@@ -119,6 +120,9 @@ internal class HedvigDeepLinkContainerImpl(
   override val travelAddon: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
     "$baseDeepLinkDomain/travel-addon"
   }
+  override val travelCertificate: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
+    "$baseDeepLinkDomain/travelCertificate"
+  }
 }
 
 val HedvigDeepLinkContainer.allDeepLinkUriPatterns: List<String>
@@ -145,4 +149,5 @@ val HedvigDeepLinkContainer.allDeepLinkUriPatterns: List<String>
     inbox.first(),
     conversation.first(),
     travelAddon.first(),
+    travelCertificate.first(),
   )


### PR DESCRIPTION
From:
https://hedviginsurance.slack.com/archives/C08C1DG4TFD/p1739365049499809?thread_ts=1739364938.167379&cid=C08C1DG4TFD

Looks like there is a deep link which we did not yet support.

Tested by running
```
adb shell am start -a android.intent.action.VIEW -d "https://dev.hedvigit.com/deeplinks/travelCertificate"
```