### PR TITLE
Fix/collapse travel addon

### DIFF
--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -272,7 +272,9 @@ private fun SummaryScreen(
                 )
               } else {
                 toggleHomeAddonExclusion(addonQuote.addonId)
-                quoteCardState.toggleState()
+                if (quoteCardState.showDetails) {
+                  quoteCardState.toggleState()
+                }
               }
             },
           )
@@ -410,7 +412,7 @@ private fun QuoteCard(quote: MovingFlowQuotes.Quote, modifier: Modifier = Modifi
 
 @Composable
 private fun AddonQuoteCard(
-  quote: MovingFlowQuotes.AddonQuote.HomeAddonQuote,
+  quote: HomeAddonQuote,
   canExcludeAddons: Boolean,
   toggleHomeAddonExclusion: () -> Unit,
   quoteCardState: QuoteCardState,
@@ -438,11 +440,12 @@ private fun AddonQuoteCard(
       }
     },
     quoteCardState = quoteCardState,
+    toggleHomeAddonExclusion = toggleHomeAddonExclusion,
   )
 }
 
 @Composable
-private fun AddonQuoteCard(quote: MovingFlowQuotes.AddonQuote.MtaAddonQuote, modifier: Modifier = Modifier) {
+private fun AddonQuoteCard(quote: MtaAddonQuote, modifier: Modifier = Modifier) {
   NonExcludableAddonCard(
     quote = quote,
     modifier = modifier,
@@ -453,6 +456,7 @@ private fun AddonQuoteCard(quote: MovingFlowQuotes.AddonQuote.MtaAddonQuote, mod
 private fun ExcludableAddonCard(
   quoteCardState: QuoteCardState,
   quote: HomeAddonQuote,
+  toggleHomeAddonExclusion: () -> Unit,
   modifier: Modifier = Modifier,
   betweenDetailsAndDocumentsContent: @Composable () -> Unit,
 ) {
@@ -486,6 +490,16 @@ private fun ExcludableAddonCard(
     },
     modifier = modifier,
     betweenDetailsAndDocumentsContent = betweenDetailsAndDocumentsContent,
+    excludedCollapsedStateButtonContent = {
+      HedvigButton(
+        text = stringResource(R.string.ADDON_ADD_COVERAGE),
+        onClick = toggleHomeAddonExclusion,
+        enabled = true,
+        buttonStyle = Secondary,
+        buttonSize = Medium,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    },
   )
 }
 

--- a/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
+++ b/app/ui/ui-tiers-and-addons/src/main/kotlin/com/hedvig/android/tiersandaddons/QuoteCard.kt
@@ -165,6 +165,55 @@ fun QuoteCard(
   displayItems: List<QuoteDisplayItem>,
   modifier: Modifier = Modifier,
   betweenDetailsAndDocumentsContent: @Composable () -> Unit = {},
+  excludedCollapsedStateButtonContent: @Composable () -> Unit = {},
+) {
+  QuoteCard(
+    quoteCardState = quoteCardState,
+    subtitle = subtitle,
+    premium = premium,
+    previousPremium = previousPremium,
+    isExcluded = isExcluded,
+    discounts = discounts,
+    displayItems = displayItems,
+    modifier = modifier,
+    displayName = displayName,
+    contractGroup = contractGroup,
+    insurableLimits = insurableLimits,
+    documents = documents,
+    titleEndSlot = {
+      Crossfade(
+        targetState = isExcluded,
+        modifier = Modifier.wrapContentSize(Alignment.TopEnd),
+      ) { show ->
+        if (show) {
+          HighlightLabel(
+            labelText = stringResource(R.string.CONTRACT_STATUS_TERMINATED),
+            size = Small,
+            color = Grey(MEDIUM),
+          )
+        }
+      }
+    },
+    betweenDetailsAndDocumentsContent = betweenDetailsAndDocumentsContent,
+    excludedCollapsedStateButtonContent = excludedCollapsedStateButtonContent,
+  )
+}
+
+@Composable
+fun QuoteCard(
+  quoteCardState: QuoteCardState,
+  displayName: String,
+  contractGroup: ContractGroup?,
+  insurableLimits: List<InsurableLimit>,
+  documents: List<InsuranceVariantDocument>,
+  subtitle: String?,
+  premium: UiMoney,
+  previousPremium: UiMoney?,
+  isExcluded: Boolean,
+  discounts: List<ContractDiscount>,
+  displayItems: List<QuoteDisplayItem>,
+  modifier: Modifier = Modifier,
+  betweenDetailsAndDocumentsContent: @Composable () -> Unit = {},
 ) {
   QuoteCard(
     quoteCardState = quoteCardState,
@@ -261,6 +310,7 @@ private fun QuoteCard(
   modifier: Modifier = Modifier,
   titleEndSlot: @Composable () -> Unit = {},
   betweenDetailsAndDocumentsContent: @Composable () -> Unit = {},
+  excludedCollapsedStateButtonContent: @Composable (() -> Unit)? = null,
 ) {
   HedvigCard(
     modifier = modifier,
@@ -285,18 +335,25 @@ private fun QuoteCard(
         modifier = Modifier.semantics(mergeDescendants = true) {},
       )
       Spacer(Modifier.height(16.dp))
-      HedvigButton(
-        text = if (quoteCardState.showDetails) {
-          stringResource(R.string.TIER_FLOW_SUMMARY_HIDE_DETAILS_BUTTON)
-        } else {
-          stringResource(R.string.TIER_FLOW_SUMMARY_SHOW_DETAILS)
-        },
-        onClick = quoteCardState::toggleState,
-        enabled = true,
-        buttonStyle = Secondary,
-        buttonSize = Medium,
-        modifier = Modifier.fillMaxWidth(),
-      )
+      if (excludedCollapsedStateButtonContent != null &&
+        !quoteCardState.showDetails &&
+        isExcluded
+      ) {
+        excludedCollapsedStateButtonContent()
+      } else {
+        HedvigButton(
+          text = if (quoteCardState.showDetails) {
+            stringResource(R.string.TIER_FLOW_SUMMARY_HIDE_DETAILS_BUTTON)
+          } else {
+            stringResource(R.string.TIER_FLOW_SUMMARY_SHOW_DETAILS)
+          },
+          onClick = quoteCardState::toggleState,
+          enabled = true,
+          buttonStyle = Secondary,
+          buttonSize = Medium,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
       AnimatedVisibility(
         visible = quoteCardState.showDetails,
         enter = expandVertically(expandFrom = Alignment.Top),


### PR DESCRIPTION
Make removable home addon card behaviour as it is on ios - autocollapse with dynamic button.

### a11y
- [x] if these are UI changes - check for their accessibility
_(a11y of this particular button is fine, but I noticed that TalkBack doesn't see discount lines that were recently added)_