### PR TITLE
Remove addon exclusion from moving flow summary

### DIFF
--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
@@ -32,7 +32,6 @@ import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiCurrencyCode.SEK
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.data.changetier.data.ChangeTierDeductibleAddonQuote
-import com.hedvig.android.data.changetier.data.ChangeTierDeductibleDisplayItem
 import com.hedvig.android.data.changetier.data.Deductible
 import com.hedvig.android.data.changetier.data.Tier
 import com.hedvig.android.data.changetier.data.TierDeductibleQuote
@@ -72,7 +71,6 @@ import com.hedvig.android.feature.change.tier.ui.stepsummary.SummaryState.Making
 import com.hedvig.android.feature.change.tier.ui.stepsummary.SummaryState.Success
 import com.hedvig.android.tiersandaddons.QuoteCard
 import com.hedvig.android.tiersandaddons.QuoteDisplayItem
-import com.hedvig.android.tiersandaddons.rememberQuoteCardState
 import hedvig.resources.R
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
@@ -335,16 +333,18 @@ private fun SummaryTopAppBar(onIconClick: () -> Unit) {
 
 @Composable
 private fun SummaryCard(uiState: Success, modifier: Modifier = Modifier) {
-  val state = rememberQuoteCardState()
   val addonDocs = uiState.quote.addons.flatMap { it.addonVariant.documents }
   val allDocuments: List<InsuranceVariantDocument> =
     uiState.quote.productVariant.documents + addonDocs
   QuoteCard(
+    displayName = uiState.quote.productVariant.displayName,
+    contractGroup = uiState.quote.productVariant.contractGroup,
+    insurableLimits = uiState.quote.productVariant.insurableLimits,
+    documents = allDocuments,
     subtitle = uiState.currentContractData.contractDisplaySubtitle,
-    isExcluded = false,
     premium = uiState.quote.newTotalCost.monthlyNet,
-    costBreakdown = uiState.quote.costBreakdown,
     previousPremium = uiState.quote.newTotalCost.monthlyGross,
+    costBreakdown = uiState.quote.costBreakdown,
     displayItems = uiState.quote.displayItems.map {
       QuoteDisplayItem(
         it.displayTitle,
@@ -353,11 +353,6 @@ private fun SummaryCard(uiState: Success, modifier: Modifier = Modifier) {
       )
     },
     modifier = modifier,
-    quoteCardState = state,
-    displayName = uiState.quote.productVariant.displayName,
-    contractGroup = uiState.quote.productVariant.contractGroup,
-    insurableLimits = uiState.quote.productVariant.insurableLimits,
-    documents = allDocuments,
   )
 }
 

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/data/MovingFlowQuotes.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/data/MovingFlowQuotes.kt
@@ -48,6 +48,7 @@ internal data class MovingFlowQuotes(
     val defaultChoice: Boolean,
     val relatedAddonQuotes: List<HomeAddonQuote>,
   ) : Quote {
+    val presentableRelatedAddonQuotes = relatedAddonQuotes.filterNot(HomeAddonQuote::isExcludedByUser)
     val tierDisplayName = productVariant.displayTierName ?: tierName
 
     @Serializable

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/di/movingFlowModule.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/di/movingFlowModule.kt
@@ -64,7 +64,6 @@ val movingFlowModule = module {
       get(),
       get(),
       get(),
-      get(),
     )
   }
 }

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryDestination.kt
@@ -58,15 +58,8 @@ import com.hedvig.android.data.productvariant.InsuranceVariantDocument
 import com.hedvig.android.data.productvariant.InsuranceVariantDocument.InsuranceDocumentType.CERTIFICATE
 import com.hedvig.android.data.productvariant.ProductVariant
 import com.hedvig.android.data.productvariant.ProductVariantPeril
-import com.hedvig.android.design.system.hedvig.AccordionData
-import com.hedvig.android.design.system.hedvig.AccordionList
-import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Large
-import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Medium
-import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Ghost
-import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Secondary
 import com.hedvig.android.design.system.hedvig.ErrorDialog
 import com.hedvig.android.design.system.hedvig.HedvigAlertDialog
-import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgress
@@ -78,13 +71,11 @@ import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTa
 import com.hedvig.android.design.system.hedvig.LocalTextStyle
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority.Info
 import com.hedvig.android.design.system.hedvig.Surface
-import com.hedvig.android.design.system.hedvig.a11y.FlowHeading
 import com.hedvig.android.design.system.hedvig.a11y.getPerMonthDescription
 import com.hedvig.android.design.system.hedvig.datepicker.HedvigDateTimeFormatterDefaults
 import com.hedvig.android.design.system.hedvig.datepicker.getLocale
 import com.hedvig.android.design.system.hedvig.placeholder.hedvigPlaceholder
 import com.hedvig.android.design.system.hedvig.placeholder.shimmer
-import com.hedvig.android.design.system.hedvig.rememberHedvigBottomSheetState
 import com.hedvig.android.feature.movingflow.data.AddonId
 import com.hedvig.android.feature.movingflow.data.MovingFlowQuotes
 import com.hedvig.android.feature.movingflow.data.MovingFlowQuotes.AddonQuote.HomeAddonQuote
@@ -94,15 +85,11 @@ import com.hedvig.android.feature.movingflow.data.MovingFlowQuotes.MoveHomeQuote
 import com.hedvig.android.feature.movingflow.data.MovingFlowQuotes.MoveHomeQuote.Deductible
 import com.hedvig.android.feature.movingflow.data.MovingFlowQuotes.MoveMtaQuote
 import com.hedvig.android.feature.movingflow.ui.MovingFlowTopAppBar
-import com.hedvig.android.feature.movingflow.ui.summary.SummaryUiState.Content
 import com.hedvig.android.feature.movingflow.ui.summary.SummaryUiState.Content.SubmitError.Generic
 import com.hedvig.android.feature.movingflow.ui.summary.SummaryUiState.Content.SubmitError.WithMessage
-import com.hedvig.android.feature.movingflow.ui.summary.SummaryUiState.Loading
 import com.hedvig.android.placeholder.PlaceholderHighlight
 import com.hedvig.android.tiersandaddons.QuoteCard
-import com.hedvig.android.tiersandaddons.QuoteCardState
 import com.hedvig.android.tiersandaddons.QuoteDisplayItem
-import com.hedvig.android.tiersandaddons.rememberQuoteCardState
 import hedvig.resources.R
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
@@ -116,7 +103,7 @@ internal fun SummaryDestination(
   onNavigateToFinishedScreen: (LocalDate) -> Unit,
 ) {
   val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
-  if (uiState is Content && uiState.navigateToFinishedScreenWithDate != null) {
+  if (uiState is SummaryUiState.Content && uiState.navigateToFinishedScreenWithDate != null) {
     LaunchedEffect(uiState.navigateToFinishedScreenWithDate) {
       onNavigateToFinishedScreen(uiState.navigateToFinishedScreenWithDate)
     }
@@ -126,7 +113,6 @@ internal fun SummaryDestination(
     navigateUp = navigateUp,
     navigateBack = navigateBack,
     exitFlow = exitFlow,
-    toggleHomeAddonExclusion = { viewModel.emit(SummaryEvent.ToggleHomeAddonExclusion(it)) },
     onConfirmChanges = { viewModel.emit(SummaryEvent.ConfirmChanges) },
     onDismissSubmissionError = { viewModel.emit(SummaryEvent.DismissSubmissionError) },
   )
@@ -138,7 +124,6 @@ private fun SummaryScreen(
   navigateUp: () -> Unit,
   navigateBack: () -> Unit,
   exitFlow: () -> Unit,
-  toggleHomeAddonExclusion: (AddonId) -> Unit,
   onConfirmChanges: () -> Unit,
   onDismissSubmissionError: () -> Unit,
 ) {
@@ -159,7 +144,7 @@ private fun SummaryScreen(
         propagateMinConstraints = true,
       ) {
         when (uiState) {
-          Loading -> HedvigFullScreenCenterAlignedProgress()
+          SummaryUiState.Loading -> HedvigFullScreenCenterAlignedProgress()
 
           SummaryUiState.Error -> HedvigErrorSection(
             onButtonClick = navigateBack,
@@ -167,10 +152,9 @@ private fun SummaryScreen(
             buttonText = stringResource(R.string.general_back_button),
           )
 
-          is Content -> {
+          is SummaryUiState.Content -> {
             SummaryScreen(
               content = uiState,
-              toggleHomeAddonExclusion = toggleHomeAddonExclusion,
               onConfirmChanges = onConfirmChanges,
               onDismissSubmissionError = onDismissSubmissionError,
             )
@@ -184,7 +168,6 @@ private fun SummaryScreen(
 @Composable
 private fun SummaryScreen(
   content: SummaryUiState.Content,
-  toggleHomeAddonExclusion: (AddonId) -> Unit,
   onConfirmChanges: () -> Unit,
   onDismissSubmissionError: () -> Unit,
 ) {
@@ -212,37 +195,6 @@ private fun SummaryScreen(
       onDismiss = onDismissSubmissionError,
     )
   }
-  val exclusionBottomSheetState = rememberHedvigBottomSheetState<ExclusionDialogInfo>()
-  HedvigBottomSheet(exclusionBottomSheetState) { data ->
-    FlowHeading(
-      stringResource(R.string.ADDON_REMOVE_TITLE, data.addonName),
-      stringResource(R.string.ADDON_REMOVE_DESCRIPTION),
-      baseStyle = HedvigTheme.typography.bodySmall,
-    )
-    Spacer(Modifier.height(32.dp))
-    HedvigButton(
-      text = stringResource(R.string.ADDON_REMOVE_CONFIRM_BUTTON, data.addonName),
-      onClick = {
-        exclusionBottomSheetState.dismiss()
-        toggleHomeAddonExclusion(data.addonId)
-        data.addonCardState.toggleState()
-      },
-      enabled = true,
-      buttonSize = Large,
-      modifier = Modifier.fillMaxWidth(),
-    )
-    Spacer(Modifier.height(8.dp))
-    HedvigButton(
-      text = stringResource(R.string.ADDON_REMOVE_CANCEL_BUTTON),
-      onClick = { exclusionBottomSheetState.dismiss() },
-      enabled = true,
-      buttonStyle = Ghost,
-      buttonSize = Large,
-      modifier = Modifier.fillMaxWidth(),
-    )
-    Spacer(Modifier.height(8.dp))
-    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
-  }
   Box(propagateMinConstraints = true) {
     var bottomAttachedContentHeightPx by remember { mutableIntStateOf(0) }
     Column(
@@ -254,28 +206,9 @@ private fun SummaryScreen(
       Spacer(Modifier.height(16.dp))
       Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         QuoteCard(content.summaryInfo.moveHomeQuote)
-        for (addonQuote in content.summaryInfo.moveHomeQuote.relatedAddonQuotes) {
-          val quoteCardState = rememberQuoteCardState()
+        for (addonQuote in content.summaryInfo.moveHomeQuote.presentableRelatedAddonQuotes) {
           AddonQuoteCard(
             quote = addonQuote,
-            quoteCardState = quoteCardState,
-            canExcludeAddons = content.canExcludeAddons,
-            toggleHomeAddonExclusion = {
-              if (!addonQuote.isExcludedByUser) {
-                exclusionBottomSheetState.show(
-                  ExclusionDialogInfo(
-                    addonQuote.addonId,
-                    addonQuote.exposureName,
-                    addonCardState = quoteCardState,
-                  ),
-                )
-              } else {
-                toggleHomeAddonExclusion(addonQuote.addonId)
-                if (quoteCardState.showDetails) {
-                  quoteCardState.toggleState()
-                }
-              }
-            },
           )
         }
         for (mtaQuote in content.summaryInfo.moveMtaQuotes) {
@@ -392,6 +325,9 @@ private fun QuoteCard(quote: MovingFlowQuotes.Quote, modifier: Modifier = Modifi
     subtitle = quote.exposureName,
     premium = quote.premium,
     previousPremium = quote.previousPremium,
+    costBreakdown = quote.discounts.map {
+      it.displayName to it.discountValue
+    },
     displayItems = quote.displayItems.map {
       QuoteDisplayItem(
         title = it.title,
@@ -399,78 +335,20 @@ private fun QuoteCard(quote: MovingFlowQuotes.Quote, modifier: Modifier = Modifi
         value = it.value,
       )
     },
-    costBreakdown = quote.discounts.map {
-      it.displayName to it.discountValue
-    },
     modifier = modifier,
   )
 }
 
 @Composable
-private fun AddonQuoteCard(
-  quote: HomeAddonQuote,
-  canExcludeAddons: Boolean,
-  toggleHomeAddonExclusion: () -> Unit,
-  quoteCardState: QuoteCardState,
-  modifier: Modifier = Modifier,
-) {
-  ExcludableAddonCard(
-    quote = quote,
-    modifier = modifier,
-    betweenDetailsAndDocumentsContent = {
-      if (canExcludeAddons) {
-        HedvigButton(
-          text = stringResource(
-            if (quote.isExcludedByUser) {
-              R.string.ADDON_ADD_COVERAGE
-            } else {
-              R.string.GENERAL_REMOVE
-            },
-          ),
-          onClick = toggleHomeAddonExclusion,
-          enabled = true,
-          buttonStyle = Secondary,
-          buttonSize = Medium,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-    },
-    quoteCardState = quoteCardState,
-    toggleHomeAddonExclusion = toggleHomeAddonExclusion,
-  )
-}
-
-@Composable
-private fun AddonQuoteCard(quote: MtaAddonQuote, modifier: Modifier = Modifier) {
-  NonExcludableAddonCard(
-    quote = quote,
-    modifier = modifier,
-  )
-}
-
-@Composable
-private fun ExcludableAddonCard(
-  quoteCardState: QuoteCardState,
-  quote: HomeAddonQuote,
-  toggleHomeAddonExclusion: () -> Unit,
-  modifier: Modifier = Modifier,
-  betweenDetailsAndDocumentsContent: @Composable () -> Unit,
-) {
-  val subtitle = if (quote.isExcludedByUser) {
-    null
-  } else {
-    quote.coverageDisplayName
-  }
+private fun AddonQuoteCard(quote: MovingFlowQuotes.AddonQuote, modifier: Modifier = Modifier) {
   QuoteCard(
-    quoteCardState = quoteCardState,
     displayName = quote.addonVariant.displayName,
     contractGroup = null,
     insurableLimits = emptyList(),
     documents = quote.addonVariant.documents,
-    subtitle = subtitle,
+    subtitle = quote.coverageDisplayName,
     premium = quote.premium,
     previousPremium = quote.previousPremium,
-    isExcluded = quote.isExcludedByUser,
     costBreakdown = quote.discounts.map {
       it.displayName to it.discountValue
     },
@@ -482,46 +360,6 @@ private fun ExcludableAddonCard(
       )
     },
     modifier = modifier,
-    betweenDetailsAndDocumentsContent = betweenDetailsAndDocumentsContent,
-    excludedCollapsedStateButtonContent = {
-      HedvigButton(
-        text = stringResource(R.string.ADDON_ADD_COVERAGE),
-        onClick = toggleHomeAddonExclusion,
-        enabled = true,
-        buttonStyle = Secondary,
-        buttonSize = Medium,
-        modifier = Modifier.fillMaxWidth(),
-      )
-    },
-  )
-}
-
-@Composable
-private fun NonExcludableAddonCard(quote: MovingFlowQuotes.AddonQuote, modifier: Modifier = Modifier) {
-  val subtitle = quote.coverageDisplayName
-  val quoteCardState = rememberQuoteCardState()
-  QuoteCard(
-    quoteCardState = quoteCardState,
-    displayName = quote.addonVariant.displayName,
-    contractGroup = null,
-    insurableLimits = emptyList(),
-    documents = quote.addonVariant.documents,
-    subtitle = subtitle,
-    premium = quote.premium,
-    previousPremium = quote.previousPremium,
-    isExcluded = false,
-    costBreakdown = quote.discounts.map {
-      it.displayName to it.discountValue
-    },
-    displayItems = quote.displayItems.map {
-      QuoteDisplayItem(
-        title = it.title,
-        subtitle = it.subtitle,
-        value = it.value,
-      )
-    },
-    modifier = modifier,
-    betweenDetailsAndDocumentsContent = {},
   )
 }
 
@@ -532,37 +370,6 @@ private fun formatStartDate(startDate: LocalDate): String {
     HedvigDateTimeFormatterDefaults.dateMonthAndYear(locale).format(startDate.toJavaLocalDate())
   }
 }
-
-@Composable
-private fun QuestionsAndAnswers(modifier: Modifier = Modifier) {
-  val faqs = remember {
-    listOf(
-      R.string.CHANGE_ADDRESS_FAQ_DATE_TITLE to R.string.CHANGE_ADDRESS_FAQ_DATE_LABEL,
-      R.string.CHANGE_ADDRESS_FAQ_PRICE_TITLE to R.string.CHANGE_ADDRESS_FAQ_PRICE_LABEL,
-      R.string.CHANGE_ADDRESS_FAQ_RENTBRF_TITLE to R.string.CHANGE_ADDRESS_FAQ_RENTBRF_LABEL,
-      R.string.CHANGE_ADDRESS_FAQ_STORAGE_TITLE to R.string.CHANGE_ADDRESS_FAQ_STORAGE_LABEL,
-      R.string.CHANGE_ADDRESS_FAQ_STUDENT_TITLE to R.string.CHANGE_ADDRESS_FAQ_STUDENT_LABEL,
-    )
-  }
-  Column(modifier) {
-    HedvigText(stringResource(R.string.CHANGE_ADDRESS_QA))
-    Spacer(Modifier.height(24.dp))
-    AccordionList(
-      items = faqs.map { (title, description) ->
-        AccordionData(
-          title = stringResource(title),
-          description = stringResource(description),
-        )
-      },
-    )
-  }
-}
-
-private data class ExclusionDialogInfo(
-  val addonId: AddonId,
-  val addonName: String,
-  val addonCardState: QuoteCardState,
-)
 
 @HedvigMultiScreenPreview
 @Preview(device = "spec:width=1080px,height=3800px,dpi=440")
@@ -577,7 +384,6 @@ private fun PreviewSummaryScreen(
         navigateUp = {},
         navigateBack = {},
         exitFlow = {},
-        toggleHomeAddonExclusion = {},
         onConfirmChanges = {},
         onDismissSubmissionError = {},
       )
@@ -733,7 +539,6 @@ private class SummaryUiStateProvider : PreviewParameterProvider<SummaryUiState> 
       isSubmitting = false,
       submitError = null,
       navigateToFinishedScreenWithDate = null,
-      canExcludeAddons = true,
       totalPremium = UiMoney(199.0, SEK),
       grossPremium = UiMoney(249.0, SEK),
     ),

--- a/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
+++ b/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
@@ -17,9 +17,6 @@ enum class Feature(
   EDIT_COINSURED("Let member edit co insured"),
   HELP_CENTER("Enable the help center screens"),
   TRAVEL_ADDON("Let members purchase addons"),
-  ENABLE_ADDONS_REMOVAL_FROM_MOVING_FLOW(
-    "Allow members to to exclude specific addons to their home insurance when completing the moving flow",
-  ),
   ENABLE_VIDEO_PLAYER_IN_CHAT_MESSAGES(
     "When enabled, it allows the chat to show media in inline video players in the chat messages",
   ),

--- a/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags-public/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -21,11 +21,6 @@ internal class UnleashFeatureFlagProvider(
           Feature.EDIT_COINSURED -> hedvigUnleashClient.client.isEnabled("edit_coinsured", false)
           Feature.HELP_CENTER -> hedvigUnleashClient.client.isEnabled("help_center", true)
           Feature.TRAVEL_ADDON -> hedvigUnleashClient.client.isEnabled("enable_addons", false)
-          Feature.ENABLE_ADDONS_REMOVAL_FROM_MOVING_FLOW -> hedvigUnleashClient.client.isEnabled(
-            "enable_addons_removal_from_moving_flow",
-            false,
-          )
-
           Feature.ENABLE_VIDEO_PLAYER_IN_CHAT_MESSAGES -> hedvigUnleashClient.client.isEnabled(
             "enable_video_player_in_chat_messages",
             false,


### PR DESCRIPTION
The exclusion will now happen one step earlier
Also adjust the "show details" card to show the information on a bottom sheet instead.

This simplifies the card a lot by not having to expand at all and contain content in-between other content but moving all of the extra info into the new bottom sheet