### PR TITLE
Chore: deprecated unleash

### DIFF
--- a/app/featureflags/feature-flags-android/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags-android/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -13,30 +13,29 @@ internal class UnleashFeatureFlagProvider(
     return hedvigUnleashClient.featureUpdatedFlow
       .map {
         when (feature) {
-          Feature.DISABLE_CHAT -> hedvigUnleashClient.client.isEnabled("disable_chat", false)
+          Feature.DISABLE_CHAT -> hedvigUnleashClient.client.isEnabled("disable_chat")
 
-          Feature.MOVING_FLOW -> hedvigUnleashClient.client.isEnabled("moving_flow", false)
+          Feature.MOVING_FLOW -> hedvigUnleashClient.client.isEnabled("moving_flow")
 
-          Feature.PAYMENT_SCREEN -> hedvigUnleashClient.client.isEnabled("payment_screen", false)
+          Feature.PAYMENT_SCREEN -> hedvigUnleashClient.client.isEnabled("payment_screen")
 
           Feature.TERMINATION_FLOW -> hedvigUnleashClient.client.isEnabled("termination_flow", true)
 
-          Feature.UPDATE_NECESSARY -> hedvigUnleashClient.client.isEnabled("update_necessary", false)
+          Feature.UPDATE_NECESSARY -> hedvigUnleashClient.client.isEnabled("update_necessary")
 
-          Feature.EDIT_COINSURED -> hedvigUnleashClient.client.isEnabled("edit_coinsured", false)
+          Feature.EDIT_COINSURED -> hedvigUnleashClient.client.isEnabled("edit_coinsured")
 
           Feature.HELP_CENTER -> hedvigUnleashClient.client.isEnabled("help_center", true)
 
-          Feature.TRAVEL_ADDON -> hedvigUnleashClient.client.isEnabled("enable_addons", false)
+          Feature.TRAVEL_ADDON -> hedvigUnleashClient.client.isEnabled("enable_addons")
 
           Feature.ENABLE_VIDEO_PLAYER_IN_CHAT_MESSAGES -> hedvigUnleashClient.client.isEnabled(
             "enable_video_player_in_chat_messages",
-            false,
           )
 
-          Feature.DISABLE_REDEEM_CAMPAIGN -> hedvigUnleashClient.client.isEnabled("disable_redeem_campaign", false)
+          Feature.DISABLE_REDEEM_CAMPAIGN -> hedvigUnleashClient.client.isEnabled("disable_redeem_campaign")
 
-          Feature.ENABLE_CLAIM_HISTORY -> hedvigUnleashClient.client.isEnabled("enable_claim_history", false)
+          Feature.ENABLE_CLAIM_HISTORY -> hedvigUnleashClient.client.isEnabled("enable_claim_history")
         }
       }.distinctUntilChanged()
   }

--- a/app/featureflags/feature-flags-android/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags-android/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -19,7 +19,7 @@ internal class UnleashFeatureFlagProvider(
 
           Feature.PAYMENT_SCREEN -> hedvigUnleashClient.client.isEnabled("payment_screen")
 
-          Feature.TERMINATION_FLOW -> hedvigUnleashClient.client.isEnabled("termination_flow", true)
+          Feature.TERMINATION_FLOW -> !hedvigUnleashClient.client.isEnabled("disable_termination_flow")
 
           Feature.UPDATE_NECESSARY -> hedvigUnleashClient.client.isEnabled("update_necessary")
 

--- a/app/featureflags/feature-flags-android/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags-android/src/main/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -25,7 +25,7 @@ internal class UnleashFeatureFlagProvider(
 
           Feature.EDIT_COINSURED -> hedvigUnleashClient.client.isEnabled("edit_coinsured")
 
-          Feature.HELP_CENTER -> hedvigUnleashClient.client.isEnabled("help_center", true)
+          Feature.HELP_CENTER -> !hedvigUnleashClient.client.isEnabled("disable_help_center")
 
           Feature.TRAVEL_ADDON -> hedvigUnleashClient.client.isEnabled("enable_addons")
 


### PR DESCRIPTION
Related to [this unleash bug](https://github.com/Unleash/unleash-android-sdk/issues/141). 

Unleash Frontend API only returns enabled feature toggles, so any default true features will not be able to turn off. They deprecated the overload with default value, and instead recommend to use new kill-switch flags for such features.

Only 2 flags affected for us, HELP_CENTER and TERMINATION_FLOW. Kill-switches for both added to unleash.