### PR TITLE
Fix/travel cert stale data with change list

### DIFF
--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
@@ -16,7 +16,6 @@ import com.hedvig.android.feature.profile.navigation.ProfileDestinations
 import com.hedvig.android.feature.profile.navigation.SettingsDestinations
 import com.hedvig.android.feature.profile.settings.SettingsDestination
 import com.hedvig.android.feature.profile.settings.SettingsViewModel
-import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
 import com.hedvig.android.navigation.compose.navgraph
@@ -83,9 +82,7 @@ fun NavGraphBuilder.profileGraph(
       )
     }
     navdestination<ProfileDestinations.MyInfo>(
-      deepLinks = navDeepLinks(hedvigDeepLinkContainer.contactInfo).also {
-        logcat { "Stelios it$it + {${hedvigDeepLinkContainer.contactInfo}}" }
-      },
+      deepLinks = navDeepLinks(hedvigDeepLinkContainer.contactInfo),
     ) {
       val viewModel: MyInfoViewModel = koinViewModel()
       MyInfoDestination(

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewho/TravelCertificateTravellersInput.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewho/TravelCertificateTravellersInput.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hedvig.android.design.system.hedvig.Checkbox
 import com.hedvig.android.design.system.hedvig.CheckboxDefaults.CheckboxSize.Large
 import com.hedvig.android.design.system.hedvig.CheckboxDefaults.CheckboxStyle
@@ -44,14 +45,14 @@ internal fun TravelCertificateTravellersInputDestination(
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   TravelCertificateTravellersInput(
-    uiState,
-    navigateUp,
-    { viewModel.emit(TravelCertificateTravellersInputEvent.RetryLoadData) },
-    onNavigateToOverview,
-    { viewModel.emit(TravelCertificateTravellersInputEvent.ChangeCoInsuredChecked(it)) },
-    { viewModel.emit(TravelCertificateTravellersInputEvent.ChangeMemberChecked) },
-    onNavigateToCoInsuredAddInfo,
-    { viewModel.emit(TravelCertificateTravellersInputEvent.GenerateTravelCertificate) },
+    uiState = uiState,
+    navigateUp = navigateUp,
+    reload = { viewModel.emit(TravelCertificateTravellersInputEvent.RetryLoadData) },
+    onNavigateToOverview = onNavigateToOverview,
+    changeCoInsuredChecked = { viewModel.emit(TravelCertificateTravellersInputEvent.ChangeCoInsuredChecked(it)) },
+    changeMemberChecked = { viewModel.emit(TravelCertificateTravellersInputEvent.ChangeMemberChecked) },
+    onNavigateToCoInsuredAddInfo = onNavigateToCoInsuredAddInfo,
+    onGenerateTravelCertificate = { viewModel.emit(TravelCertificateTravellersInputEvent.GenerateTravelCertificate) },
   )
 }
 
@@ -92,7 +93,9 @@ private fun TravelCertificateTravellersInput(
           HedvigText(
             text = stringResource(id = R.string.travel_certificate_who_is_traveling),
             style = HedvigTheme.typography.headlineMedium,
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(horizontal = 16.dp),
           )
           Spacer(Modifier.weight(1f))
           Spacer(Modifier.height(16.dp))
@@ -106,16 +109,16 @@ private fun TravelCertificateTravellersInput(
             checkboxStyle = CheckboxStyle.Default,
             checkboxSize = Large,
           )
-          for (i in uiState.coInsuredList) {
+          for (coInsured in uiState.coInsuredList) {
             Spacer(Modifier.height(4.dp))
 
             Checkbox(
-              optionText = i.name,
-              chosenState = if (i.isIncluded) Chosen else NotChosen,
+              optionText = coInsured.name,
+              chosenState = if (coInsured.isIncluded) Chosen else NotChosen,
               modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-              onClick = { changeCoInsuredChecked(i) },
+              onClick = { changeCoInsuredChecked(coInsured) },
               checkboxStyle = CheckboxStyle.Default,
               checkboxSize = Large,
             )
@@ -129,7 +132,9 @@ private fun TravelCertificateTravellersInput(
                 buttonText = stringResource(R.string.travel_certificate_missing_coinsured_button),
                 onButtonClick = dropUnlessResumed { onNavigateToCoInsuredAddInfo() },
               ),
-              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+              modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
             )
           }
           Spacer(Modifier.height(16.dp))

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewho/TravelCertificateTravellersInput.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/generatewho/TravelCertificateTravellersInput.kt
@@ -167,8 +167,8 @@ private fun PreviewTravelCertificateTravellersInput() {
         Success(
           true,
           listOf(
-            CoInsured("id", "Co-insured Baby", null, null, false),
-            CoInsured("id2", "Co-insured Baby 2", null, null, true),
+            CoInsured(CoInsured.CoInsuredId("id"), "Co-insured Baby", null, null, false),
+            CoInsured(CoInsured.CoInsuredId("id2"), "Co-insured Baby 2", null, null, true),
           ),
           "The Member Themselves",
           true,


### PR DESCRIPTION
This part:
```
var fetchedCoInsuredList by remember { mutableStateOf<List<CoInsured>>(listOf()) }
val coInsuredIncludedMap = remember { mutableStateMapOf<CoInsuredId, Boolean>() }
val coInsuredList by remember {
 derivedStateOf {
  fetchedCoInsuredList.map {
   it.copy(isIncluded = coInsuredIncludedMap.get(it.id) ?: it.isIncluded)
  }
 }
}
```
Is the core of it, where we keep the fetched list separate, we keep the mutable map separately, and then we derive the final value from those two both to show in the UI, but also for when we send the generate request to the backend