### PR TITLE
Fix: if exception during setDataSource fail gracefully

### DIFF
--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/data/AudioRecordingManager.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/data/AudioRecordingManager.kt
@@ -89,33 +89,21 @@ internal class AndroidAudioRecordingManager(
     }
 
     player = MediaPlayer().apply {
-      try {
-        setDataSource(filePath)
-        setOnPreparedListener {
-          onStateUpdate(
-            AudioRecordingStepState.AudioRecording.Playback(
-              filePath = filePath,
-              isPlaying = false,
-              isPrepared = true,
-              hasError = false,
-            ),
-          )
-        }
-        setOnCompletionListener {
-          // Playback completed
-        }
-        prepare()
-      } catch (e: Exception) {
+      setDataSource(filePath)
+      setOnPreparedListener {
         onStateUpdate(
           AudioRecordingStepState.AudioRecording.Playback(
             filePath = filePath,
             isPlaying = false,
-            isPrepared = false,
-            hasError = true,
+            isPrepared = true,
+            hasError = false,
           ),
         )
-        cleanupPlayer()
       }
+      setOnCompletionListener {
+        // Playback completed
+      }
+      prepare()
     }
   }
 

--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/data/AudioRecordingManager.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/data/AudioRecordingManager.kt
@@ -75,22 +75,47 @@ internal class AndroidAudioRecordingManager(
 
     cleanupRecorder()
 
+    val file = File(filePath)
+    if (!file.exists()) {
+      onStateUpdate(
+        AudioRecordingStepState.AudioRecording.Playback(
+          filePath = filePath,
+          isPlaying = false,
+          isPrepared = false,
+          hasError = true,
+        ),
+      )
+      return
+    }
+
     player = MediaPlayer().apply {
-      setDataSource(filePath)
-      setOnPreparedListener {
+      try {
+        setDataSource(filePath)
+        setOnPreparedListener {
+          onStateUpdate(
+            AudioRecordingStepState.AudioRecording.Playback(
+              filePath = filePath,
+              isPlaying = false,
+              isPrepared = true,
+              hasError = false,
+            ),
+          )
+        }
+        setOnCompletionListener {
+          // Playback completed
+        }
+        prepare()
+      } catch (e: Exception) {
         onStateUpdate(
           AudioRecordingStepState.AudioRecording.Playback(
             filePath = filePath,
             isPlaying = false,
-            isPrepared = true,
-            hasError = false,
+            isPrepared = false,
+            hasError = true,
           ),
         )
+        cleanupPlayer()
       }
-      setOnCompletionListener {
-        // Playback completed
-      }
-      prepare()
     }
   }
 

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
@@ -57,6 +57,8 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import androidx.lifecycle.Lifecycle
@@ -69,6 +71,8 @@ import com.hedvig.android.compose.ui.EmptyContentDescription
 import com.hedvig.android.compose.ui.withoutPlacement
 import com.hedvig.android.core.uidata.DecimalFormatter
 import com.hedvig.android.design.system.hedvig.ButtonDefaults
+import com.hedvig.android.design.system.hedvig.EmptyState
+import com.hedvig.android.design.system.hedvig.EmptyStateDefaults
 import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
 import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigCircularProgressIndicator
@@ -123,6 +127,7 @@ import hedvig.resources.TALKBACK_PLAYBACK_BUTTON_STATE
 import hedvig.resources.TALKBACK_RECORDING_DURATION
 import hedvig.resources.TALKBACK_RECORDING_NOW
 import hedvig.resources.claims_skip_button
+import hedvig.resources.something_went_wrong
 import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -364,106 +369,140 @@ private fun AudioRecordingBottomSheet(
     stopRecording()
   }
   HedvigBottomSheet(bottomSheetState, modifier) {
-    Column {
-      HedvigText(
-        stringResource(Res.string.CLAIM_TRIAGING_TITLE),
-        modifier = Modifier.fillMaxWidth().semantics {
-          heading()
-        },
-        textAlign = TextAlign.Center,
-      )
-      DynamicClock(audioRecordingState, clock, audioPlayer)
-      Spacer(Modifier.height(16.dp))
+    AudioRecordingSheetContent(
+      clock = clock,
+      submitAudioFile = submitAudioFile,
+      redo = redo,
+      continueButtonLoading = continueButtonLoading,
+      audioPlayer = audioPlayer,
+      audioRecordingState = audioRecordingState,
+      stopRecording = stopRecording,
+      recordAudioPermissionState = recordAudioPermissionState,
+      startRecording = startRecording,
+    )
+  }
+}
 
-      AnimatedContent(
-        targetState = audioRecordingState,
-        transitionSpec = {
-          EnterTransition.None.togetherWith(ExitTransition.None)
-        },
-        contentKey = { state ->
-          when (state) {
-            is AudioRecordingStepState.AudioRecording.Playback -> {
-              if (state.isPrepared) "playback" else "loading"
-            }
+@Composable
+private fun AudioRecordingSheetContent(
+  clock: Clock,
+  submitAudioFile: () -> Unit,
+  redo: () -> Unit,
+  continueButtonLoading: Boolean,
+  audioPlayer: AudioPlayer?,
+  audioRecordingState: AudioRecordingStepState.AudioRecording,
+  stopRecording: () -> Unit,
+  startRecording: () -> Unit,
+  recordAudioPermissionState: PermissionState
+) {
+  Column {
+    HedvigText(
+      stringResource(Res.string.CLAIM_TRIAGING_TITLE),
+      modifier = Modifier.fillMaxWidth().semantics {
+        heading()
+      },
+      textAlign = TextAlign.Center,
+    )
+    DynamicClock(audioRecordingState, clock, audioPlayer)
+    Spacer(Modifier.height(16.dp))
 
-            is AudioRecordingStepState.AudioRecording.Recording -> {
-              "recording"
-            }
-
-            else -> {
-              "resting"
-            }
+    AnimatedContent(
+      targetState = audioRecordingState,
+      transitionSpec = {
+        EnterTransition.None.togetherWith(ExitTransition.None)
+      },
+      contentKey = { state ->
+        when (state) {
+          is AudioRecordingStepState.AudioRecording.Playback -> {
+            if (state.isPrepared) "playback" else "loading"
           }
-        },
-      ) { target ->
-        Box(
-          modifier = Modifier.height(158.dp).fillMaxWidth().padding(horizontal = 45.dp),
-          contentAlignment = Alignment.Center,
-          propagateMinConstraints = true,
-        ) {
-          when (target) {
-            is AudioRecordingStepState.AudioRecording.Playback if !target.isPrepared -> {
-              HedvigCircularProgressIndicator(Modifier.wrapContentSize())
-            }
 
-            is AudioRecordingStepState.AudioRecording.Playback -> {
-              val audioPlayerState by audioPlayer?.audioPlayerState?.collectAsStateWithLifecycle()
-                ?: remember { mutableStateOf(null) }
-              if (audioPlayerState is AudioPlayerState.Ready) {
-                AudioWaves(
-                  isRecording = false,
-                  progressPercentage = (audioPlayerState as AudioPlayerState.Ready).progressPercentage,
-                )
-              }
-            }
+          is AudioRecordingStepState.AudioRecording.Recording -> {
+            "recording"
+          }
 
-            is AudioRecordingStepState.AudioRecording.Recording -> {
+          else -> {
+            "resting"
+          }
+        }
+      },
+    ) { target ->
+      Box(
+        modifier = Modifier.height(158.dp).fillMaxWidth().padding(horizontal = 45.dp),
+        contentAlignment = Alignment.Center,
+        propagateMinConstraints = true,
+      ) {
+        when (target) {
+          is AudioRecordingStepState.AudioRecording.Playback if !target.isPrepared && !target.hasError -> {
+            HedvigCircularProgressIndicator(Modifier.wrapContentSize())
+          }
+
+          is AudioRecordingStepState.AudioRecording.Playback if target.hasError -> {
+            EmptyState(
+              text = stringResource(Res.string.something_went_wrong),
+              modifier = Modifier,
+              iconStyle = EmptyStateDefaults.EmptyStateIconStyle.ERROR,
+              description = null
+            )
+          }
+
+          is AudioRecordingStepState.AudioRecording.Playback -> {
+            val audioPlayerState by audioPlayer?.audioPlayerState?.collectAsStateWithLifecycle()
+              ?: remember { mutableStateOf(null) }
+            if (audioPlayerState is AudioPlayerState.Ready) {
               AudioWaves(
-                isRecording = true,
-                progressPercentage = null,
-                amplitudes = target.amplitudes,
+                isRecording = false,
+                progressPercentage = (audioPlayerState as AudioPlayerState.Ready).progressPercentage,
               )
             }
+          }
 
-            else -> {
-              RestingAudioPlayer()
-            }
+          is AudioRecordingStepState.AudioRecording.Recording -> {
+            AudioWaves(
+              isRecording = true,
+              progressPercentage = null,
+              amplitudes = target.amplitudes,
+            )
+          }
+
+          else -> {
+            RestingAudioPlayer()
           }
         }
       }
-      Row(
-        modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-      ) {
-        StartOverButton(
-          modifier = Modifier.weight(1f),
-          onStartOver = redo,
-          isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !continueButtonLoading,
-        )
-        Spacer(Modifier.width(4.dp))
-        ControlButton(
-          modifier = Modifier.weight(1f),
-          audioPlayer = audioPlayer,
-          onStartRecording = {
-            when (recordAudioPermissionState.status) {
-              PermissionStatus.Granted -> startRecording()
-              is PermissionStatus.Denied -> recordAudioPermissionState.launchPermissionRequest()
-            }
-          },
-          onStopRecording = stopRecording,
-          audioRecordingState = audioRecordingState,
-          isEnabled = !continueButtonLoading,
-        )
-        Spacer(Modifier.width(4.dp))
-        SendButton(
-          modifier = Modifier.weight(1f),
-          onSend = submitAudioFile,
-          isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !continueButtonLoading,
-        )
-      }
-      Spacer(Modifier.height(16.dp))
-      Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
     }
+    Row(
+      modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+      StartOverButton(
+        modifier = Modifier.weight(1f),
+        onStartOver = redo,
+        isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !continueButtonLoading,
+      )
+      Spacer(Modifier.width(4.dp))
+      ControlButton(
+        modifier = Modifier.weight(1f),
+        audioPlayer = audioPlayer,
+        onStartRecording = {
+          when (recordAudioPermissionState.status) {
+            PermissionStatus.Granted -> startRecording()
+            is PermissionStatus.Denied -> recordAudioPermissionState.launchPermissionRequest()
+          }
+        },
+        onStopRecording = stopRecording,
+        audioRecordingState = audioRecordingState,
+        isEnabled = !continueButtonLoading,
+      )
+      Spacer(Modifier.width(4.dp))
+      SendButton(
+        modifier = Modifier.weight(1f),
+        onSend = submitAudioFile,
+        isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !continueButtonLoading,
+      )
+    }
+    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }
 
@@ -1083,6 +1122,65 @@ private val WAVE_WIDTH = 2.dp
 private val WAVE_SPACING = 3.dp
 private val WAVE_MIN_HEIGHT = 2.dp
 private val WAVE_MAX_HEIGHT = 30.dp
+
+@HedvigPreview
+@Composable
+private fun PreviewAudioRecordingSheetContent(
+  @PreviewParameter(AudioRecordingSheetContentStateProvider::class)
+  state: AudioRecordingStepState.AudioRecording,
+) {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      AudioRecordingSheetContent(
+        clock = Clock.System,
+        submitAudioFile = {},
+        redo = {},
+        continueButtonLoading = false,
+        audioPlayer = null,
+        audioRecordingState = state,
+        stopRecording = {},
+        startRecording = {},
+        recordAudioPermissionState = MockPermissionState(granted = true),
+      )
+    }
+  }
+}
+
+private class AudioRecordingSheetContentStateProvider :
+  CollectionPreviewParameterProvider<AudioRecordingStepState.AudioRecording>(
+    listOf(
+      AudioRecordingStepState.AudioRecording.NotRecording,
+      AudioRecordingStepState.AudioRecording.Recording(
+        amplitudes = listOf(100, 200, 150, 300),
+        startedAt = Clock.System.now(),
+        filePath = "/path/to/recording.mp4",
+      ),
+      AudioRecordingStepState.AudioRecording.Playback(
+        filePath = "/path/to/recording.mp4",
+        isPlaying = false,
+        isPrepared = true,
+        hasError = false,
+      ),
+      AudioRecordingStepState.AudioRecording.Playback(
+        filePath = "/path/to/recording.mp4",
+        isPlaying = false,
+        isPrepared = false,
+        hasError = false,
+      ),
+      AudioRecordingStepState.AudioRecording.Playback(
+        filePath = "/path/to/recording.mp4",
+        isPlaying = false,
+        isPrepared = false,
+        hasError = true,
+      ),
+    ),
+  )
+
+private class MockPermissionState(val granted: Boolean) : PermissionState {
+  override val permission: String = "android.permission.RECORD_AUDIO"
+  override val status: PermissionStatus = if (granted) PermissionStatus.Granted else PermissionStatus.Denied(false)
+  override fun launchPermissionRequest() {}
+}
 
 @HedvigPreview
 @Composable


### PR DESCRIPTION
show error state instead of crashing on this type of recording errors: [crashlytics](https://console.firebase.google.com/u/0/project/hedvig-app/crashlytics/app/android:com.hedvig.app/issues/0a055ca8cbb72888bf577de8b6d7d918?time=7d&types=crash&sessionEventKey=6A0182E9015400011634258979F67FDC_2216976214432843549)