### PR TITLE
GEN-3713 Feature/contact UI update

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,40 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -36,7 +36,8 @@ import com.hedvig.android.feature.connect.payment.trustly.ui.TrustlyDestination
 import com.hedvig.android.feature.deleteaccount.navigation.DeleteAccountDestination
 import com.hedvig.android.feature.deleteaccount.navigation.deleteAccountGraph
 import com.hedvig.android.feature.editcoinsured.navigation.EditCoInsuredDestination
-import com.hedvig.android.feature.editcoinsured.navigation.EditCoInsuredDestination.*
+import com.hedvig.android.feature.editcoinsured.navigation.EditCoInsuredDestination.CoInsuredAddInfo
+import com.hedvig.android.feature.editcoinsured.navigation.EditCoInsuredDestination.CoInsuredAddOrRemove
 import com.hedvig.android.feature.editcoinsured.navigation.EditCoInsuredDestination.EditCoInsuredTriage
 import com.hedvig.android.feature.editcoinsured.navigation.editCoInsuredGraph
 import com.hedvig.android.feature.forever.navigation.foreverGraph
@@ -67,6 +68,7 @@ import com.hedvig.android.feature.odyssey.navigation.claimFlowGraph
 import com.hedvig.android.feature.odyssey.navigation.navigateToClaimFlowDestination
 import com.hedvig.android.feature.odyssey.navigation.terminalClaimFlowStepDestinations
 import com.hedvig.android.feature.payments.navigation.paymentsGraph
+import com.hedvig.android.feature.profile.navigation.ProfileDestination
 import com.hedvig.android.feature.profile.tab.profileGraph
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceGraphDestination
 import com.hedvig.android.feature.terminateinsurance.navigation.terminateInsuranceGraph
@@ -193,6 +195,9 @@ internal fun HedvigNavHost(
       navigator = navigator,
       onNavigateToAddonPurchaseFlow = { ids ->
         navigator.navigateUnsafe(AddonPurchaseGraphDestination(ids, TravelAddonBannerSource.INSURANCES_TAB))
+      },
+      navigateToContactInfo = { backStackEntry ->
+        with(navigator) { backStackEntry.navigate(ProfileDestination.ContactInfo) }
       },
     )
     insuranceGraph(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
@@ -56,6 +56,7 @@ fun NavGraphBuilder.homeGraph(
           }
         },
         onNavigateToAddonPurchaseFlow = onNavigateToAddonPurchaseFlow,
+        navigateToContactInfo = TODO()
       )
     }
     navdestination<HomeDestination.FirstVet>(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeGraph.kt
@@ -22,6 +22,7 @@ fun NavGraphBuilder.homeGraph(
   onStartClaim: (NavBackStackEntry) -> Unit,
   navigateToClaimDetails: (NavBackStackEntry, claimId: String) -> Unit,
   navigateToConnectPayment: () -> Unit,
+  navigateToContactInfo: (NavBackStackEntry) -> Unit,
   navigateToMissingInfo: (NavBackStackEntry, String) -> Unit,
   navigateToHelpCenter: (NavBackStackEntry) -> Unit,
   openAppSettings: () -> Unit,
@@ -56,7 +57,9 @@ fun NavGraphBuilder.homeGraph(
           }
         },
         onNavigateToAddonPurchaseFlow = onNavigateToAddonPurchaseFlow,
-        navigateToContactInfo = TODO()
+        navigateToContactInfo = {
+          navigateToContactInfo(backStackEntry)
+        },
       )
     }
     navdestination<HomeDestination.FirstVet>(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -138,6 +138,7 @@ internal fun HomeDestination(
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String) -> Unit,
   navigateToFirstVet: (List<FirstVetSection>) -> Unit,
+  navigateToContactInfo: () -> Unit,
   onNavigateToAddonPurchaseFlow: (List<String>) -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -159,6 +160,7 @@ internal fun HomeDestination(
     navigateToFirstVet = navigateToFirstVet,
     markCrossSellsNotificationAsSeen = { viewModel.emit(HomeEvent.MarkCardCrossSellsAsSeen) },
     onNavigateToAddonPurchaseFlow = onNavigateToAddonPurchaseFlow,
+    navigateToContactInfo = navigateToContactInfo
   )
 }
 
@@ -178,6 +180,7 @@ private fun HomeScreen(
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String) -> Unit,
   navigateToFirstVet: (List<FirstVetSection>) -> Unit,
+  navigateToContactInfo: () -> Unit,
   markCrossSellsNotificationAsSeen: () -> Unit,
   onNavigateToAddonPurchaseFlow: (List<String>) -> Unit,
 ) {
@@ -237,6 +240,7 @@ private fun HomeScreen(
             navigateToMissingInfo = navigateToMissingInfo,
             onNavigateToNewConversation = onNavigateToNewConversation,
             markMessageAsSeen = markMessageAsSeen,
+            navigateToContactInfo = navigateToContactInfo
           )
         }
       }
@@ -355,6 +359,7 @@ private fun HomeScreenSuccess(
   markMessageAsSeen: (String) -> Unit,
   navigateToMissingInfo: (String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
+  navigateToContactInfo: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   var fullScreenSize: IntSize? by remember { mutableStateOf(null) }
@@ -421,6 +426,7 @@ private fun HomeScreenSuccess(
             onNavigateToNewConversation = onNavigateToNewConversation,
             openUrl = openUrl,
             contentPadding = PaddingValues(horizontal = 16.dp) + horizontalInsets,
+            navigateToContactInfo = navigateToContactInfo
           )
         },
         startClaimButton = {
@@ -694,6 +700,7 @@ private fun PreviewHomeScreen(
         navigateToFirstVet = {},
         markCrossSellsNotificationAsSeen = {},
         onNavigateToAddonPurchaseFlow = {},
+        navigateToContactInfo = {}
       )
     }
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -160,7 +160,7 @@ internal fun HomeDestination(
     navigateToFirstVet = navigateToFirstVet,
     markCrossSellsNotificationAsSeen = { viewModel.emit(HomeEvent.MarkCardCrossSellsAsSeen) },
     onNavigateToAddonPurchaseFlow = onNavigateToAddonPurchaseFlow,
-    navigateToContactInfo = navigateToContactInfo
+    navigateToContactInfo = navigateToContactInfo,
   )
 }
 
@@ -240,7 +240,7 @@ private fun HomeScreen(
             navigateToMissingInfo = navigateToMissingInfo,
             onNavigateToNewConversation = onNavigateToNewConversation,
             markMessageAsSeen = markMessageAsSeen,
-            navigateToContactInfo = navigateToContactInfo
+            navigateToContactInfo = navigateToContactInfo,
           )
         }
       }
@@ -426,7 +426,7 @@ private fun HomeScreenSuccess(
             onNavigateToNewConversation = onNavigateToNewConversation,
             openUrl = openUrl,
             contentPadding = PaddingValues(horizontal = 16.dp) + horizontalInsets,
-            navigateToContactInfo = navigateToContactInfo
+            navigateToContactInfo = navigateToContactInfo,
           )
         },
         startClaimButton = {
@@ -700,7 +700,7 @@ private fun PreviewHomeScreen(
         navigateToFirstVet = {},
         markCrossSellsNotificationAsSeen = {},
         onNavigateToAddonPurchaseFlow = {},
-        navigateToContactInfo = {}
+        navigateToContactInfo = {},
       )
     }
   }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.profile.contactinfo
 
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -26,11 +27,13 @@ import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterPr
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
+import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigTextField
 import com.hedvig.android.design.system.hedvig.HedvigTextFieldDefaults
 import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.NotificationDefaults
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.clearFocusOnTap
 import com.hedvig.android.feature.profile.contactinfo.ContactInfoEvent.RetryLoadData
@@ -89,24 +92,17 @@ private fun ContactInfoScreen(
 }
 
 @Composable
-private fun SuccessState(
+private fun ColumnScope.SuccessState(
   uiState: ContactInfoUiState.Content,
   updateEmailAndPhoneNumber: () -> Unit,
   focusManager: FocusManager,
 ) {
+  Spacer(Modifier.weight(1f))
   Spacer(Modifier.height(16.dp))
-  ContactInfoTextField(
-    textFieldState = uiState.phoneNumberState,
-    labelText = stringResource(R.string.PHONE_NUMBER_ROW_TITLE),
-    errorText = stringResource(R.string.PROFILE_MY_INFO_VALIDATION_DIALOG_DESCRIPTION_PHONE_NUMBER).takeIf {
-      uiState.phoneNumberHasError
-    },
-    keyboardOptions = KeyboardOptions(
-      keyboardType = KeyboardType.Phone,
-      imeAction = ImeAction.Next,
-    ),
-    inputTransformation = uiState.phoneNumberInputTransformation,
-    keyboardActionHandler = null,
+  HedvigNotificationCard(
+    message = stringResource(R.string.PROFILE_MY_INFO_REVIEW_INFO_CARD),
+    priority = NotificationDefaults.NotificationPriority.Info,
+    modifier = Modifier.padding(horizontal = 16.dp),
   )
   Spacer(Modifier.height(4.dp))
   ContactInfoTextField(
@@ -124,6 +120,20 @@ private fun SuccessState(
       updateEmailAndPhoneNumber()
       focusManager.clearFocus()
     },
+  )
+  Spacer(Modifier.height(4.dp))
+  ContactInfoTextField(
+    textFieldState = uiState.phoneNumberState,
+    labelText = stringResource(R.string.PHONE_NUMBER_ROW_TITLE),
+    errorText = stringResource(R.string.PROFILE_MY_INFO_VALIDATION_DIALOG_DESCRIPTION_PHONE_NUMBER).takeIf {
+      uiState.phoneNumberHasError
+    },
+    keyboardOptions = KeyboardOptions(
+      keyboardType = KeyboardType.Phone,
+      imeAction = ImeAction.Next,
+    ),
+    inputTransformation = uiState.phoneNumberInputTransformation,
+    keyboardActionHandler = null,
   )
   Spacer(Modifier.height(16.dp))
   if (uiState.canSubmit || uiState.submittingUpdatedInfo) {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
@@ -69,15 +69,21 @@ private fun ContactInfoScreen(
   HedvigScaffold(
     topAppBarText = stringResource(R.string.PROFILE_MY_INFO_ROW_TITLE),
     navigateUp = navigateUp,
-    modifier = Modifier.fillMaxSize().clearFocusOnTap(),
+    modifier = Modifier
+      .fillMaxSize()
+      .clearFocusOnTap(),
   ) {
     when (uiState) {
       ContactInfoUiState.Loading -> {
-        HedvigFullScreenCenterAlignedProgressDebounced(Modifier.weight(1f).wrapContentHeight())
+        HedvigFullScreenCenterAlignedProgressDebounced(Modifier
+          .weight(1f)
+          .wrapContentHeight())
       }
 
       ContactInfoUiState.Error -> {
-        HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f).wrapContentHeight())
+        HedvigErrorSection(onButtonClick = reload, modifier = Modifier
+          .weight(1f)
+          .wrapContentHeight())
       }
 
       is ContactInfoUiState.Content -> {
@@ -136,21 +142,19 @@ private fun ColumnScope.SuccessState(
     keyboardActionHandler = null,
   )
   Spacer(Modifier.height(16.dp))
-  if (uiState.canSubmit || uiState.submittingUpdatedInfo) {
-    HedvigButton(
-      text = stringResource(R.string.general_save_button),
-      enabled = uiState.canSubmit,
-      onClick = {
-        focusManager.clearFocus()
-        updateEmailAndPhoneNumber()
-      },
-      isLoading = uiState.submittingUpdatedInfo,
-      modifier = Modifier
-        .padding(horizontal = 16.dp)
-        .fillMaxSize(),
-    )
-    Spacer(Modifier.height(16.dp))
-  }
+  HedvigButton(
+    text = stringResource(R.string.general_save_button),
+    enabled = uiState.canSubmit || uiState.submittingUpdatedInfo,
+    onClick = {
+      focusManager.clearFocus()
+      updateEmailAndPhoneNumber()
+    },
+    isLoading = uiState.submittingUpdatedInfo,
+    modifier = Modifier
+      .padding(horizontal = 16.dp)
+      .fillMaxSize(),
+  )
+  Spacer(Modifier.height(16.dp))
 }
 
 @Composable

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
@@ -75,15 +75,20 @@ private fun ContactInfoScreen(
   ) {
     when (uiState) {
       ContactInfoUiState.Loading -> {
-        HedvigFullScreenCenterAlignedProgressDebounced(Modifier
-          .weight(1f)
-          .wrapContentHeight())
+        HedvigFullScreenCenterAlignedProgressDebounced(
+          Modifier
+            .weight(1f)
+            .wrapContentHeight(),
+        )
       }
 
       ContactInfoUiState.Error -> {
-        HedvigErrorSection(onButtonClick = reload, modifier = Modifier
-          .weight(1f)
-          .wrapContentHeight())
+        HedvigErrorSection(
+          onButtonClick = reload,
+          modifier = Modifier
+            .weight(1f)
+            .wrapContentHeight(),
+        )
       }
 
       is ContactInfoUiState.Content -> {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/navigation/ProfileDestinations.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/navigation/ProfileDestinations.kt
@@ -10,6 +10,9 @@ sealed interface ProfileDestination {
 
   @Serializable
   data object Profile : ProfileDestination, Destination
+
+  @Serializable
+  data object ContactInfo : ProfileDestination, Destination
 }
 
 internal sealed interface ProfileDestinations {
@@ -18,9 +21,6 @@ internal sealed interface ProfileDestinations {
 
   @Serializable
   data object Certificates : ProfileDestinations, Destination
-
-  @Serializable
-  data object ContactInfo : ProfileDestinations, Destination
 
   @Serializable
   data object AboutApp : ProfileDestinations, Destination

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
@@ -205,6 +205,7 @@ private fun ProfileScreen(
           contentPadding = padding,
           modifier = Modifier.onConsumedWindowInsetsChanged { consumedWindowInsets.insets = it },
           onNavigateToNewConversation = onNavigateToNewConversation,
+          navigateToContactInfo = navigateToContactInfo,
         )
         if (memberReminders.isNotEmpty()) {
           Spacer(Modifier.height(16.dp))

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
@@ -55,7 +55,7 @@ fun NavGraphBuilder.profileGraph(
           with(navigator) { backStackEntry.navigate(ProfileDestinations.Eurobonus) }
         },
         navigateToContactInfo = {
-          with(navigator) { backStackEntry.navigate(ProfileDestinations.ContactInfo) }
+          with(navigator) { backStackEntry.navigate(ProfileDestination.ContactInfo) }
         },
         navigateToAboutApp = {
           with(navigator) { backStackEntry.navigate(ProfileDestinations.AboutApp) }
@@ -87,7 +87,7 @@ fun NavGraphBuilder.profileGraph(
         navigateUp = navigator::navigateUp,
       )
     }
-    navdestination<ProfileDestinations.ContactInfo>(
+    navdestination<ProfileDestination.ContactInfo>(
       deepLinks = navDeepLinks(hedvigDeepLinkContainer.contactInfo),
     ) {
       val viewModel: ContactInfoViewModel = koinViewModel()

--- a/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsContactInfoUpdateReminder.graphql
+++ b/app/member-reminders/member-reminders-public/src/main/graphql/QueryNeedsContactInfoUpdateReminder.graphql
@@ -1,0 +1,7 @@
+query NeedsContactInfoUpdateReminder {
+  currentMember {
+    memberActions {
+      isContactInfoUpdateNeeded
+    }
+  }
+}

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
@@ -3,9 +3,14 @@ package com.hedvig.android.memberreminders
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.hedvig.android.apollo.ErrorMessage
+import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapLatest
+import octopus.NeedsContactInfoUpdateReminderQuery
 
 interface GetContactInfoUpdateIsNeededUseCase {
   fun invoke(): Flow<Either<ErrorMessage, MemberReminder.ContactInfoUpdateNeeded?>>
@@ -15,25 +20,20 @@ internal class GetContactInfoUpdateIsNeededUseCaseImpl(
   private val apolloClient: ApolloClient,
 ) : GetContactInfoUpdateIsNeededUseCase {
   override fun invoke(): Flow<Either<ErrorMessage, MemberReminder.ContactInfoUpdateNeeded?>> {
-//    return apolloClient.query(
-//      NeedsContactInfoUpdateReminderQuery()
-//    )
-//      .fetchPolicy(FetchPolicy.CacheAndNetwork)
-//      .safeFlow(::ErrorMessage)
-//      .mapLatest { result: Either<ErrorMessage, NeedsContactInfoUpdateReminderQuery.Data> ->
-//        either {
-//          val isContactInfoUpdateNeeded = result.
-//            .bind()
-//            .currentMember
-//            .memberActions
-//            .isContactInfoUpdateNeeded
-//          if (isContactInfoUpdateNeeded) Unit else null
-//        }
-    return flowOf(
-      either {
-        null
-        // todo: implement instead the commented out part when BE will be ready
-      },
+    return apolloClient.query(
+      NeedsContactInfoUpdateReminderQuery(),
     )
+      .fetchPolicy(FetchPolicy.CacheAndNetwork)
+      .safeFlow(::ErrorMessage)
+      .mapLatest { result: Either<ErrorMessage, NeedsContactInfoUpdateReminderQuery.Data> ->
+        either {
+          val isContactInfoUpdateNeeded = result
+            .bind()
+            .currentMember
+            .memberActions
+            ?.isContactInfoUpdateNeeded
+          if (isContactInfoUpdateNeeded == true) MemberReminder.ContactInfoUpdateNeeded() else null
+        }
+      }
   }
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
@@ -32,7 +32,7 @@ internal class GetContactInfoUpdateIsNeededUseCaseImpl(
     return flowOf(
       either {
         null
-             //todo: implement instead the commented out part when BE will be ready
+        // todo: implement instead the commented out part when BE will be ready
       },
     )
   }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
@@ -1,0 +1,39 @@
+package com.hedvig.android.memberreminders
+
+import arrow.core.Either
+import arrow.core.raise.either
+import com.apollographql.apollo.ApolloClient
+import com.hedvig.android.core.common.ErrorMessage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+interface GetContactInfoUpdateIsNeededUseCase {
+  fun invoke(): Flow<Either<ErrorMessage, MemberReminder.ContactInfoUpdateNeeded?>>
+}
+
+internal class GetContactInfoUpdateIsNeededUseCaseImpl(
+  private val apolloClient: ApolloClient,
+) : GetContactInfoUpdateIsNeededUseCase {
+  override fun invoke(): Flow<Either<ErrorMessage, MemberReminder.ContactInfoUpdateNeeded?>> {
+//    return apolloClient.query(
+//      NeedsContactInfoUpdateReminderQuery()
+//    )
+//      .fetchPolicy(FetchPolicy.CacheAndNetwork)
+//      .safeFlow(::ErrorMessage)
+//      .mapLatest { result: Either<ErrorMessage, NeedsContactInfoUpdateReminderQuery.Data> ->
+//        either {
+//          val isContactInfoUpdateNeeded = result.
+//            .bind()
+//            .currentMember
+//            .memberActions
+//            .isContactInfoUpdateNeeded
+//          if (isContactInfoUpdateNeeded) Unit else null
+//        }
+    return flowOf(
+      either {
+        null
+             //todo: implement instead the commented out part when BE will be ready
+      },
+    )
+  }
+}

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
@@ -32,7 +32,7 @@ internal class GetContactInfoUpdateIsNeededUseCaseImpl(
             .currentMember
             .memberActions
             ?.isContactInfoUpdateNeeded
-          if (isContactInfoUpdateNeeded == true) MemberReminder.ContactInfoUpdateNeeded() else null
+          if (isContactInfoUpdateNeeded == true) MemberReminder.ContactInfoUpdateNeeded else null
         }
       }
   }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.memberreminders
 
 import arrow.core.Either
 import arrow.core.NonEmptyList
+import com.hedvig.android.memberreminders.MemberReminder.ContactInfoUpdateNeeded
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -18,6 +19,7 @@ internal class GetMemberRemindersUseCaseImpl(
   private val getConnectPaymentReminderUseCase: GetConnectPaymentReminderUseCase,
   private val getUpcomingRenewalRemindersUseCase: GetUpcomingRenewalRemindersUseCase,
   private val getNeedsCoInsuredInfoRemindersUseCase: GetNeedsCoInsuredInfoRemindersUseCase,
+  private val getContactInfoUpdateIsNeededUseCase: GetContactInfoUpdateIsNeededUseCase
 ) : GetMemberRemindersUseCase {
   override fun invoke(): Flow<MemberReminders> {
     return combine(
@@ -47,17 +49,20 @@ internal class GetMemberRemindersUseCaseImpl(
         emit(upcomingRenewals)
       },
       getNeedsCoInsuredInfoRemindersUseCase.invoke(),
+      getContactInfoUpdateIsNeededUseCase.invoke()
     ) {
       enableNotifications: MemberReminder.EnableNotifications?,
       connectPayment: MemberReminder.PaymentReminder?,
       upcomingRenewalReminders: NonEmptyList<MemberReminder.UpcomingRenewal>?,
       coInsuredInfoResult: Either<CoInsuredInfoReminderError, NonEmptyList<MemberReminder.CoInsuredInfo>>,
+      contactInfoReminder: Either<com.hedvig.android.core.common.ErrorMessage, ContactInfoUpdateNeeded?>
       ->
       MemberReminders(
         connectPayment = connectPayment,
         upcomingRenewals = upcomingRenewalReminders,
         enableNotifications = enableNotifications,
         coInsuredInfo = coInsuredInfoResult.getOrNull(),
+        updateContactInfo = contactInfoReminder.getOrNull()
       )
     }
   }
@@ -68,6 +73,7 @@ data class MemberReminders(
   val upcomingRenewals: List<MemberReminder.UpcomingRenewal>? = null,
   val enableNotifications: MemberReminder.EnableNotifications? = null,
   val coInsuredInfo: List<MemberReminder.CoInsuredInfo>? = null,
+  val updateContactInfo: ContactInfoUpdateNeeded? = null
 ) {
   /**
    * In some cases a reminder may be present but may not be applicable in our current app state.
@@ -89,6 +95,9 @@ data class MemberReminders(
       }
       upcomingRenewals?.let {
         addAll(it)
+      }
+      updateContactInfo?.let {
+        add(it)
       }
     }
   }
@@ -123,4 +132,8 @@ sealed interface MemberReminder {
     val contractId: String,
     override val id: String = UUID.randomUUID().toString(),
   ) : MemberReminder
+
+  data class ContactInfoUpdateNeeded(
+    override val id: String = UUID.randomUUID().toString(),
+  ): MemberReminder
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
@@ -19,7 +19,7 @@ internal class GetMemberRemindersUseCaseImpl(
   private val getConnectPaymentReminderUseCase: GetConnectPaymentReminderUseCase,
   private val getUpcomingRenewalRemindersUseCase: GetUpcomingRenewalRemindersUseCase,
   private val getNeedsCoInsuredInfoRemindersUseCase: GetNeedsCoInsuredInfoRemindersUseCase,
-  private val getContactInfoUpdateIsNeededUseCase: GetContactInfoUpdateIsNeededUseCase
+  private val getContactInfoUpdateIsNeededUseCase: GetContactInfoUpdateIsNeededUseCase,
 ) : GetMemberRemindersUseCase {
   override fun invoke(): Flow<MemberReminders> {
     return combine(
@@ -49,20 +49,20 @@ internal class GetMemberRemindersUseCaseImpl(
         emit(upcomingRenewals)
       },
       getNeedsCoInsuredInfoRemindersUseCase.invoke(),
-      getContactInfoUpdateIsNeededUseCase.invoke()
+      getContactInfoUpdateIsNeededUseCase.invoke(),
     ) {
       enableNotifications: MemberReminder.EnableNotifications?,
       connectPayment: MemberReminder.PaymentReminder?,
       upcomingRenewalReminders: NonEmptyList<MemberReminder.UpcomingRenewal>?,
       coInsuredInfoResult: Either<CoInsuredInfoReminderError, NonEmptyList<MemberReminder.CoInsuredInfo>>,
-      contactInfoReminder: Either<com.hedvig.android.core.common.ErrorMessage, ContactInfoUpdateNeeded?>
+      contactInfoReminder: Either<com.hedvig.android.core.common.ErrorMessage, ContactInfoUpdateNeeded?>,
       ->
       MemberReminders(
         connectPayment = connectPayment,
         upcomingRenewals = upcomingRenewalReminders,
         enableNotifications = enableNotifications,
         coInsuredInfo = coInsuredInfoResult.getOrNull(),
-        updateContactInfo = contactInfoReminder.getOrNull()
+        updateContactInfo = contactInfoReminder.getOrNull(),
       )
     }
   }
@@ -73,7 +73,7 @@ data class MemberReminders(
   val upcomingRenewals: List<MemberReminder.UpcomingRenewal>? = null,
   val enableNotifications: MemberReminder.EnableNotifications? = null,
   val coInsuredInfo: List<MemberReminder.CoInsuredInfo>? = null,
-  val updateContactInfo: ContactInfoUpdateNeeded? = null
+  val updateContactInfo: ContactInfoUpdateNeeded? = null,
 ) {
   /**
    * In some cases a reminder may be present but may not be applicable in our current app state.
@@ -135,5 +135,5 @@ sealed interface MemberReminder {
 
   data class ContactInfoUpdateNeeded(
     override val id: String = UUID.randomUUID().toString(),
-  ): MemberReminder
+  ) : MemberReminder
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
@@ -133,7 +133,7 @@ sealed interface MemberReminder {
     override val id: String = UUID.randomUUID().toString(),
   ) : MemberReminder
 
-  data class ContactInfoUpdateNeeded(
-    override val id: String = UUID.randomUUID().toString(),
-  ) : MemberReminder
+  data object ContactInfoUpdateNeeded : MemberReminder {
+    override val id: String = UUID.randomUUID().toString()
+  }
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/di/MemberRemindersModule.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/di/MemberRemindersModule.kt
@@ -52,12 +52,12 @@ val memberRemindersModule = module {
       get<GetConnectPaymentReminderUseCase>(),
       get<GetUpcomingRenewalRemindersUseCase>(),
       get<GetNeedsCoInsuredInfoRemindersUseCase>(),
-      get<GetContactInfoUpdateIsNeededUseCase>()
+      get<GetContactInfoUpdateIsNeededUseCase>(),
     )
   }
   single<GetContactInfoUpdateIsNeededUseCase> {
     GetContactInfoUpdateIsNeededUseCaseImpl(
-      get<ApolloClient>()
+      get<ApolloClient>(),
     )
   }
 }

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/di/MemberRemindersModule.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/di/MemberRemindersModule.kt
@@ -11,6 +11,8 @@ import com.hedvig.android.memberreminders.EnableNotificationsReminderSnoozeManag
 import com.hedvig.android.memberreminders.EnableNotificationsReminderSnoozeManagerImpl
 import com.hedvig.android.memberreminders.GetConnectPaymentReminderUseCase
 import com.hedvig.android.memberreminders.GetConnectPaymentReminderUseCaseImpl
+import com.hedvig.android.memberreminders.GetContactInfoUpdateIsNeededUseCase
+import com.hedvig.android.memberreminders.GetContactInfoUpdateIsNeededUseCaseImpl
 import com.hedvig.android.memberreminders.GetMemberRemindersUseCase
 import com.hedvig.android.memberreminders.GetMemberRemindersUseCaseImpl
 import com.hedvig.android.memberreminders.GetNeedsCoInsuredInfoRemindersUseCase
@@ -50,6 +52,12 @@ val memberRemindersModule = module {
       get<GetConnectPaymentReminderUseCase>(),
       get<GetUpcomingRenewalRemindersUseCase>(),
       get<GetNeedsCoInsuredInfoRemindersUseCase>(),
+      get<GetContactInfoUpdateIsNeededUseCase>()
+    )
+  }
+  single<GetContactInfoUpdateIsNeededUseCase> {
+    GetContactInfoUpdateIsNeededUseCaseImpl(
+      get<ApolloClient>()
     )
   }
 }

--- a/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCaseTest.kt
+++ b/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCaseTest.kt
@@ -6,6 +6,7 @@ import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.left
 import arrow.core.nonEmptyListOf
+import arrow.core.raise.either
 import arrow.core.right
 import assertk.assertAll
 import assertk.assertThat
@@ -13,10 +14,12 @@ import assertk.assertions.containsExactly
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isNullOrEmpty
+import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.memberreminders.MemberReminder.CoInsuredInfo
 import com.hedvig.android.memberreminders.MemberReminder.UpcomingRenewal
 import com.hedvig.android.memberreminders.test.TestEnableNotificationsReminderSnoozeManager
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
@@ -29,11 +32,13 @@ class GetMemberRemindersUseCaseTest {
     val getConnectPaymentReminderUseCase = TestGetConnectPaymentReminderUseCase()
     val getUpcomingRenewalRemindersUseCase = TestGetUpcomingRenewalRemindersUseCase()
     val getNeedsCoInsuredInfoRemindersUseCase = TestGetNeedsCoInsuredInfoRemindersUseCase()
+    val getContactInfoUpdateIsNeededUseCase = TestGetContactInfoUpdateIsNeededUseCase()
     val getMemberRemindersUseCase = GetMemberRemindersUseCaseImpl(
       enableNotificationsReminderSnoozeManager = enableNotificationsReminderManager,
       getConnectPaymentReminderUseCase = getConnectPaymentReminderUseCase,
       getUpcomingRenewalRemindersUseCase = getUpcomingRenewalRemindersUseCase,
       getNeedsCoInsuredInfoRemindersUseCase = getNeedsCoInsuredInfoRemindersUseCase,
+      getContactInfoUpdateIsNeededUseCase = getContactInfoUpdateIsNeededUseCase,
     )
 
     getMemberRemindersUseCase.invoke().test {
@@ -49,21 +54,20 @@ class GetMemberRemindersUseCaseTest {
           assertThat(this.upcomingRenewals).isNull()
           assertThat(this.coInsuredInfo).isNullOrEmpty()
         }
-      }
-    }
-  }
-
+      }    }  }
   @Test
   fun `all reminders available returns a list with all of them together`() = runTest {
     val enableNotificationsReminderManager = TestEnableNotificationsReminderSnoozeManager()
     val getConnectPaymentReminderUseCase = TestGetConnectPaymentReminderUseCase()
     val getUpcomingRenewalRemindersUseCase = TestGetUpcomingRenewalRemindersUseCase()
     val getNeedsCoInsuredInfoRemindersUseCase = TestGetNeedsCoInsuredInfoRemindersUseCase()
+    val getContactInfoUpdateIsNeededUseCase = TestGetContactInfoUpdateIsNeededUseCase()
     val getMemberRemindersUseCase = GetMemberRemindersUseCaseImpl(
       enableNotificationsReminderSnoozeManager = enableNotificationsReminderManager,
       getConnectPaymentReminderUseCase = getConnectPaymentReminderUseCase,
       getUpcomingRenewalRemindersUseCase = getUpcomingRenewalRemindersUseCase,
       getNeedsCoInsuredInfoRemindersUseCase = getNeedsCoInsuredInfoRemindersUseCase,
+      getContactInfoUpdateIsNeededUseCase = getContactInfoUpdateIsNeededUseCase,
     )
     val testId = "test"
 
@@ -88,10 +92,7 @@ class GetMemberRemindersUseCaseTest {
               UpcomingRenewal("", LocalDate.parse("2023-01-01"), "", testId),
             )
         }
-      }
-    }
-  }
-
+      }    }  }
   class TestGetConnectPaymentReminderUseCase : GetConnectPaymentReminderUseCase {
     val turbine = Turbine<Either<ConnectPaymentReminderError, PaymentReminder.ShowConnectPaymentReminder>>()
 
@@ -114,5 +115,16 @@ class GetMemberRemindersUseCaseTest {
     override fun invoke(): Flow<Either<CoInsuredInfoReminderError, NonEmptyList<CoInsuredInfo>>> {
       return turbine.asChannel().receiveAsFlow()
     }
+  }
+
+  class TestGetContactInfoUpdateIsNeededUseCase() : GetContactInfoUpdateIsNeededUseCase {
+    override fun invoke(): Flow<Either<ErrorMessage, MemberReminder.ContactInfoUpdateNeeded?>> {
+      return flowOf(
+        either {
+          null
+        },
+      )
+    }
+
   }
 }

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
@@ -85,7 +85,7 @@ fun MemberReminderCards(
         snoozeNotificationPermissionReminder = snoozeNotificationPermissionReminder,
         notificationPermissionState = notificationPermissionState,
         modifier = modifier.padding(contentPadding),
-        navigateToContactInfo = navigateToContactInfo
+        navigateToContactInfo = navigateToContactInfo,
       )
     } else if (memberReminders.isNotEmpty()) {
       val pagerState = rememberPagerState(pageCount = { memberReminders.size })
@@ -216,10 +216,7 @@ fun ReminderCardEnableNotifications(
 }
 
 @Composable
-fun ReminderCardUpdateContactInfo(
-  navigateToContactInfo: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
+fun ReminderCardUpdateContactInfo(navigateToContactInfo: () -> Unit, modifier: Modifier = Modifier) {
   HedvigNotificationCard(
     message = stringResource(R.string.MISSING_CONTACT_INFO_CARD_TEXT),
     modifier = modifier,
@@ -230,7 +227,6 @@ fun ReminderCardUpdateContactInfo(
     ),
   )
 }
-
 
 @Composable
 private fun ReminderCardConnectPayment(navigateToConnectPayment: () -> Unit, modifier: Modifier = Modifier) {

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
@@ -44,6 +44,7 @@ fun MemberReminderCardsWithoutNotification(
   navigateToAddMissingInfo: (String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
   contentPadding: PaddingValues,
+  navigateToContactInfo: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   MemberReminderCards(
@@ -55,6 +56,7 @@ fun MemberReminderCardsWithoutNotification(
     snoozeNotificationPermissionReminder = {},
     notificationPermissionState = null,
     contentPadding = contentPadding,
+    navigateToContactInfo = navigateToContactInfo,
     modifier = modifier,
   )
 }
@@ -67,6 +69,7 @@ fun MemberReminderCards(
   navigateToAddMissingInfo: (String) -> Unit,
   snoozeNotificationPermissionReminder: () -> Unit,
   onNavigateToNewConversation: () -> Unit,
+  navigateToContactInfo: () -> Unit,
   notificationPermissionState: NotificationPermissionState?,
   contentPadding: PaddingValues,
   modifier: Modifier = Modifier,
@@ -82,6 +85,7 @@ fun MemberReminderCards(
         snoozeNotificationPermissionReminder = snoozeNotificationPermissionReminder,
         notificationPermissionState = notificationPermissionState,
         modifier = modifier.padding(contentPadding),
+        navigateToContactInfo = navigateToContactInfo
       )
     } else if (memberReminders.isNotEmpty()) {
       val pagerState = rememberPagerState(pageCount = { memberReminders.size })
@@ -103,6 +107,7 @@ fun MemberReminderCards(
           onNavigateToNewConversation = onNavigateToNewConversation,
           snoozeNotificationPermissionReminder = snoozeNotificationPermissionReminder,
           notificationPermissionState = notificationPermissionState,
+          navigateToContactInfo = navigateToContactInfo,
           modifier = modifier.fillMaxWidth(),
         )
       }
@@ -126,6 +131,7 @@ private fun ColumnScope.MemberReminderCard(
   memberReminder: MemberReminder,
   navigateToAddMissingInfo: (String) -> Unit,
   navigateToConnectPayment: () -> Unit,
+  navigateToContactInfo: () -> Unit,
   openUrl: (String) -> Unit,
   snoozeNotificationPermissionReminder: () -> Unit,
   onNavigateToNewConversation: () -> Unit,
@@ -151,7 +157,7 @@ private fun ColumnScope.MemberReminderCard(
       modifier = modifier,
     )
 
-    is MemberReminder.UpcomingRenewal -> ReminderCardUpcomingRenewals(
+    is UpcomingRenewal -> ReminderCardUpcomingRenewals(
       upcomingRenewal = memberReminder,
       openUrl = openUrl,
       modifier = modifier,
@@ -173,6 +179,11 @@ private fun ColumnScope.MemberReminderCard(
         }
       }
     }
+
+    is MemberReminder.ContactInfoUpdateNeeded -> ReminderCardUpdateContactInfo(
+      navigateToContactInfo = navigateToContactInfo,
+      modifier = modifier,
+    )
   }
 }
 
@@ -203,6 +214,23 @@ fun ReminderCardEnableNotifications(
     ),
   )
 }
+
+@Composable
+fun ReminderCardUpdateContactInfo(
+  navigateToContactInfo: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  HedvigNotificationCard(
+    message = stringResource(R.string.MISSING_CONTACT_INFO_CARD_TEXT),
+    modifier = modifier,
+    priority = NotificationPriority.Info,
+    style = InfoCardStyle.Button(
+      buttonText = stringResource(R.string.MISSING_CONTACT_INFO_CARD_BUTTON),
+      onButtonClick = navigateToContactInfo,
+    ),
+  )
+}
+
 
 @Composable
 private fun ReminderCardConnectPayment(navigateToConnectPayment: () -> Unit, modifier: Modifier = Modifier) {
@@ -309,6 +337,18 @@ private fun PreviewReminderCardCoInsuredInfo() {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       ReminderCoInsuredInfo(
+        {},
+      )
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun PreviewReminderCardUpdateContactInfo() {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      ReminderCardUpdateContactInfo(
         {},
       )
     }


### PR DESCRIPTION
[ticket](https://www.notion.so/hedviginsurance/Phone-number-action-for-nulled-phone-numbers-in-app-1edc3f71cb0a8070b1ffeb3dc5265532?pvs=4)
[figma](https://www.figma.com/design/zItETkT4mu5ANVDYED5gEm/UX-Improvements--Small-Projects-?node-id=853-19288&m=dev)

Made [updates in member-service](https://github.com/HedvigInsurance/member-service/pull/1034), so we now have a new mutation `memberUpdateContactInfo` and a new property in MemberActions `isContactInfoUpdateNeeded` (true if phone number is missing or was added/reviewed more than one year). 

In this PR, if `MemberActions.isContactInfoUpdateNeeded` is true, we show a reminder on Home and Profile screens, that leads to Contact screen. The UI of Contact screen is also updated.

Will update the mutation used for contact screen to the new `memberUpdateContactInfo` in a separate PR, to keep this one shorter :)