### PR TITLE
GEN-3819: Make chip flow row items part of a selectable group

### DIFF
--- a/app/feature/feature-claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/OptionChipsFlowRow.kt
+++ b/app/feature/feature-claim-triaging/src/main/kotlin/com/hedvig/android/feature/claimtriaging/OptionChipsFlowRow.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.selectableGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import arrow.core.identity
 import com.hedvig.android.design.system.hedvig.HedvigPreview
@@ -34,7 +36,9 @@ internal fun <T> OptionChipsFlowRow(
   modifier: Modifier = Modifier,
 ) {
   FlowRow(
-    modifier = modifier,
+    modifier = modifier.semantics {
+      selectableGroup()
+    },
     horizontalArrangement = Arrangement.spacedBy(8.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {

--- a/app/ui/ui-claim-flow/src/main/kotlin/com/hedvig/android/ui/claimflow/HedvigChip.kt
+++ b/app/ui/ui-claim-flow/src/main/kotlin/com/hedvig/android/ui/claimflow/HedvigChip.kt
@@ -20,6 +20,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.design.system.hedvig.HedvigPreview
@@ -41,10 +45,20 @@ fun <T> HedvigChip(
   showChipAnimatable: Animatable<Float, AnimationVector1D>,
 ) {
   Box(
-    modifier = modifier.graphicsLayer {
-      scaleX = showChipAnimatable.value
-      scaleY = showChipAnimatable.value
-    },
+    modifier = modifier
+      .graphicsLayer {
+        scaleX = showChipAnimatable.value
+        scaleY = showChipAnimatable.value
+      }
+      .clearAndSetSemantics {
+        val name = itemDisplayName(item)
+        contentDescription = name
+        selected = isSelected
+        this.onClick {
+          onItemClick(item)
+          true
+        }
+      },
     contentAlignment = Alignment.Center,
   ) {
     val surfaceColor by animateColorAsState(


### PR DESCRIPTION
Also merge the item semantics themselves so that it functions as one selectable item

Now announces for example when focusing on the first out of 6 chips with the text label "My home":
"(Not) Selected. My home. 1 out of 6. In list. 6 items. Double tap to toggle"