### PR TITLE
Termination flow UI fixes

### DIFF
--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
@@ -1308,6 +1308,10 @@ type Contract {
   """
   coOwners: [ContractCoOwner!]
   """
+  Checks if petId is missing on the current or upcoming agreement.
+  """
+  missingPetId: Boolean!
+  """
   User messages to show due to self change is blocked.
   """
   selfChangeBlockers: ContractSelfChangeBlockers
@@ -1683,15 +1687,15 @@ returned as ExtendedItemDiscount
 """
 type ExtendedItemDiscount {
   """
-   General discount information 
+  General discount information
   """
   itemDiscount: ItemDiscount!
   """
-   Monthly reduction applied by the discount. It's a negative number 
+  Monthly reduction applied by the discount. It's a negative number
   """
   amount: Money!
   """
-   Whether discount is on a pending state or not 
+  Whether discount is on a pending state or not
   """
   isPending: Boolean!
 }
@@ -2891,6 +2895,10 @@ enum MidtermChangeIntentState {
   INITIATED
   COMPLETED
 }
+type MidtermChangePetIdOutput {
+  activationDate: Date
+  userError: UserError
+}
 type MidtermChangePriceDetailItem {
   displayName: String!
   displayValue: String!
@@ -3430,6 +3438,11 @@ type Mutation {
   """
   priceIntentConfirm(priceIntentId: UUID!): PriceIntentMutationOutput!
   """
+  Apply the customer's registered address (from SPAR lookup) directly into the price intent data
+  server-side, so the real address value never needs to be sent to the client.
+  """
+  priceIntentApplySuggestedAddress(priceIntentId: UUID!): PriceIntentMutationOutput!
+  """
   Change the start date of the given `ProductOffer`s by their ID.
   This is used because it's common to want to change the start date AFTER getting the offer.
   """
@@ -3513,6 +3526,10 @@ type Mutation {
   Commits the midterm change and creates a new agreement for it, takes id of the intent
   """
   midtermChangeIntentCommit(intentId: ID!): MidtermChangeIntentMutationOutput!
+  """
+  Called to change the Pet-Id of a cat/dog contract. Creates a midterm change without price change and commits it.
+  """
+  midtermChangePetId(contractId: ID!, petId: String!): MidtermChangePetIdOutput
   """
   Call this to confirm removal of selected addon(s).
   """
@@ -3628,11 +3645,11 @@ type PriceIntent {
   """
   product: Product!
   """
-  Submitted user form data.
+  UI-safe masked form data. PII fields (street, zipCode, city) are always masked.
   """
   data: PricingFormData!
   """
-  Data submitted in other places or inferred from other data points
+  Masked, uncommitted form data from automatic lookup (e.g. SPAR address, trial data). PII fields are masked the same way as 'data'.
   """
   suggestedData: PricingFormData!
   """
@@ -3660,6 +3677,10 @@ type PriceIntent {
   When 'true' it means user has gone trough Insurely flow with that price intent
   """
   hasCollectedInsurelyData: Boolean!
+  """
+  When 'true' all required form data has been provided and the price intent can be confirmed.
+  """
+  isReadyToConfirm: Boolean!
 }
 enum PriceIntentAnimal {
   CAT
@@ -3967,10 +3988,6 @@ type ProductOfferPriceMatch {
   externalPrice: Money!
   externalInsurer: ExternalInsurer!
   priceReduction: Money!
-  """
-  Renewal date of the external insurer's policy. Null when not provided by the external insurer.
-  """
-  renewalDate: Date
 }
 type ProductOffersMutationOutput {
   productOffers: [ProductOffer!]!
@@ -4111,7 +4128,7 @@ type Query {
   Cost for selected configuration of removed addon offer
   """
   addonRemoveOfferCost(contractId: ID!, addonIds: [ID!]!): ItemCost!
-  terminationSurvey(contractId: ID!): TerminationFlowSurvey!
+  terminationSurvey(contractId: UUID!): TerminationFlowSurvey!
   """
   Call this to get the cost of an addon offer for selected addon(s).
   """
@@ -4311,6 +4328,11 @@ type ShopSessionCustomer {
   The personal number of the customer. Can be used for looking up other information.
   """
   ssn: String
+  """
+  The customer's email address. Only available for new members.
+  Returns null for existing/returning members to protect their PII.
+  """
+  email: String
   """
   The list of fields that need to be added in order to sign properly.
   Can be updated through `Mutation.shopSessionCustomerUpdate`.

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -848,9 +848,12 @@
   <string name="TERMINATION_BUTTON">Säg upp försäkring</string>
   <string name="TERMINATION_DATE_TEXT">Välj slutdatum</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">Vi skickar en bekräftelse på uppsägningen inom några dagar. Hör gärna av dig om du inte fått den efter 5 dagar.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOM">Om du har ställt av din bil säger vi upp din försäkring automatiskt. Vi får informationen direkt från Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Eftersom din bil har avställts kommer din försäkring att sägas upp automatiskt.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_RECOMMISSION">När du har ställt på bilen hos Transportstyrelsen uppdateras din försäkring automatiskt till ditt tidigare skydd.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED">Om du har skrotat din bil säger vi upp din försäkring automatiskt. Vi får informationen direkt från Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Eftersom din bil har skrotats kommer din försäkring att sägas upp automatiskt.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Eftersom du har sålt din bil kommer din försäkring att sägas upp automatiskt.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD">Om du har sålt din bil säger vi upp din försäkring automatiskt. Vi får informationen direkt från Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">Vi avslutar din försäkring automatiskt</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO">Du kommer att få ett bekräftelsemail på din avställningsförsäkring inom några dagar, där du kommer att se ditt nya pris.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE">Vad kostar det</string>
@@ -859,6 +862,7 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">Om du har ställt av din bil via Transportstyrelsen kommer din försäkring automatiskt övergå till en avställningsförsäkring.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">Vill du inte behålla din avställningsförsäkring kan du enkelt säga upp den nedan.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Din försäkring kommer övergå till en avställningsförsäkring</string>
+  <string name="TERMINATION_FLOW_AUTO_RECOMMISSION_TITLE">Vi uppdaterar din försäkring automatiskt</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Säg upp försäkring</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">Du kan närsomhelst avsluta din försäkring. Avslutar du din försäkring kommer du endast att debiteras för den tid du varit aktiv medlem hos Hedvig. När du avslutat din försäkring kan du se din sista betalning under fliken \"Betalningar\" här i appen.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Avsluta din försäkring</string>

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -10,6 +10,7 @@
     <item quantity="one">Du har %d berättigad försäkring.</item>
     <item quantity="other">Du har %d berättigade försäkringar.</item>
   </plurals>
+  <string name="A11Y_OF">av</string>
   <string name="A11Y_PAUSE">Pausa</string>
   <string name="A11Y_PLAY">Spela</string>
   <string name="A11Y_SCROLL_DOWN">Skrolla längst ner på sidan</string>
@@ -167,6 +168,11 @@
   <string name="CHAT_TITLE">Meddelanden</string>
   <string name="CHAT_UPLOAD_PRESS_SEND_LABEL">Skicka</string>
   <string name="CHECKOUT_TITLE">Checkout</string>
+  <string name="CHIP_ID_LABEL">Chip-ID</string>
+  <string name="CHIP_ID_MISSING_BUTTON">Lägg till Chip-ID</string>
+  <string name="CHIP_ID_MISSING_MESSAGE">Chip-ID för ditt husdjur saknas</string>
+  <string name="CHIP_ID_TOP_TITLE">Uppdatera husdjurets chip-ID</string>
+  <string name="CHIP_ID_WRONG_INPUT">Måste vara 15 siffror</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_BODY">Aktivera pushnotiser så vi kan hålla dig uppdaterad om ditt ärende.</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_CTA">Aktivera</string>
   <string name="CLAIMS_CASE">Ärende</string>
@@ -209,7 +215,7 @@
   <string name="CLAIMS_USE_TEXT_INSTEAD">Beskriv i text</string>
   <string name="CLAIMS_YOUR_CLAIM">Din skadeanmälan</string>
   <string name="CLAIM_CHAT_AUDIO_RECORDING_LABEL">Röstinspelning</string>
-  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Anpassad artikel</string>
+  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Annat föremål</string>
   <string name="CLAIM_CHAT_DATE_AND_LOCATION_HINT">Om du inte vet exakt datum, fyll i på ett ungefär när det inträffade.</string>
   <string name="CLAIM_CHAT_EDIT_ANSWER_BUTTON">Ändra svar</string>
   <string name="CLAIM_CHAT_EDIT_EXPLANATION">Ändrar du det här svaret rensas allt du fyllt i efter det. Du behöver gå igenom de stegen igen.</string>
@@ -782,6 +788,7 @@
   <string name="TALKBACK_CHAT_MESSAGE_FILE" formatted="false">Vid %s skickade %s en fil av typen: %s, dubbeltryck för att öppna.</string>
   <string name="TALKBACK_CHAT_MESSAGE_GIF" formatted="false">Vid %s skickade %s en GIF-bild.</string>
   <string name="TALKBACK_CHAT_MESSAGE_TEXT" formatted="false">Vid %s sa %s: %s</string>
+  <string name="TALKBACK_CLAIM_CHAT_YOUR_ANSWER">Ditt svar: </string>
   <string name="TALKBACK_CLAIM_STATUS">Status på skadeanmälan: %s</string>
   <string name="TALKBACK_CLAIM_STATUS_CARD">Information om din skadeanmalän</string>
   <string name="TALKBACK_CONVERSATION_DESCRIPTION" formatted="false">Konversation om %s. Senaste meddelandet den %s.</string>
@@ -809,6 +816,7 @@
   <string name="TALKBACK_OPTION_SELECTED">Alternativ valt</string>
   <string name="TALKBACK_PER_MONTH">%s per månad</string>
   <string name="TALKBACK_PINCH_TO_ZOOM">Nyp för att zooma</string>
+  <string name="TALKBACK_PLAYBACK_BUTTON_STATE">Spela upp inspelning. Knapp.</string>
   <string name="TALKBACK_PLUS_DESCRIPTION">Öka</string>
   <string name="TALKBACK_PREVIOUSLY">Tidigare %1$s</string>
   <string name="TALKBACK_PREVIOUS_VALUE">Tidigare: %1$s</string>
@@ -840,7 +848,7 @@
   <string name="TERMINATION_BUTTON">Säg upp försäkring</string>
   <string name="TERMINATION_DATE_TEXT">Välj slutdatum</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">Vi skickar en bekräftelse på uppsägningen inom några dagar. Hör gärna av dig om du inte fått den efter 5 dagar.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Eftersom du har ställt av din bil kommer din försäkring att sägas upp automatiskt.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Eftersom din bil har avställts kommer din försäkring att sägas upp automatiskt.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Eftersom din bil har skrotats kommer din försäkring att sägas upp automatiskt.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Eftersom du har sålt din bil kommer din försäkring att sägas upp automatiskt.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">Vi avslutar din försäkring automatiskt</string>
@@ -851,12 +859,12 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">Om du har ställt av din bil via Transportstyrelsen kommer din försäkring automatiskt övergå till en avställningsförsäkring.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">Vill du inte behålla din avställningsförsäkring kan du enkelt säga upp den nedan.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Din försäkring kommer övergå till en avställningsförsäkring</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Eftersom din bil är påställd igen kommer din försäkring automatiskt att ändras tillbaka till ditt ordinarie skydd.</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Din bil är tillbaka på vägen</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Säg upp försäkring</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">Du kan närsomhelst avsluta din försäkring. Avslutar du din försäkring kommer du endast att debiteras för den tid du varit aktiv medlem hos Hedvig. När du avslutat din försäkring kan du se din sista betalning under fliken \"Betalningar\" här i appen.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Avsluta din försäkring</string>
   <string name="TERMINATION_FLOW_CANCEL_INSURANCE_BUTTON">Avsluta försäkring</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Eftersom din bil är påställd igen kommer din försäkring automatiskt att ändras tillbaka till ditt ordinarie skydd.</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Din bil är tillbaka på vägen</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_INFO">Observera att du bara kan säga upp en försäkring åt gången</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_SUBTITLE">Välj den försäkring du vill säga upp</string>
   <string name="TERMINATION_FLOW_CONFIRMATION">Din försäkring kommer avlutas direkt</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -848,9 +848,12 @@
   <string name="TERMINATION_BUTTON">Cancel insurance</string>
   <string name="TERMINATION_DATE_TEXT">Select termination date</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">We’ll send a cancellation confirmation within a few days. If you don’t get it after 5 days, feel free to contact us.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOM">If you’ve decommissioned your car, we’ll cancel your insurance automatically. We get this information directly from Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Since your car has been decommissioned, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_RECOMMISSION">Once your car is registered as active with Transportstyrelsen, your insurance will be updated automatically to your previous coverage.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED">If you’ve scrapped your car, we’ll cancel your insurance automatically. We get this information directly from Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Since your car has been scrapped, your insurance will be automatically cancelled.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Since you’ve sold your car, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD">If you’ve sold your car, we’ll cancel your insurance automatically. We receive this information directly from Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">We’ll cancel your insurance automatically</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO">You’ll receive a confirmation email within a few days, where you can see your new price.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE">What it costs</string>
@@ -859,6 +862,7 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">If you’ve decommissioned your car through Transportstyrelsen, your insurance will automatically switch to decommission insurance.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">If you don’t want to keep your decommission insurance, you can cancel it below.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Your insurance will switch to decommission insurance</string>
+  <string name="TERMINATION_FLOW_AUTO_RECOMMISSION_TITLE">We’ll update your insurance automatically</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Cancel insurance</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">You can cancel your insurance at any time. You will only be charged for the time you have been an active member. When the insurance is cancelled you can see your last payment under the tab \"Payments\" here in the app.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Cancelling your insurance</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -10,6 +10,7 @@
     <item quantity="one">You have %d eligible insurance.</item>
     <item quantity="other">You have %d eligible insurances.</item>
   </plurals>
+  <string name="A11Y_OF">of</string>
   <string name="A11Y_PAUSE">Pause</string>
   <string name="A11Y_PLAY">Play</string>
   <string name="A11Y_SCROLL_DOWN">Scroll to bottom</string>
@@ -167,6 +168,11 @@
   <string name="CHAT_TITLE">Messages</string>
   <string name="CHAT_UPLOAD_PRESS_SEND_LABEL">Send</string>
   <string name="CHECKOUT_TITLE">Checkout</string>
+  <string name="CHIP_ID_LABEL">Chip-ID</string>
+  <string name="CHIP_ID_MISSING_BUTTON">Add Chip-ID</string>
+  <string name="CHIP_ID_MISSING_MESSAGE">Chip ID for your pet is missing</string>
+  <string name="CHIP_ID_TOP_TITLE">Update pet Chip-ID</string>
+  <string name="CHIP_ID_WRONG_INPUT">Must be 15 digits</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_BODY">Don’t miss out on important information for your claim</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_CTA">Enable notifications</string>
   <string name="CLAIMS_CASE">Case</string>
@@ -209,7 +215,7 @@
   <string name="CLAIMS_USE_TEXT_INSTEAD">Describe using text</string>
   <string name="CLAIMS_YOUR_CLAIM">Your claim</string>
   <string name="CLAIM_CHAT_AUDIO_RECORDING_LABEL">Voice recording</string>
-  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Custom item</string>
+  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Other item</string>
   <string name="CLAIM_CHAT_DATE_AND_LOCATION_HINT">If you don\'t know the exact date, enter an approximate date.</string>
   <string name="CLAIM_CHAT_EDIT_ANSWER_BUTTON">Edit answer</string>
   <string name="CLAIM_CHAT_EDIT_EXPLANATION">Editing this answer will clear everything you’ve filled in after it. You’ll need to go through those steps again.</string>
@@ -782,6 +788,7 @@
   <string name="TALKBACK_CHAT_MESSAGE_FILE" formatted="false">At %s, %s sent a file with type: %s, double tap to open.</string>
   <string name="TALKBACK_CHAT_MESSAGE_GIF" formatted="false">At %s, %s sent a GIF picture.</string>
   <string name="TALKBACK_CHAT_MESSAGE_TEXT" formatted="false">At %s, %s said: %s</string>
+  <string name="TALKBACK_CLAIM_CHAT_YOUR_ANSWER">Your answer: </string>
   <string name="TALKBACK_CLAIM_STATUS">Claim status: %s</string>
   <string name="TALKBACK_CLAIM_STATUS_CARD">Information about your claim</string>
   <string name="TALKBACK_CONVERSATION_DESCRIPTION" formatted="false">Conversation about %s. Last message at %s.</string>
@@ -809,6 +816,7 @@
   <string name="TALKBACK_OPTION_SELECTED">Option selected</string>
   <string name="TALKBACK_PER_MONTH">%s per month</string>
   <string name="TALKBACK_PINCH_TO_ZOOM">Pinch to zoom</string>
+  <string name="TALKBACK_PLAYBACK_BUTTON_STATE">Play recording. Button.</string>
   <string name="TALKBACK_PLUS_DESCRIPTION">Increase</string>
   <string name="TALKBACK_PREVIOUSLY">Previously %1$s</string>
   <string name="TALKBACK_PREVIOUS_VALUE">Previously: %1$s</string>
@@ -840,9 +848,9 @@
   <string name="TERMINATION_BUTTON">Cancel insurance</string>
   <string name="TERMINATION_DATE_TEXT">Select termination date</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">We’ll send a cancellation confirmation within a few days. If you don’t get it after 5 days, feel free to contact us.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Since you’ve decommissioned your car, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Since your car has been decommissioned, your insurance will be automatically cancelled.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Since your car has been scrapped, your insurance will be automatically cancelled.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Since you\’ve sold your car, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Since you’ve sold your car, your insurance will be automatically cancelled.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">We’ll cancel your insurance automatically</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO">You’ll receive a confirmation email within a few days, where you can see your new price.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE">What it costs</string>
@@ -851,12 +859,12 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">If you’ve decommissioned your car through Transportstyrelsen, your insurance will automatically switch to decommission insurance.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">If you don’t want to keep your decommission insurance, you can cancel it below.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Your insurance will switch to decommission insurance</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Since your car is registered again, your insurance will automatically switch back to your regular coverage.</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Your car is back on the road</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Cancel insurance</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">You can cancel your insurance at any time. You will only be charged for the time you have been an active member. When the insurance is cancelled you can see your last payment under the tab \"Payments\" here in the app.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Cancelling your insurance</string>
   <string name="TERMINATION_FLOW_CANCEL_INSURANCE_BUTTON">Cancel insurance</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Since your car is registered again, your insurance will automatically switch back to your regular coverage.</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Your car is back on the road</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_INFO">Please note that you can only cancel one insurance at a time</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_SUBTITLE">Select the insurance you want to cancel</string>
   <string name="TERMINATION_FLOW_CONFIRMATION">Your insurance will be cancelled directly</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -10,6 +10,7 @@
     <item quantity="one">Du har %1$d berättigad försäkring.</item>
     <item quantity="other">Du har %1$d berättigade försäkringar.</item>
   </plurals>
+  <string name="A11Y_OF">av</string>
   <string name="A11Y_PAUSE">Pausa</string>
   <string name="A11Y_PLAY">Spela</string>
   <string name="A11Y_SCROLL_DOWN">Skrolla längst ner på sidan</string>
@@ -167,6 +168,11 @@
   <string name="CHAT_TITLE">Meddelanden</string>
   <string name="CHAT_UPLOAD_PRESS_SEND_LABEL">Skicka</string>
   <string name="CHECKOUT_TITLE">Checkout</string>
+  <string name="CHIP_ID_LABEL">Chip-ID</string>
+  <string name="CHIP_ID_MISSING_BUTTON">Lägg till Chip-ID</string>
+  <string name="CHIP_ID_MISSING_MESSAGE">Chip-ID för ditt husdjur saknas</string>
+  <string name="CHIP_ID_TOP_TITLE">Uppdatera husdjurets chip-ID</string>
+  <string name="CHIP_ID_WRONG_INPUT">Måste vara 15 siffror</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_BODY">Aktivera pushnotiser så vi kan hålla dig uppdaterad om ditt ärende.</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_CTA">Aktivera</string>
   <string name="CLAIMS_CASE">Ärende</string>
@@ -209,7 +215,7 @@
   <string name="CLAIMS_USE_TEXT_INSTEAD">Beskriv i text</string>
   <string name="CLAIMS_YOUR_CLAIM">Din skadeanmälan</string>
   <string name="CLAIM_CHAT_AUDIO_RECORDING_LABEL">Röstinspelning</string>
-  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Anpassad artikel</string>
+  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Annat föremål</string>
   <string name="CLAIM_CHAT_DATE_AND_LOCATION_HINT">Om du inte vet exakt datum, fyll i på ett ungefär när det inträffade.</string>
   <string name="CLAIM_CHAT_EDIT_ANSWER_BUTTON">Ändra svar</string>
   <string name="CLAIM_CHAT_EDIT_EXPLANATION">Ändrar du det här svaret rensas allt du fyllt i efter det. Du behöver gå igenom de stegen igen.</string>
@@ -782,6 +788,7 @@
   <string name="TALKBACK_CHAT_MESSAGE_FILE" formatted="false">Vid %1$s skickade %2$s en fil av typen: %3$s, dubbeltryck för att öppna.</string>
   <string name="TALKBACK_CHAT_MESSAGE_GIF" formatted="false">Vid %1$s skickade %2$s en GIF-bild.</string>
   <string name="TALKBACK_CHAT_MESSAGE_TEXT" formatted="false">Vid %1$s sa %2$s: %3$s</string>
+  <string name="TALKBACK_CLAIM_CHAT_YOUR_ANSWER">Ditt svar: </string>
   <string name="TALKBACK_CLAIM_STATUS">Status på skadeanmälan: %1$s</string>
   <string name="TALKBACK_CLAIM_STATUS_CARD">Information om din skadeanmalän</string>
   <string name="TALKBACK_CONVERSATION_DESCRIPTION" formatted="false">Konversation om %1$s. Senaste meddelandet den %2$s.</string>
@@ -809,6 +816,7 @@
   <string name="TALKBACK_OPTION_SELECTED">Alternativ valt</string>
   <string name="TALKBACK_PER_MONTH">%1$s per månad</string>
   <string name="TALKBACK_PINCH_TO_ZOOM">Nyp för att zooma</string>
+  <string name="TALKBACK_PLAYBACK_BUTTON_STATE">Spela upp inspelning. Knapp.</string>
   <string name="TALKBACK_PLUS_DESCRIPTION">Öka</string>
   <string name="TALKBACK_PREVIOUSLY">Tidigare %1$s</string>
   <string name="TALKBACK_PREVIOUS_VALUE">Tidigare: %1$s</string>
@@ -840,7 +848,7 @@
   <string name="TERMINATION_BUTTON">Säg upp försäkring</string>
   <string name="TERMINATION_DATE_TEXT">Välj slutdatum</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">Vi skickar en bekräftelse på uppsägningen inom några dagar. Hör gärna av dig om du inte fått den efter 5 dagar.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Eftersom du har ställt av din bil kommer din försäkring att sägas upp automatiskt.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Eftersom din bil har avställts kommer din försäkring att sägas upp automatiskt.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Eftersom din bil har skrotats kommer din försäkring att sägas upp automatiskt.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Eftersom du har sålt din bil kommer din försäkring att sägas upp automatiskt.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">Vi avslutar din försäkring automatiskt</string>
@@ -851,12 +859,12 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">Om du har ställt av din bil via Transportstyrelsen kommer din försäkring automatiskt övergå till en avställningsförsäkring.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">Vill du inte behålla din avställningsförsäkring kan du enkelt säga upp den nedan.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Din försäkring kommer övergå till en avställningsförsäkring</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Eftersom din bil är påställd igen kommer din försäkring automatiskt att ändras tillbaka till ditt ordinarie skydd.</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Din bil är tillbaka på vägen</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Säg upp försäkring</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">Du kan närsomhelst avsluta din försäkring. Avslutar du din försäkring kommer du endast att debiteras för den tid du varit aktiv medlem hos Hedvig. När du avslutat din försäkring kan du se din sista betalning under fliken "Betalningar" här i appen.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Avsluta din försäkring</string>
   <string name="TERMINATION_FLOW_CANCEL_INSURANCE_BUTTON">Avsluta försäkring</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Eftersom din bil är påställd igen kommer din försäkring automatiskt att ändras tillbaka till ditt ordinarie skydd.</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Din bil är tillbaka på vägen</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_INFO">Observera att du bara kan säga upp en försäkring åt gången</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_SUBTITLE">Välj den försäkring du vill säga upp</string>
   <string name="TERMINATION_FLOW_CONFIRMATION">Din försäkring kommer avlutas direkt</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -848,9 +848,12 @@
   <string name="TERMINATION_BUTTON">Säg upp försäkring</string>
   <string name="TERMINATION_DATE_TEXT">Välj slutdatum</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">Vi skickar en bekräftelse på uppsägningen inom några dagar. Hör gärna av dig om du inte fått den efter 5 dagar.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOM">Om du har ställt av din bil säger vi upp din försäkring automatiskt. Vi får informationen direkt från Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Eftersom din bil har avställts kommer din försäkring att sägas upp automatiskt.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_RECOMMISSION">När du har ställt på bilen hos Transportstyrelsen uppdateras din försäkring automatiskt till ditt tidigare skydd.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED">Om du har skrotat din bil säger vi upp din försäkring automatiskt. Vi får informationen direkt från Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Eftersom din bil har skrotats kommer din försäkring att sägas upp automatiskt.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Eftersom du har sålt din bil kommer din försäkring att sägas upp automatiskt.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD">Om du har sålt din bil säger vi upp din försäkring automatiskt. Vi får informationen direkt från Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">Vi avslutar din försäkring automatiskt</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO">Du kommer att få ett bekräftelsemail på din avställningsförsäkring inom några dagar, där du kommer att se ditt nya pris.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE">Vad kostar det</string>
@@ -859,6 +862,7 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">Om du har ställt av din bil via Transportstyrelsen kommer din försäkring automatiskt övergå till en avställningsförsäkring.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">Vill du inte behålla din avställningsförsäkring kan du enkelt säga upp den nedan.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Din försäkring kommer övergå till en avställningsförsäkring</string>
+  <string name="TERMINATION_FLOW_AUTO_RECOMMISSION_TITLE">Vi uppdaterar din försäkring automatiskt</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Säg upp försäkring</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">Du kan närsomhelst avsluta din försäkring. Avslutar du din försäkring kommer du endast att debiteras för den tid du varit aktiv medlem hos Hedvig. När du avslutat din försäkring kan du se din sista betalning under fliken "Betalningar" här i appen.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Avsluta din försäkring</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,7 @@
     <item quantity="one">You have %1$d eligible insurance.</item>
     <item quantity="other">You have %1$d eligible insurances.</item>
   </plurals>
+  <string name="A11Y_OF">of</string>
   <string name="A11Y_PAUSE">Pause</string>
   <string name="A11Y_PLAY">Play</string>
   <string name="A11Y_SCROLL_DOWN">Scroll to bottom</string>
@@ -167,6 +168,11 @@
   <string name="CHAT_TITLE">Messages</string>
   <string name="CHAT_UPLOAD_PRESS_SEND_LABEL">Send</string>
   <string name="CHECKOUT_TITLE">Checkout</string>
+  <string name="CHIP_ID_LABEL">Chip-ID</string>
+  <string name="CHIP_ID_MISSING_BUTTON">Add Chip-ID</string>
+  <string name="CHIP_ID_MISSING_MESSAGE">Chip ID for your pet is missing</string>
+  <string name="CHIP_ID_TOP_TITLE">Update pet Chip-ID</string>
+  <string name="CHIP_ID_WRONG_INPUT">Must be 15 digits</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_BODY">Don’t miss out on important information for your claim</string>
   <string name="CLAIMS_ACTIVATE_NOTIFICATIONS_CTA">Enable notifications</string>
   <string name="CLAIMS_CASE">Case</string>
@@ -209,7 +215,7 @@
   <string name="CLAIMS_USE_TEXT_INSTEAD">Describe using text</string>
   <string name="CLAIMS_YOUR_CLAIM">Your claim</string>
   <string name="CLAIM_CHAT_AUDIO_RECORDING_LABEL">Voice recording</string>
-  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Custom item</string>
+  <string name="CLAIM_CHAT_CUSTOM_ITEM_SUBTITLE">Other item</string>
   <string name="CLAIM_CHAT_DATE_AND_LOCATION_HINT">If you don't know the exact date, enter an approximate date.</string>
   <string name="CLAIM_CHAT_EDIT_ANSWER_BUTTON">Edit answer</string>
   <string name="CLAIM_CHAT_EDIT_EXPLANATION">Editing this answer will clear everything you’ve filled in after it. You’ll need to go through those steps again.</string>
@@ -782,6 +788,7 @@
   <string name="TALKBACK_CHAT_MESSAGE_FILE" formatted="false">At %1$s, %2$s sent a file with type: %3$s, double tap to open.</string>
   <string name="TALKBACK_CHAT_MESSAGE_GIF" formatted="false">At %1$s, %2$s sent a GIF picture.</string>
   <string name="TALKBACK_CHAT_MESSAGE_TEXT" formatted="false">At %1$s, %2$s said: %3$s</string>
+  <string name="TALKBACK_CLAIM_CHAT_YOUR_ANSWER">Your answer: </string>
   <string name="TALKBACK_CLAIM_STATUS">Claim status: %1$s</string>
   <string name="TALKBACK_CLAIM_STATUS_CARD">Information about your claim</string>
   <string name="TALKBACK_CONVERSATION_DESCRIPTION" formatted="false">Conversation about %1$s. Last message at %2$s.</string>
@@ -809,6 +816,7 @@
   <string name="TALKBACK_OPTION_SELECTED">Option selected</string>
   <string name="TALKBACK_PER_MONTH">%1$s per month</string>
   <string name="TALKBACK_PINCH_TO_ZOOM">Pinch to zoom</string>
+  <string name="TALKBACK_PLAYBACK_BUTTON_STATE">Play recording. Button.</string>
   <string name="TALKBACK_PLUS_DESCRIPTION">Increase</string>
   <string name="TALKBACK_PREVIOUSLY">Previously %1$s</string>
   <string name="TALKBACK_PREVIOUS_VALUE">Previously: %1$s</string>
@@ -840,9 +848,9 @@
   <string name="TERMINATION_BUTTON">Cancel insurance</string>
   <string name="TERMINATION_DATE_TEXT">Select termination date</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">We’ll send a cancellation confirmation within a few days. If you don’t get it after 5 days, feel free to contact us.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Since you’ve decommissioned your car, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Since your car has been decommissioned, your insurance will be automatically cancelled.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Since your car has been scrapped, your insurance will be automatically cancelled.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Since you\’ve sold your car, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Since you’ve sold your car, your insurance will be automatically cancelled.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">We’ll cancel your insurance automatically</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO">You’ll receive a confirmation email within a few days, where you can see your new price.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE">What it costs</string>
@@ -851,12 +859,12 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">If you’ve decommissioned your car through Transportstyrelsen, your insurance will automatically switch to decommission insurance.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">If you don’t want to keep your decommission insurance, you can cancel it below.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Your insurance will switch to decommission insurance</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Since your car is registered again, your insurance will automatically switch back to your regular coverage.</string>
-  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Your car is back on the road</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Cancel insurance</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">You can cancel your insurance at any time. You will only be charged for the time you have been an active member. When the insurance is cancelled you can see your last payment under the tab "Payments" here in the app.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Cancelling your insurance</string>
   <string name="TERMINATION_FLOW_CANCEL_INSURANCE_BUTTON">Cancel insurance</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_MESSAGE">Since your car is registered again, your insurance will automatically switch back to your regular coverage.</string>
+  <string name="TERMINATION_FLOW_CAR_BACK_TITLE">Your car is back on the road</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_INFO">Please note that you can only cancel one insurance at a time</string>
   <string name="TERMINATION_FLOW_CHOOSE_CONTRACT_SUBTITLE">Select the insurance you want to cancel</string>
   <string name="TERMINATION_FLOW_CONFIRMATION">Your insurance will be cancelled directly</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -848,9 +848,12 @@
   <string name="TERMINATION_BUTTON">Cancel insurance</string>
   <string name="TERMINATION_DATE_TEXT">Select termination date</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_ABOUT">We’ll send a cancellation confirmation within a few days. If you don’t get it after 5 days, feel free to contact us.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOM">If you’ve decommissioned your car, we’ll cancel your insurance automatically. We get this information directly from Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE">Since your car has been decommissioned, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_RECOMMISSION">Once your car is registered as active with Transportstyrelsen, your insurance will be updated automatically to your previous coverage.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED">If you’ve scrapped your car, we’ll cancel your insurance automatically. We get this information directly from Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE">Since your car has been scrapped, your insurance will be automatically cancelled.</string>
-  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE">Since you’ve sold your car, your insurance will be automatically cancelled.</string>
+  <string name="TERMINATION_FLOW_AUTO_CANCEL_SOLD">If you’ve sold your car, we’ll cancel your insurance automatically. We receive this information directly from Transportstyrelsen.</string>
   <string name="TERMINATION_FLOW_AUTO_CANCEL_TITLE">We’ll cancel your insurance automatically</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO">You’ll receive a confirmation email within a few days, where you can see your new price.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE">What it costs</string>
@@ -859,6 +862,7 @@
   <string name="TERMINATION_FLOW_AUTO_DECOM_INFO">If you’ve decommissioned your car through Transportstyrelsen, your insurance will automatically switch to decommission insurance.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION">If you don’t want to keep your decommission insurance, you can cancel it below.</string>
   <string name="TERMINATION_FLOW_AUTO_DECOM_TITLE">Your insurance will switch to decommission insurance</string>
+  <string name="TERMINATION_FLOW_AUTO_RECOMMISSION_TITLE">We’ll update your insurance automatically</string>
   <string name="TERMINATION_FLOW_CANCELLATION_TITLE">Cancel insurance</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TEXT">You can cancel your insurance at any time. You will only be charged for the time you have been an active member. When the insurance is cancelled you can see your last payment under the tab "Payments" here in the app.</string>
   <string name="TERMINATION_FLOW_CANCEL_INFO_TITLE">Cancelling your insurance</string>

--- a/app/feature/feature-terminate-insurance/src/main/graphql/QueryTerminationSurvey.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/QueryTerminationSurvey.graphql
@@ -1,4 +1,4 @@
-query TerminationSurvey($contractId: ID!) {
+query TerminationSurvey($contractId: UUID!) {
   terminationSurvey(contractId: $contractId) {
     options {
       id

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
@@ -161,9 +161,9 @@ private fun TerminationSurveyQuery.Data.TerminationSurvey.Action.toTerminationAc
     is TerminationSurveyQuery.Data.TerminationSurvey.TerminationFlowActionTerminateWithDateAction -> {
       Either.Right(
         TerminationAction.TerminateWithDate(
-        minDate = minDate,
-        maxDate = maxDate,
-        extraCoverageItems = extraCoverage.map { ExtraCoverageItem(it.displayName, it.displayValue) },
+          minDate = minDate,
+          maxDate = maxDate,
+          extraCoverageItems = extraCoverage.map { ExtraCoverageItem(it.displayName, it.displayValue) },
         ),
       )
     }
@@ -171,7 +171,7 @@ private fun TerminationSurveyQuery.Data.TerminationSurvey.Action.toTerminationAc
     is TerminationSurveyQuery.Data.TerminationSurvey.TerminationFlowActionDeleteInsuranceAction -> {
       Either.Right(
         TerminationAction.DeleteInsurance(
-        extraCoverageItems = extraCoverage.map { ExtraCoverageItem(it.displayName, it.displayValue) },
+          extraCoverageItems = extraCoverage.map { ExtraCoverageItem(it.displayName, it.displayValue) },
         ),
       )
     }
@@ -185,19 +185,49 @@ private fun TerminationSurveyQuery.Data.TerminationSurvey.Action.toTerminationAc
 private fun TerminationSurveyOptionSuggestionFragment.toSuggestion(): SurveyOptionSuggestion {
   return SurveyOptionSuggestion(
     type = when (type) {
-      TerminationFlowSurveyOptionSuggestionType.UPDATE_ADDRESS -> SuggestionType.UPDATE_ADDRESS
-      TerminationFlowSurveyOptionSuggestionType.UPGRADE_COVERAGE -> SuggestionType.UPGRADE_COVERAGE
-      TerminationFlowSurveyOptionSuggestionType.DOWNGRADE_PRICE -> SuggestionType.DOWNGRADE_PRICE
-      TerminationFlowSurveyOptionSuggestionType.REDIRECT -> SuggestionType.REDIRECT
-      TerminationFlowSurveyOptionSuggestionType.INFO -> SuggestionType.INFO
-      TerminationFlowSurveyOptionSuggestionType.AUTO_CANCEL_SOLD -> SuggestionType.AUTO_CANCEL_SOLD
-      TerminationFlowSurveyOptionSuggestionType.AUTO_CANCEL_SCRAPPED -> SuggestionType.AUTO_CANCEL_SCRAPPED
+      TerminationFlowSurveyOptionSuggestionType.UPDATE_ADDRESS -> {
+        SuggestionType.UPDATE_ADDRESS
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.UPGRADE_COVERAGE -> {
+        SuggestionType.UPGRADE_COVERAGE
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.DOWNGRADE_PRICE -> {
+        SuggestionType.DOWNGRADE_PRICE
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.REDIRECT -> {
+        SuggestionType.REDIRECT
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.INFO -> {
+        SuggestionType.INFO
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.AUTO_CANCEL_SOLD -> {
+        SuggestionType.AUTO_CANCEL_SOLD
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.AUTO_CANCEL_SCRAPPED -> {
+        SuggestionType.AUTO_CANCEL_SCRAPPED
+      }
+
       TerminationFlowSurveyOptionSuggestionType.AUTO_CANCEL_DECOMMISSION -> {
         SuggestionType.AUTO_CANCEL_DECOMMISSION
       }
-      TerminationFlowSurveyOptionSuggestionType.AUTO_DECOMMISSION -> SuggestionType.AUTO_DECOMMISSION
-      TerminationFlowSurveyOptionSuggestionType.CAR_ALREADY_DECOMMISSION -> SuggestionType.CAR_ALREADY_DECOMMISSION
-      else -> SuggestionType.UNKNOWN
+
+      TerminationFlowSurveyOptionSuggestionType.AUTO_DECOMMISSION -> {
+        SuggestionType.AUTO_DECOMMISSION
+      }
+
+      TerminationFlowSurveyOptionSuggestionType.CAR_ALREADY_DECOMMISSION -> {
+        SuggestionType.CAR_ALREADY_DECOMMISSION
+      }
+
+      else -> {
+        SuggestionType.UNKNOWN
+      }
     },
     description = description,
     url = url,

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/navigation/TerminateInsuranceGraph.kt
@@ -262,6 +262,7 @@ fun NavGraphBuilder.terminateInsuranceGraph(
         suggestionType = suggestionType,
         navigateUp = navController::navigateUp,
         closeTerminationFlow = closeTerminationFlow,
+        onNavigateToNewConversation = dropUnlessResumed { onNavigateToNewConversation() },
         onContinueTermination = {
           when (val terminationAction = action) {
             is TerminationAction.TerminateWithDate -> {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateViewModel.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/choose/ChooseInsuranceToTerminateViewModel.kt
@@ -85,23 +85,29 @@ private class ChooseInsuranceToTerminatePresenter(
 
     LaunchedEffect(terminatableInsuranceToFetchNextStepFor) {
       val currentStateValue = currentState as? ChooseInsuranceToTerminateStepUiState.Success ?: return@LaunchedEffect
-      currentState = currentStateValue.copy(navigationStepFailedToLoad = false)
-      val terminatableInsurance = terminatableInsuranceToFetchNextStepFor ?: return@LaunchedEffect
-      currentState = currentStateValue.copy(isNavigationStepLoading = true)
+      val terminatableInsurance = terminatableInsuranceToFetchNextStepFor
+      if (terminatableInsurance == null) {
+        currentState = currentStateValue.copy(navigationStepFailedToLoad = false)
+        return@LaunchedEffect
+      }
+      val loadingState = currentStateValue.copy(
+        isNavigationStepLoading = true,
+        navigationStepFailedToLoad = false,
+      )
+      currentState = loadingState
       currentState = terminateInsuranceRepository
         .getTerminationSurvey(terminatableInsurance.id)
         .fold(
           ifLeft = {
-            currentStateValue.copy(
+            loadingState.copy(
               navigationStepFailedToLoad = true,
               isNavigationStepLoading = false,
             )
           },
           ifRight = { surveyData ->
-            currentStateValue.copy(
+            loadingState.copy(
               nextStepWithInsurance = Pair(surveyData, terminatableInsurance),
-              navigationStepFailedToLoad = false,
-              isNavigationStepLoading = true,
+              isNavigationStepLoading = false,
             )
           },
         )
@@ -129,11 +135,11 @@ private class ChooseInsuranceToTerminatePresenter(
                 eligibleInsurances.firstOrNull { it.id == initialSelected }
               }
               ChooseInsuranceToTerminateStepUiState.Success(
-                eligibleInsurances,
-                selectedInsurance,
-                null,
-                false,
-                false,
+                insuranceList = eligibleInsurances,
+                selectedInsurance = selectedInsurance,
+                nextStepWithInsurance = null,
+                isNavigationStepLoading = false,
+                navigationStepFailedToLoad = false,
               )
             }
           },

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deflect/DeflectSuggestionDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deflect/DeflectSuggestionDestination.kt
@@ -25,9 +25,10 @@ import hedvig.resources.GENERAL_CONTACT_US_TITLE
 import hedvig.resources.Res
 import hedvig.resources.TERMINATION_BUTTON
 import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_ABOUT
-import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE
-import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE
-import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE
+import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_DECOM
+import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_RECOMMISSION
+import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED
+import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_SOLD
 import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_TITLE
 import hedvig.resources.TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO
 import hedvig.resources.TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE
@@ -36,8 +37,7 @@ import hedvig.resources.TERMINATION_FLOW_AUTO_DECOM_COVERED_TITLE
 import hedvig.resources.TERMINATION_FLOW_AUTO_DECOM_INFO
 import hedvig.resources.TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION
 import hedvig.resources.TERMINATION_FLOW_AUTO_DECOM_TITLE
-import hedvig.resources.TERMINATION_FLOW_CAR_BACK_MESSAGE
-import hedvig.resources.TERMINATION_FLOW_CAR_BACK_TITLE
+import hedvig.resources.TERMINATION_FLOW_AUTO_RECOMMISSION_TITLE
 import hedvig.resources.TERMINATION_FLOW_I_UNDERSTAND_TEXT
 import org.jetbrains.compose.resources.stringResource
 
@@ -171,9 +171,9 @@ private fun rememberDeflectScreenContent(
 ): DeflectScreenContent {
   val autoCancelTitle = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_TITLE)
   val autoCancelAbout = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_ABOUT)
-  val decommissionMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_DECOMMISSION_MESSAGE)
-  val soldMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_SOLD_MESSAGE)
-  val scrappedMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED_MESSAGE)
+  val decommissionMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_DECOM)
+  val soldMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_SOLD)
+  val scrappedMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_SCRAPPED)
   val decomTitle = stringResource(Res.string.TERMINATION_FLOW_AUTO_DECOM_TITLE)
   val decomInfo = stringResource(Res.string.TERMINATION_FLOW_AUTO_DECOM_INFO)
   val decomCoveredTitle = stringResource(Res.string.TERMINATION_FLOW_AUTO_DECOM_COVERED_TITLE)
@@ -181,8 +181,8 @@ private fun rememberDeflectScreenContent(
   val decomCostsTitle = stringResource(Res.string.TERMINATION_FLOW_AUTO_DECOM_COSTS_TITLE)
   val decomCostsInfo = stringResource(Res.string.TERMINATION_FLOW_AUTO_DECOM_COSTS_INFO)
   val decomNotification = stringResource(Res.string.TERMINATION_FLOW_AUTO_DECOM_NOTIFICATION)
-  val carBackTitle = stringResource(Res.string.TERMINATION_FLOW_CAR_BACK_TITLE)
-  val carBackMessage = stringResource(Res.string.TERMINATION_FLOW_CAR_BACK_MESSAGE)
+  val carBackTitle = stringResource(Res.string.TERMINATION_FLOW_AUTO_RECOMMISSION_TITLE)
+  val carBackMessage = stringResource(Res.string.TERMINATION_FLOW_AUTO_CANCEL_RECOMMISSION)
 
   return remember(suggestionType, apiDescription) {
     when (suggestionType) {

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deflect/DeflectSuggestionDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deflect/DeflectSuggestionDestination.kt
@@ -71,10 +71,10 @@ private fun DeflectSuggestionScreen(
   TerminationScaffold(
     navigateUp = navigateUp,
     closeTerminationFlow = closeTerminationFlow,
-  ) { title ->
+  ) { scaffoldTitle ->
     FlowHeading(
-      title = title,
-      description = content.title,
+      title = content.headingTitle ?: scaffoldTitle,
+      description = if (content.headingTitle != null) null else content.title,
       modifier = Modifier.padding(horizontal = 16.dp),
     )
     Spacer(Modifier.height(16.dp))
@@ -106,6 +106,7 @@ private fun DeflectSuggestionScreen(
     }
     Spacer(Modifier.weight(1f).heightIn(min = 16.dp))
     if (content.info != null) {
+      Spacer(Modifier.height(16.dp))
       HedvigNotificationCard(
         message = content.info,
         priority = NotificationDefaults.NotificationPriority.Info,
@@ -148,6 +149,7 @@ private fun DeflectSuggestionScreen(
 }
 
 private data class DeflectScreenContent(
+  val headingTitle: String?,
   val title: String,
   val message: String,
   val extraMessage: String?,
@@ -185,7 +187,7 @@ private fun rememberDeflectScreenContent(
   return remember(suggestionType, apiDescription) {
     when (suggestionType) {
       SuggestionType.AUTO_CANCEL_SOLD -> autoCancel(
-        title = autoCancelTitle,
+        headingTitle = autoCancelTitle,
         message = soldMessage,
         extraMessage = autoCancelAbout,
         canContinueTermination = false,
@@ -193,7 +195,7 @@ private fun rememberDeflectScreenContent(
       )
 
       SuggestionType.AUTO_CANCEL_SCRAPPED -> autoCancel(
-        title = autoCancelTitle,
+        headingTitle = autoCancelTitle,
         message = scrappedMessage,
         extraMessage = autoCancelAbout,
         canContinueTermination = false,
@@ -201,7 +203,7 @@ private fun rememberDeflectScreenContent(
       )
 
       SuggestionType.AUTO_CANCEL_DECOMMISSION -> autoCancel(
-        title = autoCancelTitle,
+        headingTitle = autoCancelTitle,
         message = decommissionMessage,
         extraMessage = autoCancelAbout,
         canContinueTermination = true,
@@ -209,7 +211,8 @@ private fun rememberDeflectScreenContent(
       )
 
       SuggestionType.AUTO_DECOMMISSION -> DeflectScreenContent(
-        title = decomTitle,
+        headingTitle = decomTitle,
+        title = "",
         message = decomInfo,
         extraMessage = null,
         explanations = listOf(
@@ -221,7 +224,8 @@ private fun rememberDeflectScreenContent(
       )
 
       SuggestionType.CAR_ALREADY_DECOMMISSION -> DeflectScreenContent(
-        title = carBackTitle,
+        headingTitle = carBackTitle,
+        title = "",
         message = carBackMessage,
         extraMessage = null,
         explanations = emptyList(),
@@ -230,6 +234,7 @@ private fun rememberDeflectScreenContent(
       )
 
       else -> DeflectScreenContent(
+        headingTitle = null,
         title = apiDescription,
         message = "",
         extraMessage = null,
@@ -242,14 +247,15 @@ private fun rememberDeflectScreenContent(
 }
 
 private fun autoCancel(
-  title: String,
+  headingTitle: String,
   message: String,
   extraMessage: String,
   canContinueTermination: Boolean,
   showContactUs: Boolean,
 ): DeflectScreenContent {
   return DeflectScreenContent(
-    title = title,
+    headingTitle = headingTitle,
+    title = "",
     message = message,
     extraMessage = extraMessage,
     explanations = emptyList(),
@@ -266,7 +272,8 @@ private fun PreviewDeflectAutoCancel() {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       DeflectSuggestionScreen(
         content = DeflectScreenContent(
-          title = "We'll cancel your insurance automatically",
+          headingTitle = "We'll cancel your insurance automatically",
+          title = "",
           message = "Since you've sold your car, your insurance will be automatically cancelled.",
           extraMessage = "We'll send a cancellation confirmation within a few days.",
           explanations = emptyList(),
@@ -290,7 +297,8 @@ private fun PreviewDeflectAutoDecom() {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       DeflectSuggestionScreen(
         content = DeflectScreenContent(
-          title = "Your insurance will switch to decommission insurance",
+          headingTitle = "Your insurance will switch to decommission insurance",
+          title = "",
           message = "If you've decommissioned your car, your insurance will automatically switch.",
           extraMessage = null,
           explanations = listOf(
@@ -316,7 +324,8 @@ private fun PreviewDeflectCarAlreadyDecom() {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       DeflectSuggestionScreen(
         content = DeflectScreenContent(
-          title = "Your car is back on the road",
+          headingTitle = "Your car is back on the road",
+          title = "",
           message = "Since your car is registered again, your insurance will switch back.",
           extraMessage = null,
           explanations = emptyList(),

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deflect/DeflectSuggestionDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/deflect/DeflectSuggestionDestination.kt
@@ -21,6 +21,7 @@ import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.a11y.FlowHeading
 import com.hedvig.android.feature.terminateinsurance.data.SuggestionType
 import com.hedvig.android.feature.terminateinsurance.ui.TerminationScaffold
+import hedvig.resources.GENERAL_CONTACT_US_TITLE
 import hedvig.resources.Res
 import hedvig.resources.TERMINATION_BUTTON
 import hedvig.resources.TERMINATION_FLOW_AUTO_CANCEL_ABOUT
@@ -47,6 +48,7 @@ internal fun DeflectSuggestionDestination(
   navigateUp: () -> Unit,
   closeTerminationFlow: () -> Unit,
   onContinueTermination: () -> Unit,
+  onNavigateToNewConversation: () -> Unit,
 ) {
   val content = rememberDeflectScreenContent(suggestionType, apiDescription = description)
   DeflectSuggestionScreen(
@@ -54,6 +56,7 @@ internal fun DeflectSuggestionDestination(
     navigateUp = navigateUp,
     closeTerminationFlow = closeTerminationFlow,
     onContinueTermination = onContinueTermination,
+    onNavigateToNewConversation = onNavigateToNewConversation,
   )
 }
 
@@ -63,6 +66,7 @@ private fun DeflectSuggestionScreen(
   navigateUp: () -> Unit,
   closeTerminationFlow: () -> Unit,
   onContinueTermination: () -> Unit,
+  onNavigateToNewConversation: () -> Unit,
 ) {
   TerminationScaffold(
     navigateUp = navigateUp,
@@ -128,6 +132,17 @@ private fun DeflectSuggestionScreen(
           .padding(horizontal = 16.dp),
       )
     }
+    if (content.showContactUs) {
+      Spacer(Modifier.height(8.dp))
+      HedvigTextButton(
+        text = stringResource(Res.string.GENERAL_CONTACT_US_TITLE),
+        buttonSize = Large,
+        onClick = onNavigateToNewConversation,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 16.dp),
+      )
+    }
     Spacer(Modifier.height(16.dp))
   }
 }
@@ -139,6 +154,7 @@ private data class DeflectScreenContent(
   val explanations: List<ExplanationItem>,
   val info: String?,
   val canContinueTermination: Boolean,
+  val showContactUs: Boolean = false,
 )
 
 private data class ExplanationItem(
@@ -168,14 +184,28 @@ private fun rememberDeflectScreenContent(
 
   return remember(suggestionType, apiDescription) {
     when (suggestionType) {
-      SuggestionType.AUTO_CANCEL_SOLD -> autoCancel(autoCancelTitle, soldMessage, autoCancelAbout)
+      SuggestionType.AUTO_CANCEL_SOLD -> autoCancel(
+        title = autoCancelTitle,
+        message = soldMessage,
+        extraMessage = autoCancelAbout,
+        canContinueTermination = false,
+        showContactUs = true,
+      )
 
-      SuggestionType.AUTO_CANCEL_SCRAPPED -> autoCancel(autoCancelTitle, scrappedMessage, autoCancelAbout)
+      SuggestionType.AUTO_CANCEL_SCRAPPED -> autoCancel(
+        title = autoCancelTitle,
+        message = scrappedMessage,
+        extraMessage = autoCancelAbout,
+        canContinueTermination = false,
+        showContactUs = true,
+      )
 
       SuggestionType.AUTO_CANCEL_DECOMMISSION -> autoCancel(
-        autoCancelTitle,
-        decommissionMessage,
-        autoCancelAbout,
+        title = autoCancelTitle,
+        message = decommissionMessage,
+        extraMessage = autoCancelAbout,
+        canContinueTermination = true,
+        showContactUs = false,
       )
 
       SuggestionType.AUTO_DECOMMISSION -> DeflectScreenContent(
@@ -211,14 +241,21 @@ private fun rememberDeflectScreenContent(
   }
 }
 
-private fun autoCancel(title: String, message: String, extraMessage: String): DeflectScreenContent {
+private fun autoCancel(
+  title: String,
+  message: String,
+  extraMessage: String,
+  canContinueTermination: Boolean,
+  showContactUs: Boolean,
+): DeflectScreenContent {
   return DeflectScreenContent(
     title = title,
     message = message,
     extraMessage = extraMessage,
     explanations = emptyList(),
     info = null,
-    canContinueTermination = true,
+    canContinueTermination = canContinueTermination,
+    showContactUs = showContactUs,
   )
 }
 
@@ -234,11 +271,13 @@ private fun PreviewDeflectAutoCancel() {
           extraMessage = "We'll send a cancellation confirmation within a few days.",
           explanations = emptyList(),
           info = null,
-          canContinueTermination = true,
+          canContinueTermination = false,
+          showContactUs = true,
         ),
         navigateUp = {},
         closeTerminationFlow = {},
         onContinueTermination = {},
+        onNavigateToNewConversation = {},
       )
     }
   }
@@ -264,6 +303,7 @@ private fun PreviewDeflectAutoDecom() {
         navigateUp = {},
         closeTerminationFlow = {},
         onContinueTermination = {},
+        onNavigateToNewConversation = {},
       )
     }
   }
@@ -286,6 +326,7 @@ private fun PreviewDeflectCarAlreadyDecom() {
         navigateUp = {},
         closeTerminationFlow = {},
         onContinueTermination = {},
+        onNavigateToNewConversation = {},
       )
     }
   }

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -62,7 +62,7 @@ import hedvig.resources.TERMINATION_NO_TIER_QUOTES_SUBTITLE
 import hedvig.resources.TERMINATION_OFFER_BUTTON_UPDATE_ADDRESS
 import hedvig.resources.TERMINATION_SURVEY_FEEDBACK_HINT
 import hedvig.resources.TERMINATION_SURVEY_FEEDBACK_POPOVER_HINT
-import hedvig.resources.TERMINATION_SURVEY_SUBTITLE
+import hedvig.resources.TERMINATION_OFFER_TITLE
 import hedvig.resources.general_close_button
 import hedvig.resources.general_continue_button
 import hedvig.resources.something_went_wrong
@@ -189,7 +189,7 @@ private fun TerminationSurveyScreen(
         }
         FlowHeading(
           title,
-          stringResource(Res.string.TERMINATION_SURVEY_SUBTITLE),
+          stringResource(Res.string.TERMINATION_OFFER_TITLE),
           modifier = Modifier.padding(horizontal = 16.dp),
         )
         Spacer(Modifier.weight(1f))
@@ -290,7 +290,7 @@ private fun SelectedSurveyInfoBox(
     ) {
       Column {
         val suggestion = selectedReason.suggestion
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.height(16.dp))
         HedvigNotificationCard(
           buttonLoading = actionButtonLoading,
           modifier = Modifier

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -60,9 +60,9 @@ import hedvig.resources.Res
 import hedvig.resources.SUMMARY_SCREEN_LEARN_MORE_BUTTON
 import hedvig.resources.TERMINATION_NO_TIER_QUOTES_SUBTITLE
 import hedvig.resources.TERMINATION_OFFER_BUTTON_UPDATE_ADDRESS
+import hedvig.resources.TERMINATION_OFFER_TITLE
 import hedvig.resources.TERMINATION_SURVEY_FEEDBACK_HINT
 import hedvig.resources.TERMINATION_SURVEY_FEEDBACK_POPOVER_HINT
-import hedvig.resources.TERMINATION_OFFER_TITLE
 import hedvig.resources.general_close_button
 import hedvig.resources.general_continue_button
 import hedvig.resources.something_went_wrong

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationreview/TerminationConfirmationDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/terminationreview/TerminationConfirmationDestination.kt
@@ -163,7 +163,7 @@ private fun AreYouSureScreen(
     if (type is Termination) {
       val dateTimeFormatter = rememberHedvigDateTimeFormatter()
       Spacer(Modifier.height(4.dp))
-      HedvigCard(Modifier.padding(horizontal = 16.dp)) {
+      HedvigCard(modifier.padding(horizontal = 16.dp)) {
         Column(Modifier.padding(16.dp)) {
           HedvigText(
             stringResource(Res.string.TERMINATION_FLOW_DATE_FIELD_TEXT),


### PR DESCRIPTION
## Summary
- Changed survey subtitle to "Before you cancel"
- Fixed padding on info box (4.dp → 16.dp)
- Removed "Continue termination" for sold/scrapped car deflect screens
- Added "Contact us" button for those screens

Builds on top of #2885 addressing Slack UI feedback.

https://claude.ai/code/session_017Hvwsj3qNyt6VC4GfRC3H6