### PR TITLE
GEN-3402 Fix bug with showing upcoming termination due to failed charges wrongly

### DIFF
--- a/app/feature/feature-payments/src/main/graphql/QueryUpcomingPayment.graphql
+++ b/app/feature/feature-payments/src/main/graphql/QueryUpcomingPayment.graphql
@@ -1,5 +1,9 @@
 query UpcomingPayment {
   currentMember {
+    activeContracts {
+      terminationDueToMissedPayments
+      terminationDate
+    }
     futureCharge {
       ...MemberChargeFragment
     }

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentConnection.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentConnection.kt
@@ -1,5 +1,7 @@
 package com.hedvig.android.feature.payments.data
 
+import kotlinx.datetime.LocalDate
+
 internal sealed interface PaymentConnection {
   data class Active(
     val displayName: String,
@@ -8,7 +10,9 @@ internal sealed interface PaymentConnection {
 
   data object Pending : PaymentConnection
 
-  data object NeedsSetup : PaymentConnection
+  data class NeedsSetup(
+    val terminationDateIfNotConnected: LocalDate?,
+  ) : PaymentConnection
 
   data object Unknown : PaymentConnection
 }

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentOverview.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentOverview.kt
@@ -6,7 +6,7 @@ import kotlinx.datetime.LocalDate
 internal data class PaymentOverview(
   val memberChargeShortInfo: MemberChargeShortInfo?,
   val ongoingCharges: List<OngoingCharge>,
-  val paymentConnection: PaymentConnection?,
+  val paymentConnection: PaymentConnection,
 ) {
   data class OngoingCharge(
     val id: String,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/payments/PaymentsPresenter.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/payments/PaymentsPresenter.kt
@@ -86,14 +86,15 @@ internal class PaymentsPresenter(
 
               Pending -> PaymentsUiState.Content.ConnectedPaymentInfo.Pending
 
-              NeedsSetup,
-              Unknown,
-              null,
-              -> {
-                PaymentsUiState.Content.ConnectedPaymentInfo.NotConnected(
-                  dueDateToConnect = paymentOverview.memberChargeShortInfo?.dueDate,
+              is NeedsSetup -> {
+                PaymentsUiState.Content.ConnectedPaymentInfo.NeedsSetup(
+                  dueDateToConnect = paymentConnection.terminationDateIfNotConnected,
                   allowChangingConnectedBankAccount = allowChangingConnectedBankAccount,
                 )
+              }
+
+              Unknown -> {
+                PaymentsUiState.Content.ConnectedPaymentInfo.Unknown
               }
             },
           )
@@ -142,7 +143,9 @@ internal sealed interface PaymentsUiState {
     }
 
     sealed interface ConnectedPaymentInfo {
-      data class NotConnected(
+      object Unknown : ConnectedPaymentInfo
+
+      data class NeedsSetup(
         val dueDateToConnect: LocalDate?,
         val allowChangingConnectedBankAccount: Boolean,
       ) : ConnectedPaymentInfo


### PR DESCRIPTION
We were wrongly deriving that there were failing charges if there was no payment connection and there was an upcoming charge. We now instead find the termination date of the first contract which is terminated due to failed charges, and use that date as the marker of when the contract will be terminated to show to the UI