### PR TITLE
Design: Tab row fit in one line

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Tab.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Tab.kt
@@ -48,6 +48,7 @@ import com.hedvig.android.design.system.hedvig.tokens.LargeTabTokens
 import com.hedvig.android.design.system.hedvig.tokens.MediumTabTokens
 import com.hedvig.android.design.system.hedvig.tokens.MiniTabTokens
 import com.hedvig.android.design.system.hedvig.tokens.SmallTabTokens
+import com.hedvig.android.design.system.hedvig.tokens.TabTokens
 import kotlin.math.ceil
 import kotlinx.coroutines.launch
 
@@ -301,18 +302,16 @@ object TabDefaults {
     @get:Composable
     internal abstract val tabShape: Shape
 
-    internal abstract val rowPadding: PaddingValues
+    internal val rowPadding: PaddingValues = PaddingValues(
+      horizontal = TabTokens.RowHorizontalPadding,
+      vertical = TabTokens.RowVerticalPadding,
+    )
     internal abstract val tabPadding: PaddingValues
 
     @get:Composable
     internal abstract val textStyle: TextStyle
 
     data object Mini : TabSize() {
-      override val rowPadding: PaddingValues
-        get() = PaddingValues(
-          horizontal = MiniTabTokens.RowHorizontalPadding,
-          vertical = MiniTabTokens.RowVerticalPadding,
-        )
       override val tabPadding: PaddingValues
         get() = PaddingValues(
           horizontal = MiniTabTokens.TabHorizontalPadding,
@@ -333,11 +332,6 @@ object TabDefaults {
     }
 
     data object Small : TabSize() {
-      override val rowPadding: PaddingValues
-        get() = PaddingValues(
-          horizontal = SmallTabTokens.RowHorizontalPadding,
-          vertical = SmallTabTokens.RowVerticalPadding,
-        )
       override val tabPadding: PaddingValues
         get() = PaddingValues(
           top = SmallTabTokens.TabTopPadding,
@@ -360,11 +354,6 @@ object TabDefaults {
     }
 
     data object Medium : TabSize() {
-      override val rowPadding: PaddingValues
-        get() = PaddingValues(
-          horizontal = MediumTabTokens.RowHorizontalPadding,
-          vertical = MediumTabTokens.RowVerticalPadding,
-        )
       override val tabPadding: PaddingValues
         get() = PaddingValues(
           top = MediumTabTokens.TabTopPadding,
@@ -387,11 +376,6 @@ object TabDefaults {
     }
 
     data object Large : TabSize() {
-      override val rowPadding: PaddingValues
-        get() = PaddingValues(
-          horizontal = LargeTabTokens.RowHorizontalPadding,
-          vertical = LargeTabTokens.RowVerticalPadding,
-        )
       override val tabPadding: PaddingValues
         get() = PaddingValues(
           top = LargeTabTokens.TabTopPadding,

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Tab.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Tab.kt
@@ -385,7 +385,6 @@ object TabDefaults {
             TabColors(
               tabRowBackground = Color.Transparent,
               chosenTabBackground = fromToken(ButtonSecondaryResting),
-              notChosenTabBackground = Color.Transparent,
               textColor = fromToken(TextPrimary),
             )
           }
@@ -400,7 +399,6 @@ object TabDefaults {
             TabColors(
               tabRowBackground = fromToken(SurfacePrimary),
               chosenTabBackground = fromToken(ButtonSecondaryAltResting),
-              notChosenTabBackground = Color.Transparent,
               textColor = fromToken(TextPrimary),
             )
           }
@@ -410,7 +408,6 @@ object TabDefaults {
     data class TabColors(
       val tabRowBackground: Color,
       val chosenTabBackground: Color,
-      val notChosenTabBackground: Color,
       val textColor: Color,
     )
   }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Tab.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Tab.kt
@@ -257,6 +257,7 @@ private data class TabRowLayoutInformation(
   fun calculateNumberOfItemsInRowNumber(rowIndex: Int): Int {
     return when {
       rowsRequired == 1 -> numberOfItems
+      maxItemsPerRow == realItemsPerRow -> realItemsPerRow
       rowIndex == rowsRequired - 1 -> numberOfItems % maxItemsPerRow
       else -> realItemsPerRow
     }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/TabTokens.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/tokens/TabTokens.kt
@@ -3,8 +3,6 @@ package com.hedvig.android.design.system.hedvig.tokens
 import androidx.compose.ui.unit.dp
 
 internal object MiniTabTokens {
-  val RowHorizontalPadding = 4.dp
-  val RowVerticalPadding = 4.dp
   val TabHorizontalPadding = 8.dp
   val TabVerticalPadding = 3.dp
   val ContainerShape = ShapeKeyTokens.CornerSmall
@@ -13,8 +11,6 @@ internal object MiniTabTokens {
 }
 
 internal object SmallTabTokens {
-  val RowHorizontalPadding = 4.dp
-  val RowVerticalPadding = 4.dp
   val TabHorizontalPadding = 12.dp
   val TabBottomPadding = 7.5.dp
   val TabTopPadding = 6.5.dp
@@ -24,8 +20,6 @@ internal object SmallTabTokens {
 }
 
 internal object MediumTabTokens {
-  val RowHorizontalPadding = 4.dp
-  val RowVerticalPadding = 4.dp
   val TabHorizontalPadding = 14.dp
   val TabBottomPadding = 7.dp
   val TabTopPadding = 7.dp
@@ -35,12 +29,15 @@ internal object MediumTabTokens {
 }
 
 internal object LargeTabTokens {
-  val RowHorizontalPadding = 4.dp
-  val RowVerticalPadding = 4.dp
   val TabHorizontalPadding = 32.dp
   val TabBottomPadding = 17.dp
   val TabTopPadding = 15.dp
   val ContainerShape = ShapeKeyTokens.CornerXLarge
   val TabShape = ShapeKeyTokens.CornerLarge
   val TextFont = TypographyKeyTokens.BodySmall
+}
+
+internal object TabTokens {
+  val RowHorizontalPadding = 4.dp
+  val RowVerticalPadding = 4.dp
 }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -50,7 +49,7 @@ import com.hedvig.android.data.productvariant.InsuranceVariantDocument
 import com.hedvig.android.data.productvariant.ProductVariant
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigPreview
-import com.hedvig.android.design.system.hedvig.HedvigTabRowMaxSixTabs
+import com.hedvig.android.design.system.hedvig.HedvigTabRow
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.InsuranceCard
 import com.hedvig.android.design.system.hedvig.InsuranceCardPlaceholder
@@ -73,7 +72,6 @@ import com.hedvig.android.feature.insurances.insurancedetail.yourinfo.YourInfoTa
 import com.hedvig.android.feature.insurances.ui.createChips
 import com.hedvig.android.feature.insurances.ui.createPainter
 import hedvig.resources.R
-import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 
 @Composable
@@ -333,7 +331,7 @@ private fun InsuranceContract.getAllDocuments(): List<InsuranceVariantDocument> 
 
 @Composable
 private fun PagerSelector(pagerState: PagerState, modifier: Modifier = Modifier) {
-  HedvigTabRowMaxSixTabs(
+  HedvigTabRow(
     tabTitles = listOf(
       stringResource(R.string.insurance_details_view_tab_1_title),
       stringResource(R.string.insurance_details_view_tab_2_title),

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
@@ -43,7 +43,7 @@ import com.hedvig.android.design.system.hedvig.ChosenState
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigCircularProgressIndicator
-import com.hedvig.android.design.system.hedvig.HedvigTabRowMaxSixTabs
+import com.hedvig.android.design.system.hedvig.HedvigTabRow
 import com.hedvig.android.design.system.hedvig.HedvigTabRowState
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
@@ -299,7 +299,7 @@ private fun ColumnScope.PreferencesSheetContent(
 
 @Composable
 private fun PreferencesPagerSelector(tabRowState: HedvigTabRowState, modifier: Modifier = Modifier) {
-  HedvigTabRowMaxSixTabs(
+  HedvigTabRow(
     tabTitles = listOf(
       stringResource(R.string.market_picker_modal_title),
       stringResource(R.string.language_picker_modal_title),

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -288,9 +288,9 @@ private fun ComparisonScreenPreview() {
     ) {
       ComparisonScreen(
         uiState = Success(
-          coverageLevels = listOf(
+          coverageLevels = List(4) { coverageIndex ->
             CoverageLevel(
-              title = "Coverage level 1",
+              title = "Cover #${coverageIndex + 1}",
               items = List(8) { index ->
                 CoverageLevel.ComparisonItem(
                   title = " title".repeat((index + 1) * 2).trimStart(),
@@ -298,8 +298,8 @@ private fun ComparisonScreenPreview() {
                   coveredStatus = if (index % 2 == 0) Description("description") else Checkmark,
                 )
               },
-            ),
-          ),
+            )
+          },
           initialTabIndex = 1,
         ),
         navigateUp = {},

--- a/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
+++ b/app/shared/tier-comparison/src/main/kotlin/com/hedvig/android/shared/tier/comparison/ui/ComparisonDestination.kt
@@ -42,7 +42,7 @@ import com.hedvig.android.design.system.hedvig.HedvigCircularProgressIndicator
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
-import com.hedvig.android.design.system.hedvig.HedvigTabRowMaxSixTabs
+import com.hedvig.android.design.system.hedvig.HedvigTabRow
 import com.hedvig.android.design.system.hedvig.HedvigTabletLandscapePreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
@@ -140,7 +140,7 @@ private fun ComparisonScreen(uiState: Success, navigateUp: () -> Unit) {
     Spacer(Modifier.height(24.dp))
     val pagerState = rememberPagerState(initialPage = uiState.initialTabIndex) { uiState.coverageLevels.size }
     val tabRowState = rememberHedvigTabRowState(pagerState)
-    HedvigTabRowMaxSixTabs(
+    HedvigTabRow(
       tabRowState = tabRowState,
       tabTitles = uiState.coverageLevels.map { it.title },
       tabStyle = TabDefaults.TabStyle.Filled,

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/tabs/Tabs.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/tabs/Tabs.kt
@@ -1,24 +1,23 @@
 package com.hedvig.android.sample.design.showcase.tabs
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.design.system.hedvig.HedvigTabRowMaxSixTabs
+import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigTabRow
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.design.system.hedvig.TabDefaults.TabSize
 import com.hedvig.android.design.system.hedvig.TabDefaults.TabSize.Large
 import com.hedvig.android.design.system.hedvig.TabDefaults.TabSize.Medium
 import com.hedvig.android.design.system.hedvig.TabDefaults.TabSize.Mini
@@ -29,8 +28,7 @@ import com.hedvig.android.design.system.hedvig.TabDefaults.TabStyle.Filled
 @Composable
 fun TabsShowcase() {
   Surface(
-    modifier = Modifier
-      .fillMaxSize(),
+    modifier = Modifier.fillMaxSize(),
     color = HedvigTheme.colorScheme.backgroundPrimary,
   ) {
     Column(
@@ -40,108 +38,53 @@ fun TabsShowcase() {
         .fillMaxSize()
         .verticalScroll(rememberScrollState()),
       horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-      HedvigText(text = "1 tab")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = listOf("One title"),
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "3 tabs")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles3,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "4 tabs")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles4,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "5 tabs")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles5,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "6 tabs")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles6,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "Small, Filled and Default")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles3,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles3,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Small,
-        tabStyle = Default,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "Mini Filled")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles3,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Mini,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "Medium Filled")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles3,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Medium,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigText(text = "Large Filled")
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles3,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Large,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
-      HedvigTabRowMaxSixTabs(
-        tabTitles = titles6,
-        modifier = Modifier.fillMaxWidth(),
-        tabSize = Large,
-        tabStyle = Filled,
-      )
-      Spacer(modifier = Modifier.height(16.dp))
+      for (size in listOf(Mini, Small, Medium, Large)) {
+        HedvigText(text = size.toString())
+        AllStyles(size)
+      }
+      for (tabNumbers in 1..7) {
+        HedvigText(text = "$tabNumbers tabs")
+        HedvigTabRow(
+          tabTitles = titles[tabNumbers - 1],
+          modifier = Modifier.fillMaxWidth(),
+          tabSize = Small,
+          tabStyle = Filled,
+        )
+      }
     }
   }
 }
 
-private val titles2 = listOf("Overview", "Documents")
-private val titles3 = listOf("Overview", "C", "Documents")
-private val titles4 = listOf("Overview", "C", "Documents", "Documents2")
-private val titles5 = listOf("Overview", "C", "Documents", "Documents2", "Something else")
-private val titles6 = listOf("Overview", "C", "Documents", "Something else", "Overview", "Overview")
+@Composable
+private fun AllStyles(size: TabSize) {
+  for (style in listOf(Filled, Default)) {
+    HedvigTabRow(
+      tabTitles = titles[2],
+      modifier = Modifier.fillMaxWidth(),
+      tabSize = size,
+      tabStyle = style,
+    )
+  }
+}
+
+private val titles = listOf(
+  listOf("Overview"),
+  listOf("Overview", "Documents"),
+  listOf("Overview", "C", "Documents"),
+  listOf("Overview", "C", "Documents", "Documents2"),
+  listOf("Overview", "C", "Documents", "Documents2", "Something else"),
+  listOf("Overview", "C", "Documents", "Something else", "Overview", "Overview"),
+  listOf("Overview", "C", "Documents", "Something else", "Overview", "Overview", "More Overview"),
+)
+
+@HedvigPreview
+@Composable
+private fun PreviewTabsShowcase() {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      TabsShowcase()
+    }
+  }
+}


### PR DESCRIPTION
The core change is that we can use textMeasurer to do this part
```
val (minItemWidth, fixedItemHeight) = remember(textMeasurer, tabTitles, density) {
  var width = 0
  var height = 0
  for (title in tabTitles) {
    val textLayoutResult = textMeasurer.measure(title, textStyle, maxLines = 1)
    width = maxOf(width, textLayoutResult.size.width)
    height = maxOf(height, textLayoutResult.size.height)
  }
  with(density) {
    val extraHorizontalSpace = tabInternalPadding.calculateStartPadding(layoutDirection)
      .plus(tabInternalPadding.calculateEndPadding(layoutDirection))
    val extraVerticalSpace = tabInternalPadding.calculateTopPadding() + tabInternalPadding.calculateBottomPadding()
    DpSize(width.toDp() + extraHorizontalSpace, height.toDp() + extraVerticalSpace)
  }
}
```
Which lets us get the real size immediately without waiting for a frame, so it makes the rest of the calculations much easier as a consequence.

This was done on top of https://github.com/HedvigInsurance/android/pull/2473 because I noticed that we got a fourth line of rows more often than we really needed to. This PR does not change the fact that it's possible to have a second or an nth row, it only makes sure that it does not go to the next row unless there really is no space for the content.

New screenshots in the same scenario after this PR:
| 1/7 | 3/7 | 7/7 |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/52ab03bd-f369-417c-b54a-3d5472b94397) | ![image](https://github.com/user-attachments/assets/3f91f40e-269e-4d91-b412-6b9bd9d0481a) | ![image](https://github.com/user-attachments/assets/92f7c162-0e11-4c93-a45f-d987dfc318b2) |
