### PR TITLE
Change ordering of payment entries

### DIFF
--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/history/PaymentHistoryDestination.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/history/PaymentHistoryDestination.kt
@@ -79,8 +79,7 @@ private fun PaymentHistoryScreen(
             PaymentHistory.NoHistoryData to { _: String -> }
           } else {
             PaymentHistory.PastCharges(
-              chargesInYear = uiState.paymentHistory.sortedBy { it.dueDate }.groupBy { it.dueDate.year }
-                .map { (year, charges) ->
+              chargesInYear = uiState.paymentHistory.groupBy { it.dueDate.year }.map { (year, charges) ->
                   PaymentHistory.PastCharges.YearCharges(
                     year = year,
                     charge = charges.map { charge ->


### PR DESCRIPTION
Change ordering of payment entries in payment history. Show latest payment first instead of last.