### PR TITLE
Client generated message ID

### DIFF
--- a/app/data/data-chat/build.gradle.kts
+++ b/app/data/data-chat/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
   id("hedvig.gradle.plugin")
   id("hedvig.kotlin.library")
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.room)
 }
 
 hedvig {
@@ -16,5 +18,22 @@ dependencies {
   implementation(projects.coreUiData)
   implementation(projects.dataContractPublic)
   implementation(projects.dataProductVariantPublic)
+
+  testImplementation(libs.assertK)
+  testImplementation(libs.coroutines.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.room.paging)
+  testImplementation(libs.room.runtime)
+  testImplementation(libs.sqlite.bundled)
+  testImplementation(projects.testClock)
+  kspTest(libs.room.ksp)
 }
 
+val schemaDirectory = project
+  .rootDir
+  .resolve("app/data/data-chat/build/generated/ksp/test/kotlin")
+  .absolutePath
+
+room {
+  schemaDirectory(schemaDirectory)
+}

--- a/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatDao.kt
+++ b/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatDao.kt
@@ -34,7 +34,7 @@ interface ChatDao {
     """
     SELECT * FROM chat_messages
     WHERE conversationId LIKE :conversationId
-    ORDER BY sentAt DESC
+    ORDER BY isBeingSent DESC, sentAt DESC 
     """,
   )
   fun messages(conversationId: Uuid): PagingSource<Int, ChatMessageEntity>

--- a/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatDao.kt
+++ b/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatDao.kt
@@ -54,6 +54,7 @@ interface ChatDao {
     SELECT id FROM chat_messages
     WHERE conversationId LIKE :conversationId
         AND failedToSend IS NULL
+        AND isBeingSent IS FALSE
     ORDER BY sentAt DESC
     LIMIT 1
     """,

--- a/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatMessageEntity.kt
+++ b/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatMessageEntity.kt
@@ -17,6 +17,7 @@ data class ChatMessageEntity(
   val url: String?,
   val mimeType: String?,
   val failedToSend: FailedToSendType?,
+  // todo chat id: add field for "sending" for ongoing messages being sent
 ) {
   enum class Sender {
     HEDVIG,

--- a/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatMessageEntity.kt
+++ b/app/data/data-chat/src/main/kotlin/com/hedvig/android/data/chat/database/ChatMessageEntity.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.data.chat.database
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.benasher44.uuid.Uuid
@@ -17,7 +18,8 @@ data class ChatMessageEntity(
   val url: String?,
   val mimeType: String?,
   val failedToSend: FailedToSendType?,
-  // todo chat id: add field for "sending" for ongoing messages being sent
+  @ColumnInfo(defaultValue = "0")
+  val isBeingSent: Boolean,
 ) {
   enum class Sender {
     HEDVIG,

--- a/app/data/data-chat/src/test/kotlin/com/hedvig/android/data/chat/database/ChatDaoTest.kt
+++ b/app/data/data-chat/src/test/kotlin/com/hedvig/android/data/chat/database/ChatDaoTest.kt
@@ -1,0 +1,90 @@
+package com.hedvig.android.data.chat.database
+
+import androidx.paging.PagingSource
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.benasher44.uuid.Uuid
+import com.hedvig.android.data.chat.database.converter.InstantConverter
+import com.hedvig.android.data.chat.database.converter.UuidConverter
+import com.hedvig.android.test.clock.TestClock
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class ChatDaoTest {
+  lateinit var chatMessageDatabase: TestChatMessageDatabase
+
+  @Before
+  fun openDb() {
+    chatMessageDatabase = Room.inMemoryDatabaseBuilder<TestChatMessageDatabase>()
+      .setDriver(BundledSQLiteDriver())
+      .setQueryCoroutineContext(Dispatchers.IO)
+      .build()
+  }
+
+  @After
+  fun closeDb() {
+    chatMessageDatabase.close()
+  }
+
+  @Test
+  fun `messages currently being sent are loaded at the end of the list, regardless of the timestamp they were sent at`() =
+    runTest {
+      val clock = TestClock()
+      val chatDao = chatMessageDatabase.chatDao()
+
+      val conversationId = Uuid.randomUUID()
+      val sentChatMessage1 = textChatMessageEntity("message1", conversationId, clock)
+      clock.advanceTimeBy(1.seconds)
+      val loadingChatMessage1 = textChatMessageEntity("loading1", conversationId, clock, isBeingSent = true)
+      clock.advanceTimeBy(1.seconds)
+      val sentChatMessage2 = textChatMessageEntity("message2", conversationId, clock)
+      chatDao.insertAll(listOf(sentChatMessage1, loadingChatMessage1, sentChatMessage2))
+
+      val pagingSource = chatDao.messages(conversationId)
+      val page = pagingSource.load(PagingSource.LoadParams.Refresh(null, 3, true)) as PagingSource.LoadResult.Page
+
+      val messages = page.data
+      assertThat(messages).containsExactly(
+        loadingChatMessage1,
+        sentChatMessage2,
+        sentChatMessage1,
+      )
+    }
+}
+
+private fun textChatMessageEntity(
+  text: String,
+  conversationId: UUID,
+  clock: TestClock,
+  isBeingSent: Boolean = false,
+): ChatMessageEntity = ChatMessageEntity(
+  id = Uuid.randomUUID(),
+  conversationId = conversationId,
+  sender = ChatMessageEntity.Sender.HEDVIG,
+  sentAt = clock.now(),
+  text = text,
+  gifUrl = null,
+  url = null,
+  mimeType = null,
+  failedToSend = null,
+  isBeingSent = isBeingSent,
+)
+
+@Database(
+  entities = [ChatMessageEntity::class],
+  version = 1,
+)
+@TypeConverters(InstantConverter::class, UuidConverter::class)
+abstract class TestChatMessageDatabase : RoomDatabase() {
+  abstract fun chatDao(): ChatDao
+}

--- a/app/database/database-core/src/main/kotlin/com/hedvig/android/database/AppDatabase.kt
+++ b/app/database/database-core/src/main/kotlin/com/hedvig/android/database/AppDatabase.kt
@@ -15,9 +15,10 @@ import com.hedvig.android.data.chat.database.converter.UuidConverter
 
 @Database(
   entities = [ChatMessageEntity::class, RemoteKeyEntity::class],
-  version = 2,
+  version = 3,
   autoMigrations = [
     AutoMigration(from = 1, to = 2, spec = Migration1To2::class),
+    AutoMigration(from = 2, to = 3, spec = Migration2To3::class),
   ],
 )
 @TypeConverters(InstantConverter::class, UuidConverter::class)
@@ -29,3 +30,5 @@ abstract class AppDatabase : RoomDatabase() {
 
 @DeleteTable(tableName = "conversations")
 internal class Migration1To2 : AutoMigrationSpec
+
+internal class Migration2To3 : AutoMigrationSpec

--- a/app/database/schemas/com.hedvig.android.database.AppDatabase/3.json
+++ b/app/database/schemas/com.hedvig.android.database.AppDatabase/3.json
@@ -1,0 +1,109 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "2dbdd93e1ce2b257ffaf2b79fc2f1c7e",
+    "entities": [
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `sender` TEXT NOT NULL, `sentAt` TEXT NOT NULL, `text` TEXT, `gifUrl` TEXT, `url` TEXT, `mimeType` TEXT, `failedToSend` TEXT, `isBeingSent` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentAt",
+            "columnName": "sentAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gifUrl",
+            "columnName": "gifUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failedToSend",
+            "columnName": "failedToSend",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isBeingSent",
+            "columnName": "isBeingSent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversationId` TEXT NOT NULL, `olderToken` TEXT, `newerToken` TEXT, PRIMARY KEY(`conversationId`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "olderToken",
+            "columnName": "olderToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "newerToken",
+            "columnName": "newerToken",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversationId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2dbdd93e1ce2b257ffaf2b79fc2f1c7e')"
+    ]
+  }
+}

--- a/app/feature/feature-chat/src/main/graphql/MutationConversationSendMessage.graphql
+++ b/app/feature/feature-chat/src/main/graphql/MutationConversationSendMessage.graphql
@@ -1,5 +1,5 @@
-mutation ConversationSendMessage($conversationId: UUID!, $text: String, $fileUploadToken: String) {
-  conversationSendMessage(input: {id: $conversationId, text: $text, fileUploadToken: $fileUploadToken}) {
+mutation ConversationSendMessage($conversationId: UUID!, $messageId: UUID!, $text: String, $fileUploadToken: String) {
+  conversationSendMessage(input: {id: $conversationId, messageId: $messageId, text: $text, fileUploadToken: $fileUploadToken}) {
     message {
       ...ChatMessageFragment
     }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -580,7 +580,7 @@ private fun ConversationInput.toChatMessageEntity(
         url = this.fileUploadToken,
         mimeType = CbmChatMessage.ChatMessageFile.MimeType.OTHER.toString(),
         failedToSend = null,
-        // todo sending = true
+        isBeingSent = true,
       )
     }
 
@@ -595,7 +595,7 @@ private fun ConversationInput.toChatMessageEntity(
         url = null,
         mimeType = null,
         failedToSend = null,
-        // todo sending = true
+        isBeingSent = true,
       )
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -216,7 +216,6 @@ internal class CbmChatRepositoryImpl(
 
             else -> {}
           }
-          chatDao.deleteMessage(conversationId, messageId)
         }
       }
     }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -74,7 +74,11 @@ internal interface CbmChatRepository {
 
   suspend fun retrySendMessage(conversationId: Uuid, messageId: String): Either<MessageSendError, CbmChatMessage>
 
-  suspend fun sendText(conversationId: Uuid, messageId: Uuid?, text: String): Either<MessageSendError, CbmChatMessage>
+  suspend fun sendText(
+    conversationId: Uuid,
+    retryingMessageId: Uuid?,
+    text: String,
+  ): Either<MessageSendError, CbmChatMessage>
 
   suspend fun sendPhotos(conversationId: Uuid, uriList: List<Uri>): List<Either<MessageSendError, CbmChatMessage>>
 
@@ -220,12 +224,13 @@ internal class CbmChatRepositoryImpl(
 
   override suspend fun sendText(
     conversationId: Uuid,
-    messageId: Uuid?,
+    retryingMessageId: Uuid?,
     text: String,
   ): Either<MessageSendError, CbmChatMessage> {
-    return sendMessage(conversationId, ConversationInput.Text(text)).onLeft {
+    val messageId = retryingMessageId ?: Uuid.randomUUID()
+    return sendMessage(conversationId, messageId, ConversationInput.Text(text)).onLeft { error ->
       val failedMessage = CbmChatMessage.FailedToBeSent.ChatMessageText(
-        messageId?.toString() ?: Uuid.randomUUID().toString(),
+        messageId.toString(),
         clock.now(),
         text,
       )
@@ -253,18 +258,19 @@ internal class CbmChatRepositoryImpl(
 
   private suspend fun sendOneMedia(
     conversationId: Uuid,
-    messageId: Uuid?,
+    retryingMessageId: Uuid?,
     uri: Uri,
   ): Either<MessageSendError, CbmChatMessage> {
+    val messageId = retryingMessageId ?: Uuid.randomUUID()
     return either {
       val uploadToken = uploadMediaToBotService(uri)
-      sendMessage(conversationId, ConversationInput.File(uploadToken)).bind()
+      sendMessage(conversationId, messageId, ConversationInput.File(uploadToken)).bind()
     }.onLeft { messageSendError ->
       if (messageSendError !is MessageSendError.FileTooBigError) {
         val failedMessage = CbmChatMessage.FailedToBeSent.ChatMessageMedia(
-          messageId?.toString() ?: Uuid.randomUUID().toString(),
-          clock.now(),
-          uri,
+          id = messageId.toString(),
+          sentAt = clock.now(),
+          uri = uri,
         )
         messageSendError.handleFailedToSendMedia(failedMessage, uri, conversationId)
       }
@@ -273,19 +279,20 @@ internal class CbmChatRepositoryImpl(
 
   private suspend fun sendOnePhoto(
     conversationId: Uuid,
-    messageId: Uuid?,
+    retryingMessageId: Uuid?,
     uri: Uri,
   ): Either<MessageSendError, CbmChatMessage> {
+    val messageId = retryingMessageId ?: Uuid.randomUUID()
     return either {
       val uploadToken = uploadPhotoToBotService(uri)
-      sendMessage(conversationId, ConversationInput.File(uploadToken)).bind()
-    }.onLeft {
+      sendMessage(conversationId, messageId, ConversationInput.File(uploadToken)).bind()
+    }.onLeft { messageSendError ->
       val failedMessage = CbmChatMessage.FailedToBeSent.ChatMessagePhoto(
-        messageId?.toString() ?: Uuid.randomUUID().toString(),
+        messageId.toString(),
         clock.now(),
         uri,
       )
-      it.handleFailedToSendMedia(failedMessage, uri, conversationId)
+      messageSendError.handleFailedToSendMedia(failedMessage, uri, conversationId)
     }
   }
 
@@ -308,13 +315,22 @@ internal class CbmChatRepositoryImpl(
 
   private suspend fun sendMessage(
     conversationId: Uuid,
+    messageId: Uuid,
     input: ConversationInput,
   ): Either<MessageSendError, CbmChatMessage> {
     return either {
+      chatDao.insert(input.toChatMessageEntity(clock, conversationId, messageId))
       val response = apolloClient
-        .mutation(ConversationSendMessageMutation(conversationId.toString(), input.text, input.fileUploadToken))
+        .mutation(
+          ConversationSendMessageMutation(
+            conversationId = conversationId.toString(),
+            messageId = messageId.toString(),
+            text = input.text,
+            fileUploadToken = input.fileUploadToken,
+          ),
+        )
         .safeExecute(::ErrorMessage)
-        .mapLeft(ErrorMessage::toMessageSendError)
+        .mapLeft { message -> message.toMessageSendError() }
         .bind()
       val sentMessage = response.conversationSendMessage.message
       ensureNotNull(sentMessage) {
@@ -540,6 +556,48 @@ private fun ChatMessageFragment.toChatMessage(): CbmChatMessage? = when (this) {
   else -> {
     logcat(LogPriority.WARN) { "Got unknown message type, can not map message:$this" }
     null
+  }
+}
+
+/**
+ * Convert the chat input into a chat message entity which represents a message currently being sent over the network
+ */
+private fun ConversationInput.toChatMessageEntity(
+  clock: Clock,
+  conversationId: Uuid,
+  messageId: Uuid,
+): ChatMessageEntity {
+  val sentAt = clock.now()
+  return when (this) {
+    is ConversationInput.File -> {
+      ChatMessageEntity(
+        id = messageId,
+        conversationId = conversationId,
+        sender = ChatMessageEntity.Sender.MEMBER,
+        sentAt = sentAt,
+        text = null,
+        gifUrl = null,
+        url = this.fileUploadToken,
+        mimeType = CbmChatMessage.ChatMessageFile.MimeType.OTHER.toString(),
+        failedToSend = null,
+        // todo sending = true
+      )
+    }
+
+    is ConversationInput.Text -> {
+      ChatMessageEntity(
+        id = messageId,
+        conversationId = conversationId,
+        sender = ChatMessageEntity.Sender.MEMBER,
+        sentAt = sentAt,
+        text = text,
+        gifUrl = null,
+        url = null,
+        mimeType = null,
+        failedToSend = null,
+        // todo sending = true
+      )
+    }
   }
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepositoryDemo.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepositoryDemo.kt
@@ -54,7 +54,7 @@ internal class CbmChatRepositoryDemo(
 
   override suspend fun sendText(
     conversationId: Uuid,
-    messageId: Uuid?,
+    retryingMessageId: Uuid?,
     text: String,
   ): Either<MessageSendError, CbmChatMessage> {
     return demoErrorMessage.left()

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/model/CbmChatMessage.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/model/CbmChatMessage.kt
@@ -94,6 +94,7 @@ internal fun CbmChatMessage.toChatMessageEntity(conversationId: Uuid): ChatMessa
       url = url,
       mimeType = mimeType.name,
       failedToSend = null,
+      isBeingSent = false,
     )
 
     is CbmChatMessage.ChatMessageGif -> ChatMessageEntity(
@@ -106,6 +107,7 @@ internal fun CbmChatMessage.toChatMessageEntity(conversationId: Uuid): ChatMessa
       url = null,
       mimeType = null,
       failedToSend = null,
+      isBeingSent = false,
     )
 
     is CbmChatMessage.ChatMessageText -> ChatMessageEntity(
@@ -118,6 +120,7 @@ internal fun CbmChatMessage.toChatMessageEntity(conversationId: Uuid): ChatMessa
       url = null,
       mimeType = null,
       failedToSend = null,
+      isBeingSent = false,
     )
 
     is CbmChatMessage.FailedToBeSent.ChatMessageText -> ChatMessageEntity(
@@ -130,6 +133,7 @@ internal fun CbmChatMessage.toChatMessageEntity(conversationId: Uuid): ChatMessa
       url = null,
       mimeType = null,
       failedToSend = TEXT,
+      isBeingSent = false,
     )
 
     is CbmChatMessage.FailedToBeSent.ChatMessagePhoto -> ChatMessageEntity(
@@ -142,6 +146,7 @@ internal fun CbmChatMessage.toChatMessageEntity(conversationId: Uuid): ChatMessa
       url = uri.toString(),
       mimeType = null,
       failedToSend = PHOTO,
+      isBeingSent = false,
     )
 
     is CbmChatMessage.FailedToBeSent.ChatMessageMedia -> ChatMessageEntity(
@@ -154,6 +159,7 @@ internal fun CbmChatMessage.toChatMessageEntity(conversationId: Uuid): ChatMessa
       url = uri.toString(),
       mimeType = null,
       failedToSend = MEDIA,
+      isBeingSent = false,
     )
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ androidx-other-splashscreen = "1.2.0-beta02"
 androidx-other-startup = "1.2.0"
 androidx-other-workManager = "2.10.1"
 androidx-test = "1.6.1"
+androidx-testEspresso = "3.6.1"
 androidx-testRunners = "1.6.2"
 androidx-ui-alpha = "1.8.1"
 androidxGraphicsShapes = "1.0.1"
@@ -134,6 +135,7 @@ androidx-other-splashscreen = { module = "androidx.core:core-splashscreen", vers
 androidx-other-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-other-startup" }
 androidx-other-workManager = { module = "androidx.work:work-runtime", version.ref = "androidx-other-workManager" }
 androidx-test = { module = "androidx.test:core-ktx", version.ref = "androidx-test" }
+androidx-testEspresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-testEspresso" }
 androidx-testRunners = { module = "androidx.test:runner", version.ref = "androidx-testRunners" }
 apollo-adapters-datetime = { module = "com.apollographql.adapters:apollo-adapters-kotlinx-datetime", version.ref = "apolloAdapters" }
 apollo-annotations = { module = "com.apollographql.apollo:apollo-annotations", version.ref = "apollo" }
@@ -203,6 +205,7 @@ room-common = { module = "androidx.room:room-common", version.ref = "room" }
 room-ksp = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-paging = { module = "androidx.room:room-paging", version.ref = "room" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 slimber = { module = "com.github.PaulWoitaschek:Slimber", version.ref = "slimber" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "testParameterInjector" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,6 @@ androidx-other-splashscreen = "1.2.0-beta02"
 androidx-other-startup = "1.2.0"
 androidx-other-workManager = "2.10.1"
 androidx-test = "1.6.1"
-androidx-testEspresso = "3.6.1"
 androidx-testRunners = "1.6.2"
 androidx-ui-alpha = "1.8.1"
 androidxGraphicsShapes = "1.0.1"
@@ -135,7 +134,6 @@ androidx-other-splashscreen = { module = "androidx.core:core-splashscreen", vers
 androidx-other-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-other-startup" }
 androidx-other-workManager = { module = "androidx.work:work-runtime", version.ref = "androidx-other-workManager" }
 androidx-test = { module = "androidx.test:core-ktx", version.ref = "androidx-test" }
-androidx-testEspresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-testEspresso" }
 androidx-testRunners = { module = "androidx.test:runner", version.ref = "androidx-testRunners" }
 apollo-adapters-datetime = { module = "com.apollographql.adapters:apollo-adapters-kotlinx-datetime", version.ref = "apolloAdapters" }
 apollo-annotations = { module = "com.apollographql.apollo:apollo-annotations", version.ref = "apollo" }


### PR DESCRIPTION
Mark ongoing messages to the backend as `isSending` in the DB.
Use the fact that the ID has to be unique to then override that message with either the error version of that message, or the real version of that message when it arrives back from the backend