### PR TITLE
Add clarification error when the lokalise task is not setup properly

### DIFF
--- a/lokalise-gradle-plugin/lokalise/src/main/kotlin/com/hedvig/android/lokalise/HedvigLokalisePlugin.kt
+++ b/lokalise-gradle-plugin/lokalise/src/main/kotlin/com/hedvig/android/lokalise/HedvigLokalisePlugin.kt
@@ -28,6 +28,15 @@ class HedvigLokalisePlugin : Plugin<Project> {
           """.trimMargin(),
         )
       project.tasks.register("downloadStrings", DownloadStringsTask::class.java) { task ->
+        if (!extension.lokaliseToken.isPresent) {
+          error(
+            """
+            |The lokalise extension for task "downloadStrings" does not look to be properly setup.
+            |Are you sure the `lokalise.properties` file exists in your directory?
+            |Hint: Look at the `lokalise {...` plugin extension setup in the resources gradle project.
+            """.trimMargin(),
+          )
+        }
         task.lokaliseProjectId.set(extension.lokaliseProjectId)
         task.lokaliseToken.set(extension.lokaliseToken)
         task.downloadConfig.set(extension.downloadConfig)


### PR DESCRIPTION
This aims to help new project clone setups with figuring out why the translation download gradle task does not work