### PR TITLE
GEN-4132 Add labels in edit-coinsured

### DIFF
--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/CoInsured.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/CoInsured.kt
@@ -13,6 +13,8 @@ internal data class CoInsured(
   val birthDate: LocalDate?,
   val ssn: String?,
   val hasMissingInfo: Boolean,
+  val activatesOn: LocalDate?,
+  val terminatesOn: LocalDate?,
   val internalId: String = UUID.randomUUID().toString(),
 ) {
   val id = "$firstName-$lastName-$birthDate-$ssn"

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetCoInsuredUseCase.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/data/GetCoInsuredUseCase.kt
@@ -56,6 +56,8 @@ internal class GetCoInsuredUseCaseImpl(
     birthDate = birthdate,
     ssn = ssn,
     hasMissingInfo = hasMissingInfo,
+    activatesOn = activatesOn,
+    terminatesOn = terminatesOn,
   )
 }
 

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/AddCoInsuredBottomSheetContent.kt
@@ -486,6 +486,8 @@ private fun AddCoInsuredBottomSheetContentPreview() {
               LocalDate.fromEpochDays(300),
               "1234",
               false,
+              activatesOn = LocalDate(2025, 10, 1),
+              terminatesOn = null,
             ),
             CoInsured(
               "Test",
@@ -493,6 +495,8 @@ private fun AddCoInsuredBottomSheetContentPreview() {
               LocalDate.fromEpochDays(300),
               "1234",
               false,
+              activatesOn = null,
+              terminatesOn = LocalDate(2025, 10, 1),
             ),
           ),
         ),

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/CoInsuredList.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/CoInsuredList.kt
@@ -39,6 +39,8 @@ internal fun CoInsuredList(
         onRemove = {},
         onEdit = {},
         contentPadding = contentPadding,
+        activatesOn = null,
+        terminatesOn = null,
       )
     }
 
@@ -50,6 +52,8 @@ internal fun CoInsuredList(
         hasMissingInfo = coInsured.hasMissingInfo,
         isMember = false,
         allowEdit = allowEdit,
+        activatesOn = coInsured.activatesOn,
+        terminatesOn = coInsured.terminatesOn,
         onRemove = {
           onRemove(coInsured)
         },
@@ -77,6 +81,8 @@ private fun PreviewCoInsuredList() {
               LocalDate.fromEpochDays(300),
               "19910113-1093",
               hasMissingInfo = false,
+              activatesOn = null,
+              terminatesOn = LocalDate(2025, 12, 1),
             ),
             CoInsured(
               null,
@@ -84,6 +90,8 @@ private fun PreviewCoInsuredList() {
               null,
               null,
               hasMissingInfo = true,
+              activatesOn = LocalDate(2025, 10, 1),
+              terminatesOn = null,
             ),
           ),
           member = Member(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddMissingInfoDestination.kt
@@ -338,6 +338,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 LocalDate.fromEpochDays(300),
                 "19910113-1093",
                 hasMissingInfo = false,
+                activatesOn = null,
+                terminatesOn = LocalDate(2025, 10, 1),
               ),
               CoInsured(
                 null,
@@ -345,6 +347,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 null,
                 null,
                 hasMissingInfo = true,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
             ),
             updatedCoInsured = listOf(
@@ -354,6 +358,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 LocalDate.fromEpochDays(300),
                 "19910113-1093",
                 hasMissingInfo = false,
+                activatesOn = null,
+                terminatesOn = LocalDate(2025, 10, 1),
               ),
               CoInsured(
                 null,
@@ -361,6 +367,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 null,
                 null,
                 hasMissingInfo = true,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
               CoInsured(
                 null,
@@ -368,6 +376,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 null,
                 null,
                 hasMissingInfo = true,
+                activatesOn = null,
+                terminatesOn = null,
               ),
             ),
             member = Member(
@@ -423,6 +433,8 @@ private fun EditCoInsuredScreenNonEditablePreview() {
                 LocalDate.fromEpochDays(300),
                 "19910113-1093",
                 hasMissingInfo = false,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
               CoInsured(
                 null,
@@ -430,6 +442,8 @@ private fun EditCoInsuredScreenNonEditablePreview() {
                 null,
                 null,
                 hasMissingInfo = true,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
             ),
             member = Member(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -376,6 +376,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 LocalDate.fromEpochDays(300),
                 "19910113-1093",
                 hasMissingInfo = false,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
               CoInsured(
                 null,
@@ -383,6 +385,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 null,
                 null,
                 hasMissingInfo = true,
+                activatesOn = null,
+                terminatesOn = LocalDate(2025, 10, 1),
               ),
             ),
             updatedCoInsured = listOf(
@@ -392,6 +396,8 @@ private fun EditCoInsuredScreenEditablePreview() {
                 LocalDate.fromEpochDays(300),
                 "19910113-1093",
                 hasMissingInfo = false,
+                activatesOn = null,
+                terminatesOn = null,
               ),
             ),
             member = Member(
@@ -450,6 +456,8 @@ private fun EditCoInsuredScreenNonEditablePreview() {
                 LocalDate.fromEpochDays(300),
                 "19910113-1093",
                 hasMissingInfo = false,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
               CoInsured(
                 null,
@@ -457,6 +465,8 @@ private fun EditCoInsuredScreenNonEditablePreview() {
                 null,
                 null,
                 hasMissingInfo = true,
+                activatesOn = LocalDate(2025, 10, 1),
+                terminatesOn = null,
               ),
             ),
             member = Member(

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
@@ -279,9 +279,21 @@ internal class EditCoInsuredPresenter(
             },
             ifRight = {
               Snapshot.withMutableSnapshot {
+                val originalCoInsuredIds = listState.originalCoInsured?.map { originalCoInsured ->
+                  originalCoInsured.id
+                } ?: emptyList()
+                val updatedCoinsuredList = it.coInsured
+                val updatedCoinsuredListWithDate = updatedCoinsuredList
+                  .map { updatedCoinsured ->
+                    if (originalCoInsuredIds.contains(updatedCoinsured.id)) {
+                      updatedCoinsured
+                    } else {
+                      updatedCoinsured.copy(activatesOn = it.activatedDate) // todo: wdyt?
+                    }
+                  }
                 intentId = it.id
                 listState = listState.copy(
-                  updatedCoInsured = it.coInsured,
+                  updatedCoInsured = updatedCoinsuredListWithDate,
                   priceInfo = Loaded.PriceInfo(
                     previousPrice = it.currentPremium,
                     newPrice = it.newPremium,
@@ -364,7 +376,7 @@ internal class EditCoInsuredPresenter(
           birthDate = birthDate,
           ssn = ssn,
           hasMissingInfo = false,
-          activatesOn = null, // todo: would that be a correct way? we don't know anything yet here about the dates
+          activatesOn = null, // todo: would that be a correct way? we don't know anything yet here about dates
           terminatesOn = null,
         )
         val old = listState.coInsured.first { it.internalId == selectedCoInsuredId }
@@ -376,10 +388,11 @@ internal class EditCoInsuredPresenter(
           birthDate = birthDate,
           ssn = ssn,
           hasMissingInfo = false,
-          activatesOn = null, // todo: would that be a correct way? we don't know anything yet here about the dates
+          activatesOn = null, // todo: would that be a correct way? we don't know anything yet here about dates
           terminatesOn = null,
         )
-        (listState.coInsured + updatedCoInsured)
+        val result = (listState.coInsured + updatedCoInsured)
+        result
       }
     }
   }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
@@ -283,14 +283,11 @@ internal class EditCoInsuredPresenter(
                   originalCoInsured.id
                 } ?: emptyList()
                 val updatedCoinsuredList = it.coInsured
-                val updatedCoinsuredListWithDate = updatedCoinsuredList
-                  .map { updatedCoinsured ->
-                    if (originalCoInsuredIds.contains(updatedCoinsured.id)) {
-                      updatedCoinsured
-                    } else {
-                      updatedCoinsured.copy(activatesOn = it.activatedDate) // todo: wdyt?
-                    }
-                  }
+                val updatedCoinsuredListWithDate = updateCoInsuredWithActivationDates(
+                  coInsured = updatedCoinsuredList,
+                  originalIds = originalCoInsuredIds,
+                  activationDate = it.activatedDate,
+                ) // todo: check here
                 intentId = it.id
                 listState = listState.copy(
                   updatedCoInsured = updatedCoinsuredListWithDate,
@@ -393,6 +390,20 @@ internal class EditCoInsuredPresenter(
         )
         val result = (listState.coInsured + updatedCoInsured)
         result
+      }
+    }
+  }
+
+  private fun updateCoInsuredWithActivationDates(
+    coInsured: List<CoInsured>,
+    originalIds: List<String>,
+    activationDate: LocalDate,
+  ): List<CoInsured> {
+    return coInsured.map { it ->
+      if (originalIds.contains(it.id)) {
+        it
+      } else {
+        it.copy(activatesOn = activationDate)
       }
     }
   }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredPresenter.kt
@@ -364,6 +364,8 @@ internal class EditCoInsuredPresenter(
           birthDate = birthDate,
           ssn = ssn,
           hasMissingInfo = false,
+          activatesOn = null, // todo: would that be a correct way? we don't know anything yet here about the dates
+          terminatesOn = null,
         )
         val old = listState.coInsured.first { it.internalId == selectedCoInsuredId }
         listState.coInsured.updated(old, updatedCoInsured)
@@ -374,6 +376,8 @@ internal class EditCoInsuredPresenter(
           birthDate = birthDate,
           ssn = ssn,
           hasMissingInfo = false,
+          activatesOn = null, // todo: would that be a correct way? we don't know anything yet here about the dates
+          terminatesOn = null,
         )
         (listState.coInsured + updatedCoInsured)
       }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/InsuredRow.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/InsuredRow.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -16,13 +18,22 @@ import androidx.compose.ui.unit.dp
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.HighlightLabel
+import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighLightSize.Small
+import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor.Amber
+import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor.Red
+import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade.LIGHT
+import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade.MEDIUM
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.design.system.hedvig.Icon
 import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.design.system.hedvig.datepicker.rememberHedvigDateTimeFormatter
 import com.hedvig.android.design.system.hedvig.icon.Close
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.Lock
 import hedvig.resources.R
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toJavaLocalDate
 
 @Composable
 internal fun InsuredRow(
@@ -31,6 +42,8 @@ internal fun InsuredRow(
   hasMissingInfo: Boolean,
   allowEdit: Boolean,
   isMember: Boolean,
+  activatesOn: LocalDate?,
+  terminatesOn: LocalDate?,
   onRemove: () -> Unit,
   onEdit: () -> Unit,
   contentPadding: PaddingValues,
@@ -56,6 +69,30 @@ internal fun InsuredRow(
             text = identifier,
             color = HedvigTheme.colorScheme.textSecondary,
           )
+          val dateTimeFormatter = rememberHedvigDateTimeFormatter()
+          if (activatesOn != null) {
+            val dateTimeFormatter = rememberHedvigDateTimeFormatter()
+            Spacer(Modifier.height(4.dp))
+            HighlightLabel(
+              labelText = stringResource(
+                id = R.string.CONTRACT_ADD_COINSURED_ACTIVE_FROM,
+                dateTimeFormatter.format(activatesOn.toJavaLocalDate()),
+              ),
+              size = Small,
+              color = Amber(MEDIUM),
+            )
+          }
+          if (terminatesOn != null) {
+            Spacer(Modifier.height(4.dp))
+            HighlightLabel(
+              labelText = stringResource(
+                id = R.string.CONTRACT_ADD_COINSURED_ACTIVE_UNTIL,
+                dateTimeFormatter.format(terminatesOn.toJavaLocalDate()),
+              ),
+              size = Small,
+              color = Red(LIGHT),
+            )
+          }
         }
       }
     },
@@ -116,6 +153,8 @@ private fun InsuredRowPreviewEditable() {
         onEdit = {},
         allowEdit = true,
         contentPadding = PaddingValues(horizontal = 0.dp),
+        activatesOn = null,
+        terminatesOn = LocalDate(2025, 12, 1),
       )
     }
   }
@@ -135,6 +174,8 @@ private fun InsuredRowPreviewMissingInfo() {
         onEdit = {},
         allowEdit = false,
         contentPadding = PaddingValues(horizontal = 0.dp),
+        activatesOn = null,
+        terminatesOn = null,
       )
     }
   }
@@ -154,6 +195,8 @@ private fun InsuredRowPreviewMember() {
         onEdit = {},
         allowEdit = false,
         contentPadding = PaddingValues(horizontal = 0.dp),
+        activatesOn = LocalDate(2025, 10, 1),
+        terminatesOn = LocalDate(2026, 10, 1),
       )
     }
   }

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/RemoveCoInsuredBottomSheetContent.kt
@@ -27,6 +27,7 @@ import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import hedvig.resources.R
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun RemoveCoInsuredBottomSheetContent(
@@ -98,6 +99,8 @@ private fun RemoveCoInsuredBottomSheetContentPreview() {
           birthDate = null,
           ssn = "144412022193",
           hasMissingInfo = false,
+          activatesOn = LocalDate(2025, 10, 1),
+          terminatesOn = null,
         ),
         errorMessage = null,
       )
@@ -120,6 +123,8 @@ private fun RemoveCoInsuredBottomSheetContentWithCoInsuredPreview() {
           birthDate = null,
           ssn = "144412022193",
           hasMissingInfo = false,
+          activatesOn = LocalDate(2025, 10, 1),
+          terminatesOn = null,
         ),
         errorMessage = null,
       )

--- a/app/feature/feature-edit-coinsured/src/test/kotlin/com/hedvig/android/feature/editcoinsured/ui/data/TestData.kt
+++ b/app/feature/feature-edit-coinsured/src/test/kotlin/com/hedvig/android/feature/editcoinsured/ui/data/TestData.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.feature.editcoinsured.ui.data
 
 import com.hedvig.android.feature.editcoinsured.data.CoInsured
 import com.hedvig.android.feature.editcoinsured.data.Member
+import kotlinx.datetime.LocalDate
 
 internal val testContractId = "123"
 
@@ -13,6 +14,8 @@ internal val coInsuredTestList = listOf(
     birthDate = null,
     ssn = "199304111344",
     hasMissingInfo = false,
+    activatesOn = LocalDate(2025, 12, 1),
+    terminatesOn = null,
   ),
   CoInsured(
     internalId = "2",
@@ -21,6 +24,8 @@ internal val coInsuredTestList = listOf(
     birthDate = null,
     ssn = "187405053912",
     hasMissingInfo = false,
+    activatesOn = null,
+    terminatesOn = null,
   ),
   CoInsured(
     internalId = "3",
@@ -29,6 +34,8 @@ internal val coInsuredTestList = listOf(
     birthDate = null,
     ssn = "173304113940",
     hasMissingInfo = false,
+    activatesOn = LocalDate(2025, 12, 1),
+    terminatesOn = null,
   ),
 )
 


### PR DESCRIPTION
[figma](https://www.figma.com/design/zItETkT4mu5ANVDYED5gEm/UX-Improvements--Small-Projects-?node-id=1638-1469&m=dev)
Added missing "activatesOn", "terminatesOn" labels that are there in design and ios.