### PR TITLE
Fix nullable button text modeling

### DIFF
--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceStep.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceStep.kt
@@ -1,6 +1,5 @@
 package com.hedvig.android.feature.terminateinsurance.data
 
-import com.hedvig.android.feature.terminateinsurance.data.SurveyOptionSuggestion.Action.UnknownAction
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceDestination
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminationGraphParameters
 import com.hedvig.android.logger.LogPriority
@@ -74,7 +73,8 @@ internal fun TerminationFlowStepFragment.CurrentStep.toTerminateInsuranceStep():
   }
 }
 
-private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option>.toOptionList(): List<TerminationSurveyOption> {
+private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option>.toOptionList():
+  List<TerminationSurveyOption> {
   return map {
     // remade a bit of logic here. If we receive unknown actions in suggestion for one of the subOptions
     // (or the option itself),
@@ -84,7 +84,7 @@ private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentSte
       title = it.title,
       listIndex = this.indexOf(it),
       feedBackRequired = it.feedBack != null ||
-        (it.suggestion?.toSuggestion() == UnknownAction) ||
+        (it.suggestion?.toSuggestion() == SurveyOptionSuggestion.Unknown) ||
         it.subOptions?.noUnknownActions() == false,
       subOptions = it.subOptions?.toSubOptionList() ?: emptyList(),
       suggestion = it.suggestion?.toSuggestion(),
@@ -92,13 +92,15 @@ private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentSte
   }
 }
 
-private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option.SubOption>.noUnknownActions(): Boolean {
+private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option.SubOption>.noUnknownActions():
+  Boolean {
   return none { subOption ->
-    subOption.suggestion?.toSuggestion() == UnknownAction
+    subOption.suggestion?.toSuggestion() == SurveyOptionSuggestion.Unknown
   }
 }
 
-private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option.SubOption>.toSubOptionList(): List<TerminationSurveyOption> {
+private fun List<TerminationFlowStepFragment.FlowTerminationSurveyStepCurrentStep.Option.SubOption>.toSubOptionList():
+  List<TerminationSurveyOption> {
   // no subOptions if one of them contains some action that we don't know how to handle
   val filtered = takeIf { subs ->
     subs.noUnknownActions()
@@ -121,7 +123,7 @@ private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): Survey
     is FlowTerminationSurveyOptionSuggestionActionFlowTerminationSurveyOptionSuggestionFragment -> {
       when (action) {
         FlowTerminationSurveyRedirectAction.UPDATE_ADDRESS -> {
-          SurveyOptionSuggestion.Action.UpdateAddress(
+          SurveyOptionSuggestion.Known.Action.UpdateAddress(
             description = description,
             buttonTitle = buttonTitle,
             infoType = this.infoType.toInfoType(),
@@ -129,7 +131,7 @@ private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): Survey
         }
 
         FlowTerminationSurveyRedirectAction.CHANGE_TIER_FOUND_BETTER_PRICE -> {
-          SurveyOptionSuggestion.Action.DowngradePriceByChangingTier(
+          SurveyOptionSuggestion.Known.Action.DowngradePriceByChangingTier(
             description = description,
             buttonTitle = buttonTitle,
             infoType = this.infoType.toInfoType(),
@@ -138,7 +140,7 @@ private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): Survey
 
         FlowTerminationSurveyRedirectAction.CHANGE_TIER_MISSING_COVERAGE_AND_TERMS -> {
           if (isTierFeatureEnabled) {
-            SurveyOptionSuggestion.Action.UpgradeCoverageByChangingTier(
+            SurveyOptionSuggestion.Known.Action.UpgradeCoverageByChangingTier(
               description = description,
               buttonTitle = buttonTitle,
               infoType = this.infoType.toInfoType(),
@@ -150,7 +152,7 @@ private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): Survey
                 "FlowTerminationSurveyStepCurrentStep suggestion: CHANGE_TIER_MISSING_COVERAGE_AND_TERMS but tier feature flag is disabled!"
               },
             )
-            UnknownAction
+            SurveyOptionSuggestion.Unknown
           }
         }
 
@@ -159,13 +161,13 @@ private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): Survey
             LogPriority.WARN,
             message = { "FlowTerminationSurveyStepCurrentStep unknown suggestion type: ${this.action.rawValue}" },
           )
-          UnknownAction
+          SurveyOptionSuggestion.Unknown
         }
       }
     }
 
     is FlowTerminationSurveyOptionSuggestionRedirectFlowTerminationSurveyOptionSuggestionFragment -> {
-      SurveyOptionSuggestion.Redirect(
+      SurveyOptionSuggestion.Known.Action.Redirect(
         buttonTitle = this.buttonTitle,
         description = this.description,
         url = this.url,
@@ -174,7 +176,7 @@ private fun FlowTerminationSurveyOptionSuggestionFragment.toSuggestion(): Survey
     }
 
     is FlowTerminationSurveyOptionSuggestionInfoFlowTerminationSurveyOptionSuggestionFragment -> {
-      SurveyOptionSuggestion.Info(
+      SurveyOptionSuggestion.Known.Info(
         description = this.description,
         infoType = this.infoType.toInfoType(),
       )

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminationSurveyOption.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminationSurveyOption.kt
@@ -15,56 +15,54 @@ internal data class TerminationSurveyOption(
 
 @Serializable
 internal sealed interface SurveyOptionSuggestion {
-  val description: String
-  val buttonTitle: String?
-  val infoType: InfoType
-
-  @Serializable
-  sealed interface Action : SurveyOptionSuggestion {
-    @Serializable
-    data class UpdateAddress(
-      override val description: String,
-      override val buttonTitle: String,
-      override val infoType: InfoType,
-    ) : Action
+  sealed interface Known : SurveyOptionSuggestion {
+    val description: String
+    val infoType: InfoType
 
     @Serializable
-    data class UpgradeCoverageByChangingTier(
-      override val description: String,
-      override val buttonTitle: String,
-      override val infoType: InfoType,
-    ) : Action
+    sealed interface Action : Known {
+      val buttonTitle: String
 
-    @Serializable
-    data class DowngradePriceByChangingTier(
-      override val description: String,
-      override val buttonTitle: String,
-      override val infoType: InfoType,
-    ) : Action
+      @Serializable
+      data class UpdateAddress(
+        override val description: String,
+        override val buttonTitle: String,
+        override val infoType: InfoType,
+      ) : Action
 
-    @Serializable // adding for filtering. may be useful in the future for old clients?
-    data object UnknownAction : Action {
-      override val description: String = ""
-      override val buttonTitle: String = ""
-      override val infoType: InfoType = InfoType.UNKNOWN
+      @Serializable
+      data class UpgradeCoverageByChangingTier(
+        override val description: String,
+        override val buttonTitle: String,
+        override val infoType: InfoType,
+      ) : Action
+
+      @Serializable
+      data class DowngradePriceByChangingTier(
+        override val description: String,
+        override val buttonTitle: String,
+        override val infoType: InfoType,
+      ) : Action
+
+      @Serializable
+      data class Redirect(
+        val url: String,
+        override val description: String,
+        override val buttonTitle: String,
+        override val infoType: InfoType,
+      ) : Action
     }
+
+    @Serializable
+    data class Info(
+      override val description: String,
+      override val infoType: InfoType,
+    ) : Known
   }
 
+  // Fallback for future-proofing old clients
   @Serializable
-  data class Redirect(
-    val url: String,
-    override val description: String,
-    override val buttonTitle: String,
-    override val infoType: InfoType,
-  ) : SurveyOptionSuggestion
-
-  @Serializable
-  data class Info(
-    override val description: String,
-    override val infoType: InfoType,
-  ) : SurveyOptionSuggestion {
-    override val buttonTitle = null
-  }
+  data object Unknown : SurveyOptionSuggestion
 }
 
 enum class InfoType {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminationSurveyOption.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminationSurveyOption.kt
@@ -20,14 +20,6 @@ internal sealed interface SurveyOptionSuggestion {
   val infoType: InfoType
 
   @Serializable
-  data class Info(
-    override val description: String,
-    override val infoType: InfoType,
-  ) : SurveyOptionSuggestion {
-    override val buttonTitle = null
-  }
-
-  @Serializable
   sealed interface Action : SurveyOptionSuggestion {
     @Serializable
     data class UpdateAddress(
@@ -65,6 +57,14 @@ internal sealed interface SurveyOptionSuggestion {
     override val buttonTitle: String,
     override val infoType: InfoType,
   ) : SurveyOptionSuggestion
+
+  @Serializable
+  data class Info(
+    override val description: String,
+    override val infoType: InfoType,
+  ) : SurveyOptionSuggestion {
+    override val buttonTitle = null
+  }
 }
 
 enum class InfoType {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -287,38 +287,27 @@ private fun ColumnScope.SelectedSurveyInfoBox(
         Spacer(Modifier.height(4.dp))
         val text = suggestion.description
         val buttonText = suggestion.buttonTitle
-        val onSuggestionButtonClick: () -> Unit = when (suggestion) {
-          is UpdateAddress -> {
-            dropUnlessResumed { navigateToMovingFlow() }
+        val onSuggestionButtonClick: (() -> Unit)? = when (suggestion) {
+          is SurveyOptionSuggestion.Action -> {
+            when (suggestion) {
+              is DowngradePriceByChangingTier -> tryToDowngradePrice
+              is UpdateAddress -> dropUnlessResumed { navigateToMovingFlow() }
+              is UpgradeCoverageByChangingTier -> tryToUpgradeCoverage
+              UnknownAction -> null
+            }
           }
 
           is Redirect -> {
             { openUrl(suggestion.url) }
           }
-
-          is DowngradePriceByChangingTier -> {
-            {
-              tryToDowngradePrice()
-            }
-          }
-
-          is UpgradeCoverageByChangingTier -> {
-            {
-              tryToUpgradeCoverage()
-            }
-          }
-
-          UnknownAction -> {
-            {}
-          }
-
-          is SurveyOptionSuggestion.Info -> { // buttonText is always null for this type
-            {}
-          }
+          // buttonText is always null for this type
+          is SurveyOptionSuggestion.Info -> null
         }
         HedvigNotificationCard(
           buttonLoading = actionButtonLoading,
-          modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+          modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth(),
           content = {
             ProvideTextStyle(
               HedvigTheme.typography.label,
@@ -335,7 +324,7 @@ private fun ColumnScope.SelectedSurveyInfoBox(
             InfoType.OFFER -> NotificationPriority.Campaign
             InfoType.UNKNOWN -> NotificationPriority.InfoInline
           },
-          style = if (buttonText != null) {
+          style = if (buttonText != null && onSuggestionButtonClick != null) {
             InfoCardStyle.Button(
               buttonText = buttonText,
               onButtonClick = onSuggestionButtonClick,

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyViewModel.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyViewModel.kt
@@ -123,8 +123,8 @@ internal class TerminationSurveyPresenter(
           if (changeTierIntent.quotes.isEmpty()) {
             Snapshot.withMutableSnapshot {
               val optionsToDisable = options.filter { option ->
-                option.suggestion is SurveyOptionSuggestion.Action.DowngradePriceByChangingTier ||
-                  option.suggestion is SurveyOptionSuggestion.Action.UpgradeCoverageByChangingTier
+                option.suggestion is SurveyOptionSuggestion.Known.Action.DowngradePriceByChangingTier ||
+                  option.suggestion is SurveyOptionSuggestion.Known.Action.UpgradeCoverageByChangingTier
               }
               disabledOptionsIdsDueToEmptyResultingQuotes = optionsToDisable.map { it.id }
               currentState = currentState.copy(
@@ -225,11 +225,7 @@ internal data class TerminationSurveyState(
 ) {
   val selectedOption: TerminationSurveyOption? = reasons.firstOrNull { it.id == selectedOptionId }
   val continueAllowed: Boolean = selectedOption != null &&
-    (
-      selectedOption.suggestion == null ||
-        selectedOption.suggestion is SurveyOptionSuggestion.Info ||
-        selectedOption.suggestion.buttonTitle == null
-    )
+    (selectedOption.suggestion == null || selectedOption.suggestion !is SurveyOptionSuggestion.Known.Action)
 
   constructor(reasons: List<TerminationSurveyOption>) : this(
     reasons = reasons,

--- a/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepositoryImplTest.kt
+++ b/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepositoryImplTest.kt
@@ -156,8 +156,8 @@ class TerminateInsuranceRepositoryImplTest {
         .transform { list ->
           list.any { option ->
             option.subOptions.any { subOption ->
-              subOption.suggestion is SurveyOptionSuggestion.Action.DowngradePriceByChangingTier ||
-                subOption.suggestion is SurveyOptionSuggestion.Action.UpgradeCoverageByChangingTier
+              subOption.suggestion is SurveyOptionSuggestion.Known.Action.DowngradePriceByChangingTier ||
+                subOption.suggestion is SurveyOptionSuggestion.Known.Action.UpgradeCoverageByChangingTier
             }
           }
         }
@@ -201,7 +201,7 @@ class TerminateInsuranceRepositoryImplTest {
           list.filter { option ->
             option.id == "0013"
           }.all {
-            !it.feedBackRequired && it.suggestion is SurveyOptionSuggestion.Action.UpgradeCoverageByChangingTier
+            !it.feedBackRequired && it.suggestion is SurveyOptionSuggestion.Known.Action.UpgradeCoverageByChangingTier
           }
         }
         .isTrue()

--- a/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyPresenterTest.kt
+++ b/app/feature/feature-terminate-insurance/src/test/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyPresenterTest.kt
@@ -41,7 +41,7 @@ import org.junit.Test
 class TerminationSurveyPresenterTest {
   @get:Rule
   val testLogcatLogger = TestLogcatLoggingRule()
-  private val downgradeSuggestion = SurveyOptionSuggestion.Action.DowngradePriceByChangingTier(
+  private val downgradeSuggestion = SurveyOptionSuggestion.Known.Action.DowngradePriceByChangingTier(
     "description",
     "Button",
     InfoType.INFO,
@@ -54,7 +54,7 @@ class TerminationSurveyPresenterTest {
       title = "I'm moving",
       subOptions = emptyList(),
       listIndex = 0,
-      suggestion = SurveyOptionSuggestion.Action.UpdateAddress("description", "buttonTitle", InfoType.INFO),
+      suggestion = SurveyOptionSuggestion.Known.Action.UpdateAddress("description", "buttonTitle", InfoType.INFO),
     ),
     TerminationSurveyOption(
       id = "id2",


### PR DESCRIPTION
#### Model the survey suggestions more clearly

We split the suggestions first in known/unknown to have non-null description and infoType. And then we split them into actionable ones with non-null button text, and the info one which does not require the button text at all.

This allows us to simplify the `continueAllowed` as:
```
val continueAllowed: Boolean = selectedOption != null &&
    (selectedOption.suggestion == null || selectedOption.suggestion !is SurveyOptionSuggestion.Known.Action)
```
So that we know we only can move forward if we do not have a suggestion
which requires an action.

We also are able to now simply render nothing in the `Unknown` case
instead of having a card with no text inside it