### PR TITLE
Add OSS license gate to Android (RND-1996)

### DIFF
--- a/.github/workflows/license-inventory.yml
+++ b/.github/workflows/license-inventory.yml
@@ -1,0 +1,11 @@
+name: license-inventory
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays ~06:00 Europe/Stockholm
+  workflow_dispatch:
+jobs:
+  inventory:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: HedvigInsurance/prod-env/.github/workflows/license-inventory.yml@master

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,16 @@
+name: license
+on:
+  pull_request:
+  push:
+    branches: [develop, "renovate/**"]
+jobs:
+  license:
+    uses: HedvigInsurance/prod-env/.github/workflows/license-gate.yml@master
+    with:
+      # Android ships to end-user devices (a distribution context), so block weak
+      # copyleft (LGPL/MPL/EPL) as well as forbidden licenses — not just the
+      # forbidden set that backends gate on.
+      gate-severity: "HIGH,CRITICAL"
+      # Warn-only pilot: reports findings but never fails the build. Review one run,
+      # populate `ignored-licenses` for any pre-existing hits, then remove this line.
+      enforce: false


### PR DESCRIPTION
What
An action that scans licenses in a repo and blocks for certain licenses that we can not include because of compliance reasons.

This action will run on every PR and will scan licenses for dependencies

See the full action impl here: https://github.com/HedvigInsurance/prod-env/pull/757

Why
For compliance reasons we need to make sure we dont merge certain licenses. For example, adding a dependency with strong copy-left license would mean we have to open source our source code.

