### PR TITLE
Allow whitespaces in postal code input

### DIFF
--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressDestination.kt
@@ -208,6 +208,11 @@ private fun EnterNewAddressScreen(
               uiState.postalCode.updateValue(null)
             } else if (it.isDigitsOnly()) {
               uiState.postalCode.updateValue(it)
+            } else {
+              val withoutWhitespaces = it.filterNot { it.isWhitespace() }
+              if (withoutWhitespaces.isDigitsOnly()) {
+                uiState.postalCode.updateValue(withoutWhitespaces)
+              }
             }
           },
           labelText = stringResource(R.string.CHANGE_ADDRESS_NEW_POSTAL_CODE_LABEL),


### PR DESCRIPTION
This allows input like "12 3 45" to be taken as "12345"