### PR TITLE
Fix/breakdown info icon and crossthrough

### DIFF
--- a/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/main/kotlin/com/hedvig/android/design/system/hedvig/HedvigBottomSheet.kt
@@ -102,23 +102,24 @@ fun HedvigBottomSheetPriceBreakdown(state: HedvigBottomSheetState<PriceInfoForBo
           },
           endSlot = {
             Row(
-              horizontalArrangement = Arrangement.End,
+              horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
               modifier = Modifier.semantics(true) {},
             ) {
-              HedvigText(
-                stringResource(
-                  R.string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,
-                  data.totalGross,
-                ),
-                style = HedvigTheme.typography.bodySmall.copy(
-                  textDecoration = TextDecoration.LineThrough,
-                  color = HedvigTheme.colorScheme.textSecondary,
-                ),
-                modifier = Modifier.semantics {
-                  contentDescription = grossPriceDescription
-                },
-              )
-              Spacer(Modifier.width(8.dp))
+              if (data.totalGross != data.totalNet) {
+                HedvigText(
+                  stringResource(
+                    R.string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,
+                    data.totalGross,
+                  ),
+                  style = HedvigTheme.typography.bodySmall.copy(
+                    textDecoration = TextDecoration.LineThrough,
+                    color = HedvigTheme.colorScheme.textSecondary,
+                  ),
+                  modifier = Modifier.semantics {
+                    contentDescription = grossPriceDescription
+                  },
+                )
+              }
               HedvigText(
                 stringResource(
                   R.string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,

--- a/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
+++ b/app/feature/feature-edit-coinsured/src/main/kotlin/com/hedvig/android/feature/editcoinsured/ui/EditCoInsuredAddOrRemoveDestination.kt
@@ -340,23 +340,21 @@ private fun PriceInfo(
       startSlot = {
         Row(verticalAlignment = Alignment.CenterVertically) {
           HedvigText(text = stringResource(id = R.string.PRICE_NEW_PRICE))
-          if (priceInfo.currentCost.monthlyGross != priceInfo.newCost.monthlyNet) {
-            IconButton(
-              onClick = {
-                val priceInfoForBottomSheet = PriceInfoForBottomSheet(
-                  displayItems = priceInfo.newCostBreakDown,
-                  totalGross = priceInfo.newCost.monthlyGross,
-                  totalNet = priceInfo.newCost.monthlyNet,
-                )
-                costBreakdownBottomSheetState.show(priceInfoForBottomSheet)
-              },
-            ) {
-              Icon(
-                HedvigIcons.InfoFilled,
-                contentDescription = stringResource(R.string.ADDON_FLOW_LEARN_MORE_BUTTON),
-                tint = HedvigTheme.colorScheme.fillSecondary,
+          IconButton(
+            onClick = {
+              val priceInfoForBottomSheet = PriceInfoForBottomSheet(
+                displayItems = priceInfo.newCostBreakDown,
+                totalGross = priceInfo.newCost.monthlyGross,
+                totalNet = priceInfo.newCost.monthlyNet,
               )
-            }
+              costBreakdownBottomSheetState.show(priceInfoForBottomSheet)
+            },
+          ) {
+            Icon(
+              HedvigIcons.InfoFilled,
+              contentDescription = stringResource(R.string.ADDON_FLOW_LEARN_MORE_BUTTON),
+              tint = HedvigTheme.colorScheme.fillSecondary,
+            )
           }
         }
       },


### PR DESCRIPTION
#### Always show the price breakdown info icon for edit coinsured

This way we ensure that even in cases where we have the same price, if
we happen to have addons involved, which is not something that we know
purely from the price, we still allow looking at the breakdown details

---

#### Do not unconditionally show the gross price with a strikethrough

Since we do want to show this sheet even in the scenarios where the
price is the same now that we want to show breakdowns for scenarios with
addons, we just always allow this sheet to show and we take care of same
price cases inside the sheet code instead.