### PR TITLE
Bottom-align tier selector in purchase flows (RND-1965)

### DIFF
--- a/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/ui/offer/SelectTierDestination.kt
+++ b/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/ui/offer/SelectTierDestination.kt
@@ -104,7 +104,7 @@ private fun SelectTierContent(
       onRevertDeductible = onRevertDeductible,
       modifier = Modifier.padding(horizontal = 16.dp),
     )
-    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(16.dp))
     HedvigButton(
       text = "Forts\u00e4tt",
       onClick = dropUnlessResumed { onContinue() },


### PR DESCRIPTION
## Summary
- Bottom-align the customization card in `SelectTierContent` so it sits right above the Continue button instead of being vertically centered.

The single weighted `Spacer` above the card now absorbs all leftover space, with a fixed 16dp gap between card and button.

Affects all purchase flows (apartment, house, car, pet) since they share `SelectTierDestination` via `purchase-common`.

## Test plan
- [x] Verified visually by replicating the layout in `design-showcase` and installing on Pixel 5 API 33 emulator — card sits at the bottom, 16dp above the Fortsätt button
- [x] `./gradlew :purchase-common:ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)