### PR TITLE
no coinsured reminder for expiring contracts

### DIFF
--- a/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsCoInsuredInfoReminder.graphql
+++ b/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsCoInsuredInfoReminder.graphql
@@ -1,6 +1,7 @@
 query NeedsCoInsuredInfoReminder {
   currentMember {
     activeContracts {
+      terminationDate
       id
       coInsured {
         hasMissingInfo

--- a/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsCoInsuredInfoReminder.graphql
+++ b/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsCoInsuredInfoReminder.graphql
@@ -1,7 +1,6 @@
 query NeedsCoInsuredInfoReminder {
   currentMember {
     activeContracts {
-      terminationDate
       id
       coInsured {
         hasMissingInfo

--- a/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsCoInsuredInfoReminder.graphql
+++ b/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsCoInsuredInfoReminder.graphql
@@ -6,6 +6,7 @@ query NeedsCoInsuredInfoReminder {
         hasMissingInfo
         terminatesOn
       }
+      supportsCoInsured
     }
   }
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
@@ -61,11 +61,7 @@ internal class GetNeedsCoInsuredInfoRemindersUseCaseImpl(
   }
 
   private fun NeedsCoInsuredInfoReminderQuery.Data.CurrentMember.ActiveContract.hasMissingInfoAndIsNotTerminating():Boolean {
-    val contract = this
-    logcat { "Mariia: the contract ${contract.id} terminationDate: ${contract.terminationDate} " }
     return coInsured?.any {
-      logcat { "Mariia: coInsured for contract ${contract.id} hasMissingInfo: " +
-        " ${it.hasMissingInfo} terminatesOn: ${it.terminatesOn}" }
       it.hasMissingInfo && it.terminatesOn == null
     } == true
   }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
@@ -14,6 +14,7 @@ import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
+import com.hedvig.android.logger.logcat
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -59,8 +60,15 @@ internal class GetNeedsCoInsuredInfoRemindersUseCaseImpl(
     }
   }
 
-  private fun NeedsCoInsuredInfoReminderQuery.Data.CurrentMember.ActiveContract.hasMissingInfoAndIsNotTerminating() =
-    coInsured?.any { it.hasMissingInfo && it.terminatesOn == null } == true
+  private fun NeedsCoInsuredInfoReminderQuery.Data.CurrentMember.ActiveContract.hasMissingInfoAndIsNotTerminating():Boolean {
+    val contract = this
+    logcat { "Mariia: the contract ${contract.id} terminationDate: ${contract.terminationDate} " }
+    return coInsured?.any {
+      logcat { "Mariia: coInsured for contract ${contract.id} hasMissingInfo: " +
+        " ${it.hasMissingInfo} terminatesOn: ${it.terminatesOn}" }
+      it.hasMissingInfo && it.terminatesOn == null
+    } == true
+  }
 }
 
 sealed interface CoInsuredInfoReminderError {

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
@@ -14,7 +14,6 @@ import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
-import com.hedvig.android.logger.logcat
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -60,7 +59,7 @@ internal class GetNeedsCoInsuredInfoRemindersUseCaseImpl(
     }
   }
 
-  private fun NeedsCoInsuredInfoReminderQuery.Data.CurrentMember.ActiveContract.hasMissingInfoAndIsNotTerminating():Boolean {
+  private fun NeedsCoInsuredInfoReminderQuery.Data.CurrentMember.ActiveContract.hasMissingInfoAndIsNotTerminating(): Boolean {
     return coInsured?.any {
       it.hasMissingInfo && it.terminatesOn == null && supportsCoInsured
     } == true

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
@@ -62,7 +62,7 @@ internal class GetNeedsCoInsuredInfoRemindersUseCaseImpl(
 
   private fun NeedsCoInsuredInfoReminderQuery.Data.CurrentMember.ActiveContract.hasMissingInfoAndIsNotTerminating():Boolean {
     return coInsured?.any {
-      it.hasMissingInfo && it.terminatesOn == null
+      it.hasMissingInfo && it.terminatesOn == null && supportsCoInsured
     } == true
   }
 }


### PR DESCRIPTION
We previously hadn't check for allowEditCoInsured when showing banners (neither did we check for the termination date not being null, so we prompted members to add coInsured where they cannot be added - in contracts terminating in the future). 

Now I changed `supportsCoInsured` from the [backend](https://github.com/HedvigInsurance/underwriter/pull/1526) so we only would need to check for it.