### PR TITLE
Fix/a11y expandable state merged descendants

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Accordion.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Accordion.kt
@@ -73,7 +73,6 @@ private fun AccordionItem(
     },
     isExpanded = isExpanded,
     onClick = onClick,
-    titleDescription = title,
   )
 }
 

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/ExpandablePlusCard.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/ExpandablePlusCard.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
@@ -43,12 +42,9 @@ fun ExpandablePlusCard(
   content: @Composable RowScope.() -> Unit,
   expandedContent: @Composable () -> Unit,
   modifier: Modifier = Modifier,
-  // used for better accessibility voice over instead of raw collapsed "content".
-  titleDescription: String? = null,
 ) {
   val collapsedStateDescription = stringResource(R.string.TALKBACK_EXPANDABLE_STATE_COLLAPSED)
   val expandedStateDescription = stringResource(R.string.TALKBACK_EXPANDABLE_STATE_EXPANDED)
-  val cardContentDescription = stringResource(R.string.TALKBACK_EXPANDABLE_ITEM, "${titleDescription?.let { it }}")
   val collapseClickLabel = stringResource(R.string.TALKBACK_EXPANDABLE_CLICK_LABEL_COLLAPSE)
   val expandClickLabel = stringResource(R.string.TALKBACK_EXPANDABLE_CLICK_LABEL_EXPAND)
   Surface(
@@ -64,16 +60,10 @@ fun ExpandablePlusCard(
         onClickLabel = if (isExpanded) collapseClickLabel else expandClickLabel,
       )
       .semantics {
-        this.contentDescription = cardContentDescription
         this.stateDescription = if (isExpanded) expandedStateDescription else collapsedStateDescription
       },
   ) {
-    Column(
-      modifier = Modifier
-        .semantics(true) {
-        }
-        .padding(contentPadding),
-    ) {
+    Column(modifier = Modifier.padding(contentPadding)) {
       HorizontalItemsWithMaximumSpaceTaken(
         startSlot = {
           Row(verticalAlignment = Alignment.CenterVertically) {
@@ -113,14 +103,12 @@ fun ExpandablePlusCard(
           }
         },
         spaceBetween = 4.dp,
-        modifier = Modifier.semantics {
-          hideFromAccessibility()
-        },
       )
       AnimatedVisibility(
         visible = isExpanded,
         enter = fadeIn() + expandVertically(clip = false, expandFrom = Alignment.Top),
         exit = fadeOut() + shrinkVertically(clip = false, shrinkTowards = Alignment.Top),
+        modifier = Modifier.semantics(mergeDescendants = true) {},
       ) {
         expandedContent()
       }

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HorizontalItems.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HorizontalItems.kt
@@ -3,7 +3,6 @@ package com.hedvig.android.design.system.hedvig
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import kotlin.math.max
@@ -27,7 +26,7 @@ fun HorizontalItemsWithMaximumSpaceTaken(
       startSlot()
       endSlot()
     },
-    modifier = modifier.semantics(mergeDescendants = true) {},
+    modifier = modifier,
   ) { measurables, constraints ->
     val first = measurables.getOrNull(0)
     val second = measurables.getOrNull(1)

--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Peril.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/Peril.kt
@@ -131,7 +131,6 @@ private fun ExpandablePerilCard(
     },
     modifier = modifier,
     contentPadding = size.padding,
-    titleDescription = title,
   )
 }
 

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectGlassDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectGlassDamageDestination.kt
@@ -229,7 +229,6 @@ private fun QuestionsAndAnswers(modifier: Modifier = Modifier) {
           )
         },
         contentPadding = PaddingValues(12.dp),
-        titleDescription = faqItem.first,
       )
     }
   }

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectTowingDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectTowingDestination.kt
@@ -230,7 +230,6 @@ private fun QuestionsAndAnswers(modifier: Modifier = Modifier) {
           )
         },
         contentPadding = PaddingValues(12.dp),
-        titleDescription = faqItem.first,
       )
     }
   }


### PR DESCRIPTION
Do not merge descendants for all HorizontalItems

Let the callers decide if they want or do not want this to happen.
Otherwise these rows are always outside of any merged trees specified
by their parents which often becomes problematic

---

Adjust ExpandablePlusCard to have the description as a separate node

By letting the clickable modifier merge its descendants, the title
is read along with the stateDescription added on the card itself.
The expandable description is then made to be its own merged
descendants parent, which makes it so that everything in there is read
separately from the entire clickable card.