### PR TITLE
Handle nullable upload URI (RND-1677)

### DIFF
--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
@@ -844,7 +844,7 @@ type Claim {
   This target accepts multipart file uploads, and will automatically attach the uploaded files to the given claim.
   Therefore, the same claim can be refreshed in GraphQL and it should be visible in the `Claim.files` field.
   """
-  targetFileUploadUri: String!
+  targetFileUploadUri: String
   """
   A list of all the member-visible, uploaded files for this claim.
   """

--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
@@ -504,29 +504,34 @@ private fun BeforeGridContent(
       .fillMaxWidth()
       .padding(horizontal = 2.dp),
   )
-  Spacer(Modifier.height(24.dp))
-  HedvigText(
-    stringResource(Res.string.claim_status_detail_uploaded_files_info_title),
-    Modifier.padding(horizontal = 2.dp),
-  )
-  Spacer(Modifier.height(8.dp))
-  when (uiState.submittedContent) {
-    is ClaimDetailUiState.Content.SubmittedContent.Audio -> {
-      ClaimDetailHedvigAudioPlayerItem(uiState.submittedContent.signedAudioURL)
-    }
-
-    is ClaimDetailUiState.Content.SubmittedContent.FreeText -> {
-      HedvigCard(Modifier.fillMaxWidth()) {
-        HedvigText(
-          uiState.submittedContent.text,
-          Modifier.padding(16.dp),
-        )
+  val hasUploadedFilesSection = uiState.submittedContent != null ||
+    uiState.files.isNotEmpty() ||
+    uiState.isUploadingFilesEnabled
+  if (hasUploadedFilesSection) {
+    Spacer(Modifier.height(24.dp))
+    HedvigText(
+      stringResource(Res.string.claim_status_detail_uploaded_files_info_title),
+      Modifier.padding(horizontal = 2.dp),
+    )
+    Spacer(Modifier.height(8.dp))
+    when (uiState.submittedContent) {
+      is ClaimDetailUiState.Content.SubmittedContent.Audio -> {
+        ClaimDetailHedvigAudioPlayerItem(uiState.submittedContent.signedAudioURL)
       }
-    }
 
-    else -> {}
+      is ClaimDetailUiState.Content.SubmittedContent.FreeText -> {
+        HedvigCard(Modifier.fillMaxWidth()) {
+          HedvigText(
+            uiState.submittedContent.text,
+            Modifier.padding(16.dp),
+          )
+        }
+      }
+
+      null -> {}
+    }
+    Spacer(Modifier.height(8.dp))
   }
-  Spacer(Modifier.height(8.dp))
 }
 
 @Composable

--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsDestination.kt
@@ -194,19 +194,19 @@ private fun ClaimDetailScreen(
         is ClaimDetailUiState.Content -> {
           val photoCaptureState = rememberPhotoCaptureState(appPackageId = appPackageId) { uri ->
             logcat { "ChatFileState sending photoCaptureState uri:$uri" }
-            onFilesToUploadSelected(listOf(uri.toAndroidUri()), uiState.uploadUri)
+            uiState.uploadUri?.let { onFilesToUploadSelected(listOf(uri.toAndroidUri()), it) }
           }
           val photoPicker = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.PickMultipleVisualMedia(),
           ) { resultingUriList: List<Uri> ->
             logcat { "ChatFileState sending photoPicker uris:$resultingUriList" }
-            onFilesToUploadSelected(resultingUriList, uiState.uploadUri)
+            uiState.uploadUri?.let { onFilesToUploadSelected(resultingUriList, it) }
           }
           val filePicker = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.GetMultipleContents(),
           ) { resultingUriList: List<Uri> ->
             logcat { "ChatFileState sending filePicker uris:$resultingUriList" }
-            onFilesToUploadSelected(resultingUriList, uiState.uploadUri)
+            uiState.uploadUri?.let { onFilesToUploadSelected(resultingUriList, it) }
           }
           ClaimDetailContentScreen(
             uiState = uiState,

--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsViewModel.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/ClaimDetailsViewModel.kt
@@ -177,7 +177,7 @@ internal sealed interface ClaimDetailUiState {
     val claimStatusCardUiState: ClaimStatusCardUiState,
     val claimStatus: ClaimStatus,
     val claimOutcome: ClaimOutcome,
-    val uploadUri: String,
+    val uploadUri: String?,
     val isUploadingFile: Boolean,
     val uploadError: String?,
     val claimType: String?,


### PR DESCRIPTION
## Summary
- Loosens `Claim.targetFileUploadUri` from `String!` to `String` and propagates the nullability through `ClaimDetailUiState.Content.uploadUri` and the picker callbacks. Companion to the `claims-service` PartnerClaim → Claim merge.
- Hides the dangling "Uploaded files" section header when there is no submitted content, no files, and uploads are disabled. Triggered by partner claims; also fixes the pre-existing case of regular closed-non-pet claims with no submitted content.

## Coordination
**Draft until backend ships.** This PR's schema edit is hand-applied to match the upcoming `claims-service` change. Before marking ready:
1. The `claims-service` PartnerClaim → Claim merge is deployed to staging.
2. Re-run `./gradlew downloadOctopusApolloSchemaFromIntrospection` and confirm the diff is a no-op for `targetFileUploadUri` (catches unrelated schema drift).

## Test plan
- [x] `./gradlew :feature-claim-details:compileDebugKotlin` — passes
- [x] `./gradlew :feature-claim-details:ktlintCheck` — passes
- [ ] Manual smoke on staging with a member that has a partner claim:
  - [ ] Partner claim shows up in `claimsActive` / `claimsHistory`
  - [ ] Detail screen: no upload button, no audio/free-text/files, no dangling "Uploaded files" header
  - [ ] `externalId` shows in the display items
  - [ ] Regular claim path unchanged (upload still works on an open pet claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)