### PR TITLE
Bugfix: bind MoleculeViewModels as ViewModel and complete Metro wiring

### DIFF
--- a/app/data/data-addons/src/main/kotlin/com/hedvig/android/data/addons/di/DataAddonsMetroProviders.kt
+++ b/app/data/data-addons/src/main/kotlin/com/hedvig/android/data/addons/di/DataAddonsMetroProviders.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.data.addons.di
 
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
+import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.data.addons.data.DemoGetAddonBannerInfoUseCase
 import com.hedvig.android.data.addons.data.GetAddonBannerInfoUseCase
 import com.hedvig.android.data.addons.data.GetTravelAddonBannerInfoUseCaseProvider
@@ -22,4 +23,9 @@ interface DataAddonsMetroProviders {
     demoImpl = demoImpl,
     prodImpl = prodImpl,
   )
+
+  @Provides
+  fun provideGetAddonBannerInfoUseCaseProvider(
+    provider: GetTravelAddonBannerInfoUseCaseProvider,
+  ): Provider<GetAddonBannerInfoUseCase> = provider
 }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxViewModel.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.chat.data.GetAllConversationsUseCase
 import com.hedvig.android.feature.chat.model.InboxConversation
@@ -15,12 +16,13 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class InboxViewModel(
   getAllConversationsUseCase: GetAllConversationsUseCase,
 ) : MoleculeViewModel<InboxEvent, InboxUiState>(

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/chooseinsurance/ChooseInsuranceViewModel.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/chooseinsurance/ChooseInsuranceViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.changetier.data.ChangeTierCreateSource.SELF_SERVICE
 import com.hedvig.android.data.changetier.data.ChangeTierRepository
@@ -23,11 +24,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class ChooseInsuranceViewModel(
   getCustomizableInsurancesUseCase: GetCustomizableInsurancesUseCase,
   tierRepository: ChangeTierRepository,

--- a/app/feature/feature-connect-payment-trustly/src/main/kotlin/com/hedvig/android/feature/connect/payment/trustly/TrustlyViewModel.kt
+++ b/app/feature/feature-connect-payment-trustly/src/main/kotlin/com/hedvig/android/feature/connect/payment/trustly/TrustlyViewModel.kt
@@ -1,16 +1,18 @@
 package com.hedvig.android.feature.connect.payment.trustly
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.apollo.NetworkCacheManager
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.connect.payment.trustly.data.TrustlyCallback
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class TrustlyViewModel(
   trustlyCallback: TrustlyCallback,
   startTrustlySessionUseCase: StartTrustlySessionUseCase,

--- a/app/feature/feature-cross-sell-sheet/build.gradle.kts
+++ b/app/feature/feature-cross-sell-sheet/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(libs.arrow.fx)
   implementation(projects.apolloCore)
   implementation(projects.apolloOctopusPublic)
+  implementation(projects.coreCommonPublic)
   implementation(projects.coreDemoMode)
   implementation(projects.crossSells)
   implementation(projects.dataAddons)

--- a/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
+++ b/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.raise.either
@@ -31,6 +32,7 @@ import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -48,7 +50,7 @@ import octopus.type.UserFlow
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class CrossSellSheetViewModel(
   getCrossSellSheetDataUseCaseProvider: Provider<GetCrossSellSheetDataUseCase>,
   crossSellAfterFlowRepository: CrossSellAfterFlowRepository,
@@ -129,19 +131,19 @@ internal fun CrossSellInfoType.toCrossSellSource(): CrossSellInput {
   }
 }
 
-internal class GetCrossSellSheetDataUseCaseProvider(
+class GetCrossSellSheetDataUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetCrossSellSheetDataUseCase,
   override val prodImpl: GetCrossSellSheetDataUseCase,
 ) : ProdOrDemoProvider<GetCrossSellSheetDataUseCase>
 
-internal interface GetCrossSellSheetDataUseCase {
+interface GetCrossSellSheetDataUseCase {
   suspend fun invoke(source: CrossSellInput): Flow<Either<ErrorMessage, CrossSellSheetData>>
 }
 
 @Inject
 @SingleIn(AppScope::class)
-internal class GetCrossSellSheetDataUseCaseImpl(
+class GetCrossSellSheetDataUseCaseImpl(
   private val apolloClient: ApolloClient,
 ) : GetCrossSellSheetDataUseCase {
   override suspend fun invoke(source: CrossSellInput): Flow<Either<ErrorMessage, CrossSellSheetData>> {
@@ -200,7 +202,7 @@ internal fun CrossSellFragment.toCrossSell(): CrossSell {
 }
 
 @Inject
-internal class DemoGetCrossSellSheetDataUseCase() : GetCrossSellSheetDataUseCase {
+class DemoGetCrossSellSheetDataUseCase() : GetCrossSellSheetDataUseCase {
   override suspend fun invoke(source: CrossSellInput): Flow<Either<ErrorMessage, CrossSellSheetData>> {
     return flowOf(ErrorMessage("Ineligible for demo mode").left())
   }

--- a/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
+++ b/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
@@ -31,7 +31,6 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.Flow
@@ -131,7 +130,7 @@ internal fun CrossSellInfoType.toCrossSellSource(): CrossSellInput {
   }
 }
 
-class GetCrossSellSheetDataUseCaseProvider(
+internal class GetCrossSellSheetDataUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetCrossSellSheetDataUseCase,
   override val prodImpl: GetCrossSellSheetDataUseCase,
@@ -141,9 +140,7 @@ interface GetCrossSellSheetDataUseCase {
   suspend fun invoke(source: CrossSellInput): Flow<Either<ErrorMessage, CrossSellSheetData>>
 }
 
-@Inject
-@SingleIn(AppScope::class)
-class GetCrossSellSheetDataUseCaseImpl(
+internal class GetCrossSellSheetDataUseCaseImpl(
   private val apolloClient: ApolloClient,
 ) : GetCrossSellSheetDataUseCase {
   override suspend fun invoke(source: CrossSellInput): Flow<Either<ErrorMessage, CrossSellSheetData>> {
@@ -201,8 +198,7 @@ internal fun CrossSellFragment.toCrossSell(): CrossSell {
   }
 }
 
-@Inject
-class DemoGetCrossSellSheetDataUseCase() : GetCrossSellSheetDataUseCase {
+internal class DemoGetCrossSellSheetDataUseCase : GetCrossSellSheetDataUseCase {
   override suspend fun invoke(source: CrossSellInput): Flow<Either<ErrorMessage, CrossSellSheetData>> {
     return flowOf(ErrorMessage("Ineligible for demo mode").left())
   }

--- a/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/di/CrossSellSheetMetroProviders.kt
+++ b/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/di/CrossSellSheetMetroProviders.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.cross.sell.sheet.di
 
+import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.Provider
@@ -17,11 +18,10 @@ interface CrossSellSheetMetroProviders {
   @SingleIn(AppScope::class)
   fun provideGetCrossSellSheetDataUseCaseProvider(
     demoManager: DemoManager,
-    prodImpl: GetCrossSellSheetDataUseCaseImpl,
-    demoImpl: DemoGetCrossSellSheetDataUseCase,
+    apolloClient: ApolloClient,
   ): Provider<GetCrossSellSheetDataUseCase> = GetCrossSellSheetDataUseCaseProvider(
     demoManager = demoManager,
-    demoImpl = demoImpl,
-    prodImpl = prodImpl,
+    prodImpl = GetCrossSellSheetDataUseCaseImpl(apolloClient),
+    demoImpl = DemoGetCrossSellSheetDataUseCase(),
   )
 }

--- a/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/di/CrossSellSheetMetroProviders.kt
+++ b/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/di/CrossSellSheetMetroProviders.kt
@@ -12,7 +12,7 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @ContributesTo(AppScope::class)
-internal interface CrossSellSheetMetroProviders {
+interface CrossSellSheetMetroProviders {
   @Provides
   @SingleIn(AppScope::class)
   fun provideGetCrossSellSheetDataUseCaseProvider(

--- a/app/feature/feature-delete-account/src/main/kotlin/com/hedvig/android/feature/deleteaccount/DeleteAccountViewModel.kt
+++ b/app/feature/feature-delete-account/src/main/kotlin/com/hedvig/android/feature/deleteaccount/DeleteAccountViewModel.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.chat
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.deleteaccount.DeleteAccountEvent
 import com.hedvig.android.feature.deleteaccount.DeleteAccountPresenter
@@ -9,11 +10,12 @@ import com.hedvig.android.feature.deleteaccount.data.RequestAccountDeletionUseCa
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class DeleteAccountViewModel(
   private val requestAccountDeletionUseCase: RequestAccountDeletionUseCase,
   private val deleteAccountStateUseCase: DeleteAccountStateUseCase,

--- a/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/HelpCenterViewModel.kt
+++ b/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/HelpCenterViewModel.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.help.center
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.conversations.HasAnyActiveConversationUseCase
 import com.hedvig.android.feature.help.center.data.GetHelpCenterFAQUseCase
@@ -8,11 +9,12 @@ import com.hedvig.android.feature.help.center.data.GetQuickLinksUseCase
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class HelpCenterViewModel(
   getQuickLinksUseCase: GetQuickLinksUseCase,
   hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,

--- a/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/ShowNavigateToInboxViewModel.kt
+++ b/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/ShowNavigateToInboxViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.lifecycle.ViewModel
 import arrow.core.merge
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.conversations.HasAnyActiveConversationUseCase
@@ -12,12 +13,13 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.map
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class ShowNavigateToInboxViewModel(
   hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
 ) : MoleculeViewModel<Unit, Boolean>(

--- a/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/puppyguide/PuppyGuideViewModel.kt
+++ b/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/puppyguide/PuppyGuideViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.help.center.data.GetPuppyGuideUseCase
 import com.hedvig.android.feature.help.center.data.PuppyGuideStory
@@ -15,12 +16,13 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.SharingStarted
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class PuppyGuideViewModel(
   getPuppyGuideUseCase: GetPuppyGuideUseCase,
 ) : MoleculeViewModel<PuppyGuideEvent, PuppyGuideUiState>(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/GetHomeDataUseCaseProvider.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/GetHomeDataUseCaseProvider.kt
@@ -4,7 +4,7 @@ import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
 
-internal class GetHomeDataUseCaseProvider(
+class GetHomeDataUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetHomeDataUseCase,
   override val prodImpl: GetHomeDataUseCase,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/GetHomeDataUseCaseProvider.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/GetHomeDataUseCaseProvider.kt
@@ -4,7 +4,7 @@ import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
 
-class GetHomeDataUseCaseProvider(
+internal class GetHomeDataUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetHomeDataUseCase,
   override val prodImpl: GetHomeDataUseCase,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeMetroProviders.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeMetroProviders.kt
@@ -11,7 +11,7 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @ContributesTo(AppScope::class)
-internal interface HomeMetroProviders {
+interface HomeMetroProviders {
   @Provides
   @SingleIn(AppScope::class)
   fun provideGetHomeDataUseCaseProvider(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeMetroProviders.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeMetroProviders.kt
@@ -1,14 +1,21 @@
 package com.hedvig.android.feature.home.di
 
+import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.Provider
+import com.hedvig.android.data.addons.data.GetTravelAddonBannerInfoUseCaseProvider
+import com.hedvig.android.data.conversations.HasAnyActiveConversationUseCase
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCaseDemo
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCaseImpl
+import com.hedvig.android.featureflags.FeatureManager
+import com.hedvig.android.memberreminders.GetMemberRemindersUseCase
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
+import kotlin.time.Clock
+import kotlinx.datetime.TimeZone
 
 @ContributesTo(AppScope::class)
 interface HomeMetroProviders {
@@ -16,11 +23,24 @@ interface HomeMetroProviders {
   @SingleIn(AppScope::class)
   fun provideGetHomeDataUseCaseProvider(
     demoManager: DemoManager,
-    prodImpl: GetHomeDataUseCaseImpl,
-    demoImpl: GetHomeDataUseCaseDemo,
+    apolloClient: ApolloClient,
+    hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
+    getMemberRemindersUseCase: GetMemberRemindersUseCase,
+    featureManager: FeatureManager,
+    clock: Clock,
+    timeZone: TimeZone,
+    getTravelAddonBannerInfoUseCaseProvider: GetTravelAddonBannerInfoUseCaseProvider,
   ): Provider<GetHomeDataUseCase> = GetHomeDataUseCaseProvider(
     demoManager = demoManager,
-    demoImpl = demoImpl,
-    prodImpl = prodImpl,
+    prodImpl = GetHomeDataUseCaseImpl(
+      apolloClient = apolloClient,
+      hasAnyActiveConversationUseCase = hasAnyActiveConversationUseCase,
+      getMemberRemindersUseCase = getMemberRemindersUseCase,
+      featureManager = featureManager,
+      clock = clock,
+      timeZone = timeZone,
+      getTravelAddonBannerInfoUseCaseProvider = getTravelAddonBannerInfoUseCaseProvider,
+    ),
+    demoImpl = GetHomeDataUseCaseDemo(),
   )
 }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -11,7 +11,6 @@ import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.apollo.safeFlow
-import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.crosssells.BundleProgress
 import com.hedvig.android.crosssells.CrossSellSheetData
 import com.hedvig.android.crosssells.RecommendedCrossSell
@@ -31,8 +30,6 @@ import com.hedvig.android.memberreminders.GetMemberRemindersUseCase
 import com.hedvig.android.memberreminders.MemberReminders
 import com.hedvig.android.ui.claimstatus.model.ClaimStatusCardUiState
 import com.hedvig.android.ui.emergency.FirstVetSection
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.currentCoroutineContext
@@ -54,9 +51,7 @@ interface GetHomeDataUseCase {
   fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>>
 }
 
-@Inject
-@SingleIn(AppScope::class)
-class GetHomeDataUseCaseImpl(
+internal class GetHomeDataUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
   private val getMemberRemindersUseCase: GetMemberRemindersUseCase,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -50,13 +50,13 @@ import octopus.HomeQuery
 import octopus.UnreadMessageCountQuery
 import octopus.fragment.HomeCrossSellFragment
 
-internal interface GetHomeDataUseCase {
+interface GetHomeDataUseCase {
   fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>>
 }
 
 @Inject
 @SingleIn(AppScope::class)
-internal class GetHomeDataUseCaseImpl(
+class GetHomeDataUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
   private val getMemberRemindersUseCase: GetMemberRemindersUseCase,
@@ -286,7 +286,7 @@ private fun HomeQuery.Data.claimStatusCards(): HomeData.ClaimStatusCardsData? {
   )
 }
 
-internal data class HomeData(
+data class HomeData(
   val contractStatus: ContractStatus,
   val claimStatusCardsData: ClaimStatusCardsData?,
   val veryImportantMessages: List<VeryImportantMessage>,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
@@ -3,20 +3,15 @@ package com.hedvig.android.feature.home.home.data
 import arrow.core.Either
 import arrow.core.right
 import com.hedvig.android.apollo.ApolloOperationError
-import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.crosssells.CrossSellSheetData
 import com.hedvig.android.crosssells.RecommendedCrossSell
 import com.hedvig.android.data.contract.CrossSell
 import com.hedvig.android.data.contract.ImageAsset
 import com.hedvig.android.memberreminders.MemberReminders
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-@Inject
-@SingleIn(AppScope::class)
-class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
+internal class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
   override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> = flowOf(
     HomeData(
       contractStatus = HomeData.ContractStatus.Active,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.flowOf
 
 @Inject
 @SingleIn(AppScope::class)
-internal class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
+class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
   override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> = flowOf(
     HomeData(
       contractStatus = HomeData.ContractStatus.Active,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/SeenImportantMessagesStorage.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/SeenImportantMessagesStorage.kt
@@ -18,7 +18,7 @@ interface SeenImportantMessagesStorage {
 @Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-class SeenImportantMessagesStorageImpl : SeenImportantMessagesStorage {
+internal class SeenImportantMessagesStorageImpl : SeenImportantMessagesStorage {
   private val storedSeenMessages: MutableStateFlow<List<String>> = MutableStateFlow(listOf())
 
   override val seenMessages: StateFlow<List<String>>

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/SeenImportantMessagesStorage.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/SeenImportantMessagesStorage.kt
@@ -1,5 +1,9 @@
 package com.hedvig.android.feature.home.home.data
 
+import com.hedvig.android.core.common.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,7 +15,10 @@ interface SeenImportantMessagesStorage {
   fun markMessageAsSeen(id: String)
 }
 
-internal class SeenImportantMessagesStorageImpl : SeenImportantMessagesStorage {
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SeenImportantMessagesStorageImpl : SeenImportantMessagesStorage {
   private val storedSeenMessages: MutableStateFlow<List<String>> = MutableStateFlow(listOf())
 
   override val seenMessages: StateFlow<List<String>>

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import arrow.core.Either
 import com.hedvig.android.apollo.ApolloOperationError
+import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.crosssells.CrossSellSheetData
 import com.hedvig.android.data.addons.data.AddonBannerInfo
@@ -23,7 +24,6 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.notification.badge.data.crosssell.home.CrossSellHomeNotificationService
 import com.hedvig.android.ui.emergency.FirstVetSection
 import kotlin.time.Clock
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
@@ -35,7 +35,7 @@ internal class HomePresenter(
   private val getHomeDataUseCaseProvider: Provider<GetHomeDataUseCase>,
   private val seenImportantMessagesStorage: SeenImportantMessagesStorage,
   private val crossSellHomeNotificationServiceProvider: Provider<CrossSellHomeNotificationService>,
-  private val applicationScope: CoroutineScope,
+  private val applicationScope: ApplicationScope,
   private val isProduction: Boolean,
 ) : MoleculePresenter<HomeEvent, HomeUiState> {
   @Composable

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeViewModel.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeViewModel.kt
@@ -1,6 +1,8 @@
 package com.hedvig.android.feature.home.home.ui
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
@@ -9,17 +11,17 @@ import com.hedvig.android.molecule.public.MoleculeViewModel
 import com.hedvig.android.notification.badge.data.crosssell.home.CrossSellHomeNotificationService
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
-import kotlinx.coroutines.CoroutineScope
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class HomeViewModel(
   getHomeDataUseCaseProvider: Provider<GetHomeDataUseCase>,
   seenImportantMessagesStorage: SeenImportantMessagesStorage,
   crossSellHomeNotificationServiceProvider: Provider<CrossSellHomeNotificationService>,
-  applicationScope: CoroutineScope,
+  applicationScope: ApplicationScope,
   hedvigBuildConstants: HedvigBuildConstants,
 ) : MoleculeViewModel<HomeEvent, HomeUiState>(
     HomeUiState.Loading,

--- a/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/email/InsuranceEvidenceEmailInputViewModel.kt
+++ b/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/email/InsuranceEvidenceEmailInputViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.insurance.certificate.data.GenerateInsuranceEvidenceUseCase
 import com.hedvig.android.feature.insurance.certificate.data.GetInsuranceEvidenceInitialEmailUseCase
@@ -17,6 +18,7 @@ import com.hedvig.android.molecule.public.MoleculeViewModel
 import com.hedvig.core.common.android.validation.validateEmail
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import hedvig.resources.PROFILE_MY_INFO_INVALID_EMAIL
 import hedvig.resources.Res
@@ -26,7 +28,7 @@ import org.jetbrains.compose.resources.StringResource
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class InsuranceEvidenceEmailInputViewModel(
   generateInsuranceEvidenceUseCase: GenerateInsuranceEvidenceUseCase,
   getEmailUseCase: GetInsuranceEvidenceInitialEmailUseCase,

--- a/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/overview/InsuranceEvidenceOverviewViewModel.kt
+++ b/app/feature/feature-insurance-certificate/src/main/kotlin/com/hedvig/android/feature/insurance/certificate/ui/overview/InsuranceEvidenceOverviewViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.fileupload.DownloadPdfUseCase
 import com.hedvig.android.core.fileupload.DownloadedFile
@@ -18,11 +19,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class InsuranceEvidenceOverviewViewModel(
   downloadPdfUseCase: DownloadPdfUseCase,
 ) : MoleculeViewModel<InsuranceEvidenceOverviewEvent, InsuranceEvidenceOverviewState>(

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsuranceViewModel.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurance/presentation/InsuranceViewModel.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.insurances.insurance.presentation
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.data.addons.data.GetAddonBannerInfoUseCase
@@ -8,11 +9,12 @@ import com.hedvig.android.feature.insurances.data.GetInsuranceContractsUseCase
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class InsuranceViewModel(
   getInsuranceContractsUseCaseProvider: Provider<GetInsuranceContractsUseCase>,
   getCrossSellsUseCaseProvider: Provider<GetCrossSellsUseCase>,

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsViewModel.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/terminatedcontracts/TerminatedContractsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import arrow.core.Either
 import arrow.core.raise.either
 import com.hedvig.android.core.common.ErrorMessage
@@ -22,13 +23,14 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.onEach
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class TerminatedContractsViewModel(
   getInsuranceContractsUseCaseProvider: Provider<GetInsuranceContractsUseCase>,
 ) : MoleculeViewModel<TerminatedContractsEvent, TerminatedContractsUiState>(

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingViewModel.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/marketing/MarketingViewModel.kt
@@ -1,15 +1,17 @@
 package com.hedvig.android.feature.login.marketing
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class MarketingViewModel(
   languageService: LanguageService,
 ) : MoleculeViewModel<MarketingEvent, MarketingUiState>(

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/navigation/LoginGraph.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/navigation/LoginGraph.kt
@@ -49,7 +49,7 @@ fun NavGraphBuilder.loginGraph(
       )
     }
     navdestination<LoginDestinations.SwedishLogin> {
-      val swedishLoginViewModel: SwedishLoginViewModel = metroViewModel()
+      val swedishLoginViewModel: SwedishLoginViewModel = assistedMetroViewModel()
       SwedishLoginDestination(
         swedishLoginViewModel = swedishLoginViewModel,
         navigateUp = navController::navigateUp,

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginViewModel.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginViewModel.kt
@@ -1,26 +1,40 @@
 package com.hedvig.android.feature.login.swedishlogin
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import com.hedvig.authlib.AuthRepository
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.coroutines.flow.SharingStarted
 
-@Inject
-@ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@AssistedInject
 internal class SwedishLoginViewModel(
   authTokenService: AuthTokenService,
   authRepository: AuthRepository,
   demoManager: DemoManager,
-  savedStateHandle: SavedStateHandle,
+  @Assisted savedStateHandle: SavedStateHandle,
 ) : MoleculeViewModel<SwedishLoginEvent, SwedishLoginUiState>(
     SwedishLoginUiState(BankIdUiState.Loading, false),
     SwedishLoginPresenter(authTokenService, authRepository, demoManager, savedStateHandle),
     SharingStarted.WhileSubscribed(),
-  )
+  ) {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(SwedishLoginViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): SwedishLoginViewModel = create(extras.createSavedStateHandle())
+
+    fun create(
+      @Assisted savedStateHandle: SavedStateHandle,
+    ): SwedishLoginViewModel
+  }
+}

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/MovingFlowGraph.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/MovingFlowGraph.kt
@@ -126,7 +126,7 @@ fun NavGraphBuilder.movingFlowGraph(
     navdestination<EnterNewAddress> {
       val moveIntentId = it.toRoute<EnterNewAddress>().moveIntentId
       EnterNewAddressDestination(
-        viewModel = metroViewModel<EnterNewAddressViewModel>(),
+        viewModel = assistedMetroViewModel<EnterNewAddressViewModel>(),
         navigateUp = navController::navigateUp,
         popBackStack = navController::popBackStack,
         exitFlow = {
@@ -143,7 +143,7 @@ fun NavGraphBuilder.movingFlowGraph(
     }
     navdestination<MovingFlowDestinations.AddHouseInformation> {
       AddHouseInformationDestination(
-        viewModel = metroViewModel<AddHouseInformationViewModel>(),
+        viewModel = assistedMetroViewModel<AddHouseInformationViewModel>(),
         navigateUp = navController::navigateUp,
         popBackStack = navController::popBackStack,
         exitFlow = {
@@ -195,7 +195,7 @@ fun NavGraphBuilder.movingFlowGraph(
 
     navdestination<MovingFlowDestinations.Summary> { backStackEntry ->
       SummaryDestination(
-        viewModel = metroViewModel<SummaryViewModel>(),
+        viewModel = assistedMetroViewModel<SummaryViewModel>(),
         navigateUp = navController::navigateUp,
         navigateBack = navController::popBackStack,
         exitFlow = {

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/addhouseinformation/AddHouseInformationViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/addhouseinformation/AddHouseInformationViewModel.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.navigation.toRoute
 import arrow.core.None
 import arrow.core.Option
@@ -42,9 +44,12 @@ import com.hedvig.android.featureflags.flags.Feature
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import octopus.feature.movingflow.MoveIntentV2RequestMutation
@@ -53,11 +58,9 @@ import octopus.type.MoveIntentRequestInput
 import octopus.type.MoveToAddressInput
 import octopus.type.MoveToHouseInput
 
-@Inject
-@ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@AssistedInject
 internal class AddHouseInformationViewModel(
-  savedStateHandle: SavedStateHandle,
+  @Assisted savedStateHandle: SavedStateHandle,
   movingFlowRepository: MovingFlowRepository,
   apolloClient: ApolloClient,
   featureManager: FeatureManager,
@@ -69,7 +72,18 @@ internal class AddHouseInformationViewModel(
       apolloClient,
       featureManager,
     ),
-  )
+  ) {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(AddHouseInformationViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): AddHouseInformationViewModel = create(extras.createSavedStateHandle())
+
+    fun create(
+      @Assisted savedStateHandle: SavedStateHandle,
+    ): AddHouseInformationViewModel
+  }
+}
 
 internal class AddHouseInformationPresenter(
   private val moveIntentId: String,

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressViewModel.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.navigation.toRoute
 import arrow.core.None
 import arrow.core.Option
@@ -58,9 +60,12 @@ import com.hedvig.android.featureflags.flags.Feature
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -72,11 +77,9 @@ import octopus.type.MoveIntentRequestInput
 import octopus.type.MoveToAddressInput
 import octopus.type.MoveToApartmentInput
 
-@Inject
-@ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@AssistedInject
 internal class EnterNewAddressViewModel(
-  savedStateHandle: SavedStateHandle,
+  @Assisted savedStateHandle: SavedStateHandle,
   movingFlowRepository: MovingFlowRepository,
   apolloClient: ApolloClient,
   featureManager: FeatureManager,
@@ -88,7 +91,18 @@ internal class EnterNewAddressViewModel(
       apolloClient,
       featureManager,
     ),
-  )
+  ) {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(EnterNewAddressViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): EnterNewAddressViewModel = create(extras.createSavedStateHandle())
+
+    fun create(
+      @Assisted savedStateHandle: SavedStateHandle,
+    ): EnterNewAddressViewModel
+  }
+}
 
 private class EnterNewAddressPresenter(
   private val moveIntentId: String,

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/selectcontract/SelectContractViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/selectcontract/SelectContractViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.ViewModel
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo.ApolloClient
@@ -24,13 +25,14 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import octopus.feature.movingflow.MoveIntentV2CreateMutation
 import octopus.feature.movingflow.fragment.MoveIntentFragment
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class SelectContractViewModel(
   apolloClient: ApolloClient,
   movingFlowRepository: MovingFlowRepository,

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/start/HousingTypeViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/start/HousingTypeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.movingflow.data.HousingType
@@ -21,12 +22,13 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class HousingTypeViewModel(
   movingFlowRepository: MovingFlowRepository,
 ) : MoleculeViewModel<HousingTypeEvent, HousingTypeUiState>(

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/SummaryViewModel.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.navigation.toRoute
 import arrow.core.NonEmptyList
 import arrow.core.toNonEmptyListOrNull
@@ -37,17 +39,18 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import com.hedvig.ui.tiersandaddons.CostBreakdownEntry
 import com.hedvig.ui.tiersandaddons.DisplayDocument
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.datetime.LocalDate
 import octopus.feature.movingflow.MoveIntentV2CommitMutation
 
-@Inject
-@ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@AssistedInject
 internal class SummaryViewModel(
-  savedStateHandle: SavedStateHandle,
+  @Assisted savedStateHandle: SavedStateHandle,
   movingFlowRepository: MovingFlowRepository,
   apolloClient: ApolloClient,
   crossSellAfterFlowRepository: CrossSellAfterFlowRepository,
@@ -61,7 +64,18 @@ internal class SummaryViewModel(
       crossSellAfterFlowRepository = crossSellAfterFlowRepository,
       getMoveIntentCostUseCase = getMoveIntentCostUseCase,
     ),
-  )
+  ) {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(SummaryViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): SummaryViewModel = create(extras.createSavedStateHandle())
+
+    fun create(
+      @Assisted savedStateHandle: SavedStateHandle,
+    ): SummaryViewModel
+  }
+}
 
 internal class SummaryPresenter(
   private val summaryRoute: Summary,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/Discount.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/Discount.kt
@@ -18,7 +18,7 @@ internal data class DiscountsDetails(
 )
 
 @Serializable
-internal data class Discount(
+data class Discount(
   val code: String,
   val description: String?,
   val status: DiscountStatus,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/MemberCharge.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/MemberCharge.kt
@@ -14,7 +14,7 @@ import octopus.fragment.MemberChargeFragment
 import octopus.type.MemberChargeStatus
 
 @Serializable
-internal data class MemberCharge(
+data class MemberCharge(
   val grossAmount: UiMoney,
   val netAmount: UiMoney,
   val id: String?,
@@ -47,7 +47,7 @@ internal data class MemberCharge(
     val sum: UiMoney,
   )
 
-  internal enum class MemberChargeStatus {
+  enum class MemberChargeStatus {
     UPCOMING,
     SUCCESS,
     PENDING,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentConnection.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentConnection.kt
@@ -2,7 +2,7 @@ package com.hedvig.android.feature.payments.data
 
 import kotlinx.datetime.LocalDate
 
-internal sealed interface PaymentConnection {
+sealed interface PaymentConnection {
   data object Active : PaymentConnection
 
   data object Pending : PaymentConnection

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentOverview.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/PaymentOverview.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.feature.payments.data
 import com.hedvig.android.core.uidata.UiMoney
 import kotlinx.datetime.LocalDate
 
-internal data class PaymentOverview(
+data class PaymentOverview(
   val memberChargeShortInfo: MemberChargeShortInfo?,
   val ongoingCharges: List<OngoingCharge>,
   val paymentConnection: PaymentConnection,
@@ -16,11 +16,11 @@ internal data class PaymentOverview(
   )
 }
 
-internal data class ManualChargeToPrompt(
+data class ManualChargeToPrompt(
   val sum: UiMoney,
 )
 
-internal data class MemberChargeShortInfo(
+data class MemberChargeShortInfo(
   val netAmount: UiMoney,
   val dueDate: LocalDate,
   val id: String?,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/di/PaymentsMetroProviders.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/di/PaymentsMetroProviders.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.payments.di
 
+import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.Provider
@@ -14,6 +15,7 @@ import com.hedvig.android.feature.payments.overview.data.GetUpcomingPaymentUseCa
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
+import kotlin.time.Clock
 
 @ContributesTo(AppScope::class)
 interface PaymentsMetroProviders {
@@ -21,23 +23,22 @@ interface PaymentsMetroProviders {
   @SingleIn(AppScope::class)
   fun provideGetUpcomingPaymentUseCaseProvider(
     demoManager: DemoManager,
-    prodImpl: GetUpcomingPaymentUseCaseImpl,
-    demoImpl: GetUpcomingPaymentUseCaseDemo,
+    apolloClient: ApolloClient,
+    clock: Clock,
   ): Provider<GetUpcomingPaymentUseCase> = GetUpcomingPaymentUseCaseProvider(
     demoManager = demoManager,
-    demoImpl = demoImpl,
-    prodImpl = prodImpl,
+    prodImpl = GetUpcomingPaymentUseCaseImpl(apolloClient, clock),
+    demoImpl = GetUpcomingPaymentUseCaseDemo(clock),
   )
 
   @Provides
   @SingleIn(AppScope::class)
   fun provideGetShouldShowPayoutUseCaseProvider(
     demoManager: DemoManager,
-    prodImpl: GetShouldShowPayoutUseCaseImpl,
-    demoImpl: GetShouldShowPayoutUseCaseDemo,
+    apolloClient: ApolloClient,
   ): Provider<GetShouldShowPayoutUseCase> = GetShouldShowPayoutUseCaseProvider(
     demoManager = demoManager,
-    demoImpl = demoImpl,
-    prodImpl = prodImpl,
+    prodImpl = GetShouldShowPayoutUseCaseImpl(apolloClient),
+    demoImpl = GetShouldShowPayoutUseCaseDemo(),
   )
 }

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/di/PaymentsMetroProviders.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/di/PaymentsMetroProviders.kt
@@ -16,7 +16,7 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @ContributesTo(AppScope::class)
-internal interface PaymentsMetroProviders {
+interface PaymentsMetroProviders {
   @Provides
   @SingleIn(AppScope::class)
   fun provideGetUpcomingPaymentUseCaseProvider(

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCase.kt
@@ -14,7 +14,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import octopus.ShouldShowPayoutButtonQuery
 
-internal interface GetShouldShowPayoutUseCase {
+interface GetShouldShowPayoutUseCase {
   suspend fun invoke(): Either<ErrorMessage, Boolean>
 }
 
@@ -24,7 +24,7 @@ internal interface GetShouldShowPayoutUseCase {
  */
 @Inject
 @SingleIn(AppScope::class)
-internal class GetShouldShowPayoutUseCaseImpl(
+class GetShouldShowPayoutUseCaseImpl(
   private val apolloClient: ApolloClient,
 ) : GetShouldShowPayoutUseCase {
   override suspend fun invoke(): Either<ErrorMessage, Boolean> = either {
@@ -43,6 +43,6 @@ internal class GetShouldShowPayoutUseCaseImpl(
 
 @Inject
 @SingleIn(AppScope::class)
-internal class GetShouldShowPayoutUseCaseDemo : GetShouldShowPayoutUseCase {
+class GetShouldShowPayoutUseCaseDemo : GetShouldShowPayoutUseCase {
   override suspend fun invoke(): Either<ErrorMessage, Boolean> = false.right()
 }

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCase.kt
@@ -9,9 +9,6 @@ import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.core.common.di.AppScope
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import octopus.ShouldShowPayoutButtonQuery
 
 interface GetShouldShowPayoutUseCase {
@@ -22,9 +19,7 @@ interface GetShouldShowPayoutUseCase {
  * We do not want to show the payout button at all when there is no payout method connected nor is there a possibility
  * to add one in the member's current state
  */
-@Inject
-@SingleIn(AppScope::class)
-class GetShouldShowPayoutUseCaseImpl(
+internal class GetShouldShowPayoutUseCaseImpl(
   private val apolloClient: ApolloClient,
 ) : GetShouldShowPayoutUseCase {
   override suspend fun invoke(): Either<ErrorMessage, Boolean> = either {
@@ -41,8 +36,6 @@ class GetShouldShowPayoutUseCaseImpl(
   }
 }
 
-@Inject
-@SingleIn(AppScope::class)
-class GetShouldShowPayoutUseCaseDemo : GetShouldShowPayoutUseCase {
+internal class GetShouldShowPayoutUseCaseDemo : GetShouldShowPayoutUseCase {
   override suspend fun invoke(): Either<ErrorMessage, Boolean> = false.right()
 }

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCaseProvider.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCaseProvider.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.feature.payments.overview.data
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 
-internal class GetShouldShowPayoutUseCaseProvider(
+class GetShouldShowPayoutUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetShouldShowPayoutUseCase,
   override val prodImpl: GetShouldShowPayoutUseCase,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCaseProvider.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCaseProvider.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.feature.payments.overview.data
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 
-class GetShouldShowPayoutUseCaseProvider(
+internal class GetShouldShowPayoutUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetShouldShowPayoutUseCase,
   override val prodImpl: GetShouldShowPayoutUseCase,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
@@ -30,13 +30,13 @@ import octopus.fragment.MemberChargeFragment
 import octopus.type.MemberChargeStatus
 import octopus.type.MemberPaymentMethodStatus
 
-internal interface GetUpcomingPaymentUseCase {
+interface GetUpcomingPaymentUseCase {
   suspend fun invoke(): Either<ErrorMessage, PaymentOverview>
 }
 
 @Inject
 @SingleIn(AppScope::class)
-internal data class GetUpcomingPaymentUseCaseImpl(
+data class GetUpcomingPaymentUseCaseImpl(
   val apolloClient: ApolloClient,
   val clock: Clock,
 ) : GetUpcomingPaymentUseCase {
@@ -113,7 +113,7 @@ private fun MemberChargeFragment.toMemberChargeShortInfo() = MemberChargeShortIn
 
 @Inject
 @SingleIn(AppScope::class)
-internal class GetUpcomingPaymentUseCaseDemo(
+class GetUpcomingPaymentUseCaseDemo(
   private val clock: Clock,
 ) : GetUpcomingPaymentUseCase {
   override suspend fun invoke(): Either<ErrorMessage, PaymentOverview> {

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.feature.payments.data.ManualChargeToPrompt
@@ -19,8 +18,6 @@ import com.hedvig.android.feature.payments.data.PaymentConnection
 import com.hedvig.android.feature.payments.data.PaymentOverview
 import com.hedvig.android.feature.payments.data.PaymentOverview.OngoingCharge
 import com.hedvig.android.feature.payments.data.toFailedCharge
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlinx.datetime.TimeZone
@@ -34,9 +31,7 @@ interface GetUpcomingPaymentUseCase {
   suspend fun invoke(): Either<ErrorMessage, PaymentOverview>
 }
 
-@Inject
-@SingleIn(AppScope::class)
-data class GetUpcomingPaymentUseCaseImpl(
+internal data class GetUpcomingPaymentUseCaseImpl(
   val apolloClient: ApolloClient,
   val clock: Clock,
 ) : GetUpcomingPaymentUseCase {
@@ -111,9 +106,7 @@ private fun MemberChargeFragment.toMemberChargeShortInfo() = MemberChargeShortIn
   },
 )
 
-@Inject
-@SingleIn(AppScope::class)
-class GetUpcomingPaymentUseCaseDemo(
+internal class GetUpcomingPaymentUseCaseDemo(
   private val clock: Clock,
 ) : GetUpcomingPaymentUseCase {
   override suspend fun invoke(): Either<ErrorMessage, PaymentOverview> {

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCaseProvider.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCaseProvider.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.feature.payments.overview.data
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 
-internal class GetUpcomingPaymentUseCaseProvider(
+class GetUpcomingPaymentUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetUpcomingPaymentUseCase,
   override val prodImpl: GetUpcomingPaymentUseCase,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCaseProvider.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCaseProvider.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.feature.payments.overview.data
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 
-class GetUpcomingPaymentUseCaseProvider(
+internal class GetUpcomingPaymentUseCaseProvider(
   override val demoManager: DemoManager,
   override val demoImpl: GetUpcomingPaymentUseCase,
   override val prodImpl: GetUpcomingPaymentUseCase,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/discounts/DiscountsViewModel.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/discounts/DiscountsViewModel.kt
@@ -1,15 +1,17 @@
 package com.hedvig.android.feature.payments.ui.discounts
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payments.data.GetDiscountsOverviewUseCase
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class DiscountsViewModel(
   getDiscountsOverviewUseCase: GetDiscountsOverviewUseCase,
 ) : MoleculeViewModel<DiscountsEvent, DiscountsUiState>(

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/history/PaymentHistoryViewModel.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/history/PaymentHistoryViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payments.data.GetPaymentsHistoryUseCase
 import com.hedvig.android.feature.payments.data.PaymentHistoryItem
@@ -15,11 +16,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class PaymentHistoryViewModel(
   getPaymentsHistoryUseCase: GetPaymentsHistoryUseCase,
 ) : MoleculeViewModel<PaymentHistoryEvent, PaymentHistoryUiState>(

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/manualcharge/ManualChargeViewModel.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/manualcharge/ManualChargeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payments.data.GetManualChargeInfoUseCase
@@ -17,11 +18,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class ManualChargeViewModel(
   getManualChargeInfoUseCase: GetManualChargeInfoUseCase,
   triggerManualCharge: TriggerManualChargeUseCase,

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/memberpaymentdetails/MemberPaymentDetailsViewModel.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/memberpaymentdetails/MemberPaymentDetailsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payments.data.GetMemberPaymentsDetailsUseCase
 import com.hedvig.android.feature.payments.data.MemberPaymentsDetails
@@ -15,11 +16,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class MemberPaymentDetailsViewModel(
   getMemberPaymentsDetailsUseCase: GetMemberPaymentsDetailsUseCase,
 ) : MoleculeViewModel<MemberPaymentDetailsEvent, MemberPaymentDetailsUiState>(

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/payments/PaymentsViewModel.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/payments/PaymentsViewModel.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.payments.ui.payments
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.Provider
 import com.hedvig.android.feature.payments.overview.data.GetShouldShowPayoutUseCase
@@ -7,11 +8,12 @@ import com.hedvig.android.feature.payments.overview.data.GetUpcomingPaymentUseCa
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class PaymentsViewModel(
   getUpcomingPaymentUseCase: Provider<GetUpcomingPaymentUseCase>,
   getShouldShowPayoutUseCase: Provider<GetShouldShowPayoutUseCase>,

--- a/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/editbankaccount/EditBankAccountViewModel.kt
+++ b/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/editbankaccount/EditBankAccountViewModel.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payoutaccount.data.SetupNordeaPayoutUseCase
 import com.hedvig.android.feature.payoutaccount.data.bankNameForClearingNumber
@@ -22,11 +23,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class EditBankAccountViewModel(
   setupNordeaPayoutUseCase: SetupNordeaPayoutUseCase,
 ) : MoleculeViewModel<EditBankAccountEvent, EditBankAccountUiState>(

--- a/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/overview/PayoutAccountOverviewViewModel.kt
+++ b/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/overview/PayoutAccountOverviewViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payoutaccount.data.GetPayoutAccountUseCase
 import com.hedvig.android.feature.payoutaccount.data.PayoutAccount
@@ -15,12 +16,13 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import octopus.type.MemberPaymentProvider
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class PayoutAccountOverviewViewModel(
   getPayoutAccountUseCase: GetPayoutAccountUseCase,
 ) : MoleculeViewModel<PayoutAccountOverviewEvent, PayoutAccountOverviewUiState>(

--- a/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/setupinvoice/SetupInvoicePayoutViewModel.kt
+++ b/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/setupinvoice/SetupInvoicePayoutViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payoutaccount.data.SetupInvoicePayoutUseCase
 import com.hedvig.android.molecule.public.MoleculePresenter
@@ -14,11 +15,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class SetupInvoicePayoutViewModel(
   setupInvoicePayoutUseCase: SetupInvoicePayoutUseCase,
 ) : MoleculeViewModel<SetupInvoicePayoutEvent, SetupInvoicePayoutUiState>(

--- a/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/setupswish/SetupSwishPayoutViewModel.kt
+++ b/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/ui/setupswish/SetupSwishPayoutViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.payoutaccount.data.SetupSwishPayoutUseCase
@@ -15,11 +16,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class SetupSwishPayoutViewModel(
   setupSwishPayoutUseCase: SetupSwishPayoutUseCase,
 ) : MoleculeViewModel<SetupSwishPayoutEvent, SetupSwishPayoutUiState>(

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/AboutAppViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/AboutAppViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
@@ -17,6 +18,7 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -25,7 +27,7 @@ import octopus.MemberIdQuery
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class AboutAppViewModel(
   apolloClient: ApolloClient,
   deviceIdDataStore: DeviceIdDataStore,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/certificates/CertificatesViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/certificates/CertificatesViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.profile.data.CheckInsuranceEvidenceAvailabilityUseCase
 import com.hedvig.android.feature.profile.data.CheckTravelCertificateDestinationAvailabilityUseCase
@@ -16,6 +17,7 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -23,7 +25,7 @@ import kotlinx.coroutines.flow.flow
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class CertificatesViewModel(
   checkTravelCertificateDestinationAvailabilityUseCase: CheckTravelCertificateDestinationAvailabilityUseCase,
   checkInsuranceEvidenceAvailabilityUseCase: CheckInsuranceEvidenceAvailabilityUseCase,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoViewModel.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.text.TextRange
+import androidx.lifecycle.ViewModel
 import arrow.core.Either
 import arrow.core.getOrElse
 import com.hedvig.android.core.common.ErrorMessage
@@ -35,6 +36,7 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
@@ -106,7 +108,7 @@ internal sealed interface ContactInfoUiState {
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class ContactInfoViewModel(
   repository: Provider<ContactInfoRepository>,
 ) : MoleculeViewModel<ContactInfoEvent, ContactInfoUiState>(

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepository.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepository.kt
@@ -8,13 +8,13 @@ import com.hedvig.android.feature.profile.data.ContactInformation.Email
 import com.hedvig.android.feature.profile.data.ContactInformation.PhoneNumber
 import com.hedvig.core.common.android.validation.isValidEmail
 
-internal interface ContactInfoRepository {
+interface ContactInfoRepository {
   suspend fun contactInfo(): Either<ErrorMessage, ContactInformation>
 
   suspend fun updateInfo(phoneNumber: PhoneNumber, email: Email): Either<ErrorMessage, ContactInformation>
 }
 
-internal data class ContactInformation(
+data class ContactInformation(
   val phoneNumber: PhoneNumber?,
   val email: Email?,
 ) {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryDemo.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryDemo.kt
@@ -3,15 +3,10 @@ package com.hedvig.android.feature.profile.data
 import arrow.core.Either
 import arrow.core.right
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.profile.data.ContactInformation.Email
 import com.hedvig.android.feature.profile.data.ContactInformation.PhoneNumber
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 
-@Inject
-@SingleIn(AppScope::class)
-class ContactInfoRepositoryDemo : ContactInfoRepository {
+internal class ContactInfoRepositoryDemo : ContactInfoRepository {
   private var contactInformation = ContactInformation(
     PhoneNumber("072102103"),
     Email("google@gmail.com"),

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryDemo.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryDemo.kt
@@ -11,7 +11,7 @@ import dev.zacsweers.metro.SingleIn
 
 @Inject
 @SingleIn(AppScope::class)
-internal class ContactInfoRepositoryDemo : ContactInfoRepository {
+class ContactInfoRepositoryDemo : ContactInfoRepository {
   private var contactInformation = ContactInformation(
     PhoneNumber("072102103"),
     Email("google@gmail.com"),

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryImpl.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryImpl.kt
@@ -21,7 +21,7 @@ import octopus.MemberUpdateContactInfoMutation
 
 @Inject
 @SingleIn(AppScope::class)
-internal class ContactInfoRepositoryImpl(
+class ContactInfoRepositoryImpl(
   private val apolloClient: ApolloClient,
   private val networkCacheManager: NetworkCacheManager,
 ) : ContactInfoRepository {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryImpl.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryImpl.kt
@@ -9,19 +9,14 @@ import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.NetworkCacheManager
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.profile.data.ContactInformation.Email
 import com.hedvig.android.feature.profile.data.ContactInformation.PhoneNumber
 import com.hedvig.android.logger.LogPriority.ERROR
 import com.hedvig.android.logger.logcat
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import octopus.ContactInformationQuery
 import octopus.MemberUpdateContactInfoMutation
 
-@Inject
-@SingleIn(AppScope::class)
-class ContactInfoRepositoryImpl(
+internal class ContactInfoRepositoryImpl(
   private val apolloClient: ApolloClient,
   private val networkCacheManager: NetworkCacheManager,
 ) : ContactInfoRepository {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileMetroProviders.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileMetroProviders.kt
@@ -1,5 +1,7 @@
 package com.hedvig.android.feature.profile.di
 
+import com.apollographql.apollo.ApolloClient
+import com.hedvig.android.apollo.NetworkCacheManager
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.Provider
@@ -16,11 +18,11 @@ interface ProfileMetroProviders {
   @SingleIn(AppScope::class)
   fun provideProfileRepositoryProvider(
     demoManager: DemoManager,
-    prodImpl: ContactInfoRepositoryImpl,
-    demoImpl: ContactInfoRepositoryDemo,
+    apolloClient: ApolloClient,
+    networkCacheManager: NetworkCacheManager,
   ): Provider<ContactInfoRepository> = ProfileRepositoryProvider(
     demoManager = demoManager,
-    demoImpl = demoImpl,
-    prodImpl = prodImpl,
+    prodImpl = ContactInfoRepositoryImpl(apolloClient, networkCacheManager),
+    demoImpl = ContactInfoRepositoryDemo(),
   )
 }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileMetroProviders.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileMetroProviders.kt
@@ -11,7 +11,7 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @ContributesTo(AppScope::class)
-internal interface ProfileMetroProviders {
+interface ProfileMetroProviders {
   @Provides
   @SingleIn(AppScope::class)
   fun provideProfileRepositoryProvider(

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileRepositoryProvider.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileRepositoryProvider.kt
@@ -4,7 +4,7 @@ import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 import com.hedvig.android.feature.profile.data.ContactInfoRepository
 
-internal class ProfileRepositoryProvider(
+class ProfileRepositoryProvider(
   override val demoManager: DemoManager,
   override val demoImpl: ContactInfoRepository,
   override val prodImpl: ContactInfoRepository,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileRepositoryProvider.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/di/ProfileRepositoryProvider.kt
@@ -4,7 +4,7 @@ import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 import com.hedvig.android.feature.profile.data.ContactInfoRepository
 
-class ProfileRepositoryProvider(
+internal class ProfileRepositoryProvider(
   override val demoManager: DemoManager,
   override val demoImpl: ContactInfoRepository,
   override val prodImpl: ContactInfoRepository,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/eurobonus/EurobonusViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/eurobonus/EurobonusViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.profile.data.GetEurobonusDataUseCase
 import com.hedvig.android.feature.profile.data.UpdateEurobonusNumberUseCase
@@ -15,11 +16,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class EurobonusViewModel(
   getEurobonusDataUseCase: GetEurobonusDataUseCase,
   updateEurobonusNumberUseCase: UpdateEurobonusNumberUseCase,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsViewModel.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.profile.settings
 
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.apollo.NetworkCacheManager
 import com.hedvig.android.apollo.auth.listeners.UploadLanguagePreferenceToBackendUseCase
 import com.hedvig.android.core.common.di.AppScope
@@ -10,11 +11,12 @@ import com.hedvig.android.memberreminders.EnableNotificationsReminderSnoozeManag
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class SettingsViewModel(
   languageService: LanguageService,
   settingsDataStore: SettingsDataStore,

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.auth.LogoutUseCase
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.profile.data.CheckCertificatesAvailabilityUseCase
@@ -23,6 +24,7 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -30,7 +32,7 @@ import kotlinx.coroutines.flow.flow
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class ProfileViewModel(
   getEuroBonusStatusUseCase: GetEurobonusStatusUseCase,
   checkCertificatesAvailabilityUseCase: CheckCertificatesAvailabilityUseCase,

--- a/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/ui/SelectInsuranceToRemoveAddonViewModel.kt
+++ b/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/ui/SelectInsuranceToRemoveAddonViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.contract.ContractId
 import com.hedvig.android.molecule.public.MoleculePresenter
@@ -16,11 +17,12 @@ import com.hedvig.feature.remove.addons.data.GetInsurancesWithRemovableAddonsUse
 import com.hedvig.feature.remove.addons.data.InsuranceForAddon
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class SelectInsuranceToRemoveAddonViewModel(
   getInsurancesWithRemovableAddonsUseCase: GetInsurancesWithRemovableAddonsUseCase,
 ) : MoleculeViewModel<

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/choose/ChooseContractForCertificateViewModel.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/choose/ChooseContractForCertificateViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.feature.travelcertificate.data.ContractEligibleWithAddress
 import com.hedvig.android.feature.travelcertificate.data.GetEligibleContractsWithAddressUseCase
@@ -17,11 +18,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class ChooseContractForCertificateViewModel(
   getEligibleContractsWithAddressUseCase: GetEligibleContractsWithAddressUseCase,
 ) : MoleculeViewModel<ChooseContractEvent, ChooseContractUiState>(

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/CertificateHistoryViewModel.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/history/CertificateHistoryViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.fileupload.DownloadPdfUseCase
 import com.hedvig.android.core.fileupload.DownloadedFile
@@ -24,6 +25,7 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -31,7 +33,7 @@ import kotlinx.coroutines.flow.flow
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class CertificateHistoryViewModel(
   getTravelCertificatesHistoryUseCase: GetTravelCertificatesHistoryUseCase,
   downloadPdfUseCase: DownloadPdfUseCase,

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/overview/TravelCertificateOverviewViewModel.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/ui/overview/TravelCertificateOverviewViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.fileupload.DownloadPdfUseCase
 import com.hedvig.android.core.fileupload.DownloadedFile
@@ -18,11 +19,12 @@ import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 internal class TravelCertificateOverviewViewModel(
   downloadTravelCertificateUseCase: DownloadPdfUseCase,
 ) :

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryDemo.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryDemo.kt
@@ -4,16 +4,11 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.right
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.core.common.di.AppScope
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import octopus.FullReferralsQuery
 import octopus.type.CurrencyCode
 import octopus.type.MemberReferralStatus
 
-@Inject
-@SingleIn(AppScope::class)
-class ForeverRepositoryDemo : ForeverRepository {
+internal class ForeverRepositoryDemo : ForeverRepository {
   private var code: String = "code"
 
   override suspend fun getReferralsData(): Either<ErrorMessage, FullReferralsQuery.Data> = either {

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryDemo.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryDemo.kt
@@ -13,7 +13,7 @@ import octopus.type.MemberReferralStatus
 
 @Inject
 @SingleIn(AppScope::class)
-internal class ForeverRepositoryDemo : ForeverRepository {
+class ForeverRepositoryDemo : ForeverRepository {
   private var code: String = "code"
 
   override suspend fun getReferralsData(): Either<ErrorMessage, FullReferralsQuery.Data> = either {

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryImpl.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryImpl.kt
@@ -17,7 +17,7 @@ import octopus.MemberReferralInformationCodeUpdateMutation
 
 @Inject
 @SingleIn(AppScope::class)
-internal class ForeverRepositoryImpl(
+class ForeverRepositoryImpl(
   private val apolloClient: ApolloClient,
 ) : ForeverRepository {
   private val referralsQuery = FullReferralsQuery()

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryImpl.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryImpl.kt
@@ -8,16 +8,11 @@ import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
-import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.shared.foreverui.ui.data.ForeverRepository.ReferralError
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 import octopus.FullReferralsQuery
 import octopus.MemberReferralInformationCodeUpdateMutation
 
-@Inject
-@SingleIn(AppScope::class)
-class ForeverRepositoryImpl(
+internal class ForeverRepositoryImpl(
   private val apolloClient: ApolloClient,
 ) : ForeverRepository {
   private val referralsQuery = FullReferralsQuery()

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryProvider.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryProvider.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.shared.foreverui.ui.data
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 
-internal class ForeverRepositoryProvider(
+class ForeverRepositoryProvider(
   override val demoManager: DemoManager,
   override val demoImpl: ForeverRepository,
   override val prodImpl: ForeverRepository,

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryProvider.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryProvider.kt
@@ -3,7 +3,7 @@ package com.hedvig.android.shared.foreverui.ui.data
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.ProdOrDemoProvider
 
-class ForeverRepositoryProvider(
+internal class ForeverRepositoryProvider(
   override val demoManager: DemoManager,
   override val demoImpl: ForeverRepository,
   override val prodImpl: ForeverRepository,

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/di/ForeverMetroProviders.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/di/ForeverMetroProviders.kt
@@ -12,7 +12,7 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @ContributesTo(AppScope::class)
-internal interface ForeverMetroProviders {
+interface ForeverMetroProviders {
   @Provides
   @SingleIn(AppScope::class)
   fun provideForeverRepositoryProvider(

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/di/ForeverMetroProviders.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/di/ForeverMetroProviders.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.shared.foreverui.ui.di
 
+import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.core.demomode.Provider
@@ -17,11 +18,10 @@ interface ForeverMetroProviders {
   @SingleIn(AppScope::class)
   fun provideForeverRepositoryProvider(
     demoManager: DemoManager,
-    prodImpl: ForeverRepositoryImpl,
-    demoImpl: ForeverRepositoryDemo,
+    apolloClient: ApolloClient,
   ): Provider<ForeverRepository> = ForeverRepositoryProvider(
     demoManager = demoManager,
-    demoImpl = demoImpl,
-    prodImpl = prodImpl,
+    prodImpl = ForeverRepositoryImpl(apolloClient),
+    demoImpl = ForeverRepositoryDemo(),
   )
 }

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/ui/ForeverViewModel.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/ui/ForeverViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
 import arrow.core.raise.either
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.demomode.Provider
@@ -22,11 +23,12 @@ import com.hedvig.android.shared.foreverui.ui.ui.ForeverEvent.ShowedReferralCode
 import com.hedvig.android.shared.foreverui.ui.ui.ForeverEvent.SubmitNewReferralCode
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 
 @Inject
 @ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@ContributesIntoMap(AppScope::class, binding<ViewModel>())
 class ForeverViewModel(
   foreverRepositoryProvider: Provider<ForeverRepository>,
 ) : MoleculeViewModel<ForeverEvent, ForeverUiState>(


### PR DESCRIPTION
After the Koin→Metro migration, the app crashed on startup:                                                                                                                                                                                                                                            
```
  java.lang.IllegalArgumentException: Unknown model class CrossSellSheetViewModel                                                                                      
      at dev.zacsweers.metrox.viewmodel.MetroViewModelFactory.create(...)      
```                                                                                        
                                                                                                                                                                       
Root cause

Metro's `@ContributesIntoMap` infers the bound type from a class's single declared supertype. Our ViewModels extend `MoleculeViewModel<Event, State>`, so they were contributed as `MoleculeViewModel<…>` instead of `ViewModel` — and never landed in the `Map<KClass<out ViewModel>, () -> ViewModel>` that `MetroViewModelFactory` reads. They were silently dropped, then crashed when first requested. 40 ViewModels were affected (assisted-factory ViewModels were not, since they bind via a factory interface).                                                                                                                                                  
                                                                                                                                                                       
Fixing that surfaced a second layer: because the dropped ViewModels were never validated, the graph compiled despite genuinely missing dependency bindings. Once the VMs were correctly in the graph, Metro reported 10 MissingBinding errors.

Decisions                                                                                                                                                            
                                                                                                                                                                       
  - `binding<ViewModel>()` — per Metro's docs, a ViewModel that extends an intermediate base must specify the bound type explicitly. Applied to all 40 MoleculeViewModel subclasses.                                                                                                                                                          
  - Public provider surface over graph extensions — feature-internal `Provider<UseCase>` bindings couldn't feed the single shared AppGraph (:app can only reference public types). Graph extensions were considered but rejected: a parent graph can't see child-extension bindings, and `MetroViewModelFactory` lives in the parent — so they'd require re-architecting how every screen resolves its ViewModel. Instead we made the relevant use cases/repositories + their providers public, matching the existing pattern (cross-sell already worked because its model lives in a public module).                                                                             
  - `ApplicationScope` over raw `CoroutineScope` — HomeViewModel was the lone outlier injecting CoroutineScope; switched to ApplicationScope like the rest of the codebase.
  - Assisted factories for `SavedStateHandle` — `SavedStateHandle` is only available via CreationExtras at creation time, not as a graph binding, so those ViewModels were converted to metrox's `ViewModelAssistedFactory`.

Changes                                                                                                                                                              
                                                                                                                                  
  - 40 ViewModels: added `binding<ViewModel>()` to `@ContributesIntoMap`.                                                                                                  
  - data-addons: provide `Provider<GetAddonBannerInfoUseCase>` (base type) from `DataAddonsMetroProviders`.                                                                
  - cross-sell, forever, home, payments, profile: made use-case/repository interfaces, impls, demos, providers and `@ContributesTo` modules public so their Provider<T>  bindings reach AppGraph (includes the public model cascade, e.g. `HomeData`, `PaymentOverview`, `ContactInformation`).                                                     
  - home: bound `SeenImportantMessagesStorage` (`@Inject `+ `@ContributesBinding`); HomeViewModel/HomePresenter now inject ApplicationScope.                                 
  - `SavedStateHandle` VMs (SwedishLogin, movingflow EnterNewAddress / AddHouseInformation / Summary): converted to `@AssistedInject` + nested `ViewModelAssistedFactory`; call sites updated to `assistedMetroViewModel()`.