### PR TITLE
Add device name logging

### DIFF
--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
@@ -1878,6 +1878,14 @@ type MemberInsuranceCost {
   freeUntil: Date
 }
 """
+ All fields should be non-empty 
+"""
+input MemberLogDeviceInput {
+  os: String!
+  brand: String!
+  model: String!
+}
+"""
 Container for mutations that refer to the currently authenticated member.
 """
 type MemberMutationOutput {
@@ -1984,12 +1992,6 @@ input MemberUpdateEurobonusNumberInput {
 }
 input MemberUpdateLanguageInput {
   ietfLanguageTag: String!
-}
-""" All fields should be non-empty """
-input MemberLogDeviceInput {
-  os: String!
-  brand: String!
-  model: String!
 }
 input MemberUpdatePhoneNumberInput {
   phoneNumber: String!

--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
@@ -1985,6 +1985,12 @@ input MemberUpdateEurobonusNumberInput {
 input MemberUpdateLanguageInput {
   ietfLanguageTag: String!
 }
+""" All fields should be non-empty """
+input MemberLogDeviceInput {
+  os: String!
+  brand: String!
+  model: String!
+}
 input MemberUpdatePhoneNumberInput {
   phoneNumber: String!
 }
@@ -2440,6 +2446,7 @@ type Mutation {
   memberUpdateLanguage(input: MemberUpdateLanguageInput!): MemberMutationOutput!
   memberDeletionRequest: UserError
   memberUpdateSubscriptionPreference(subscribe: Boolean): UserError
+  memberLogDevice(input: MemberLogDeviceInput!): UserError
   """
   Mutation that updates member email and phone number, or confirms them if they have not changed.
   """

--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -214,6 +214,7 @@ dependencies {
   implementation(projects.languageCore)
   implementation(projects.languageData)
   implementation(projects.languageMigration)
+  implementation(projects.loggingDeviceModel)
   implementation(projects.loggingPublic)
   implementation(projects.memberRemindersPublic)
   implementation(projects.navigationActivity)

--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationModule.kt
@@ -90,6 +90,7 @@ import com.hedvig.android.featureflags.di.featureManagerModule
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.language.di.languageMigrationModule
 import com.hedvig.android.language.di.languageModule
+import com.hedvig.android.logging.device.model.di.loggingDeviceModelModule
 import com.hedvig.android.memberreminders.di.memberRemindersModule
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.navigation.core.di.deepLinkModule
@@ -420,6 +421,7 @@ val applicationModule = module {
       languageAuthListenersModule,
       languageMigrationModule,
       languageModule,
+      loggingDeviceModelModule,
       loginModule,
       memberRemindersModule,
       movingFlowModule,

--- a/app/logging/logging-device-model/build.gradle.kts
+++ b/app/logging/logging-device-model/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+  id("hedvig.android.library")
+  id("hedvig.gradle.plugin")
+}
+
+hedvig {
+  apollo("octopus")
+}
+
+dependencies {
+  implementation(libs.apollo.runtime)
+  implementation(libs.koin.core)
+  implementation(projects.apolloCore)
+  implementation(projects.apolloOctopusPublic)
+  implementation(projects.authEventCore)
+}

--- a/app/logging/logging-device-model/src/main/AndroidManifest.xml
+++ b/app/logging/logging-device-model/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/app/logging/logging-device-model/src/main/graphql/MutationMemberLogDevice.graphql
+++ b/app/logging/logging-device-model/src/main/graphql/MutationMemberLogDevice.graphql
@@ -1,0 +1,5 @@
+mutation MemberLogDevice($os: String!, $brand: String!, $model: String!) {
+  memberLogDevice(input: {os: $os,brand: $brand,model: $model}) {
+    message
+  }
+}

--- a/app/logging/logging-device-model/src/main/kotlin/com/hedvig/android/logging/device/model/DefaultAndroidInfoProvider.kt
+++ b/app/logging/logging-device-model/src/main/kotlin/com/hedvig/android/logging/device/model/DefaultAndroidInfoProvider.kt
@@ -1,0 +1,38 @@
+package com.hedvig.android.logging.device.model
+
+import android.os.Build
+import java.util.Locale
+
+internal class AndroidInfoProvider(
+  rawDeviceBrand: String,
+  rawDeviceModel: String,
+  rawOsVersion: String
+) {
+
+  constructor() : this(
+    Build.BRAND.orEmpty(),
+    Build.MODEL.orEmpty(),
+    Build.VERSION.RELEASE.orEmpty()
+  )
+
+  val deviceName: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    if (deviceBrand.isBlank()) {
+      deviceModel
+    } else if (deviceModel.contains(deviceBrand)) {
+      deviceModel
+    } else {
+      "$deviceBrand $deviceModel"
+    }
+  }
+
+  val deviceBrand: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    rawDeviceBrand.replaceFirstChar {
+      if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
+    }
+  }
+
+  val deviceModel: String = rawDeviceModel
+
+  val osVersion: String = rawOsVersion
+}
+

--- a/app/logging/logging-device-model/src/main/kotlin/com/hedvig/android/logging/device/model/DeviceNameLoggingAuthListener.kt
+++ b/app/logging/logging-device-model/src/main/kotlin/com/hedvig/android/logging/device/model/DeviceNameLoggingAuthListener.kt
@@ -1,0 +1,34 @@
+package com.hedvig.android.logging.device.model
+
+import com.apollographql.apollo.ApolloClient
+import com.hedvig.android.apollo.safeExecute
+import com.hedvig.android.auth.event.AuthEventListener
+import com.hedvig.android.logger.LogPriority
+import com.hedvig.android.logger.logcat
+import octopus.MemberLogDeviceMutation
+
+internal class DeviceNameLoggingAuthListener(
+  private val apolloClient: ApolloClient,
+) : AuthEventListener {
+  override suspend fun loggedIn(accessToken: String) {
+    val androidInfoProvider = AndroidInfoProvider()
+    apolloClient.mutation(
+      MemberLogDeviceMutation(
+        os = androidInfoProvider.osVersion,
+        brand = androidInfoProvider.deviceBrand,
+        model = androidInfoProvider.deviceName,
+      )
+    ).safeExecute().fold(
+      ifLeft = {
+        logcat(LogPriority.INFO) { "MemberLogDeviceMutation failed with error: ${it}" }
+      },
+      ifRight = {
+        if (it.memberLogDevice?.message != null) {
+          logcat(LogPriority.INFO) { "MemberLogDeviceMutation failed with userError: ${it.memberLogDevice.message}" }
+        } else {
+          logcat(LogPriority.INFO) { "MemberLogDeviceMutation succeeded" }
+        }
+      }
+    )
+  }
+}

--- a/app/logging/logging-device-model/src/main/kotlin/com/hedvig/android/logging/device/model/di/LoggingDeviceModelModule.kt
+++ b/app/logging/logging-device-model/src/main/kotlin/com/hedvig/android/logging/device/model/di/LoggingDeviceModelModule.kt
@@ -1,0 +1,10 @@
+package com.hedvig.android.logging.device.model.di
+
+import com.hedvig.android.auth.event.AuthEventListener
+import com.hedvig.android.logging.device.model.DeviceNameLoggingAuthListener
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val loggingDeviceModelModule = module {
+  single<DeviceNameLoggingAuthListener> { DeviceNameLoggingAuthListener(get()) } bind AuthEventListener::class
+}


### PR DESCRIPTION
Introduce a new module `logging-device-model` that logs device information (OS version, brand, model) upon user login.

- Add `DeviceNameLoggingAuthListener` to trigger device logging on login.
- Create `AndroidInfoProvider` to fetch device details.
- Define `MemberLogDeviceMutation` GraphQL mutation to send device info to the backend.
- Integrate the new module into the main application.
- Update GraphQL schema with `MemberLogDeviceInput` and `memberLogDevice` mutation.