### PR TITLE
GEN-3290 bring moving flow button out of BS

### DIFF
--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/EditInsuranceBottomSheetContent.kt
@@ -33,12 +33,12 @@ import hedvig.resources.R
 
 @Composable
 internal fun EditInsuranceBottomSheetContent(
-  allowChangeAddress: Boolean,
   allowEditCoInsured: Boolean,
   allowChangeTier: Boolean,
+  allowTerminatingInsurance: Boolean,
   onEditCoInsuredClick: () -> Unit,
-  onChangeAddressClick: () -> Unit,
   onChangeTierClick: () -> Unit,
+  onCancelInsuranceClick: () -> Unit,
   onDismiss: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -57,22 +57,22 @@ internal fun EditInsuranceBottomSheetContent(
     Column(
       verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-      if (allowChangeAddress) {
+      if (allowChangeTier) {
         RadioOptionRightAligned(
-          chosenState = if (selectedItemIndex == 0) Chosen else NotChosen,
-          onClick = { selectedItemIndex = 0 },
           optionContent = {
             Column {
               HedvigText(
-                text = stringResource(R.string.insurance_details_change_address_button),
+                text = stringResource(R.string.insurance_details_change_coverage),
               )
               HedvigText(
-                text = stringResource(R.string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_SUBTITLE),
+                text = stringResource(R.string.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_SUBTITLE),
                 color = HedvigTheme.colorScheme.textSecondary,
                 style = HedvigTheme.typography.label,
               )
             }
           },
+          chosenState = if (selectedItemIndex == 0) Chosen else NotChosen,
+          onClick = { selectedItemIndex = 0 },
         )
       }
       if (allowEditCoInsured) {
@@ -93,22 +93,22 @@ internal fun EditInsuranceBottomSheetContent(
           onClick = { selectedItemIndex = 1 },
         )
       }
-      if (allowChangeTier) {
+      if (allowTerminatingInsurance) {
         RadioOptionRightAligned(
+          chosenState = if (selectedItemIndex == 2) Chosen else NotChosen,
+          onClick = { selectedItemIndex = 2 },
           optionContent = {
             Column {
               HedvigText(
-                text = stringResource(R.string.insurance_details_change_coverage),
+                text = stringResource(R.string.HC_QUICK_ACTIONS_CANCELLATION_TITLE),
               )
               HedvigText(
-                text = stringResource(R.string.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_SUBTITLE),
+                text = stringResource(R.string.HC_QUICK_ACTIONS_CANCELLATION_SUBTITLE),
                 color = HedvigTheme.colorScheme.textSecondary,
                 style = HedvigTheme.typography.label,
               )
             }
           },
-          chosenState = if (selectedItemIndex == 2) Chosen else NotChosen,
-          onClick = { selectedItemIndex = 2 },
         )
       }
     }
@@ -117,11 +117,11 @@ internal fun EditInsuranceBottomSheetContent(
       text = stringResource(id = R.string.general_continue_button),
       enabled = selectedItemIndex != -1,
       onClick = dropUnlessResumed {
-        if (selectedItemIndex == 0 && allowChangeAddress) {
-          onChangeAddressClick()
+        if (selectedItemIndex == 2 && allowTerminatingInsurance) {
+          onCancelInsuranceClick()
         } else if (selectedItemIndex == 1 && allowEditCoInsured) {
           onEditCoInsuredClick()
-        } else if (selectedItemIndex == 2 && allowChangeTier) {
+        } else if (selectedItemIndex == 0 && allowChangeTier) {
           onChangeTierClick()
         }
       },
@@ -145,14 +145,14 @@ private fun PreviewEditInsuranceBottomSheetContent() {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       EditInsuranceBottomSheetContent(
-        allowChangeAddress = true,
+        allowTerminatingInsurance = true,
         allowEditCoInsured = true,
         allowChangeTier = true,
         onChangeTierClick = {},
         onEditCoInsuredClick = {},
-        onChangeAddressClick = {},
         onDismiss = {},
         modifier = Modifier.padding(horizontal = 16.dp),
+        onCancelInsuranceClick = {},
       )
     }
   }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -19,6 +19,7 @@ import com.hedvig.android.core.common.daysUntil
 import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.ContractType
 import com.hedvig.android.data.productvariant.ProductVariant
+import com.hedvig.android.design.system.hedvig.ButtonDefaults
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Ghost
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.design.system.hedvig.HedvigButton
@@ -78,7 +79,7 @@ internal fun YourInfoTab(
   val editYourInfoBottomSheet = rememberHedvigBottomSheetState<Unit>()
   HedvigBottomSheet(editYourInfoBottomSheet) {
     EditInsuranceBottomSheetContent(
-      allowChangeAddress = allowChangeAddress,
+      allowTerminatingInsurance = allowTerminatingInsurance,
       allowEditCoInsured = allowEditCoInsured,
       allowChangeTier = allowChangeTier,
       onChangeTierClick = {
@@ -89,12 +90,12 @@ internal fun YourInfoTab(
         editYourInfoBottomSheet.dismiss()
         onEditCoInsuredClick()
       },
-      onChangeAddressClick = {
-        editYourInfoBottomSheet.dismiss()
-        onChangeAddressClick()
-      },
       onDismiss = {
         editYourInfoBottomSheet.dismiss()
+      },
+      onCancelInsuranceClick = {
+        editYourInfoBottomSheet.dismiss()
+        onCancelInsuranceClick()
       },
     )
   }
@@ -171,22 +172,27 @@ internal fun YourInfoTab(
     }
     Spacer(Modifier.height(16.dp))
     if (!isTerminated) {
-      if (allowChangeAddress || allowEditCoInsured || allowChangeTier) {
+      if (allowEditCoInsured || allowChangeTier || allowTerminatingInsurance) {
         HedvigButton(
           text = stringResource(R.string.CONTRACT_EDIT_INFO_LABEL),
           enabled = true,
           onClick = { editYourInfoBottomSheet.show() },
-          modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+          buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
+          modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth(),
         )
         Spacer(Modifier.height(8.dp))
       }
-      if (allowTerminatingInsurance) {
+      if (allowChangeAddress) {
         HedvigButton(
-          text = stringResource(R.string.TERMINATION_BUTTON),
+          text = stringResource(R.string.insurance_details_move_button),
           buttonStyle = Ghost,
           enabled = true,
-          onClick = { onCancelInsuranceClick() },
-          modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+          onClick = { onChangeAddressClick() },
+          modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth(),
         )
         Spacer(Modifier.height(8.dp))
       }


### PR DESCRIPTION
Ui changes in insurance details according to [figma](https://www.figma.com/design/zItETkT4mu5ANVDYED5gEm/Retention-UX-Improvements-App?node-id=0-1&p=f&t=p5MqtY3Q1DUyajo7-0)