### PR TITLE
Show product pillow above purchase summary card

### DIFF
--- a/app/app/src/debug/AndroidManifest.xml
+++ b/app/app/src/debug/AndroidManifest.xml
@@ -21,5 +21,10 @@
 <!--      android:exported="true"-->
 <!--      android:permission="@null"-->
 <!--      tools:replace="android:permission" />-->
+
+    <activity
+      android:name="com.hedvig.android.app.debug.MockPurchaseSummaryActivity"
+      android:exported="true"
+      android:label="Mock Purchase Summary" />
   </application>
 </manifest>

--- a/app/app/src/debug/kotlin/com/hedvig/android/app/debug/MockPurchaseSummaryActivity.kt
+++ b/app/app/src/debug/kotlin/com/hedvig/android/app/debug/MockPurchaseSummaryActivity.kt
@@ -1,0 +1,66 @@
+package com.hedvig.android.app.debug
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.hedvig.android.data.contract.ContractGroup
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.feature.purchase.common.navigation.SummaryParameters
+import com.hedvig.android.feature.purchase.common.navigation.TierOfferData
+import com.hedvig.android.feature.purchase.common.ui.summary.PurchaseSummaryScreen
+
+class MockPurchaseSummaryActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      var groupIndex by remember { mutableStateOf(0) }
+      val group = ContractGroup.entries[groupIndex % ContractGroup.entries.size]
+      HedvigTheme {
+        Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+          PurchaseSummaryScreen(
+            params = SummaryParameters(
+              shopSessionId = "mock-session",
+              selectedOffer = TierOfferData(
+                offerId = "mock-1",
+                tierDisplayName = "Hem Standard",
+                tierDescription = "Vår mest populära försäkring",
+                grossAmount = 139.0,
+                grossCurrencyCode = "SEK",
+                netAmount = 118.0,
+                netCurrencyCode = "SEK",
+                usps = emptyList(),
+                exposureDisplayName = "Storgatan 1",
+                deductibleDisplayName = "1 500 kr",
+                hasDiscount = true,
+              ),
+              productDisplayName = mockProductName(group),
+              contractGroup = group,
+            ),
+            isSubmitting = false,
+            navigateUp = { finish() },
+            onConfirm = { groupIndex++ },
+          )
+        }
+      }
+    }
+  }
+}
+
+private fun mockProductName(group: ContractGroup): String = when (group) {
+  ContractGroup.HOMEOWNER -> "Hemförsäkring Bostadsrätt"
+  ContractGroup.RENTAL -> "Hemförsäkring Hyresrätt"
+  ContractGroup.HOUSE -> "Villaförsäkring"
+  ContractGroup.STUDENT -> "Studentförsäkring"
+  ContractGroup.ACCIDENT -> "Olycksfallsförsäkring"
+  ContractGroup.CAR -> "Bilförsäkring"
+  ContractGroup.CAT -> "Kattförsäkring"
+  ContractGroup.DOG -> "Hundförsäkring"
+  ContractGroup.TRAVEL -> "Reseförsäkring"
+  ContractGroup.COUNTRY_HOME -> "Fritidshusförsäkring"
+  ContractGroup.UNKNOWN -> "Försäkring"
+}

--- a/app/feature/feature-purchase-apartment/src/main/kotlin/com/hedvig/android/feature/purchase/apartment/data/PurchaseApartmentModels.kt
+++ b/app/feature/feature-purchase-apartment/src/main/kotlin/com/hedvig/android/feature/purchase/apartment/data/PurchaseApartmentModels.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.purchase.apartment.data
 
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.ContractGroup
 
 internal data class SessionAndIntent(
   val shopSessionId: String,
@@ -9,6 +10,7 @@ internal data class SessionAndIntent(
 
 internal data class ApartmentOffers(
   val productDisplayName: String,
+  val contractGroup: ContractGroup,
   val offers: List<ApartmentTierOffer>,
 )
 

--- a/app/feature/feature-purchase-apartment/src/main/kotlin/com/hedvig/android/feature/purchase/apartment/data/SubmitFormAndGetOffersUseCase.kt
+++ b/app/feature/feature-purchase-apartment/src/main/kotlin/com/hedvig/android/feature/purchase/apartment/data/SubmitFormAndGetOffersUseCase.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.toContractGroup
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import octopus.ApartmentPriceIntentConfirmMutation
@@ -78,6 +79,7 @@ internal class SubmitFormAndGetOffersUseCaseImpl(
 
       ApartmentOffers(
         productDisplayName = offers.first().variant.displayName,
+        contractGroup = offers.first().variant.typeOfContract.toContractGroup(),
         offers = offers.map { it.toTierOffer() },
       )
     }

--- a/app/feature/feature-purchase-apartment/src/main/kotlin/com/hedvig/android/feature/purchase/apartment/navigation/ApartmentPurchaseNavGraph.kt
+++ b/app/feature/feature-purchase-apartment/src/main/kotlin/com/hedvig/android/feature/purchase/apartment/navigation/ApartmentPurchaseNavGraph.kt
@@ -72,6 +72,7 @@ fun NavGraphBuilder.apartmentPurchaseNavGraph(
                   )
                 },
                 productDisplayName = offers.productDisplayName,
+                contractGroup = offers.contractGroup,
               ),
             ),
           )

--- a/app/feature/feature-purchase-car/src/main/kotlin/com/hedvig/android/feature/purchase/car/data/CarPurchaseModels.kt
+++ b/app/feature/feature-purchase-car/src/main/kotlin/com/hedvig/android/feature/purchase/car/data/CarPurchaseModels.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.purchase.car.data
 
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.ContractGroup
 
 internal data class SessionAndIntent(
   val shopSessionId: String,
@@ -11,6 +12,7 @@ internal data class SessionAndIntent(
 
 internal data class CarOffers(
   val productDisplayName: String,
+  val contractGroup: ContractGroup,
   val offers: List<CarTierOffer>,
 )
 

--- a/app/feature/feature-purchase-car/src/main/kotlin/com/hedvig/android/feature/purchase/car/data/SubmitCarFormAndGetOffersUseCase.kt
+++ b/app/feature/feature-purchase-car/src/main/kotlin/com/hedvig/android/feature/purchase/car/data/SubmitCarFormAndGetOffersUseCase.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.toContractGroup
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import octopus.CarPriceIntentConfirmMutation
@@ -84,6 +85,7 @@ internal class SubmitCarFormAndGetOffersUseCaseImpl(
 
       CarOffers(
         productDisplayName = offers.first().variant.displayName,
+        contractGroup = offers.first().variant.typeOfContract.toContractGroup(),
         offers = offers.map { it.toTierOffer() },
       )
     }

--- a/app/feature/feature-purchase-car/src/main/kotlin/com/hedvig/android/feature/purchase/car/navigation/CarPurchaseNavGraph.kt
+++ b/app/feature/feature-purchase-car/src/main/kotlin/com/hedvig/android/feature/purchase/car/navigation/CarPurchaseNavGraph.kt
@@ -71,6 +71,7 @@ fun NavGraphBuilder.carPurchaseNavGraph(
                   )
                 },
                 productDisplayName = offers.productDisplayName,
+                contractGroup = offers.contractGroup,
               ),
             ),
           )

--- a/app/feature/feature-purchase-house/src/main/kotlin/com/hedvig/android/feature/purchase/house/data/HousePurchaseModels.kt
+++ b/app/feature/feature-purchase-house/src/main/kotlin/com/hedvig/android/feature/purchase/house/data/HousePurchaseModels.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.purchase.house.data
 
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.ContractGroup
 
 internal data class SessionAndIntent(
   val shopSessionId: String,
@@ -11,6 +12,7 @@ internal data class SessionAndIntent(
 
 internal data class HouseOffers(
   val productDisplayName: String,
+  val contractGroup: ContractGroup,
   val offers: List<HouseTierOffer>,
 )
 

--- a/app/feature/feature-purchase-house/src/main/kotlin/com/hedvig/android/feature/purchase/house/data/SubmitVacationHomeFormAndGetOffersUseCase.kt
+++ b/app/feature/feature-purchase-house/src/main/kotlin/com/hedvig/android/feature/purchase/house/data/SubmitVacationHomeFormAndGetOffersUseCase.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.toContractGroup
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import octopus.HousePriceIntentConfirmMutation
@@ -97,6 +98,7 @@ internal class SubmitVacationHomeFormAndGetOffersUseCaseImpl(
 
       HouseOffers(
         productDisplayName = offers.first().variant.displayName,
+        contractGroup = offers.first().variant.typeOfContract.toContractGroup(),
         offers = offers.map { it.toHouseTierOffer() },
       )
     }

--- a/app/feature/feature-purchase-house/src/main/kotlin/com/hedvig/android/feature/purchase/house/navigation/HousePurchaseNavGraph.kt
+++ b/app/feature/feature-purchase-house/src/main/kotlin/com/hedvig/android/feature/purchase/house/navigation/HousePurchaseNavGraph.kt
@@ -68,6 +68,7 @@ fun NavGraphBuilder.housePurchaseNavGraph(
                   )
                 },
                 productDisplayName = offers.productDisplayName,
+                contractGroup = offers.contractGroup,
               ),
             ),
           )

--- a/app/feature/feature-purchase-pet/src/main/kotlin/com/hedvig/android/feature/purchase/pet/data/PetPurchaseModels.kt
+++ b/app/feature/feature-purchase-pet/src/main/kotlin/com/hedvig/android/feature/purchase/pet/data/PetPurchaseModels.kt
@@ -1,6 +1,7 @@
 package com.hedvig.android.feature.purchase.pet.data
 
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.ContractGroup
 
 internal const val PRODUCT_NAME_DOG = "SE_PET_DOG"
 internal const val PRODUCT_NAME_CAT = "SE_PET_CAT"
@@ -20,6 +21,7 @@ internal data class Breed(
 
 internal data class PetOffers(
   val productDisplayName: String,
+  val contractGroup: ContractGroup,
   val offers: List<PetTierOffer>,
 )
 

--- a/app/feature/feature-purchase-pet/src/main/kotlin/com/hedvig/android/feature/purchase/pet/data/SubmitPetFormAndGetOffersUseCase.kt
+++ b/app/feature/feature-purchase-pet/src/main/kotlin/com/hedvig/android/feature/purchase/pet/data/SubmitPetFormAndGetOffersUseCase.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.uidata.UiMoney
+import com.hedvig.android.data.contract.toContractGroup
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import kotlinx.datetime.LocalDate
@@ -90,6 +91,7 @@ internal class SubmitPetFormAndGetOffersUseCaseImpl(
 
       PetOffers(
         productDisplayName = offers.first().variant.displayName,
+        contractGroup = offers.first().variant.typeOfContract.toContractGroup(),
         offers = offers.map { it.toTierOffer() },
       )
     }

--- a/app/feature/feature-purchase-pet/src/main/kotlin/com/hedvig/android/feature/purchase/pet/navigation/PetPurchaseNavGraph.kt
+++ b/app/feature/feature-purchase-pet/src/main/kotlin/com/hedvig/android/feature/purchase/pet/navigation/PetPurchaseNavGraph.kt
@@ -77,6 +77,7 @@ fun NavGraphBuilder.petPurchaseNavGraph(
                   )
                 },
                 productDisplayName = offers.productDisplayName,
+                contractGroup = offers.contractGroup,
               ),
             ),
           )

--- a/app/purchase-common/build.gradle.kts
+++ b/app/purchase-common/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
   api(libs.androidx.navigation.common)
+  api(projects.dataContract)
 
   implementation(libs.androidx.navigation.compose)
   implementation(libs.apollo.normalizedCache)

--- a/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/navigation/PurchaseCommonDestination.kt
+++ b/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/navigation/PurchaseCommonDestination.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.purchase.common.navigation
 
+import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.navigation.common.Destination
 import com.hedvig.android.navigation.common.DestinationNavTypeAware
 import kotlin.reflect.KType
@@ -63,6 +64,7 @@ data class SelectTierParameters(
   val shopSessionId: String,
   val offers: List<TierOfferData>,
   val productDisplayName: String,
+  val contractGroup: ContractGroup,
 )
 
 @Serializable
@@ -70,6 +72,7 @@ data class SummaryParameters(
   val shopSessionId: String,
   val selectedOffer: TierOfferData,
   val productDisplayName: String,
+  val contractGroup: ContractGroup,
 )
 
 @Serializable

--- a/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/ui/offer/SelectTierViewModel.kt
+++ b/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/ui/offer/SelectTierViewModel.kt
@@ -115,6 +115,7 @@ class SelectTierPresenter(
             shopSessionId = params.shopSessionId,
             selectedOffer = selectedOffer,
             productDisplayName = params.productDisplayName,
+            contractGroup = params.contractGroup,
           )
         }
 

--- a/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/ui/summary/PurchaseSummaryDestination.kt
+++ b/app/purchase-common/src/main/kotlin/com/hedvig/android/feature/purchase/common/ui/summary/PurchaseSummaryDestination.kt
@@ -1,19 +1,25 @@
 package com.hedvig.android.feature.purchase.common.ui.summary
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hedvig.android.data.contract.ContractGroup
+import com.hedvig.android.data.contract.pillowResource
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize.Large
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Primary
 import com.hedvig.android.design.system.hedvig.ErrorDialog
@@ -28,6 +34,7 @@ import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.feature.purchase.common.navigation.SigningParameters
 import com.hedvig.android.feature.purchase.common.navigation.SummaryParameters
 import com.hedvig.android.feature.purchase.common.navigation.TierOfferData
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun PurchaseSummaryDestination(
@@ -60,7 +67,7 @@ fun PurchaseSummaryDestination(
 }
 
 @Composable
-private fun PurchaseSummaryScreen(
+fun PurchaseSummaryScreen(
   params: SummaryParameters,
   isSubmitting: Boolean,
   navigateUp: () -> Unit,
@@ -68,7 +75,19 @@ private fun PurchaseSummaryScreen(
 ) {
   HedvigScaffold(navigateUp) {
     val offer = params.selectedOffer
-    HedvigCard(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 24.dp),
+      contentAlignment = Alignment.Center,
+    ) {
+      Image(
+        painter = painterResource(params.contractGroup.pillowResource()),
+        contentDescription = null,
+        modifier = Modifier.size(128.dp),
+      )
+    }
+    HedvigCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
       Column(modifier = Modifier.padding(16.dp)) {
         HedvigText(
           text = params.productDisplayName,
@@ -176,6 +195,7 @@ private fun PreviewPurchaseSummary() {
             hasDiscount = true,
           ),
           productDisplayName = "Hemf\u00f6rs\u00e4kring Hyresr\u00e4tt",
+          contractGroup = ContractGroup.RENTAL,
         ),
         isSubmitting = false,
         navigateUp = {},


### PR DESCRIPTION
## Summary
- Adds a product pillow image above the existing summary card on `PurchaseSummaryDestination`. The right pillow is picked from `ContractGroup.pillowResource()` based on the contract being purchased.
- Threads `contractGroup` through `SelectTierParameters` → `SummaryParameters` from each feature's offer fetch (`ProductVariant.typeOfContract.toContractGroup()`), so apartment / car / house / pet flows all populate it.
- Adds a debug-only `MockPurchaseSummaryActivity` that renders the screen with test data and cycles `ContractGroup.entries` on each CTA tap — useful for design iteration without driving a real purchase flow.

## Verification
Verified in the emulator via the mock activity. Two screenshots from the cycle:

**HOMEOWNER pillow + product name "Hemförsäkring Bostadsrätt":**
- Pillow renders above the card, card content unchanged.

**CAT pillow + product name "Kattförsäkring" (after cycling 6 taps):**
- Pillow swaps dynamically when `contractGroup` changes, confirming the wiring.

Launch the mock activity manually with:
`adb shell am start -n com.hedvig.dev.app/com.hedvig.android.app.debug.MockPurchaseSummaryActivity`

## Test plan
- [ ] Drive an apartment purchase to the summary screen — confirm rental/homeowner pillow shows
- [ ] Drive a pet purchase to the summary screen — confirm cat/dog pillow shows
- [ ] Drive a car or house purchase to the summary screen — confirm car/villa pillow shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)