### PR TITLE
Fix the two CI cron jobs

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -10,6 +10,12 @@ inputs:
     required: true
   lokalise-token:
     required: true
+  download-schema:
+    required: false
+    default: true
+  download-strings:
+    required: false
+    default: true
 runs:
   using: "composite"
   steps:
@@ -33,3 +39,9 @@ runs:
       uses: gradle/actions/setup-gradle@v4
       with:
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
+    - name: Download apollo schema
+      if: ${{ inputs.download-schema }}
+      run: ./gradlew downloadOctopusApolloSchemaFromIntrospection
+    - name: Download strings
+      if: ${{ inputs.download-strings }}
+      run: ./gradlew downloadStrings

--- a/.github/workflows/graphql-schema.yml
+++ b/.github/workflows/graphql-schema.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Setup CI
         uses: ./.github/actions/common-setup
         with:
+          download-strings: false
           gradle-cache-read-only: true
           datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
           lokalise-id: ${{ secrets.LOKALISE_ID }}

--- a/.github/workflows/strings.yml
+++ b/.github/workflows/strings.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Setup CI
         uses: ./.github/actions/common-setup
         with:
+          download-schema: false
           gradle-cache-read-only: false
           datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
           lokalise-id: ${{ secrets.LOKALISE_ID }}

--- a/scripts/ci-prebuild.sh
+++ b/scripts/ci-prebuild.sh
@@ -8,6 +8,3 @@ cat <<EOT > lokalise.properties
 id=${LOKALISE_ID}
 token=${LOKALISE_TOKEN}
 EOT
-
-./gradlew downloadOctopusApolloSchemaFromIntrospection
-./gradlew downloadStrings


### PR DESCRIPTION
Downloading strings and the schema would happen in both cases. Work around this issue by making those steps to optionally be skipped. Disable the respective download step that is not relevant to that job's purpose.

## a11y
- [ ] if these are UI changes - check for their accessibility