### PR TITLE
a11y: unscrollable screens

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
@@ -243,9 +243,13 @@ fun HedvigDialog(
     onDismissRequest = onDismissRequest,
     properties = dialogProperties,
   ) {
-    HedvigDialogContent(dialogProperties.usePlatformDefaultWidth, applyDefaultPadding, style,
+    HedvigDialogContent(
+      dialogProperties.usePlatformDefaultWidth,
+      applyDefaultPadding,
+      style,
       modifier.verticalScroll(rememberScrollState()),
-      content)
+      content,
+    )
   }
 }
 

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.derivedStateOf
@@ -241,7 +243,9 @@ fun HedvigDialog(
     onDismissRequest = onDismissRequest,
     properties = dialogProperties,
   ) {
-    HedvigDialogContent(dialogProperties.usePlatformDefaultWidth, applyDefaultPadding, style, modifier, content)
+    HedvigDialogContent(dialogProperties.usePlatformDefaultWidth, applyDefaultPadding, style,
+      modifier.verticalScroll(rememberScrollState()),
+      content)
   }
 }
 

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
@@ -66,6 +66,7 @@ fun ErrorDialog(
     style = NoButtons,
     onDismissRequest = onDismiss,
     modifier = modifier,
+    applyVerticalScroll = true,
   ) {
     EmptyState(
       text = title,
@@ -103,6 +104,7 @@ fun HedvigAlertDialog(
       buttonSize = buttonSize,
     ),
     onDismissRequest = onDismissRequest,
+    applyVerticalScroll = true,
     modifier = modifier,
   ) {
     Column(
@@ -233,6 +235,7 @@ fun MultiSelectDialog(
 @Composable
 fun HedvigDialog(
   onDismissRequest: () -> Unit,
+  applyVerticalScroll: Boolean,
   modifier: Modifier = Modifier,
   applyDefaultPadding: Boolean = true,
   dialogProperties: DialogProperties = DialogDefaults.defaultProperties,
@@ -247,7 +250,14 @@ fun HedvigDialog(
       dialogProperties.usePlatformDefaultWidth,
       applyDefaultPadding,
       style,
-      modifier.verticalScroll(rememberScrollState()),
+      modifier
+        .then(
+          if (applyVerticalScroll) {
+            Modifier.verticalScroll(rememberScrollState())
+          } else {
+            Modifier
+          },
+        ),
       content,
     )
   }
@@ -368,6 +378,7 @@ private fun CoreSelectDialog(
   HedvigDialog(
     onDismissRequest = { onDismissRequest.invoke() },
     applyDefaultPadding = false,
+    applyVerticalScroll = false,
   ) {
     Column(
       horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dropdown.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Dropdown.kt
@@ -93,6 +93,7 @@ fun DropdownWithDialog(
         isDialogVisible = false
       },
       style = DialogDefaults.DialogStyle.NoButtons,
+      applyVerticalScroll = true,
     ) {
       Surface(
         color = dropdownColors.containerColor(false).value,
@@ -161,6 +162,7 @@ fun DropdownWithDialog(
         isDialogVisible = false
       },
       style = DialogDefaults.DialogStyle.NoButtons,
+      applyVerticalScroll = false,
     ) {
       dialogContent {
         onDoAlongWithDismissRequest?.invoke()
@@ -212,6 +214,7 @@ fun DropdownWithDialog(
         isDialogVisible = false
       },
       style = DialogDefaults.DialogStyle.NoButtons,
+      applyVerticalScroll = false,
     ) {
       dialogContent {
         isDialogVisible = false

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
@@ -46,13 +46,14 @@ fun HedvigErrorSection(
   }
 }
 
-
 @HedvigShortMultiScreenPreview
 @Composable
 fun HedvigErrorSectionPreview() {
   HedvigTheme {
-    Surface(color = HedvigTheme.colorScheme.backgroundPrimary,
-      modifier = Modifier.fillMaxSize()) {
+    Surface(
+      color = HedvigTheme.colorScheme.backgroundPrimary,
+      modifier = Modifier.fillMaxSize(),
+    ) {
       HedvigErrorSection({})
     }
   }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
@@ -3,6 +3,7 @@ package com.hedvig.android.design.system.hedvig
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -42,5 +43,17 @@ fun HedvigErrorSection(
         onButtonClick = onButtonClick,
       ),
     )
+  }
+}
+
+
+@HedvigShortMultiScreenPreview
+@Composable
+fun HedvigErrorSectionPreview() {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary,
+      modifier = Modifier.fillMaxSize()) {
+      HedvigErrorSection({})
+    }
   }
 }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigErrorSection.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,7 +30,8 @@ fun HedvigErrorSection(
     verticalArrangement = Arrangement.Center,
     modifier = modifier
       .windowInsetsPadding(windowInsets)
-      .padding(horizontal = 16.dp),
+      .padding(horizontal = 16.dp)
+      .verticalScroll(rememberScrollState()),
   ) {
     EmptyState(
       text = title,

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
@@ -183,8 +183,21 @@ private annotation class HedvigTabletPreview
 )
 annotation class HedvigTabletLandscapePreview
 
+@Preview(
+  name = "lightMode small screen landscape",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:width=300dp,height=240dp,dpi=240,orientation=landscape",
+)
+@Preview(
+  name = "lightMode small screen portrait",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:width=300dp,height=240dp,dpi=240,orientation=portrait",
+)
+annotation class HedvigVerySmallScreenPreview
+
 @HedvigPreview
 @HedvigLandscapePreview
 @HedvigTabletPreview
 @HedvigTabletLandscapePreview
+@HedvigVerySmallScreenPreview
 annotation class HedvigMultiScreenPreview

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
@@ -184,11 +184,6 @@ private annotation class HedvigTabletPreview
 annotation class HedvigTabletLandscapePreview
 
 @Preview(
-  name = "lightMode small screen landscape",
-  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
-  device = "spec:width=300dp,height=240dp,dpi=240,orientation=landscape",
-)
-@Preview(
   name = "lightMode small screen portrait",
   uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
   device = "spec:width=300dp,height=240dp,dpi=240,orientation=portrait",

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigPreview.kt
@@ -136,11 +136,11 @@ fun rememberPreviewSimpleCache(): Cache {
 }
 
 @Preview(
-  name = "lightMode portrait",
+  name = "00_lightMode portrait",
   uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
 )
 @Preview(
-  name = "nightMode portrait",
+  name = "01_nightMode portrait",
   uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
 )
 annotation class HedvigPreview
@@ -158,6 +158,14 @@ annotation class HedvigPreview
   device = "spec:parent=pixel_5,orientation=landscape",
 )
 private annotation class HedvigLandscapePreview
+
+@Preview(
+  name = "02_lightMode landscape",
+  locale = "en",
+  uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
+  device = "spec:parent=pixel_5,orientation=landscape",
+)
+private annotation class HedvigOnlyLightLandscapePreview
 
 @Preview(
   name = "lightMode tablet portrait",
@@ -184,7 +192,7 @@ private annotation class HedvigTabletPreview
 annotation class HedvigTabletLandscapePreview
 
 @Preview(
-  name = "lightMode small screen portrait",
+  name = "03_lightMode small screen portrait",
   uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL,
   device = "spec:width=300dp,height=240dp,dpi=240,orientation=portrait",
 )
@@ -196,3 +204,8 @@ annotation class HedvigVerySmallScreenPreview
 @HedvigTabletLandscapePreview
 @HedvigVerySmallScreenPreview
 annotation class HedvigMultiScreenPreview
+
+@HedvigPreview
+@HedvigOnlyLightLandscapePreview
+@HedvigVerySmallScreenPreview
+annotation class HedvigShortMultiScreenPreview

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
@@ -259,6 +259,7 @@ private fun SummaryTopAppBar(onExitTierFlow: () -> Unit) {
         },
         confirmButtonText = stringResource(R.string.GENERAL_YES),
       ),
+      applyVerticalScroll = true,
     ) {
       Column(horizontalAlignment = Alignment.CenterHorizontally) {
         HedvigText(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -90,7 +90,7 @@ internal fun AddCoInsuredBottomSheetContent(
   onCoInsuredSelected: (CoInsured) -> Unit,
 ) {
   Column(
-    modifier = Modifier.verticalScroll(rememberScrollState())
+    modifier = Modifier
   ) {
     Spacer(Modifier.height(16.dp))
     HedvigText(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -12,14 +12,11 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,7 +88,7 @@ internal fun AddCoInsuredBottomSheetContent(
   onCoInsuredSelected: (CoInsured) -> Unit,
 ) {
   Column(
-    modifier = Modifier
+    modifier = Modifier,
   ) {
     Spacer(Modifier.height(16.dp))
     HedvigText(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -342,7 +343,7 @@ private fun ManualInputFields(
           capitalization = KeyboardCapitalization.Words,
           keyboardType = KeyboardType.Text,
         ),
-        modifier = Modifier.weight(1f).requiredHeight(64.dp),
+        modifier = Modifier.weight(1f).defaultMinSize(minHeight = 64.dp),
       )
       Spacer(Modifier.width(4.dp))
       HedvigTextField(
@@ -357,7 +358,7 @@ private fun ManualInputFields(
           capitalization = KeyboardCapitalization.Words,
           keyboardType = KeyboardType.Text,
         ),
-        modifier = Modifier.weight(1f).requiredHeight(64.dp),
+        modifier = Modifier.weight(1f).defaultMinSize(minHeight = 64.dp),
       )
     }
     AnimatedVisibility(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,6 +46,7 @@ import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigCard
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
 import com.hedvig.android.design.system.hedvig.HedvigTextField
@@ -86,7 +89,9 @@ internal fun AddCoInsuredBottomSheetContent(
   onAddNewCoInsured: () -> Unit,
   onCoInsuredSelected: (CoInsured) -> Unit,
 ) {
-  Column {
+  Column(
+    modifier = Modifier.verticalScroll(rememberScrollState())
+  ) {
     Spacer(Modifier.height(16.dp))
     HedvigText(
       text = stringResource(id = R.string.CONTRACT_ADD_COINSURED),
@@ -459,7 +464,7 @@ private fun AddBottomSheetContentState.SaveButtonLabel.stringRes() = when (this)
 }
 
 @Composable
-@HedvigPreview
+@HedvigShortMultiScreenPreview
 private fun AddCoInsuredBottomSheetContentPreview() {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -29,9 +29,7 @@ import com.hedvig.android.design.system.hedvig.ErrorDialog
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
-import com.hedvig.android.design.system.hedvig.HedvigMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
-import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
 import com.hedvig.android.design.system.hedvig.HedvigTheme

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -32,6 +32,7 @@ import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProg
 import com.hedvig.android.design.system.hedvig.HedvigMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.NotificationDefaults
@@ -299,10 +300,10 @@ internal fun ClearBottomSheetContentStateOnSheetDismissedEffect(
 }
 
 @Composable
-@HedvigPreview
+@HedvigShortMultiScreenPreview
 private fun EditCoInsuredScreenErrorPreview() {
   HedvigTheme {
-    Surface {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       EditCoInsuredScreen(
         navigateUp = { },
         uiState = EditCoInsuredState.Error("Something"),
@@ -325,10 +326,10 @@ private fun EditCoInsuredScreenErrorPreview() {
 }
 
 @Composable
-@HedvigMultiScreenPreview
+@HedvigShortMultiScreenPreview
 private fun EditCoInsuredScreenEditablePreview() {
   HedvigTheme {
-    Surface {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       EditCoInsuredScreen(
         navigateUp = { },
         uiState = EditCoInsuredState.Loaded(
@@ -410,10 +411,10 @@ private fun EditCoInsuredScreenEditablePreview() {
 }
 
 @Composable
-@HedvigPreview
+@HedvigShortMultiScreenPreview
 private fun EditCoInsuredScreenNonEditablePreview() {
   HedvigTheme {
-    Surface {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       EditCoInsuredScreen(
         navigateUp = { },
         uiState = EditCoInsuredState.Loaded(

--- a/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/home/HelpCenterHomeDestination.kt
+++ b/app/feature/feature-help-center/src/main/kotlin/com/hedvig/android/feature/help/center/home/HelpCenterHomeDestination.kt
@@ -225,8 +225,9 @@ private fun HelpCenterHomeScreen(
           onDismissQuickActionDialog()
         },
         style = DialogDefaults.DialogStyle.NoButtons,
+        applyVerticalScroll = true,
       ) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp).verticalScroll(rememberScrollState())) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
           var selectedIndex by remember { mutableStateOf<Int?>(null) }
           Spacer(Modifier.height(24.dp))
           HedvigText(

--- a/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/email/InsuranceEvidenceEmailInputDestination.kt
+++ b/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/email/InsuranceEvidenceEmailInputDestination.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -155,6 +157,7 @@ private fun InsuranceEvidenceEmailSuccessScreen(
         uiState = uiState,
         onSubmit = onSubmit,
         onChangeEmail = onChangeEmail,
+        modifier = Modifier.fillMaxSize()
       )
       Column(
         Modifier.fillMaxSize(),
@@ -195,7 +198,8 @@ private fun SuccessContent(
   var emailInput by remember {
     mutableStateOf(uiState.email ?: "")
   }
-  Column(modifier) {
+  Column(modifier
+    .verticalScroll(rememberScrollState())) {
     Spacer(modifier = Modifier.height(8.dp))
     FlowHeading(
       stringResource(R.string.INSURANCE_EVIDENCE_DOCUMENT_TITLE),

--- a/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/email/InsuranceEvidenceEmailInputDestination.kt
+++ b/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/email/InsuranceEvidenceEmailInputDestination.kt
@@ -42,6 +42,7 @@ import com.hedvig.android.design.system.hedvig.HedvigTextFieldDefaults.ErrorStat
 import com.hedvig.android.design.system.hedvig.HedvigTextFieldDefaults.TextFieldSize.Medium
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HedvigTooltip
+import com.hedvig.android.design.system.hedvig.HedvigVerySmallScreenPreview
 import com.hedvig.android.design.system.hedvig.Icon
 import com.hedvig.android.design.system.hedvig.IconButton
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority
@@ -157,7 +158,7 @@ private fun InsuranceEvidenceEmailSuccessScreen(
         uiState = uiState,
         onSubmit = onSubmit,
         onChangeEmail = onChangeEmail,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
       )
       Column(
         Modifier.fillMaxSize(),
@@ -198,8 +199,10 @@ private fun SuccessContent(
   var emailInput by remember {
     mutableStateOf(uiState.email ?: "")
   }
-  Column(modifier
-    .verticalScroll(rememberScrollState())) {
+  Column(
+    modifier
+      .verticalScroll(rememberScrollState()),
+  ) {
     Spacer(modifier = Modifier.height(8.dp))
     FlowHeading(
       stringResource(R.string.INSURANCE_EVIDENCE_DOCUMENT_TITLE),
@@ -282,6 +285,7 @@ internal fun ExplanationBottomSheet(sheetState: HedvigBottomSheetState<Unit>) {
   }
 }
 
+@HedvigVerySmallScreenPreview
 @HedvigPreview
 @Composable
 private fun PreviewInsuranceEvidenceEmailInputScreen(

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/MovingFlowTopAppBar.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/MovingFlowTopAppBar.kt
@@ -68,6 +68,7 @@ private fun MovingFlowTopAppBar(
         },
         confirmButtonText = stringResource(R.string.GENERAL_YES),
       ),
+      applyVerticalScroll = true,
     ) {
       Column(horizontalAlignment = Alignment.CenterHorizontally) {
         HedvigText(

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/addhouseinformation/AddHouseInformationDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/addhouseinformation/AddHouseInformationDestination.kt
@@ -291,6 +291,7 @@ private fun ExtraBuildingsCard(
       dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
       onDismissRequest = { extraBuildingsDialogOpen = false },
       style = NoButtons,
+      applyVerticalScroll = false,
     ) {
       ExtraBuildingsDialogContent(
         extraBuildings = extraBuildings,

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -170,6 +170,7 @@ private fun TerminationSurveyScreen(
           HedvigDialog(
             onDismissRequest = closeEmptyQuotesDialog,
             dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+            applyVerticalScroll = true,
           ) {
             EmptyQuotesDialogContent(closeEmptyQuotesDialog)
           }

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
@@ -37,9 +37,11 @@ import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgress
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
+import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HedvigTooltip
+import com.hedvig.android.design.system.hedvig.HedvigVerySmallScreenPreview
 import com.hedvig.android.design.system.hedvig.HorizontalDivider
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.design.system.hedvig.Icon
@@ -365,7 +367,7 @@ private fun TravelCertificatesList(
   }
 }
 
-@HedvigPreview
+@HedvigShortMultiScreenPreview
 @Composable
 private fun PreviewTravelCertificateHistoryScreenWithEmptyList(
   @PreviewParameter(TravelCertificateHistoryUiStatePreviewProvider::class) uiState: CertificateHistoryUiState,

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
@@ -35,13 +35,11 @@ import com.hedvig.android.design.system.hedvig.FeatureAddonBanner
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgress
-import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HedvigTooltip
-import com.hedvig.android.design.system.hedvig.HedvigVerySmallScreenPreview
 import com.hedvig.android.design.system.hedvig.HorizontalDivider
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.design.system.hedvig.Icon

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/TravelCertificateHistory.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -205,7 +207,8 @@ private fun TravelCertificateSuccessScreen(
     Box(Modifier.weight(1f)) {
       Column(
         Modifier
-          .fillMaxSize(),
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState()),
       ) {
         if (historyList.isEmpty()) {
           Spacer(modifier = Modifier.weight(1f))

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/dialog/ShowcaseDialog.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/dialog/ShowcaseDialog.kt
@@ -44,6 +44,7 @@ fun DialogShowcase() {
         },
         buttonSize = SMALL,
       ),
+      applyVerticalScroll = true,
     ) {
       EmptyState(
         text = "Are you sure?",


### PR DESCRIPTION
Fixed the scroll in the places where I noticed that, applying scroll actively in the dialogs (bc we have a few dialogs with lazyList - I think it's better to explicitly set it every time). AlertDialog and ErrorDialog will have vertical scroll by default.

Also added HedvigVerySmallScreenPreview to make it easier not to forget about these cases (it does not entirely make up for huge fonts scenarios, but it's close), and HedvigShortMultiScreenPreview (bc HedvigMultiScreenPreview is a bit excessive I think in most cases).

