### PR TITLE
RND-1139: Automatically refresh after updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@
     `./gradlew downloadStrings`
 5. Build and install via Android Studio
 
+### Access to Hedvig dependencies
+
+Create a personal access token on GitHub. Add the token and your github username to `gradle.properties` located in   
+`/Users/{user}/.gradle/` as such:
+`authlibUsername={github username}`
+`authlibPassword={personal access token}}`
+
+This will allow gradle to download the authlib dependency.
+
 ## Formatting
 
 Formatting is handled with ktlint with extra configuration defined in [`.editorconfig`](.editorconfig)

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/GetContractForContractIdUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/GetContractForContractIdUseCase.kt
@@ -10,38 +10,34 @@ import com.hedvig.android.feature.insurances.data.InsuranceContract
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 internal interface GetContractForContractIdUseCase {
-  fun invoke(contractId: String): Flow<Either<GetContractForContractIdError, InsuranceContract>>
+  suspend fun invoke(contractId: String): Flow<Either<GetContractForContractIdError, InsuranceContract>>
 }
 
 internal class GetContractForContractIdUseCaseImpl(
   private val getInsuranceContractsUseCaseProvider: Provider<GetInsuranceContractsUseCase>,
 ) : GetContractForContractIdUseCase {
-  override fun invoke(contractId: String): Flow<Either<GetContractForContractIdError, InsuranceContract>> {
-    return flow {
-      getInsuranceContractsUseCaseProvider
-        .provide()
-        .invoke(forceNetworkFetch = false)
-        .map { insuranceContractResult ->
-          either {
-            val contract = insuranceContractResult
-              .mapLeft { GetContractForContractIdError.GenericError(it) }
-              .bind()
-              .firstOrNull { it.id == contractId }
-            ensureNotNull(contract) {
-              GetContractForContractIdError.NoContractFound(
-                ErrorMessage("No contract found with id: $contractId").also {
-                  logcat(LogPriority.ERROR) { it.message.toString() }
-                },
-              )
-            }
+  override suspend fun invoke(contractId: String): Flow<Either<GetContractForContractIdError, InsuranceContract>> {
+    return getInsuranceContractsUseCaseProvider
+      .provide()
+      .invoke(forceNetworkFetch = true)
+      .map { insuranceContractResult ->
+        either {
+          val contract = insuranceContractResult
+            .mapLeft { GetContractForContractIdError.GenericError(it) }
+            .bind()
+            .firstOrNull { it.id == contractId }
+          ensureNotNull(contract) {
+            GetContractForContractIdError.NoContractFound(
+              ErrorMessage("No contract found with id: $contractId").also {
+                logcat(LogPriority.ERROR) { it.message.toString() }
+              },
+            )
           }
         }
-        .collect(this)
-    }
+      }
   }
 }
 


### PR DESCRIPTION
Refresh insurance detail view after modifying co-insured. Already works in travel certificate flow so no changes needed there, however backend takes a couple of seconds to update so if you are too fast in completing the flow no updates will be seen.