### PR TITLE
Feat: legal info in profile tab (GEN-5174)

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -384,6 +384,7 @@ internal fun HedvigNavHost(
       navigateToChipId = {
         navController.navigate(ChipIdGraphDestination())
       },
+      languageService = languageService
     )
     cbmChatGraph(
       hedvigDeepLinkContainer = hedvigDeepLinkContainer,

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -515,6 +515,10 @@
   <string name="KEY_GEAR_ITEM_VIEW_VALUATION_PAGE_TITLE">Värdering</string>
   <string name="KIVRA_NOTIFICATION_BOX_TEXT">Du kan inte ändra betalmetod just nu. Kontakta oss för hjälp.</string>
   <string name="KIVRA_PAYMENT_INFO">Fakturan skickas till din Kivra-inkorg 14 dagar före förfallodatumet varje månad.</string>
+  <string name="LEGAL_A11Y">Tillgänglighet</string>
+  <string name="LEGAL_CATEGORY_LABEL">Juridisk information</string>
+  <string name="LEGAL_INFORMATION">Juridisk information</string>
+  <string name="LEGAL_PRIVACY_POLICY">Personuppgifter</string>
   <string name="LETTER_TO_EIR_SUBJECT">Fråga angående skadeanmälan - Fordon reg. %1$s</string>
   <string name="LOGIN_MARKET_PICKER_PREFERENCES">Välj land och språk</string>
   <string name="LOGOUT_BUTTON">Logga ut</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -515,6 +515,10 @@
   <string name="KEY_GEAR_ITEM_VIEW_VALUATION_PAGE_TITLE">Valuation</string>
   <string name="KIVRA_NOTIFICATION_BOX_TEXT">You can’t change the payment method right now. Contact us for help.</string>
   <string name="KIVRA_PAYMENT_INFO">The invoice is sent to your Kivra inbox 14 days before the due date each month.</string>
+  <string name="LEGAL_A11Y">Accessibility</string>
+  <string name="LEGAL_CATEGORY_LABEL">Legal</string>
+  <string name="LEGAL_INFORMATION">Legal information</string>
+  <string name="LEGAL_PRIVACY_POLICY">Privacy policy</string>
   <string name="LETTER_TO_EIR_SUBJECT">Question regarding claim, Vehicle reg. %1$s</string>
   <string name="LOGIN_MARKET_PICKER_PREFERENCES">Preferences</string>
   <string name="LOGOUT_BUTTON">Logout</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -515,6 +515,10 @@
   <string name="KEY_GEAR_ITEM_VIEW_VALUATION_PAGE_TITLE">Värdering</string>
   <string name="KIVRA_NOTIFICATION_BOX_TEXT">Du kan inte ändra betalmetod just nu. Kontakta oss för hjälp.</string>
   <string name="KIVRA_PAYMENT_INFO">Fakturan skickas till din Kivra-inkorg 14 dagar före förfallodatumet varje månad.</string>
+  <string name="LEGAL_A11Y">Tillgänglighet</string>
+  <string name="LEGAL_CATEGORY_LABEL">Juridisk information</string>
+  <string name="LEGAL_INFORMATION">Juridisk information</string>
+  <string name="LEGAL_PRIVACY_POLICY">Personuppgifter</string>
   <string name="LETTER_TO_EIR_SUBJECT">Fråga angående skadeanmälan - Fordon reg. %1$s</string>
   <string name="LOGIN_MARKET_PICKER_PREFERENCES">Välj land och språk</string>
   <string name="LOGOUT_BUTTON">Logga ut</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -515,6 +515,10 @@
   <string name="KEY_GEAR_ITEM_VIEW_VALUATION_PAGE_TITLE">Valuation</string>
   <string name="KIVRA_NOTIFICATION_BOX_TEXT">You can’t change the payment method right now. Contact us for help.</string>
   <string name="KIVRA_PAYMENT_INFO">The invoice is sent to your Kivra inbox 14 days before the due date each month.</string>
+  <string name="LEGAL_A11Y">Accessibility</string>
+  <string name="LEGAL_CATEGORY_LABEL">Legal</string>
+  <string name="LEGAL_INFORMATION">Legal information</string>
+  <string name="LEGAL_PRIVACY_POLICY">Privacy policy</string>
   <string name="LETTER_TO_EIR_SUBJECT">Question regarding claim, Vehicle reg. %1$s</string>
   <string name="LOGIN_MARKET_PICKER_PREFERENCES">Preferences</string>
   <string name="LOGOUT_BUTTON">Logout</string>

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/icon/Bookmark.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/icon/Bookmark.kt
@@ -1,0 +1,85 @@
+package com.hedvig.android.design.system.hedvig.icon
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+
+@Suppress("UnusedReceiverParameter")
+val HedvigIcons.Bookmark: ImageVector
+  get() {
+    val current = _Bookmark
+    if (current != null) return current
+
+    return ImageVector.Builder(
+      name = "com.hedvig.android.design.system.hedvig.icon.Bookmark",
+      defaultWidth = 24.0.dp,
+      defaultHeight = 24.0.dp,
+      viewportWidth = 24.0f,
+      viewportHeight = 24.0f,
+    ).apply {
+      path(
+        fill = SolidColor(Color(0xFF121212)),
+        pathFillType = PathFillType.EvenOdd
+      ) {
+        moveTo(7.5f, 3.75f)
+        curveTo(6.80964f, 3.75f, 6.25f, 4.30964f, 6.25f, 5f)
+        verticalLineTo(18.3159f)
+        curveTo(6.25f, 19.3076f, 7.34933f, 19.9044f, 8.18092f, 19.3642f)
+        lineTo(10.502f, 17.8565f)
+        curveTo(11.413f, 17.2647f, 12.587f, 17.2647f, 13.498f, 17.8565f)
+        lineTo(15.8191f, 19.3642f)
+        curveTo(16.6507f, 19.9044f, 17.75f, 19.3076f, 17.75f, 18.3159f)
+        verticalLineTo(5f)
+        curveTo(17.75f, 4.30964f, 17.1904f, 3.75f, 16.5f, 3.75f)
+        horizontalLineTo(7.5f)
+        close()
+        moveTo(4.75f, 5f)
+        curveTo(4.75f, 3.48122f, 5.98122f, 2.25f, 7.5f, 2.25f)
+        horizontalLineTo(16.5f)
+        curveTo(18.0188f, 2.25f, 19.25f, 3.48122f, 19.25f, 5f)
+        verticalLineTo(18.3159f)
+        curveTo(19.25f, 20.4975f, 16.8315f, 21.8105f, 15.002f, 20.6221f)
+        lineTo(12.6809f, 19.1144f)
+        curveTo(12.2668f, 18.8454f, 11.7332f, 18.8454f, 11.3191f, 19.1144f)
+        lineTo(8.99802f, 20.6221f)
+        curveTo(7.16853f, 21.8105f, 4.75f, 20.4975f, 4.75f, 18.3159f)
+        verticalLineTo(5f)
+        close()
+      }
+    }.build().also { _Bookmark = it }
+  }
+
+@Suppress("ObjectPropertyName", "ktlint:standard:backing-property-naming")
+private var _Bookmark: ImageVector? = null
+
+@Preview
+@Composable
+private fun IconPreview() {
+  HedvigTheme {
+    Column(
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Image(
+        imageVector = HedvigIcons.Bookmark,
+        contentDescription = com.hedvig.android.compose.ui.EmptyContentDescription,
+        modifier = Modifier
+          .width((24.0).dp)
+          .height((24.0).dp),
+      )
+    }
+  }
+}

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/legal/LegalInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/legal/LegalInfoDestination.kt
@@ -1,0 +1,146 @@
+package com.hedvig.android.feature.profile.legal
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.compose.ui.EmptyContentDescription
+import com.hedvig.android.core.icons.HedvigIcons
+import com.hedvig.android.core.icons.hedvig.small.hedvig.ArrowNorthEast
+import com.hedvig.android.design.system.hedvig.DividerPosition
+import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigScaffold
+import com.hedvig.android.design.system.hedvig.HedvigText
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.Icon
+import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.design.system.hedvig.horizontalDivider
+import com.hedvig.android.language.Language
+import com.hedvig.android.language.LanguageService
+import hedvig.resources.LEGAL_A11Y
+import hedvig.resources.LEGAL_CATEGORY_LABEL
+import hedvig.resources.LEGAL_INFORMATION
+import hedvig.resources.LEGAL_PRIVACY_POLICY
+import hedvig.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun LegalInfoDestination(
+  openUrl: (String) -> Unit,
+  navigateUp: () -> Unit,
+  languageService: LanguageService,
+) {
+  HedvigScaffold(
+    navigateUp = navigateUp,
+    topAppBarText = stringResource(Res.string.LEGAL_CATEGORY_LABEL),
+  ) {
+    val linkContainer = LinkContainer(languageService)
+    val horizontalDividerModifier = Modifier.horizontalDivider(DividerPosition.Bottom, horizontalPadding = 16.dp)
+    LinkRow(
+      modifier = horizontalDividerModifier,
+      text = stringResource(Res.string.LEGAL_PRIVACY_POLICY),
+      link = linkContainer.getPrivacyPolicyLink(),
+      onLinkClick = openUrl,
+    )
+    LinkRow(
+      modifier = horizontalDividerModifier,
+      text = stringResource(Res.string.LEGAL_INFORMATION),
+      link = linkContainer.getLegalInfoLink(),
+      onLinkClick = openUrl,
+    )
+    LinkRow(
+      text = stringResource(Res.string.LEGAL_A11Y),
+      link = linkContainer.getA11yLink(),
+      onLinkClick = openUrl,
+    )
+  }
+}
+
+private class LinkContainer(
+  val languageService: LanguageService,
+) {
+  private val privacyPolicyLinkEn = "https://www.hedvig.com/se-en/hedvig/privacy-policy"
+  private val privacyPolicyLinkSe = "https://www.hedvig.com/se/hedvig/personuppgifter"
+  fun getPrivacyPolicyLink(): String {
+    return when (languageService.getLanguage()) {
+      Language.SV_SE -> privacyPolicyLinkSe
+      Language.EN_SE -> privacyPolicyLinkEn
+    }
+  }
+
+  private val legalInfoLinkEn = "https://www.hedvig.com/se-en/hedvig/legal"
+  private val legalInfoLinkSe = "https://www.hedvig.com/se/hedvig/legal"
+  fun getLegalInfoLink(): String {
+    return when (languageService.getLanguage()) {
+      Language.SV_SE -> legalInfoLinkSe
+      Language.EN_SE -> legalInfoLinkEn
+    }
+  }
+
+  private val a11yLinkEn = "https://www.hedvig.com/se-en/help/accessibility"
+  private val a11yLinkSe = "https://www.hedvig.com/se/hjalp/tillganglighet"
+  fun getA11yLink(): String {
+    return when (languageService.getLanguage()) {
+      Language.SV_SE -> a11yLinkSe
+      Language.EN_SE -> a11yLinkEn
+    }
+  }
+}
+
+
+@Composable
+private fun LinkRow(
+  link: String,
+  text: String,
+  onLinkClick: (String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier
+      .fillMaxWidth()
+      .clickable(
+        onClick = {
+          onLinkClick(link)
+        },
+        enabled = true,
+      )
+      .padding(16.dp)
+      .semantics(mergeDescendants = true) {},
+  ) {
+    HedvigText(
+      text = text,
+    )
+    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.width(8.dp))
+    Icon(
+      imageVector = HedvigIcons.ArrowNorthEast,
+      contentDescription = EmptyContentDescription,
+      modifier = Modifier
+        .size(24.dp),
+    )
+  }
+}
+
+
+@HedvigPreview
+@Composable
+private fun PreviewLinkRow() {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      LinkRow(
+        link = "",
+        text = "Legal information",
+        onLinkClick = {},
+      )
+    }
+  }
+}

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/legal/LegalInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/legal/LegalInfoDestination.kt
@@ -125,7 +125,7 @@ private fun LinkRow(
       imageVector = HedvigIcons.ArrowNorthEast,
       contentDescription = EmptyContentDescription,
       modifier = Modifier
-        .size(24.dp),
+        .size(16.dp),
     )
   }
 }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/navigation/ProfileDestinations.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/navigation/ProfileDestinations.kt
@@ -30,6 +30,9 @@ internal sealed interface ProfileDestinations {
 
   @Serializable
   data object SettingsGraph : ProfileDestinations, Destination
+
+  @Serializable
+  data object Legal: ProfileDestinations, Destination
 }
 
 internal sealed interface SettingsDestinations {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
@@ -62,6 +62,7 @@ import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Icon
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.horizontalDivider
+import com.hedvig.android.design.system.hedvig.icon.Bookmark
 import com.hedvig.android.design.system.hedvig.icon.Clock
 import com.hedvig.android.design.system.hedvig.icon.Eurobonus
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
@@ -81,6 +82,7 @@ import com.hedvig.android.pullrefresh.PullRefreshIndicator
 import com.hedvig.android.pullrefresh.pullRefresh
 import com.hedvig.android.pullrefresh.rememberPullRefreshState
 import hedvig.resources.GENERAL_YES
+import hedvig.resources.LEGAL_CATEGORY_LABEL
 import hedvig.resources.LOGOUT_BUTTON
 import hedvig.resources.PROFILE_ABOUT_ROW
 import hedvig.resources.PROFILE_LOGOUT_DIALOG_MESSAGE
@@ -109,6 +111,7 @@ internal fun ProfileDestination(
   onNavigateToNewConversation: () -> Unit,
   viewModel: ProfileViewModel,
   navigateToChipId: () -> Unit,
+  navigateToLegalInfo: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -129,6 +132,7 @@ internal fun ProfileDestination(
     onLogout = { viewModel.emit(ProfileUiEvent.Logout) },
     onNavigateToNewConversation = onNavigateToNewConversation,
     navigateToChipId = navigateToChipId,
+    navigateToLegalInfo = navigateToLegalInfo
   )
 }
 
@@ -151,6 +155,7 @@ private fun ProfileScreen(
   snoozeNotificationPermission: () -> Unit,
   onLogout: () -> Unit,
   navigateToChipId: () -> Unit,
+  navigateToLegalInfo: () -> Unit,
 ) {
   val systemBarInsetTopDp = with(LocalDensity.current) {
     WindowInsets.systemBars.getTop(this).toDp()
@@ -204,6 +209,7 @@ private fun ProfileScreen(
         navigateToEurobonus = navigateToEurobonus,
         navigateToClaimHistory = navigateToClaimHistory,
         navigateToCertificates = navigateToCertificates,
+        navigateToLegalInfo = navigateToLegalInfo
       )
       Spacer(Modifier.height(16.dp))
       Spacer(Modifier.weight(1f))
@@ -266,6 +272,7 @@ private fun ProfileRows(
   navigateToEurobonus: () -> Unit,
   navigateToClaimHistory: () -> Unit,
   navigateToCertificates: () -> Unit,
+  navigateToLegalInfo: () -> Unit,
 ) {
   AnimatedContent(
     targetState = profileUiState,
@@ -286,6 +293,7 @@ private fun ProfileRows(
             navigateToEurobonus = navigateToEurobonus,
             navigateToClaimHistory = navigateToClaimHistory,
             navigateToCertificates = navigateToCertificates,
+            navigateToLegalInfo = navigateToLegalInfo
           )
         }
       }
@@ -332,6 +340,7 @@ private fun ColumnScope.ProfileItemRows(
   navigateToEurobonus: () -> Unit,
   navigateToClaimHistory: () -> Unit,
   navigateToCertificates: () -> Unit,
+  navigateToLegalInfo: () -> Unit,
 ) {
   val horizontalDividerModifier = Modifier.horizontalDivider(DividerPosition.Bottom, horizontalPadding = 16.dp)
   ProfileRow(
@@ -374,6 +383,12 @@ private fun ColumnScope.ProfileItemRows(
     onClick = navigateToAboutApp,
     isLoading = false,
     modifier = horizontalDividerModifier,
+  )
+  ProfileRow(
+    title = stringResource(Res.string.LEGAL_CATEGORY_LABEL),
+    icon = HedvigIcons.Bookmark,
+    onClick = navigateToLegalInfo,
+    isLoading = false,
   )
   ProfileRow(
     title = stringResource(Res.string.profile_appSettingsSection_row_headline),
@@ -437,6 +452,7 @@ private fun PreviewProfileRows(
         {},
         {},
         {},
+        {}
       )
     }
   }
@@ -480,6 +496,7 @@ private fun PreviewAnimatedProfileItemRows() {
             {},
             {},
             {},
+            {}
           )
         }
       }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
@@ -389,6 +389,7 @@ private fun ColumnScope.ProfileItemRows(
     icon = HedvigIcons.Bookmark,
     onClick = navigateToLegalInfo,
     isLoading = false,
+    modifier = horizontalDividerModifier,
   )
   ProfileRow(
     title = stringResource(Res.string.profile_appSettingsSection_row_headline),

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileGraph.kt
@@ -17,12 +17,14 @@ import com.hedvig.android.feature.profile.contactinfo.ContactInfoDestination
 import com.hedvig.android.feature.profile.contactinfo.ContactInfoViewModel
 import com.hedvig.android.feature.profile.eurobonus.EurobonusDestination
 import com.hedvig.android.feature.profile.eurobonus.EurobonusViewModel
+import com.hedvig.android.feature.profile.legal.LegalInfoDestination
 import com.hedvig.android.feature.profile.navigation.ProfileDestination
 import com.hedvig.android.feature.profile.navigation.ProfileDestinations
 import com.hedvig.android.feature.profile.navigation.ProfileDestinations.Certificates
 import com.hedvig.android.feature.profile.navigation.SettingsDestinations
 import com.hedvig.android.feature.profile.settings.SettingsDestination
 import com.hedvig.android.feature.profile.settings.SettingsViewModel
+import com.hedvig.android.language.LanguageService
 import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
 import com.hedvig.android.navigation.compose.navgraph
@@ -47,6 +49,7 @@ fun NavGraphBuilder.profileGraph(
   onNavigateToInsuranceEvidence: () -> Unit,
   openUrl: (String) -> Unit,
   navigateToChipId: () -> Unit,
+  languageService: LanguageService
 ) {
   navgraph<ProfileDestination.Graph>(
     startDestination = ProfileDestination.Profile::class,
@@ -85,8 +88,20 @@ fun NavGraphBuilder.profileGraph(
           onNavigateToNewConversation()
         },
         navigateToChipId = navigateToChipId,
+        navigateToLegalInfo = dropUnlessResumed {
+          navController.navigate(ProfileDestinations.Legal)
+        },
       )
     }
+
+    navdestination<ProfileDestinations.Legal> {
+      LegalInfoDestination(
+        openUrl = openUrl,
+        navigateUp = navController::navigateUp,
+        languageService = languageService
+      )
+    }
+
     navdestination<ProfileDestinations.Eurobonus>(
       deepLinks = navDeepLinks(hedvigDeepLinkContainer.eurobonus),
     ) {


### PR DESCRIPTION
Add required link to legal info in profile tab. [Figma](https://www.figma.com/design/xLvOP4XvZ4vEdc5e99BzG5/App-P1-2026?node-id=318-1032&m=dev)