### PR TITLE
Notifications/marketing channel title

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CrossSellNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CrossSellNotificationSender.kt
@@ -27,8 +27,6 @@ class CrossSellNotificationSender(
     // TODO drop support for this notification type if we see we never get it
     logcat(LogPriority.ASSERT) { "We never expect to get a notification of type $type" }
     return
-    val title = remoteMessage.data[DATA_MESSAGE_TITLE]
-    val body = remoteMessage.data[DATA_MESSAGE_BODY]
     val title = remoteMessage.titleFromCustomerIoData() ?: remoteMessage.data[DATA_MESSAGE_TITLE]
     val body = remoteMessage.bodyFromCustomerIoData() ?: remoteMessage.data[DATA_MESSAGE_BODY]
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CrossSellNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CrossSellNotificationSender.kt
@@ -29,6 +29,8 @@ class CrossSellNotificationSender(
     return
     val title = remoteMessage.data[DATA_MESSAGE_TITLE]
     val body = remoteMessage.data[DATA_MESSAGE_BODY]
+    val title = remoteMessage.titleFromCustomerIoData() ?: remoteMessage.data[DATA_MESSAGE_TITLE]
+    val body = remoteMessage.bodyFromCustomerIoData() ?: remoteMessage.data[DATA_MESSAGE_BODY]
 
     @Suppress("UNUSED_VARIABLE") // Unused when there's no cross sale detail screen in the app
     val id = remoteMessage.data[CROSS_SELL_ID]

--- a/app/notification/notification-core/src/main/kotlin/com/hedvig/android/notification/core/NotificationChannel.kt
+++ b/app/notification/notification-core/src/main/kotlin/com/hedvig/android/notification/core/NotificationChannel.kt
@@ -30,6 +30,7 @@ sealed interface HedvigNotificationChannel {
       setupNotificationChannel(
         context,
         channelId,
+        context.resources.getString(hedvig.resources.R.string.PAYMENTS__CAMPAIGNS),
         context.resources.getString(hedvig.resources.R.string.NOTIFICATION_CHANNEL_CROSS_SELL_TITLE),
       )
     }


### PR DESCRIPTION
If this is approved here https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1741170122734959 we can just merge it.

It moves the old title to the description where it probably was meant to be in the first place. And adds a new title, being "Campaigns"/"Kampanjer".