### PR TITLE
UI fix: Chevron hiding

### DIFF
--- a/app/feature/feature-claim-history/src/androidMain/kotlin/com/hedvig/android/feature/claimhistory/ClaimHistoryDestination.kt
+++ b/app/feature/feature-claim-history/src/androidMain/kotlin/com/hedvig/android/feature/claimhistory/ClaimHistoryDestination.kt
@@ -155,6 +155,7 @@ private fun ClaimHistoryItem(index: Int, claim: ClaimHistory, navigateToClaimDet
             ),
             size = HighlightLabelDefaults.HighLightSize.Small,
             color = HighlightLabelDefaults.HighlightColor.Outline,
+            modifier = Modifier.weight(1f, false),
           )
         }
         Icon(


### PR DESCRIPTION
Measure the chevron first by applying a weight to HighlightLabel

Measuring the label last means that the space for the chevron is always
accounted for before trying to fit the rest of the space to the label

| portrait | landscape |
| --- | --- |
| <img width="424" height="928" alt="image" src="https://github.com/user-attachments/assets/94340e68-f45d-4058-904b-14669b6abcc3" /> | <img width="929" height="433" alt="image" src="https://github.com/user-attachments/assets/fd18e56b-823f-4e98-8d0f-84ca5b23f103" /> |
