### PR TITLE
Bug: markdown rendering on conversation list

### DIFF
--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -17,30 +17,19 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.halilibo.richtext.commonmark.CommonMarkdownParseOptions
-import com.halilibo.richtext.commonmark.Markdown
-import com.halilibo.richtext.ui.RichTextStyle
-import com.halilibo.richtext.ui.string.RichTextStringStyle
 import com.hedvig.android.compose.ui.preview.TripleBooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleCase
 import com.hedvig.android.design.system.hedvig.DividerPosition
@@ -54,8 +43,6 @@ import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighLightS
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
-import com.hedvig.android.design.system.hedvig.ProvideTextStyle
-import com.hedvig.android.design.system.hedvig.RichText
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TopAppBarWithBack
 import com.hedvig.android.design.system.hedvig.datepicker.formatInstantForTalkBack
@@ -264,51 +251,22 @@ private fun ConversationCard(
           },
         )
         val message = when (latestMessage) {
-          is Text -> latestMessage.text
+          is Text -> latestMessage.text.markdownToPlainText()
           is File -> stringResource(Res.string.CHAT_SENT_A_FILE)
           is Unknown -> stringResource(Res.string.CHAT_SENT_A_MESSAGE)
         }
-        val textColor = if (conversation.hasNewMessages) {
-          HedvigTheme.colorScheme.textPrimary
-        } else {
-          HedvigTheme.colorScheme.textSecondary
-        }
-        val previewTextStyle = HedvigTheme.typography.label.copy(color = textColor)
-        // The card itself is clickable and opens the conversation, any link inside the message
-        // preview should do the same rather than launch its own URL, so we redirect link taps
-        // through LocalUriHandler and strip the link styling so the text is plain text instead.
-        val redirectingUriHandler = remember(conversation.conversationId, onConversationClick) {
-          object : UriHandler {
-            override fun openUri(uri: String) {
-              onConversationClick(conversation.conversationId)
-            }
-          }
-        }
-        CompositionLocalProvider(LocalUriHandler provides redirectingUriHandler) {
-          ProvideTextStyle(previewTextStyle) {
-            val simpleTextStyle = SpanStyle(
-              color = textColor,
-              textDecoration = TextDecoration.None,
+        HedvigText(
+          text = "$sender: $message",
+          style = if (conversation.hasNewMessages) {
+            HedvigTheme.typography.label
+          } else {
+            HedvigTheme.typography.label.copy(
+              color = HedvigTheme.colorScheme.textSecondary,
             )
-            RichText(
-              style = RichTextStyle.Default.copy(
-                stringStyle = RichTextStringStyle(
-                  linkStyle = TextLinkStyles(
-                    style = simpleTextStyle,
-                    focusedStyle = simpleTextStyle,
-                    hoveredStyle = simpleTextStyle,
-                    pressedStyle = simpleTextStyle,
-                  ),
-                ),
-              ),
-            ) {
-              Markdown(
-                content = "$sender: $message",
-                markdownParseOptions = CommonMarkdownParseOptions(autolink = false),
-              )
-            }
-          }
-        }
+          },
+          overflow = TextOverflow.Ellipsis,
+          maxLines = 1,
+        )
       }
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -17,19 +17,30 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.halilibo.richtext.commonmark.CommonMarkdownParseOptions
+import com.halilibo.richtext.commonmark.Markdown
+import com.halilibo.richtext.ui.RichTextStyle
+import com.halilibo.richtext.ui.string.RichTextStringStyle
 import com.hedvig.android.compose.ui.preview.TripleBooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleCase
 import com.hedvig.android.design.system.hedvig.DividerPosition
@@ -43,6 +54,8 @@ import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighLightS
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
+import com.hedvig.android.design.system.hedvig.ProvideTextStyle
+import com.hedvig.android.design.system.hedvig.RichText
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TopAppBarWithBack
 import com.hedvig.android.design.system.hedvig.datepicker.formatInstantForTalkBack
@@ -251,43 +264,55 @@ private fun ConversationCard(
           },
         )
         val message = when (latestMessage) {
-          is Text -> latestMessage.text.stripMarkdownForPreview()
+          is Text -> latestMessage.text
           is File -> stringResource(Res.string.CHAT_SENT_A_FILE)
           is Unknown -> stringResource(Res.string.CHAT_SENT_A_MESSAGE)
         }
-        HedvigText(
-          text = "$sender: $message",
-          style = if (conversation.hasNewMessages) {
-            HedvigTheme.typography.label
-          } else {
-            HedvigTheme.typography.label.copy(
-              color = HedvigTheme.colorScheme.textSecondary,
+        val textColor = if (conversation.hasNewMessages) {
+          HedvigTheme.colorScheme.textPrimary
+        } else {
+          HedvigTheme.colorScheme.textSecondary
+        }
+        val previewTextStyle = HedvigTheme.typography.label.copy(color = textColor)
+        // The card itself is clickable and opens the conversation, any link inside the message
+        // preview should do the same rather than launch its own URL, so we redirect link taps
+        // through LocalUriHandler and strip the link styling so the text is plain text instead.
+        val redirectingUriHandler = remember(conversation.conversationId, onConversationClick) {
+          object : UriHandler {
+            override fun openUri(uri: String) {
+              onConversationClick(conversation.conversationId)
+            }
+          }
+        }
+        CompositionLocalProvider(LocalUriHandler provides redirectingUriHandler) {
+          ProvideTextStyle(previewTextStyle) {
+            val simpleTextStyle = SpanStyle(
+              color = textColor,
+              textDecoration = TextDecoration.None,
             )
-          },
-          overflow = TextOverflow.Ellipsis,
-          maxLines = 1,
-        )
+            RichText(
+              style = RichTextStyle.Default.copy(
+                stringStyle = RichTextStringStyle(
+                  linkStyle = TextLinkStyles(
+                    style = simpleTextStyle,
+                    focusedStyle = simpleTextStyle,
+                    hoveredStyle = simpleTextStyle,
+                    pressedStyle = simpleTextStyle,
+                  ),
+                ),
+              ),
+            ) {
+              Markdown(
+                content = "$sender: $message",
+                markdownParseOptions = CommonMarkdownParseOptions(autolink = false),
+              )
+            }
+          }
+        }
       }
     }
   }
 }
-
-// Inbox previews are single-line and non-interactive, so we strip markdown rather than render it —
-// links should still be clickable inside the conversation, not from the list.
-private fun String.stripMarkdownForPreview(): String {
-  return this
-    .replace(markdownImageRegex, "")
-    .replace(markdownLinkRegex, "$1")
-    .replace(markdownBoldRegex, "$2")
-    .replace(markdownItalicRegex, "$2")
-    .replace(markdownInlineCodeRegex, "$1")
-}
-
-private val markdownImageRegex = Regex("""!\[[^]]*]\([^)]*\)""")
-private val markdownLinkRegex = Regex("""\[([^]]+)]\([^)]*\)""")
-private val markdownBoldRegex = Regex("""(\*\*|__)(.+?)\1""")
-private val markdownItalicRegex = Regex("""(?<![*_\w])([*_])([^*_\n]+)\1(?![*_\w])""")
-private val markdownInlineCodeRegex = Regex("""`([^`\n]+)`""")
 
 @HedvigPreview
 @PreviewFontScale

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -251,7 +251,7 @@ private fun ConversationCard(
           },
         )
         val message = when (latestMessage) {
-          is Text -> latestMessage.text
+          is Text -> latestMessage.text.stripMarkdownForPreview()
           is File -> stringResource(Res.string.CHAT_SENT_A_FILE)
           is Unknown -> stringResource(Res.string.CHAT_SENT_A_MESSAGE)
         }
@@ -271,6 +271,23 @@ private fun ConversationCard(
     }
   }
 }
+
+// Inbox previews are single-line and non-interactive, so we strip markdown rather than render it —
+// links should still be clickable inside the conversation, not from the list.
+private fun String.stripMarkdownForPreview(): String {
+  return this
+    .replace(markdownImageRegex, "")
+    .replace(markdownLinkRegex, "$1")
+    .replace(markdownBoldRegex, "$2")
+    .replace(markdownItalicRegex, "$2")
+    .replace(markdownInlineCodeRegex, "$1")
+}
+
+private val markdownImageRegex = Regex("""!\[[^]]*]\([^)]*\)""")
+private val markdownLinkRegex = Regex("""\[([^]]+)]\([^)]*\)""")
+private val markdownBoldRegex = Regex("""(\*\*|__)(.+?)\1""")
+private val markdownItalicRegex = Regex("""(?<![*_\w])([*_])([^*_\n]+)\1(?![*_\w])""")
+private val markdownInlineCodeRegex = Regex("""`([^`\n]+)`""")
 
 @HedvigPreview
 @PreviewFontScale
@@ -321,7 +338,7 @@ private val mockInboxConversation1 = InboxConversation(
   conversationId = "1",
   header = Header.ClaimConversation("claimType"),
   latestMessage = Text(
-    "Please tell us more about how the phone broke.",
+    "You can find more details [here](https://hedvig.com/details).",
     Sender.HEDVIG,
     Clock.System.now(),
   ),

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/MarkdownPlainText.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/MarkdownPlainText.kt
@@ -1,0 +1,47 @@
+package com.hedvig.android.feature.chat.inbox
+
+import com.halilibo.richtext.commonmark.CommonMarkdownParseOptions
+import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
+import com.halilibo.richtext.markdown.node.AstBlockNodeType
+import com.halilibo.richtext.markdown.node.AstCode
+import com.halilibo.richtext.markdown.node.AstHardLineBreak
+import com.halilibo.richtext.markdown.node.AstImage
+import com.halilibo.richtext.markdown.node.AstNode
+import com.halilibo.richtext.markdown.node.AstSoftLineBreak
+import com.halilibo.richtext.markdown.node.AstText
+
+// The inbox conversation row shows a single ellipsized preview line with no clickable regions,
+// so we strip markdown formatting rather than render it. Walking the commonmark AST means any
+// syntax the parser understands collapses to its text content, so future markdown features need
+// no changes here.
+internal fun String.markdownToPlainText(): String = buildString {
+  appendPlainText(inboxMarkdownParser.parse(this@markdownToPlainText))
+}
+
+private val inboxMarkdownParser = CommonmarkAstNodeParser(CommonMarkdownParseOptions(autolink = false))
+
+private fun StringBuilder.appendPlainText(node: AstNode) {
+  val type = node.type
+  if (type is AstText) {
+    append(type.literal)
+    return
+  }
+  if (type is AstCode) {
+    append(type.literal)
+    return
+  }
+  if (type === AstSoftLineBreak || type === AstHardLineBreak) {
+    append(' ')
+    return
+  }
+  // Alt text isn't useful in a one-line preview, so we drop the image entirely.
+  if (type is AstImage) return
+  // Container node — recurse into children, separating block-level siblings with a space so
+  // paragraphs don't run together.
+  var child = node.links.firstChild
+  while (child != null) {
+    appendPlainText(child)
+    if (child.links.next != null && child.type is AstBlockNodeType) append(' ')
+    child = child.links.next
+  }
+}


### PR DESCRIPTION
Before, the links were rendered like `Do this thing [here](https......)`
This strips that out while still keeping it a plain text so it will render like `Do this thing here`