### PR TITLE
add link role button description

### DIFF
--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
@@ -666,7 +666,7 @@ private fun DocumentCard(title: String) {
         Row(horizontalArrangement = Arrangement.End, verticalAlignment = Alignment.CenterVertically) {
           Icon(
             imageVector = HedvigIcons.ArrowNorthEast,
-            contentDescription = null,
+            contentDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK),
             modifier = Modifier.size(16.dp),
           )
         }

--- a/app/feature/feature-image-viewer/src/main/kotlin/com/hedvig/android/feature/imageviewer/ImageViewerDestination.kt
+++ b/app/feature/feature-image-viewer/src/main/kotlin/com/hedvig/android/feature/imageviewer/ImageViewerDestination.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
 import coil.ImageLoader
@@ -100,7 +99,7 @@ internal fun ImageViewerDestination(
               ) {
                 Icon(
                   imageVector = HedvigIcons.ArrowNorthEast,
-                  contentDescription = null,
+                  contentDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK),
                   modifier = Modifier.size(24.dp),
                 )
               }

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/documents/DocumentsTab.kt
@@ -114,7 +114,7 @@ private fun DocumentCard(onClick: () -> Unit, title: String, subtitle: String?, 
         endSlot = {
           Icon(
             imageVector = HedvigIcons.ArrowNorthEast,
-            contentDescription = null,
+            contentDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK),
             modifier = Modifier
               .wrapContentSize(Alignment.CenterEnd)
               .size(24.dp),

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingDestination.kt
@@ -27,7 +27,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
@@ -153,9 +158,12 @@ private fun MarketingScreen(
               .fillMaxWidth()
               .testTag("login_button"),
           )
+          val linkRoleDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK)
           HedvigTextButton(
             text = stringResource(R.string.MARKETING_GET_HEDVIG),
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().semantics {
+              contentDescription = linkRoleDescription
+            },
             enabled = uiState is MarketingUiState.Success,
             buttonSize = Large,
             onClick = {

--- a/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
+++ b/app/feature/feature-odyssey/src/main/kotlin/com/hedvig/android/feature/odyssey/step/informdeflect/DeflectCarOtherDamageDestination.kt
@@ -90,7 +90,7 @@ private fun DeflectCarOtherDamageScreen(
       Spacer(modifier = Modifier.width(8.dp))
       Icon(
         imageVector = HedvigIcons.ArrowNorthEast,
-        contentDescription = null,
+        contentDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK),
         modifier = Modifier.size(16.dp),
       )
     }

--- a/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
+++ b/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
@@ -318,6 +318,7 @@ private fun RecommendationSection(
       textAlign = TextAlign.Center,
     )
     Spacer(Modifier.height(48.dp))
+    val linkRoleDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK)
     HedvigButton(
       text = recommendedCrossSell.buttonText,
       onClick = {
@@ -325,7 +326,9 @@ private fun RecommendationSection(
         dismissSheet()
       },
       enabled = true,
-      Modifier.fillMaxWidth(),
+      Modifier.fillMaxWidth().semantics {
+        contentDescription = linkRoleDescription
+      },
     )
     Spacer(Modifier.height(12.dp))
     val bottomLabelText = recommendedCrossSell.buttonDescription
@@ -472,6 +475,7 @@ private fun CrossSellItem(
       )
     }
     Spacer(Modifier.width(16.dp))
+    val linkRoleDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK)
     HedvigButton(
       text = stringResource(R.string.cross_sell_get_price),
       onClick = {
@@ -480,11 +484,15 @@ private fun CrossSellItem(
       },
       buttonSize = Small,
       buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
-      modifier = Modifier.hedvigPlaceholder(
-        visible = isLoading,
-        shape = HedvigTheme.shapes.cornerSmall,
-        highlight = PlaceholderHighlight.shimmer(),
-      ),
+      modifier = Modifier
+        .semantics {
+          contentDescription = linkRoleDescription
+        }
+        .hedvigPlaceholder(
+          visible = isLoading,
+          shape = HedvigTheme.shapes.cornerSmall,
+          highlight = PlaceholderHighlight.shimmer(),
+        ),
       enabled = !isLoading,
     )
   }

--- a/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
+++ b/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
@@ -329,7 +329,7 @@ fun QuoteCard(
                         val density = LocalDensity.current
                         Icon(
                           imageVector = HedvigIcons.ArrowNorthEast,
-                          contentDescription = null,
+                          contentDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK),
                           tint = HedvigTheme.colorScheme.fillPrimary,
                           modifier = Modifier
                             .wrapContentSize(Alignment.Center)
@@ -560,7 +560,7 @@ private fun QuoteCard(
                         val density = LocalDensity.current
                         Icon(
                           imageVector = HedvigIcons.ArrowNorthEast,
-                          contentDescription = null, // CHECKED
+                          contentDescription = stringResource(R.string.TALKBACK_OPEN_EXTERNAL_LINK),
                           tint = HedvigTheme.colorScheme.fillPrimary,
                           modifier = Modifier
                             .wrapContentSize(Alignment.Center)


### PR DESCRIPTION
Added "Open link in external browser" as a content description for link to be open externally. I don't think there is a ready to use role for this (there was also a suggestion to use LinkAnnotation.Clickable, which correctly announces the link, but it works best for texts, hardly for buttons)

The order of announcing in the button with text-only (not composable) is not ideal (it says, for example: "Open link in external browser - Get a price quote - Button - Double tap to activate"). In other cases, where we have a composable inside button, the order is better: "Report you claim - Open link in external browser - Button - Double tap to activate" - in the car claims, where there is an NorthEast arrow icon inside.