### PR TITLE
Fix bottom sheet showing before properly navigating back

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,6 +50,8 @@ jobs:
           HEDVIG_GITHUB_PACKAGES_USER: ${{ secrets.HEDVIG_GITHUB_PACKAGES_USER }}
           HEDVIG_GITHUB_PACKAGES_TOKEN: ${{ secrets.HEDVIG_GITHUB_PACKAGES_TOKEN }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          LOKALISE_ID: ${{ secrets.LOKALISE_ID }}
+          LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
       - name: Setup JDK 17
         uses: actions/setup-java@v4.7.0
         with:

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -54,8 +54,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.lifecycle.withStateAtLeast
 import arrow.core.nonEmptyListOf
 import com.google.accompanist.permissions.isGranted
 import com.hedvig.android.compose.pager.indicator.HorizontalPagerIndicator
@@ -592,9 +595,12 @@ private fun CrossSellBottomSheet(
   markCrossSellsNotificationAsSeen: () -> Unit,
   onCrossSellClick: (String) -> Unit,
 ) {
-  LaunchedEffect(forceShowCrossSells) {
-    if (forceShowCrossSells?.isNotEmpty() == true) {
-      state.show(forceShowCrossSells)
+  val lifecycle = LocalLifecycleOwner.current.lifecycle
+  LaunchedEffect(forceShowCrossSells, lifecycle) {
+    lifecycle.withStateAtLeast(Lifecycle.State.RESUMED) {
+      if (forceShowCrossSells?.isNotEmpty() == true) {
+        state.show(forceShowCrossSells)
+      }
     }
   }
   LaunchedEffect(state) {


### PR DESCRIPTION
Now it will wait until we've settled back to the home screen before it considers showing the bottom sheet.
There are no changes required as to when we mark the cross sells as seen, since that step is linked with the sheet actually being actually shown, which now simply happens a bit later.