### PR TITLE
Omit multipart from logs and add hardcoded 48 MB file size upload limit

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -96,7 +96,6 @@ import com.hedvig.android.tracking.datadog.di.trackingDatadogModule
 import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import java.io.File
-import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import org.koin.dsl.bind
 import org.koin.dsl.module

--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -96,6 +96,7 @@ import com.hedvig.android.tracking.datadog.di.trackingDatadogModule
 import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import java.io.File
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -109,6 +110,8 @@ private val networkModule = module {
     val languageService = get<LanguageService>()
     val builder: OkHttpClient.Builder = OkHttpClient
       .Builder()
+      .connectTimeout(240, TimeUnit.SECONDS)
+
       .addDatadogConfiguration(get<HedvigBuildConstants>())
       .addInterceptor { chain ->
         chain.proceed(

--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -110,8 +110,6 @@ private val networkModule = module {
     val languageService = get<LanguageService>()
     val builder: OkHttpClient.Builder = OkHttpClient
       .Builder()
-      .connectTimeout(240, TimeUnit.SECONDS)
-
       .addDatadogConfiguration(get<HedvigBuildConstants>())
       .addInterceptor { chain ->
         chain.proceed(

--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -27,6 +27,7 @@ import com.hedvig.android.apollo.di.networkCacheManagerModule
 import com.hedvig.android.app.apollo.DeviceIdInterceptor
 import com.hedvig.android.app.apollo.LoggingInterceptor
 import com.hedvig.android.app.apollo.LogoutOnUnauthenticatedInterceptor
+import com.hedvig.android.app.logginginterceptor.HedvigHttpLoggingInterceptor
 import com.hedvig.android.app.notification.senders.ChatNotificationSender
 import com.hedvig.android.app.notification.senders.ContactInfoSender
 import com.hedvig.android.app.notification.senders.CrossSellNotificationSender
@@ -96,7 +97,6 @@ import com.hedvig.app.BuildConfig
 import com.hedvig.app.R
 import java.io.File
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import timber.log.Timber
@@ -129,14 +129,14 @@ private val networkModule = module {
         )
       }.addInterceptor(DeviceIdInterceptor(get(), get()))
     if (!get<HedvigBuildConstants>().isProduction) {
-      val logger = HttpLoggingInterceptor { message ->
+      val logger = HedvigHttpLoggingInterceptor { message ->
         if (message.contains("Content-Disposition")) {
           Timber.tag("OkHttp").v("File upload omitted from log")
         } else {
           Timber.tag("OkHttp").v(message)
         }
       }
-      logger.level = HttpLoggingInterceptor.Level.BODY
+      logger.level = HedvigHttpLoggingInterceptor.Level.BODY
       builder.addInterceptor(logger)
     }
     builder

--- a/app/app/src/main/kotlin/com/hedvig/android/app/logginginterceptor/HedvigLoggingInterceptor.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/logginginterceptor/HedvigLoggingInterceptor.kt
@@ -1,0 +1,302 @@
+package com.hedvig.android.app.logginginterceptor
+
+import java.io.EOFException
+import java.io.IOException
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.TreeSet
+import java.util.concurrent.TimeUnit
+import kotlin.collections.plusAssign
+import kotlin.text.equals
+import kotlin.text.plus
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.internal.http.promisesBody
+import okhttp3.internal.platform.Platform
+import okio.Buffer
+import okio.GzipSource
+
+private const val MAX_LOG_SIZE = 100 * 1024
+
+class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
+  private val logger: Logger = Logger.DEFAULT
+) : Interceptor {
+
+  @Volatile private var headersToRedact = emptySet<String>()
+
+  @set:JvmName("level")
+  @Volatile var level = Level.NONE
+
+  enum class Level {
+    /** No logs. */
+    NONE,
+
+    /**
+     * Logs request and response lines.
+     *
+     * Example:
+     * ```
+     * --> POST /greeting http/1.1 (3-byte body)
+     *
+     * <-- 200 OK (22ms, 6-byte body)
+     * ```
+     */
+    BASIC,
+
+    /**
+     * Logs request and response lines and their respective headers.
+     *
+     * Example:
+     * ```
+     * --> POST /greeting http/1.1
+     * Host: example.com
+     * Content-Type: plain/text
+     * Content-Length: 3
+     * --> END POST
+     *
+     * <-- 200 OK (22ms)
+     * Content-Type: plain/text
+     * Content-Length: 6
+     * <-- END HTTP
+     * ```
+     */
+    HEADERS,
+
+    /**
+     * Logs request and response lines and their respective headers and bodies (if present).
+     *
+     * Example:
+     * ```
+     * --> POST /greeting http/1.1
+     * Host: example.com
+     * Content-Type: plain/text
+     * Content-Length: 3
+     *
+     * Hi?
+     * --> END POST
+     *
+     * <-- 200 OK (22ms)
+     * Content-Type: plain/text
+     * Content-Length: 6
+     *
+     * Hello!
+     * <-- END HTTP
+     * ```
+     */
+    BODY
+  }
+
+  fun interface Logger {
+    fun log(message: String)
+
+    companion object {
+      /** A [Logger] defaults output appropriate for the current platform. */
+      @JvmField
+      val DEFAULT: Logger = DefaultLogger()
+      private class DefaultLogger : Logger {
+        override fun log(message: String) {
+          Platform.get().log(message)
+        }
+      }
+    }
+  }
+
+  fun redactHeader(name: String) {
+    val newHeadersToRedact = TreeSet(String.CASE_INSENSITIVE_ORDER)
+    newHeadersToRedact += headersToRedact
+    newHeadersToRedact += name
+    headersToRedact = newHeadersToRedact
+  }
+
+  /**
+   * Sets the level and returns this.
+   *
+   * This was deprecated in OkHttp 4.0 in favor of the [level] val. In OkHttp 4.3 it is
+   * un-deprecated because Java callers can't chain when assigning Kotlin vals. (The getter remains
+   * deprecated).
+   */
+  fun setLevel(level: Level) = apply {
+    this.level = level
+  }
+
+  @JvmName("-deprecated_level")
+  @Deprecated(
+    message = "moved to var",
+    replaceWith = ReplaceWith(expression = "level"),
+    level = DeprecationLevel.ERROR
+  )
+  fun getLevel(): Level = level
+
+  @Throws(IOException::class)
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val level = this.level
+
+    val request = chain.request()
+    if (level == Level.NONE) {
+      return chain.proceed(request)
+    }
+
+    val logBody = level == Level.BODY
+    val logHeaders = logBody || level == Level.HEADERS
+
+    val requestBody = request.body
+
+    val connection = chain.connection()
+    var requestStartMessage =
+      ("--> ${request.method} ${request.url}${if (connection != null) " " + connection.protocol() else ""}")
+    if (!logHeaders && requestBody != null) {
+      requestStartMessage += " (${requestBody.contentLength()}-byte body)"
+    }
+    logger.log(requestStartMessage)
+
+    if (logHeaders) {
+      val headers = request.headers
+
+      if (requestBody != null) {
+        // Request body headers are only present when installed as a network interceptor. When not
+        // already present, force them to be included (if available) so their values are known.
+        requestBody.contentType()?.let {
+          if (headers["Content-Type"] == null) {
+            logger.log("Content-Type: $it")
+          }
+        }
+        if (requestBody.contentLength() != -1L) {
+          if (headers["Content-Length"] == null) {
+            logger.log("Content-Length: ${requestBody.contentLength()}")
+          }
+        }
+      }
+
+      for (i in 0 until headers.size) {
+        logHeader(headers, i)
+      }
+
+      if (!logBody || requestBody == null) {
+        logger.log("--> END ${request.method}")
+      } else if (bodyHasUnknownEncoding(request.headers)) {
+        logger.log("--> END ${request.method} (encoded body omitted)")
+      } else if (requestBody.isDuplex()) {
+        logger.log("--> END ${request.method} (duplex request body omitted)")
+      } else if (requestBody.isOneShot()) {
+        logger.log("--> END ${request.method} (one-shot body omitted)")
+      } else {
+        val buffer = Buffer()
+        requestBody.writeTo(buffer)
+
+        val contentType = requestBody.contentType()
+        val charset: Charset = contentType?.charset(UTF_8) ?: UTF_8
+
+        logger.log("")
+        if (buffer.size > MAX_LOG_SIZE) {
+          logger.log("--> END ${requestBody.contentLength()}-byte body")
+        } else if (buffer.isProbablyUtf8()) {
+          logger.log(buffer.readString(charset))
+          logger.log("--> END ${request.method} (${requestBody.contentLength()}-byte body)")
+        } else {
+          logger.log(
+            "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)")
+        }
+      }
+    }
+
+    val startNs = System.nanoTime()
+    val response: Response
+    try {
+      response = chain.proceed(request)
+    } catch (e: Exception) {
+      logger.log("<-- HTTP FAILED: $e")
+      throw e
+    }
+
+    val tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
+
+    val responseBody = response.body!!
+    val contentLength = responseBody.contentLength()
+    val bodySize = if (contentLength != -1L) "$contentLength-byte" else "unknown-length"
+    logger.log(
+      "<-- ${response.code}${if (response.message.isEmpty()) "" else ' ' + response.message} ${response.request.url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
+
+    if (logHeaders) {
+      val headers = response.headers
+      for (i in 0 until headers.size) {
+        logHeader(headers, i)
+      }
+
+      if (!logBody || !response.promisesBody()) {
+        logger.log("<-- END HTTP")
+      } else if (bodyHasUnknownEncoding(response.headers)) {
+        logger.log("<-- END HTTP (encoded body omitted)")
+      } else {
+        val source = responseBody.source()
+        source.request(Long.MAX_VALUE) // Buffer the entire body.
+        var buffer = source.buffer
+
+        var gzippedLength: Long? = null
+        if ("gzip".equals(headers["Content-Encoding"], ignoreCase = true)) {
+          gzippedLength = buffer.size
+          GzipSource(buffer.clone()).use { gzippedResponseBody ->
+            buffer = Buffer()
+            buffer.writeAll(gzippedResponseBody)
+          }
+        }
+
+        if (buffer.size > MAX_LOG_SIZE) {
+          logger.log("<-- END HTTP (${buffer.size}-byte body truncated)")
+        } else {
+          val contentType = responseBody.contentType()
+          val charset: Charset = contentType?.charset(UTF_8) ?: UTF_8
+
+          if (!buffer.isProbablyUtf8()) {
+            logger.log("")
+            logger.log("<-- END HTTP (binary ${buffer.size}-byte body omitted)")
+            return response
+          }
+          if (contentLength != 0L) {
+            logger.log("")
+            logger.log(buffer.clone().readString(charset))
+          }
+          if (gzippedLength != null) {
+            logger.log("<-- END HTTP (${buffer.size}-byte, $gzippedLength-gzipped-byte body)")
+          } else {
+            logger.log("<-- END HTTP (${buffer.size}-byte body)")
+          }
+        }
+      }
+    }
+
+    return response
+  }
+
+  private fun logHeader(headers: Headers, i: Int) {
+    val value = if (headers.name(i) in headersToRedact) "██" else headers.value(i)
+    logger.log(headers.name(i) + ": " + value)
+  }
+
+  private fun bodyHasUnknownEncoding(headers: Headers): Boolean {
+    val contentEncoding = headers["Content-Encoding"] ?: return false
+    return !contentEncoding.equals("identity", ignoreCase = true) &&
+      !contentEncoding.equals("gzip", ignoreCase = true)
+  }
+}
+
+
+internal fun Buffer.isProbablyUtf8(): Boolean {
+  try {
+    val prefix = Buffer()
+    val byteCount = size.coerceAtMost(64)
+    copyTo(prefix, 0, byteCount)
+    for (i in 0 until 16) {
+      if (prefix.exhausted()) {
+        break
+      }
+      val codePoint = prefix.readUtf8CodePoint()
+      if (Character.isISOControl(codePoint) && !Character.isWhitespace(codePoint)) {
+        return false
+      }
+    }
+    return true
+  } catch (_: EOFException) {
+    return false // Truncated UTF-8 sequence.
+  }
+}

--- a/app/app/src/main/kotlin/com/hedvig/android/app/logginginterceptor/HedvigLoggingInterceptor.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/logginginterceptor/HedvigLoggingInterceptor.kt
@@ -20,13 +20,14 @@ import okio.GzipSource
 private const val MAX_LOG_SIZE = 100 * 1024
 
 class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
-  private val logger: Logger = Logger.DEFAULT
+  private val logger: Logger = Logger.DEFAULT,
 ) : Interceptor {
-
-  @Volatile private var headersToRedact = emptySet<String>()
+  @Volatile
+  private var headersToRedact = emptySet<String>()
 
   @set:JvmName("level")
-  @Volatile var level = Level.NONE
+  @Volatile
+  var level = Level.NONE
 
   enum class Level {
     /** No logs. */
@@ -84,7 +85,7 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
      * <-- END HTTP
      * ```
      */
-    BODY
+    BODY,
   }
 
   fun interface Logger {
@@ -94,6 +95,7 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
       /** A [Logger] defaults output appropriate for the current platform. */
       @JvmField
       val DEFAULT: Logger = DefaultLogger()
+
       private class DefaultLogger : Logger {
         override fun log(message: String) {
           Platform.get().log(message)
@@ -124,7 +126,7 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
   @Deprecated(
     message = "moved to var",
     replaceWith = ReplaceWith(expression = "level"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.ERROR,
   )
   fun getLevel(): Level = level
 
@@ -195,11 +197,13 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
             logger.log("--> END ${request.method} (${requestBody.contentLength()}-byte body)")
           } else {
             logger.log(
-              "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)")
+              "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)",
+            )
           }
         } catch (e: OutOfMemoryError) {
           logger.log(
-          "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted) with OutOfMemoryError: $e")
+            "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted) with OutOfMemoryError: $e",
+          )
         }
       }
     }
@@ -219,7 +223,8 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
     val contentLength = responseBody.contentLength()
     val bodySize = if (contentLength != -1L) "$contentLength-byte" else "unknown-length"
     logger.log(
-      "<-- ${response.code}${if (response.message.isEmpty()) "" else ' ' + response.message} ${response.request.url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
+      "<-- ${response.code}${if (response.message.isEmpty()) "" else ' ' + response.message} ${response.request.url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})",
+    )
 
     if (logHeaders) {
       val headers = response.headers
@@ -283,7 +288,6 @@ class HedvigHttpLoggingInterceptor @JvmOverloads constructor(
       !contentEncoding.equals("gzip", ignoreCase = true)
   }
 }
-
 
 internal fun Buffer.isProbablyUtf8(): Boolean {
   try {

--- a/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
+++ b/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
@@ -1,29 +1,16 @@
 package com.hedvig.android.core.fileupload
 
 import android.content.ContentResolver
-import android.content.Context
 import android.net.Uri
-import android.os.Build
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
-import androidx.annotation.RequiresApi
 import com.hedvig.android.logger.logcat
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.lang.IllegalStateException
-import java.nio.channels.FileChannel
-
-
 import java.util.Locale
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.BufferedSink
-import okio.IOException
-import okio.buffer
-import okio.source
 
 class FileService(
   private val contentResolver: ContentResolver,
@@ -37,9 +24,7 @@ class FileService(
       }
 
       override fun writeTo(sink: BufferedSink) {
-        val size = getFileSize(contentResolver, uri)
-        val maxMemory = Runtime.getRuntime().maxMemory()
-        if (size< maxMemory) {
+        if (fileDoesNotExceedMemory(uri)) {
           contentResolver.openInputStream(uri)?.use { inputStream ->
             val buffer = ByteArray(4 * 1024)
             var bytesRead: Int
@@ -51,17 +36,15 @@ class FileService(
               }
             } catch (e: OutOfMemoryError) {
               System.gc()
-              throw OutOfMemoryError("Could not open input stream for uri:$uri with OutOfMemoryError: $e")
+              error("Could not open input stream for uri:$uri with OutOfMemoryError: $e")
             }
           } ?: error("Could not open input stream for uri:$uri")
         } else {
-          throw OutOfMemoryError("Could not open input stream for uri:$uri not enough memory")
+          error("Could not open input stream for uri:$uri with OutOfMemoryError")
         }
       }
     },
   )
-
-
 
   fun getFileName(uri: Uri): String? {
     if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
@@ -105,10 +88,19 @@ class FileService(
   }
 
   private fun getFileExtension(path: String): String = MimeTypeMap.getFileExtensionFromUrl(path)
+
+  fun fileDoesNotExceedMemory(uri: Uri): Boolean {
+    val size = getFileSize(contentResolver, uri)
+    val maxMemory = Runtime.getRuntime().maxMemory()
+    logcat {
+      "Mariia: size of the file: ${size / 1024 / 1024} Mb, " +
+        "maxMemory: ${maxMemory / 1024 / 1024} Mb"
+    }
+    return size < maxMemory
+  }
 }
 
-
-fun getFileSize(contentResolver: ContentResolver, uri: Uri): Long {
+private fun getFileSize(contentResolver: ContentResolver, uri: Uri): Long {
   return contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.SIZE), null, null, null)?.use { cursor ->
     val sizeIndex = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
     if (cursor.moveToFirst()) cursor.getLong(sizeIndex) else -1

--- a/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
+++ b/app/core/core-file-upload/src/main/kotlin/com/hedvig/android/core/fileupload/FileService.kt
@@ -1,15 +1,28 @@
 package com.hedvig.android.core.fileupload
 
 import android.content.ContentResolver
+import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
+import androidx.annotation.RequiresApi
+import com.hedvig.android.logger.logcat
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.lang.IllegalStateException
+import java.nio.channels.FileChannel
+
+
 import java.util.Locale
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.BufferedSink
+import okio.IOException
+import okio.buffer
 import okio.source
 
 class FileService(
@@ -24,12 +37,31 @@ class FileService(
       }
 
       override fun writeTo(sink: BufferedSink) {
-        contentResolver.openInputStream(uri)?.use { inputStream ->
-          sink.writeAll(inputStream.source())
-        } ?: error("Could not open input stream for uri:$uri")
+        val size = getFileSize(contentResolver, uri)
+        val maxMemory = Runtime.getRuntime().maxMemory()
+        if (size< maxMemory) {
+          contentResolver.openInputStream(uri)?.use { inputStream ->
+            val buffer = ByteArray(4 * 1024)
+            var bytesRead: Int
+            val outputStream = sink.outputStream()
+            try {
+              while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                outputStream.write(buffer, 0, bytesRead)
+                outputStream.flush()
+              }
+            } catch (e: OutOfMemoryError) {
+              System.gc()
+              throw OutOfMemoryError("Could not open input stream for uri:$uri with OutOfMemoryError: $e")
+            }
+          } ?: error("Could not open input stream for uri:$uri")
+        } else {
+          throw OutOfMemoryError("Could not open input stream for uri:$uri not enough memory")
+        }
       }
     },
   )
+
+
 
   fun getFileName(uri: Uri): String? {
     if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
@@ -73,4 +105,12 @@ class FileService(
   }
 
   private fun getFileExtension(path: String): String = MimeTypeMap.getFileExtensionFromUrl(path)
+}
+
+
+fun getFileSize(contentResolver: ContentResolver, uri: Uri): Long {
+  return contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+    val sizeIndex = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
+    if (cursor.moveToFirst()) cursor.getLong(sizeIndex) else -1
+  } ?: -1
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -340,7 +340,7 @@ internal class CbmChatRepositoryImpl(
       .onLeft {
       }.mapLeft {
         val errorMessage = "Failed to upload file with path:${file.absolutePath}. Error:$it"
-        logcat(LogPriority.ERROR) { errorMessage }
+        logcat(ERROR) { errorMessage }
         it.toErrorMessage().message ?: errorMessage
       }.bind()
       .firstOrNull()
@@ -351,18 +351,23 @@ internal class CbmChatRepositoryImpl(
   }
 
   private suspend fun Raise<String>.uploadMediaToBotService(uri: Uri): String {
-    val uploadToken = botServiceService
-      .uploadFile(fileService.createFormData(uri))
-      .mapLeft {
-        val errorMessage = "Failed to upload media with uri:$uri. Error:$it"
-        logcat(LogPriority.ERROR) { errorMessage }
-        it.toErrorMessage().message ?: errorMessage
-      }.bind()
-      .firstOrNull()
-      ?.uploadToken
-    ensureNotNull(uploadToken) { "No upload token" }
-    logcat { "Uploaded file with uri:$uri. UploadToken:$uploadToken" }
-    return uploadToken
+    val fileDoesNotExceedMemory = fileService.fileDoesNotExceedMemory(uri)
+    if (fileDoesNotExceedMemory) {
+      val uploadToken = botServiceService
+        .uploadFile(fileService.createFormData(uri))
+        .mapLeft {
+          val errorMessage = "Failed to upload media with uri:$uri. Error:$it"
+          logcat(ERROR) { errorMessage }
+          it.toErrorMessage().message ?: errorMessage
+        }.bind()
+        .firstOrNull()
+        ?.uploadToken
+      ensureNotNull(uploadToken) { "No upload token" }
+      logcat { "Uploaded file with uri:$uri. UploadToken:$uploadToken" }
+      return uploadToken
+    } else {
+      raise("Failed to upload media with uri:$uri with Out Of Memory error.")
+    }
   }
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -351,23 +351,18 @@ internal class CbmChatRepositoryImpl(
   }
 
   private suspend fun Raise<String>.uploadMediaToBotService(uri: Uri): String {
-    val fileDoesNotExceedMemory = fileService.fileDoesNotExceedMemory(uri)
-    if (fileDoesNotExceedMemory) {
-      val uploadToken = botServiceService
-        .uploadFile(fileService.createFormData(uri))
-        .mapLeft {
-          val errorMessage = "Failed to upload media with uri:$uri. Error:$it"
-          logcat(ERROR) { errorMessage }
-          it.toErrorMessage().message ?: errorMessage
-        }.bind()
-        .firstOrNull()
-        ?.uploadToken
-      ensureNotNull(uploadToken) { "No upload token" }
-      logcat { "Uploaded file with uri:$uri. UploadToken:$uploadToken" }
-      return uploadToken
-    } else {
-      raise("Failed to upload media with uri:$uri with Out Of Memory error.")
-    }
+    val uploadToken = botServiceService
+      .uploadFile(fileService.createFormData(uri))
+      .mapLeft {
+        val errorMessage = "Failed to upload media with uri:$uri. Error:$it"
+        logcat(ERROR) { errorMessage }
+        it.toErrorMessage().message ?: errorMessage
+      }.bind()
+      .firstOrNull()
+      ?.uploadToken
+    ensureNotNull(uploadToken) { "No upload token" }
+    logcat { "Uploaded file with uri:$uri. UploadToken:$uploadToken" }
+    return uploadToken
   }
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/model/Sender.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/model/Sender.kt
@@ -12,6 +12,7 @@ internal fun ChatMessageSender.toSender(): Sender = when (this) {
   ChatMessageSender.MEMBER -> Sender.MEMBER
   ChatMessageSender.HEDVIG -> Sender.HEDVIG
   ChatMessageSender.UNKNOWN__ -> Sender.HEDVIG
+  ChatMessageSender.AUTOMATION -> Sender.HEDVIG
 }
 
 internal fun ChatMessageEntity.Sender.toSender(): Sender {


### PR DESCRIPTION
With these changes, when we comment out
`requireFileSizeWithinBackendLimits(uri)`
the logger just skips the content so we avoid the OOM error.

The process however still tries to upload the entire thing, and the backend eventually returns with a 413.
With `requireFileSizeWithinBackendLimits(uri)` in place, it simply short-circuits early and does not try to upload.

Consolidated the size checks by removing it from `uploadMediaToBotService` explicitly since the check happens anyway from the body we get from `fileService.createFormData`