### PR TITLE
Feature: new conversation from inbox (GEN-5331)

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -413,6 +413,9 @@ internal fun HedvigNavHost(
       },
       onNavigateToImageViewer = onNavigateToImageViewer,
       navController = navController,
+      onNavigateToNewConversation = {
+        navigateToNewConversation()
+      },
     )
     addonPurchaseNavGraph(
       navController = navController,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigNavHost.kt
@@ -112,6 +112,7 @@ internal fun HedvigNavHost(
   fun navigateToConnectPayment(builder: NavOptionsBuilder.() -> Unit = {}) {
     navController.navigate(TrustlyDestination, builder)
   }
+
   val navigateToInbox = {
     navController.navigate(ChatDestination)
   }
@@ -416,6 +417,14 @@ internal fun HedvigNavHost(
       onNavigateToNewConversation = {
         navigateToNewConversation()
       },
+      navigateToClaimChat = {
+        navController.navigate(
+          ClaimChatDestination(
+            messageId = null,
+            isDevelopmentFlow = false,
+          ),
+        )
+      },
     )
     addonPurchaseNavGraph(
       navController = navController,
@@ -561,6 +570,11 @@ private fun NavGraphBuilder.nestedHomeGraphs(
       navigateToNewConversation(null)
     },
     openPlayStore = externalNavigator::tryOpenPlayStore,
+    closeFlowOnSuccess = {
+      if (!navController.typedPopBackStack<ChatDestination>(inclusive = true)) {
+        navController.popBackStack()
+      }
+    }
   )
   claimDetailsGraph(
     navController = navController,

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -500,6 +500,11 @@
   <string name="HONESTY_PLEDGE_NOTE_2">Ha kvitton eller annan dokumentation redo för snabbare hjälp</string>
   <string name="HONESTY_PLEDGE_NOTE_3">Vi hör av oss om vi behöver mer information eller fler uppgifter</string>
   <string name="HONESTY_PLEDGE_TITLE">Innan vi börjar</string>
+  <string name="INBOX_EMPTY_STATE_SUBTITLE">Inga konversationer än. Starta en genom att skriva ett meddelande</string>
+  <string name="INBOX_EMPTY_STATE_TITLE">Din inkorg är tom</string>
+  <string name="INBOX_NEW_MESSAGE">Nytt</string>
+  <string name="INBOX_NEW_MESSAGE_CLAIM_DESCRIPTION">Anmäl något som har hänt med dig eller dina saker</string>
+  <string name="INBOX_NEW_MESSAGE_SUPPORT_DESCRIPTION">Frågor om din försäkring, betalningar och annat</string>
   <string name="INSURANCES_CROSS_SELL_DISCOUNTS_AVAILABLE">Erbjudanden</string>
   <string name="INSURANCES_NO_ACTIVE">Du har ingen aktiv försäkring</string>
   <string name="INSURANCE_ADDONS_SUBHEADING">Tillägg</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -500,6 +500,11 @@
   <string name="HONESTY_PLEDGE_NOTE_2">Have receipts or other documentation ready to help us help you faster</string>
   <string name="HONESTY_PLEDGE_NOTE_3">We’ll contact you if we need more information</string>
   <string name="HONESTY_PLEDGE_TITLE">Before we start</string>
+  <string name="INBOX_EMPTY_STATE_SUBTITLE">No conversations yet. Start one by writing a message</string>
+  <string name="INBOX_EMPTY_STATE_TITLE">Your inbox is empty</string>
+  <string name="INBOX_NEW_MESSAGE">New</string>
+  <string name="INBOX_NEW_MESSAGE_CLAIM_DESCRIPTION">Make a claim for something that\'s happened to you or your things</string>
+  <string name="INBOX_NEW_MESSAGE_SUPPORT_DESCRIPTION">Questions about your insurance, payments and more</string>
   <string name="INSURANCES_CROSS_SELL_DISCOUNTS_AVAILABLE">Discounts available</string>
   <string name="INSURANCES_NO_ACTIVE">You don\'t have any active insurances</string>
   <string name="INSURANCE_ADDONS_SUBHEADING">Addons</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -499,6 +499,11 @@
   <string name="HONESTY_PLEDGE_NOTE_2">Ha kvitton eller annan dokumentation redo för snabbare hjälp</string>
   <string name="HONESTY_PLEDGE_NOTE_3">Vi hör av oss om vi behöver mer information eller fler uppgifter</string>
   <string name="HONESTY_PLEDGE_TITLE">Innan vi börjar</string>
+  <string name="INBOX_EMPTY_STATE_SUBTITLE">Inga konversationer än. Starta en genom att skriva ett meddelande</string>
+  <string name="INBOX_EMPTY_STATE_TITLE">Din inkorg är tom</string>
+  <string name="INBOX_NEW_MESSAGE">Nytt</string>
+  <string name="INBOX_NEW_MESSAGE_CLAIM_DESCRIPTION">Anmäl något som har hänt med dig eller dina saker</string>
+  <string name="INBOX_NEW_MESSAGE_SUPPORT_DESCRIPTION">Frågor om din försäkring, betalningar och annat</string>
   <string name="INSURANCES_CROSS_SELL_DISCOUNTS_AVAILABLE">Erbjudanden</string>
   <string name="INSURANCES_NO_ACTIVE">Du har ingen aktiv försäkring</string>
   <string name="INSURANCE_ADDONS_SUBHEADING">Tillägg</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -499,6 +499,11 @@
   <string name="HONESTY_PLEDGE_NOTE_2">Have receipts or other documentation ready to help us help you faster</string>
   <string name="HONESTY_PLEDGE_NOTE_3">We’ll contact you if we need more information</string>
   <string name="HONESTY_PLEDGE_TITLE">Before we start</string>
+  <string name="INBOX_EMPTY_STATE_SUBTITLE">No conversations yet. Start one by writing a message</string>
+  <string name="INBOX_EMPTY_STATE_TITLE">Your inbox is empty</string>
+  <string name="INBOX_NEW_MESSAGE">New</string>
+  <string name="INBOX_NEW_MESSAGE_CLAIM_DESCRIPTION">Make a claim for something that's happened to you or your things</string>
+  <string name="INBOX_NEW_MESSAGE_SUPPORT_DESCRIPTION">Questions about your insurance, payments and more</string>
   <string name="INSURANCES_CROSS_SELL_DISCOUNTS_AVAILABLE">Discounts available</string>
   <string name="INSURANCES_NO_ACTIVE">You don't have any active insurances</string>
   <string name="INSURANCE_ADDONS_SUBHEADING">Addons</string>

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
@@ -1,4 +1,4 @@
-package com.hedvig.android.feature.home.home.ui
+package com.hedvig.android.design.system.hedvig
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -23,24 +23,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
-import com.hedvig.android.design.system.hedvig.ButtonDefaults
-import com.hedvig.android.design.system.hedvig.Checkbox
-import com.hedvig.android.design.system.hedvig.CheckboxOption
-import com.hedvig.android.design.system.hedvig.DividerPosition
-import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
-import com.hedvig.android.design.system.hedvig.HedvigButton
-import com.hedvig.android.design.system.hedvig.HedvigPreview
-import com.hedvig.android.design.system.hedvig.HedvigText
-import com.hedvig.android.design.system.hedvig.HedvigTheme
-import com.hedvig.android.design.system.hedvig.Icon
-import com.hedvig.android.design.system.hedvig.RadioGroupDefaults
-import com.hedvig.android.design.system.hedvig.RadioGroupSize
-import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.api.HedvigBottomSheetState
-import com.hedvig.android.design.system.hedvig.horizontalDivider
 import com.hedvig.android.design.system.hedvig.icon.Checkmark
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
-import com.hedvig.android.design.system.hedvig.rememberHedvigBottomSheetState
 import hedvig.resources.CLAIMS_PLEDGE_SLIDE_LABEL
 import hedvig.resources.HONESTY_PLEDGE_DESCRIPTION
 import hedvig.resources.HONESTY_PLEDGE_HEADER
@@ -54,7 +39,7 @@ import hedvig.resources.general_continue_button
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-internal fun StartClaimBottomSheet(
+fun StartClaimBottomSheet(
   state: HedvigBottomSheetState<Unit>,
   navigateToClaimChat: () -> Unit,
   navigateToClaimChatInDevMode: () -> Unit,

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/icon/PenEdit.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/icon/PenEdit.kt
@@ -1,0 +1,107 @@
+package com.hedvig.android.design.system.hedvig.icon
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+
+@Suppress("UnusedReceiverParameter")
+val HedvigIcons.PenEdit: ImageVector
+  get() {
+    if (_PenEdit != null) {
+      return _PenEdit!!
+    }
+    _PenEdit = ImageVector.Builder(
+      name = "PenEdit",
+      defaultWidth = 24.dp,
+      defaultHeight = 24.dp,
+      viewportWidth = 24f,
+      viewportHeight = 24f
+    ).apply {
+      path(
+        fill = SolidColor(Color(0xFF121212)),
+        pathFillType = PathFillType.EvenOdd
+      ) {
+        moveTo(18.457f, 10.64f)
+        lineTo(13.367f, 5.545f)
+        lineTo(14.427f, 4.484f)
+        lineTo(19.517f, 9.579f)
+        lineTo(18.457f, 10.64f)
+        close()
+      }
+      path(
+        fill = SolidColor(Color(0xFF121212)),
+        pathFillType = PathFillType.EvenOdd
+      ) {
+        moveTo(15.297f, 3.098f)
+        curveTo(16.427f, 1.967f, 18.258f, 1.967f, 19.388f, 3.098f)
+        lineTo(20.903f, 4.615f)
+        curveTo(22.032f, 5.745f, 22.032f, 7.578f, 20.903f, 8.708f)
+        lineTo(9.257f, 20.364f)
+        curveTo(9.23f, 20.39f, 9.204f, 20.417f, 9.178f, 20.442f)
+        curveTo(8.719f, 20.903f, 8.354f, 21.269f, 7.877f, 21.478f)
+        curveTo(7.399f, 21.688f, 6.908f, 21.707f, 6.293f, 21.732f)
+        curveTo(6.26f, 21.733f, 6.227f, 21.734f, 6.193f, 21.736f)
+        curveTo(4.914f, 21.788f, 3.809f, 21.745f, 3.032f, 20.967f)
+        curveTo(2.255f, 20.19f, 2.212f, 19.084f, 2.264f, 17.804f)
+        curveTo(2.266f, 17.77f, 2.267f, 17.737f, 2.268f, 17.704f)
+        curveTo(2.293f, 17.088f, 2.312f, 16.597f, 2.522f, 16.119f)
+        curveTo(2.731f, 15.641f, 3.097f, 15.276f, 3.559f, 14.817f)
+        curveTo(3.585f, 14.791f, 3.611f, 14.765f, 3.638f, 14.738f)
+        lineTo(15.297f, 3.098f)
+        curveTo(15.297f, 3.098f, 15.297f, 3.098f, 15.297f, 3.098f)
+        close()
+        moveTo(18.327f, 4.158f)
+        curveTo(17.783f, 3.614f, 16.901f, 3.614f, 16.358f, 4.158f)
+        lineTo(4.697f, 15.8f)
+        curveTo(4.12f, 16.376f, 3.977f, 16.535f, 3.895f, 16.722f)
+        curveTo(3.813f, 16.909f, 3.794f, 17.103f, 3.763f, 17.865f)
+        curveTo(3.708f, 19.216f, 3.837f, 19.651f, 4.093f, 19.907f)
+        curveTo(4.348f, 20.163f, 4.782f, 20.292f, 6.132f, 20.237f)
+        curveTo(6.893f, 20.206f, 7.087f, 20.187f, 7.274f, 20.105f)
+        curveTo(7.46f, 20.023f, 7.619f, 19.881f, 8.196f, 19.304f)
+        lineTo(19.842f, 7.648f)
+        curveTo(19.842f, 7.648f, 19.842f, 7.648f, 19.842f, 7.648f)
+        curveTo(20.386f, 7.103f, 20.386f, 6.22f, 19.842f, 5.675f)
+        lineTo(18.327f, 4.158f)
+        close()
+      }
+    }.build()
+
+    return _PenEdit!!
+  }
+
+@Suppress("ObjectPropertyName")
+private var _PenEdit: ImageVector? = null
+
+
+@Preview
+@Composable
+private fun IconPreview() {
+  HedvigTheme {
+    Column(
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Image(
+        imageVector = HedvigIcons.PenEdit,
+        contentDescription = com.hedvig.android.compose.ui.EmptyContentDescription,
+        modifier = Modifier
+          .width((24.0).dp)
+          .height((24.0).dp),
+      )
+    }
+  }
+}

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/di/ChatModule.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/di/ChatModule.kt
@@ -17,7 +17,6 @@ import com.hedvig.android.feature.chat.data.GetAllConversationsUseCaseImpl
 import com.hedvig.android.feature.chat.data.GetCbmChatRepositoryProvider
 import com.hedvig.android.feature.chat.inbox.InboxViewModel
 import com.hedvig.android.featureflags.FeatureManager
-import io.ktor.client.HttpClient
 import kotlin.time.Clock
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -36,8 +35,10 @@ val chatModule = module {
   }
 
   viewModel<InboxViewModel> {
-    InboxViewModel(get<GetAllConversationsUseCase>(),
-      featureManager = get<FeatureManager>())
+    InboxViewModel(
+      get<GetAllConversationsUseCase>(),
+      featureManager = get<FeatureManager>(),
+    )
   }
 
   single<CbmChatRepositoryImpl> {

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/di/ChatModule.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/di/ChatModule.kt
@@ -36,7 +36,8 @@ val chatModule = module {
   }
 
   viewModel<InboxViewModel> {
-    InboxViewModel(get<GetAllConversationsUseCase>())
+    InboxViewModel(get<GetAllConversationsUseCase>(),
+      featureManager = get<FeatureManager>())
   }
 
   single<CbmChatRepositoryImpl> {

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.compose.ui.EmptyContentDescription
+import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleBooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleCase
 import com.hedvig.android.design.system.hedvig.DividerPosition
@@ -123,7 +124,9 @@ private fun InboxScreen(
         actionType = TopAppBarActionType.BACK,
         onActionClick = navigateUp,
         topAppBarActions = {
-          NewConversationButton(onNavigateToNewConversation)
+          if (uiState is InboxUiState.Success && uiState.newConversationButtonAvailable) {
+            NewConversationButton(onNavigateToNewConversation)
+          }
         },
       )
       when (uiState) {
@@ -137,9 +140,10 @@ private fun InboxScreen(
         )
 
         is InboxUiState.Success -> InboxSuccessScreen(
-          uiState.inboxConversations,
-          onConversationClick,
-          onNavigateToNewConversation
+          inboxConversations = uiState.inboxConversations,
+          onConversationClick = onConversationClick,
+          onNavigateToNewConversation = onNavigateToNewConversation,
+          showNewConversationButton = uiState.newConversationButtonAvailable
         )
       }
     }
@@ -174,6 +178,7 @@ private fun InboxSuccessScreen(
   inboxConversations: List<InboxConversation>,
   onConversationClick: (id: String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
+  showNewConversationButton: Boolean
 ) {
   val lazyListState = rememberLazyListState()
   SideEffect {
@@ -216,12 +221,12 @@ private fun InboxSuccessScreen(
     ) {
       EmptyState(
         text = stringResource(Res.string.INBOX_EMPTY_STATE_TITLE),
-        description = stringResource(Res.string.INBOX_EMPTY_STATE_SUBTITLE),
+        description = if (showNewConversationButton) stringResource(Res.string.INBOX_EMPTY_STATE_SUBTITLE) else null,
         iconStyle = EmptyStateDefaults.EmptyStateIconStyle.NO_ICON,
-        buttonStyle = EmptyStateDefaults.EmptyStateButtonStyle.Button(
+        buttonStyle = if (showNewConversationButton) EmptyStateDefaults.EmptyStateButtonStyle.Button(
           stringResource(Res.string.open_chat),
           onNavigateToNewConversation
-        )
+        ) else EmptyStateDefaults.EmptyStateButtonStyle.NoButton
       )
     }
   }
@@ -346,12 +351,16 @@ private fun ConversationCard(
 @HedvigPreview
 @PreviewFontScale
 @Composable
-private fun EmptyInboxSuccessScreenPreview() {
+private fun EmptyInboxSuccessScreenPreview(
+  @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) case: Boolean,
+) {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       InboxScreen(
         InboxUiState.Success(
           listOf(),
+          case
+
         ),
         {},
         {},
@@ -364,7 +373,9 @@ private fun EmptyInboxSuccessScreenPreview() {
 @HedvigPreview
 @PreviewFontScale
 @Composable
-private fun InboxSuccessScreenPreview() {
+private fun InboxSuccessScreenPreview(
+  @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) case: Boolean,
+) {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       InboxScreen(
@@ -377,6 +388,7 @@ private fun InboxSuccessScreenPreview() {
             mockInboxConversation3.copy(conversationId = "101"),
             mockInboxConversationLegacy,
           ),
+          newConversationButtonAvailable = case
         ),
         {},
         {},

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -31,6 +32,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -40,9 +42,13 @@ import com.hedvig.android.compose.ui.EmptyContentDescription
 import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleBooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleCase
+import com.hedvig.android.design.system.hedvig.ButtonDefaults
 import com.hedvig.android.design.system.hedvig.DividerPosition
 import com.hedvig.android.design.system.hedvig.EmptyState
 import com.hedvig.android.design.system.hedvig.EmptyStateDefaults
+import com.hedvig.android.design.system.hedvig.HedvigBottomSheet
+import com.hedvig.android.design.system.hedvig.HedvigButton
+import com.hedvig.android.design.system.hedvig.HedvigCard
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.design.system.hedvig.HedvigPreview
@@ -54,6 +60,7 @@ import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightC
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.design.system.hedvig.Icon
+import com.hedvig.android.design.system.hedvig.StartClaimBottomSheet
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TopAppBar
 import com.hedvig.android.design.system.hedvig.TopAppBarActionType
@@ -62,6 +69,7 @@ import com.hedvig.android.design.system.hedvig.datepicker.getLocale
 import com.hedvig.android.design.system.hedvig.horizontalDivider
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.PenEdit
+import com.hedvig.android.design.system.hedvig.rememberHedvigBottomSheetState
 import com.hedvig.android.feature.chat.model.InboxConversation
 import com.hedvig.android.feature.chat.model.InboxConversation.Header
 import com.hedvig.android.feature.chat.model.InboxConversation.LatestMessage.File
@@ -81,10 +89,14 @@ import hedvig.resources.HEDVIG_NAME_TEXT
 import hedvig.resources.INBOX_EMPTY_STATE_SUBTITLE
 import hedvig.resources.INBOX_EMPTY_STATE_TITLE
 import hedvig.resources.INBOX_NEW_MESSAGE
+import hedvig.resources.INBOX_NEW_MESSAGE_CLAIM_DESCRIPTION
+import hedvig.resources.INBOX_NEW_MESSAGE_SUPPORT_DESCRIPTION
 import hedvig.resources.Res
 import hedvig.resources.TALKBACK_CONVERSATION_DESCRIPTION
 import hedvig.resources.claim_status_bar_closed
+import hedvig.resources.general_close_button
 import hedvig.resources.home_claim_card_pill_claim
+import hedvig.resources.home_tab_claim_button_text
 import hedvig.resources.open_chat
 import kotlin.time.Clock
 import org.jetbrains.compose.resources.stringResource
@@ -95,6 +107,7 @@ internal fun InboxDestination(
   navigateUp: () -> Unit,
   onConversationClick: (id: String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
+  navigateToClaimChat: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   InboxScreen(
@@ -103,6 +116,7 @@ internal fun InboxDestination(
     onConversationClick = onConversationClick,
     reload = { viewModel.emit(InboxEvent.Reload) },
     onNavigateToNewConversation = onNavigateToNewConversation,
+    navigateToClaimChat = navigateToClaimChat
   )
 }
 
@@ -113,7 +127,37 @@ private fun InboxScreen(
   onConversationClick: (id: String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
   reload: () -> Unit,
+  navigateToClaimChat: () -> Unit,
 ) {
+  val newChatSelectBottomSheetState = rememberHedvigBottomSheetState<Unit>()
+  val startClaimBottomSheetState = rememberHedvigBottomSheetState<Unit>()
+  HedvigBottomSheet(
+    newChatSelectBottomSheetState,
+    content = {
+      NewChatSelectBottomSheetContent(
+        onNavigateToNewConversation = {
+          newChatSelectBottomSheetState.dismiss()
+          onNavigateToNewConversation()
+        },
+        onStartNewClaim = {
+          newChatSelectBottomSheetState.dismiss()
+          startClaimBottomSheetState.show(Unit)
+        },
+        dismiss = {
+          newChatSelectBottomSheetState.dismiss()
+        },
+      )
+    },
+  )
+  StartClaimBottomSheet(
+    state = startClaimBottomSheetState,
+    navigateToClaimChat = {
+      startClaimBottomSheetState.dismiss()
+      navigateToClaimChat()
+    },
+    navigateToClaimChatInDevMode = {},
+    isStagingEnvironment = false,
+  )
   Surface(
     color = HedvigTheme.colorScheme.backgroundPrimary,
     modifier = Modifier.fillMaxSize(),
@@ -125,7 +169,11 @@ private fun InboxScreen(
         onActionClick = navigateUp,
         topAppBarActions = {
           if (uiState is InboxUiState.Success && uiState.newConversationButtonAvailable) {
-            NewConversationButton(onNavigateToNewConversation)
+            NewConversationButton(
+              {
+                newChatSelectBottomSheetState.show(Unit)
+              },
+            )
           }
         },
       )
@@ -142,8 +190,10 @@ private fun InboxScreen(
         is InboxUiState.Success -> InboxSuccessScreen(
           inboxConversations = uiState.inboxConversations,
           onConversationClick = onConversationClick,
-          onNavigateToNewConversation = onNavigateToNewConversation,
-          showNewConversationButton = uiState.newConversationButtonAvailable
+          onNavigateToNewConversation = {
+            newChatSelectBottomSheetState.show(Unit)
+          },
+          showNewConversationButton = uiState.newConversationButtonAvailable,
         )
       }
     }
@@ -174,11 +224,77 @@ private fun NewConversationButton(
 }
 
 @Composable
+private fun NewChatSelectBottomSheetContent(
+  onNavigateToNewConversation: () -> Unit,
+  onStartNewClaim: () -> Unit,
+  dismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier) {
+    HedvigCard(
+      onClick = onNavigateToNewConversation,
+      modifier = Modifier
+        .fillMaxWidth(),
+    ) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier.padding(start = 16.dp, bottom = 14.dp, top = 12.dp, end = 12.dp),
+      ) {
+        HedvigText(
+          text = stringResource(Res.string.CHAT_CONVERSATION_QUESTION_TITLE),
+          textAlign = TextAlign.Start,
+        )
+        HedvigText(
+          text = stringResource(Res.string.INBOX_NEW_MESSAGE_SUPPORT_DESCRIPTION),
+          textAlign = TextAlign.Start,
+          color = HedvigTheme.colorScheme.textSecondary,
+          style = HedvigTheme.typography.finePrint,
+        )
+      }
+    }
+    Spacer(Modifier.height(4.dp))
+    HedvigCard(
+      onClick = onStartNewClaim,
+      modifier = Modifier
+        .fillMaxWidth(),
+    ) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier.padding(start = 16.dp, bottom = 14.dp, top = 12.dp, end = 12.dp),
+      ) {
+        HedvigText(
+          text = stringResource(Res.string.home_tab_claim_button_text),
+          textAlign = TextAlign.Start,
+        )
+        HedvigText(
+          text = stringResource(Res.string.INBOX_NEW_MESSAGE_CLAIM_DESCRIPTION),
+          textAlign = TextAlign.Start,
+          color = HedvigTheme.colorScheme.textSecondary,
+          style = HedvigTheme.typography.finePrint,
+        )
+      }
+    }
+    Spacer(Modifier.height(16.dp))
+    HedvigButton(
+      text = stringResource(Res.string.general_close_button),
+      enabled = true,
+      buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
+      onClick = {
+        dismiss()
+      },
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
+  }
+}
+
+@Composable
 private fun InboxSuccessScreen(
   inboxConversations: List<InboxConversation>,
   onConversationClick: (id: String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
-  showNewConversationButton: Boolean
+  showNewConversationButton: Boolean,
 ) {
   val lazyListState = rememberLazyListState()
   SideEffect {
@@ -225,8 +341,8 @@ private fun InboxSuccessScreen(
         iconStyle = EmptyStateDefaults.EmptyStateIconStyle.NO_ICON,
         buttonStyle = if (showNewConversationButton) EmptyStateDefaults.EmptyStateButtonStyle.Button(
           stringResource(Res.string.open_chat),
-          onNavigateToNewConversation
-        ) else EmptyStateDefaults.EmptyStateButtonStyle.NoButton
+          onNavigateToNewConversation,
+        ) else EmptyStateDefaults.EmptyStateButtonStyle.NoButton,
       )
     }
   }
@@ -349,7 +465,6 @@ private fun ConversationCard(
 }
 
 @HedvigPreview
-@PreviewFontScale
 @Composable
 private fun EmptyInboxSuccessScreenPreview(
   @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) case: Boolean,
@@ -359,19 +474,29 @@ private fun EmptyInboxSuccessScreenPreview(
       InboxScreen(
         InboxUiState.Success(
           listOf(),
-          case
+          case,
 
-        ),
+          ),
         {},
         {},
-        {}, {},
+        {}, {}, {}
       )
     }
   }
 }
 
 @HedvigPreview
-@PreviewFontScale
+@Composable
+private fun BottomSheetPreview(
+) {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      NewChatSelectBottomSheetContent({}, {}, {})
+    }
+  }
+}
+
+@HedvigPreview
 @Composable
 private fun InboxSuccessScreenPreview(
   @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) case: Boolean,
@@ -388,11 +513,11 @@ private fun InboxSuccessScreenPreview(
             mockInboxConversation3.copy(conversationId = "101"),
             mockInboxConversationLegacy,
           ),
-          newConversationButtonAvailable = case
+          newConversationButtonAvailable = case,
         ),
         {},
         {},
-        {}, {},
+        {}, {}, {}
       )
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -44,6 +44,9 @@ import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightC
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
 import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.design.system.hedvig.TopAppBar
+import com.hedvig.android.design.system.hedvig.TopAppBarActionType
+import com.hedvig.android.design.system.hedvig.TopAppBarLayoutForActions
 import com.hedvig.android.design.system.hedvig.TopAppBarWithBack
 import com.hedvig.android.design.system.hedvig.datepicker.formatInstantForTalkBack
 import com.hedvig.android.design.system.hedvig.datepicker.getLocale
@@ -97,9 +100,13 @@ private fun InboxScreen(
     modifier = Modifier.fillMaxSize(),
   ) {
     Column {
-      TopAppBarWithBack(
+      TopAppBar(
         title = stringResource(Res.string.CHAT_CONVERSATION_INBOX),
-        onClick = navigateUp,
+        actionType = TopAppBarActionType.BACK,
+        onActionClick = navigateUp,
+        topAppBarActions = {
+          //TODO
+        }
       )
       when (uiState) {
         InboxUiState.Loading -> HedvigFullScreenCenterAlignedProgressDebounced()

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -1,7 +1,10 @@
 package com.hedvig.android.feature.chat.inbox
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -12,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -21,7 +25,9 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
@@ -30,9 +36,12 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hedvig.android.compose.ui.EmptyContentDescription
 import com.hedvig.android.compose.ui.preview.TripleBooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.TripleCase
 import com.hedvig.android.design.system.hedvig.DividerPosition
+import com.hedvig.android.design.system.hedvig.EmptyState
+import com.hedvig.android.design.system.hedvig.EmptyStateDefaults
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.design.system.hedvig.HedvigPreview
@@ -43,14 +52,15 @@ import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighLightS
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightShade
 import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTaken
+import com.hedvig.android.design.system.hedvig.Icon
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TopAppBar
 import com.hedvig.android.design.system.hedvig.TopAppBarActionType
-import com.hedvig.android.design.system.hedvig.TopAppBarLayoutForActions
-import com.hedvig.android.design.system.hedvig.TopAppBarWithBack
 import com.hedvig.android.design.system.hedvig.datepicker.formatInstantForTalkBack
 import com.hedvig.android.design.system.hedvig.datepicker.getLocale
 import com.hedvig.android.design.system.hedvig.horizontalDivider
+import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
+import com.hedvig.android.design.system.hedvig.icon.PenEdit
 import com.hedvig.android.feature.chat.model.InboxConversation
 import com.hedvig.android.feature.chat.model.InboxConversation.Header
 import com.hedvig.android.feature.chat.model.InboxConversation.LatestMessage.File
@@ -65,11 +75,16 @@ import hedvig.resources.CHAT_NEW_MESSAGE
 import hedvig.resources.CHAT_SENDER_MEMBER
 import hedvig.resources.CHAT_SENT_A_FILE
 import hedvig.resources.CHAT_SENT_A_MESSAGE
+import hedvig.resources.HC_CHAT_BUTTON
 import hedvig.resources.HEDVIG_NAME_TEXT
+import hedvig.resources.INBOX_EMPTY_STATE_SUBTITLE
+import hedvig.resources.INBOX_EMPTY_STATE_TITLE
+import hedvig.resources.INBOX_NEW_MESSAGE
 import hedvig.resources.Res
 import hedvig.resources.TALKBACK_CONVERSATION_DESCRIPTION
 import hedvig.resources.claim_status_bar_closed
 import hedvig.resources.home_claim_card_pill_claim
+import hedvig.resources.open_chat
 import kotlin.time.Clock
 import org.jetbrains.compose.resources.stringResource
 
@@ -78,6 +93,7 @@ internal fun InboxDestination(
   viewModel: InboxViewModel,
   navigateUp: () -> Unit,
   onConversationClick: (id: String) -> Unit,
+  onNavigateToNewConversation: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   InboxScreen(
@@ -85,6 +101,7 @@ internal fun InboxDestination(
     navigateUp = navigateUp,
     onConversationClick = onConversationClick,
     reload = { viewModel.emit(InboxEvent.Reload) },
+    onNavigateToNewConversation = onNavigateToNewConversation,
   )
 }
 
@@ -93,6 +110,7 @@ private fun InboxScreen(
   uiState: InboxUiState,
   navigateUp: () -> Unit,
   onConversationClick: (id: String) -> Unit,
+  onNavigateToNewConversation: () -> Unit,
   reload: () -> Unit,
 ) {
   Surface(
@@ -105,8 +123,8 @@ private fun InboxScreen(
         actionType = TopAppBarActionType.BACK,
         onActionClick = navigateUp,
         topAppBarActions = {
-          //TODO
-        }
+          NewConversationButton(onNavigateToNewConversation)
+        },
       )
       when (uiState) {
         InboxUiState.Loading -> HedvigFullScreenCenterAlignedProgressDebounced()
@@ -121,6 +139,7 @@ private fun InboxScreen(
         is InboxUiState.Success -> InboxSuccessScreen(
           uiState.inboxConversations,
           onConversationClick,
+          onNavigateToNewConversation
         )
       }
     }
@@ -128,7 +147,34 @@ private fun InboxScreen(
 }
 
 @Composable
-private fun InboxSuccessScreen(inboxConversations: List<InboxConversation>, onConversationClick: (id: String) -> Unit) {
+private fun NewConversationButton(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier
+      .clip(HedvigTheme.shapes.cornerXSmall)
+      .clickable(
+        onClickLabel = stringResource(Res.string.HC_CHAT_BUTTON),
+        role = Role.Button,
+        onClick = onClick,
+      ),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(HedvigIcons.PenEdit, EmptyContentDescription)
+    Spacer(Modifier.width(6.dp))
+    HedvigText(
+      stringResource(Res.string.INBOX_NEW_MESSAGE),
+    )
+  }
+}
+
+@Composable
+private fun InboxSuccessScreen(
+  inboxConversations: List<InboxConversation>,
+  onConversationClick: (id: String) -> Unit,
+  onNavigateToNewConversation: () -> Unit,
+) {
   val lazyListState = rememberLazyListState()
   SideEffect {
     // Keep at the top of the list if we are already at the top and there is a re-arrangement
@@ -137,28 +183,46 @@ private fun InboxSuccessScreen(inboxConversations: List<InboxConversation>, onCo
       lazyListState.requestScrollToItem(0)
     }
   }
-  LazyColumn(
-    state = lazyListState,
-    contentPadding = WindowInsets.safeDrawing
-      .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
-      .asPaddingValues(),
-  ) {
-    itemsIndexed(
-      items = inboxConversations,
-      key = { _, item -> item.conversationId },
-    ) { index, conversation ->
-      Column(
-        modifier = Modifier.animateItem(
-          fadeInSpec = null,
-          fadeOutSpec = null,
-        ),
-      ) {
-        ConversationCard(
-          conversation = conversation,
-          onConversationClick = onConversationClick,
-          modifier = Modifier.horizontalDivider(DividerPosition.Top, show = index != 0),
-        )
+  if (inboxConversations.isNotEmpty()) {
+    LazyColumn(
+      state = lazyListState,
+      contentPadding = WindowInsets.safeDrawing
+        .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
+        .asPaddingValues(),
+    ) {
+      itemsIndexed(
+        items = inboxConversations,
+        key = { _, item -> item.conversationId },
+      ) { index, conversation ->
+        Column(
+          modifier = Modifier.animateItem(
+            fadeInSpec = null,
+            fadeOutSpec = null,
+          ),
+        ) {
+          ConversationCard(
+            conversation = conversation,
+            onConversationClick = onConversationClick,
+            modifier = Modifier.horizontalDivider(DividerPosition.Top, show = index != 0),
+          )
+        }
       }
+    }
+  } else {
+    Column(
+      Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      EmptyState(
+        text = stringResource(Res.string.INBOX_EMPTY_STATE_TITLE),
+        description = stringResource(Res.string.INBOX_EMPTY_STATE_SUBTITLE),
+        iconStyle = EmptyStateDefaults.EmptyStateIconStyle.NO_ICON,
+        buttonStyle = EmptyStateDefaults.EmptyStateButtonStyle.Button(
+          stringResource(Res.string.open_chat),
+          onNavigateToNewConversation
+        )
+      )
     }
   }
 }
@@ -282,6 +346,24 @@ private fun ConversationCard(
 @HedvigPreview
 @PreviewFontScale
 @Composable
+private fun EmptyInboxSuccessScreenPreview() {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      InboxScreen(
+        InboxUiState.Success(
+          listOf(),
+        ),
+        {},
+        {},
+        {}, {},
+      )
+    }
+  }
+}
+
+@HedvigPreview
+@PreviewFontScale
+@Composable
 private fun InboxSuccessScreenPreview() {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
@@ -298,7 +380,7 @@ private fun InboxSuccessScreenPreview() {
         ),
         {},
         {},
-        {},
+        {}, {},
       )
     }
   }

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxViewModel.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxViewModel.kt
@@ -9,20 +9,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.hedvig.android.feature.chat.data.GetAllConversationsUseCase
 import com.hedvig.android.feature.chat.model.InboxConversation
+import com.hedvig.android.featureflags.FeatureManager
+import com.hedvig.android.featureflags.flags.Feature
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 
 internal class InboxViewModel(
   getAllConversationsUseCase: GetAllConversationsUseCase,
+  featureManager: FeatureManager,
 ) : MoleculeViewModel<InboxEvent, InboxUiState>(
     initialState = InboxUiState.Loading,
-    presenter = InboxPresenter(getAllConversationsUseCase),
+    presenter = InboxPresenter(getAllConversationsUseCase,featureManager),
   )
 
 internal class InboxPresenter(
   private val getAllConversationsUseCase: GetAllConversationsUseCase,
+  private val featureManager: FeatureManager,
 ) : MoleculePresenter<InboxEvent, InboxUiState> {
   @Composable
   override fun MoleculePresenterScope<InboxEvent>.present(lastState: InboxUiState): InboxUiState {
@@ -43,15 +48,22 @@ internal class InboxPresenter(
       if (currentState !is InboxUiState.Success) {
         currentState = InboxUiState.Loading
       }
-      getAllConversationsUseCase.invoke().collectLatest { result ->
-        result.fold(
+      combine(
+        getAllConversationsUseCase.invoke(),
+        featureManager.isFeatureEnabled(Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT)
+        ) { conversations, newChatButtonAvailable ->
+        conversations to newChatButtonAvailable
+      }.collectLatest { (conversations, newChatButtonAvailable) ->
+        conversations.fold(
           ifLeft = {
             if (currentState is InboxUiState.Loading) {
               currentState = InboxUiState.Failure
             }
           },
           ifRight = { conversations ->
-            currentState = InboxUiState.Success(conversations)
+            currentState = InboxUiState.Success(
+              conversations,
+              newChatButtonAvailable)
           },
         )
       }
@@ -67,6 +79,7 @@ internal sealed interface InboxUiState {
 
   data class Success(
     val inboxConversations: List<InboxConversation>,
+    val newConversationButtonAvailable: Boolean
   ) : InboxUiState
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/CbmChatGraph.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/CbmChatGraph.kt
@@ -25,6 +25,7 @@ fun NavGraphBuilder.cbmChatGraph(
   openUrl: (String) -> Unit,
   onNavigateToClaimDetails: (claimId: String) -> Unit,
   onNavigateToImageViewer: (imageUrl: String, cacheKey: String) -> Unit,
+  onNavigateToNewConversation: () -> Unit,
   navController: NavController,
 ) {
   navgraph<ChatDestination>(
@@ -43,6 +44,7 @@ fun NavGraphBuilder.cbmChatGraph(
         onConversationClick = dropUnlessResumed { conversationId ->
           navController.navigate(ChatDestinations.Chat(conversationId))
         },
+        onNavigateToNewConversation = onNavigateToNewConversation,
       )
     }
     navdestination<ChatDestinations.Chat>(

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/CbmChatGraph.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/navigation/CbmChatGraph.kt
@@ -13,6 +13,7 @@ import com.hedvig.android.feature.chat.inbox.InboxViewModel
 import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
 import com.hedvig.android.navigation.compose.navgraph
+import com.hedvig.android.navigation.compose.typedPopUpTo
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -27,6 +28,7 @@ fun NavGraphBuilder.cbmChatGraph(
   onNavigateToImageViewer: (imageUrl: String, cacheKey: String) -> Unit,
   onNavigateToNewConversation: () -> Unit,
   navController: NavController,
+  navigateToClaimChat: () -> Unit,
 ) {
   navgraph<ChatDestination>(
     startDestination = ChatDestinations.Inbox::class,
@@ -45,6 +47,7 @@ fun NavGraphBuilder.cbmChatGraph(
           navController.navigate(ChatDestinations.Chat(conversationId))
         },
         onNavigateToNewConversation = onNavigateToNewConversation,
+        navigateToClaimChat = navigateToClaimChat
       )
     }
     navdestination<ChatDestinations.Chat>(

--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatNavGraph.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatNavGraph.kt
@@ -8,6 +8,7 @@ import com.hedvig.android.navigation.common.Destination
 import com.hedvig.android.navigation.common.DestinationNavTypeAware
 import com.hedvig.android.navigation.compose.navDeepLinks
 import com.hedvig.android.navigation.compose.navdestination
+import com.hedvig.android.navigation.compose.typedPopBackStack
 import com.hedvig.android.navigation.compose.typedPopUpTo
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.ui.force.upgrade.ForceUpgradeBlockingScreen
@@ -61,6 +62,7 @@ fun NavGraphBuilder.claimChatGraph(
   imageLoader: ImageLoader,
   onNavigateToNewConversation: () -> Unit,
   openPlayStore: () -> Unit,
+  closeFlowOnSuccess: ()-> Unit,
 ) {
   navdestination<ClaimChatDestination> {
     ClaimChatDestination(
@@ -100,7 +102,7 @@ fun NavGraphBuilder.claimChatGraph(
   }
   navdestination<ClaimOutcomeNewClaimDestination>(ClaimOutcomeNewClaimDestination) {
     ClaimOutcomeNewClaimDestination(
-      navController::navigateUp,
+      closeFlowOnSuccess,
     )
   }
   navdestination<UpdateAppDestination> {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeModule.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeModule.kt
@@ -22,13 +22,12 @@ import org.koin.dsl.module
 val homeModule = module {
   single<GetHomeDataUseCaseImpl> {
     GetHomeDataUseCaseImpl(
-      get<ApolloClient>(),
-      get<HasAnyActiveConversationUseCase>(),
-      get<GetMemberRemindersUseCase>(),
-      get<FeatureManager>(),
-      get<Clock>(),
-      get<TimeZone>(),
-      get<GetTravelAddonBannerInfoUseCaseProvider>(),
+      apolloClient = get<ApolloClient>(),
+      getMemberRemindersUseCase = get<GetMemberRemindersUseCase>(),
+      featureManager = get<FeatureManager>(),
+      clock = get<Clock>(),
+      timeZone = get<TimeZone>(),
+      getTravelAddonBannerInfoUseCaseProvider = get<GetTravelAddonBannerInfoUseCaseProvider>(),
     )
   }
   single<SeenImportantMessagesStorage> {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeModule.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/di/HomeModule.kt
@@ -28,6 +28,7 @@ val homeModule = module {
       clock = get<Clock>(),
       timeZone = get<TimeZone>(),
       getTravelAddonBannerInfoUseCaseProvider = get<GetTravelAddonBannerInfoUseCaseProvider>(),
+      hasAnyActiveConversationUseCase = get<HasAnyActiveConversationUseCase>(),
     )
   }
   single<SeenImportantMessagesStorage> {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -3,6 +3,7 @@ package com.hedvig.android.feature.home.home.data
 import androidx.compose.runtime.Immutable
 import arrow.core.Either
 import arrow.core.NonEmptyList
+import arrow.core.raise.context.bind
 import arrow.core.raise.either
 import arrow.core.raise.nullable
 import arrow.core.toNonEmptyListOrNull
@@ -17,10 +18,8 @@ import com.hedvig.android.crosssells.RecommendedCrossSell
 import com.hedvig.android.data.addons.data.AddonBannerInfo
 import com.hedvig.android.data.addons.data.AddonBannerSource
 import com.hedvig.android.data.addons.data.GetTravelAddonBannerInfoUseCaseProvider
-import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.CrossSell
 import com.hedvig.android.data.contract.ImageAsset
-import com.hedvig.android.data.contract.toContractGroup
 import com.hedvig.android.data.conversations.HasAnyActiveConversationUseCase
 import com.hedvig.android.featureflags.FeatureManager
 import com.hedvig.android.featureflags.flags.Feature
@@ -58,6 +57,7 @@ internal class GetHomeDataUseCaseImpl(
   private val clock: Clock,
   private val timeZone: TimeZone,
   private val getTravelAddonBannerInfoUseCaseProvider: GetTravelAddonBannerInfoUseCaseProvider,
+  private val hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
 ) : GetHomeDataUseCase {
   override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> {
     return combine(
@@ -81,12 +81,16 @@ internal class GetHomeDataUseCaseImpl(
         emitAll(getTravelAddonBannerInfoUseCaseProvider.provide().invoke(AddonBannerSource.INSURANCES_TAB))
       },
       featureManager.isFeatureEnabled(Feature.HELP_CENTER),
+      featureManager.isFeatureEnabled(Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT),
+      hasAnyActiveConversationUseCase.invoke(alwaysHitTheNetwork = true),
     ) {
       homeQueryDataResult,
       unreadMessageCountResult,
       memberReminders,
       travelBannerInfo,
       isHelpCenterEnabled,
+      inboxAlwaysAvailable,
+      anyActiveConversations
       ->
       either {
         val homeQueryData: HomeQuery.Data = homeQueryDataResult.bind()
@@ -139,6 +143,10 @@ internal class GetHomeDataUseCaseImpl(
           recommendedCrossSell = recommendedCrossSell,
           otherCrossSells = otherCrossSellsData,
         )
+        val showChatIcon = shouldShowChatButton(
+          isInboxEnabledFromKillSwitch = inboxAlwaysAvailable,
+          hasActiveConversations = anyActiveConversations.bind()
+        )
         val unreadMessageCountData = unreadMessageCountResult.bind()
         val hasUnseenChatMessages = unreadMessageCountData
           .currentMember
@@ -166,6 +174,7 @@ internal class GetHomeDataUseCaseImpl(
           firstVetSections = firstVetActions,
           crossSells = crossSells,
           travelBannerInfo = travelBannerInfo?.firstOrNull(),
+          showChatIcon = showChatIcon,
         )
       }.onLeft { error: ApolloOperationError ->
         logcat(operationError = error) { "GetHomeDataUseCase failed with $error" }
@@ -173,16 +182,12 @@ internal class GetHomeDataUseCaseImpl(
     }
   }
 
-  private fun shouldHideChatButton(
-    isChatDisabledFromKillSwitch: Boolean,
-    isEligibleToShowTheChatIcon: Boolean,
-    isHelpCenterEnabled: Boolean,
+  private fun shouldShowChatButton(
+    isInboxEnabledFromKillSwitch: Boolean,
+    hasActiveConversations: Boolean,
   ): Boolean {
-    // If the feature flag is off, we should hide the chat button regardless of the other conditions
-    if (isChatDisabledFromKillSwitch) return true
-    // If the help center is disabled, we must always show the chat button, otherwise there is no way to get to the chat
-    if (!isHelpCenterEnabled) return false
-    return !isEligibleToShowTheChatIcon
+    if (isInboxEnabledFromKillSwitch) return true
+    return hasActiveConversations
   }
 
   private fun HomeQuery.Data.CurrentMember.toContractStatus(): HomeData.ContractStatus {
@@ -275,6 +280,7 @@ internal data class HomeData(
   val claimStatusCardsData: ClaimStatusCardsData?,
   val veryImportantMessages: List<VeryImportantMessage>,
   val memberReminders: MemberReminders,
+  val showChatIcon: Boolean,
   val hasUnseenChatMessages: Boolean,
   val showHelpCenter: Boolean,
   val firstVetSections: List<FirstVetSection>,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -53,7 +53,6 @@ internal interface GetHomeDataUseCase {
 
 internal class GetHomeDataUseCaseImpl(
   private val apolloClient: ApolloClient,
-  private val hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
   private val getMemberRemindersUseCase: GetMemberRemindersUseCase,
   private val featureManager: FeatureManager,
   private val clock: Clock,
@@ -77,20 +76,16 @@ internal class GetHomeDataUseCaseImpl(
           delay(5.seconds)
         }
       },
-      hasAnyActiveConversationUseCase.invoke(alwaysHitTheNetwork = true),
       getMemberRemindersUseCase.invoke(),
       flow {
         emitAll(getTravelAddonBannerInfoUseCaseProvider.provide().invoke(AddonBannerSource.INSURANCES_TAB))
       },
-      featureManager.isFeatureEnabled(Feature.DISABLE_CHAT),
       featureManager.isFeatureEnabled(Feature.HELP_CENTER),
     ) {
       homeQueryDataResult,
       unreadMessageCountResult,
-      isEligibleToShowTheChatIconResult,
       memberReminders,
       travelBannerInfo,
-      isChatDisabled,
       isHelpCenterEnabled,
       ->
       either {
@@ -144,11 +139,6 @@ internal class GetHomeDataUseCaseImpl(
           recommendedCrossSell = recommendedCrossSell,
           otherCrossSells = otherCrossSellsData,
         )
-        val showChatIcon = !shouldHideChatButton(
-          isChatDisabledFromKillSwitch = isChatDisabled,
-          isEligibleToShowTheChatIcon = isEligibleToShowTheChatIconResult.bind(),
-          isHelpCenterEnabled = isHelpCenterEnabled,
-        )
         val unreadMessageCountData = unreadMessageCountResult.bind()
         val hasUnseenChatMessages = unreadMessageCountData
           .currentMember
@@ -171,7 +161,6 @@ internal class GetHomeDataUseCaseImpl(
           claimStatusCardsData = homeQueryData.claimStatusCards(),
           veryImportantMessages = veryImportantMessages,
           memberReminders = memberReminders,
-          showChatIcon = showChatIcon,
           hasUnseenChatMessages = hasUnseenChatMessages,
           showHelpCenter = isHelpCenterEnabled,
           firstVetSections = firstVetActions,
@@ -286,7 +275,6 @@ internal data class HomeData(
   val claimStatusCardsData: ClaimStatusCardsData?,
   val veryImportantMessages: List<VeryImportantMessage>,
   val memberReminders: MemberReminders,
-  val showChatIcon: Boolean,
   val hasUnseenChatMessages: Boolean,
   val showHelpCenter: Boolean,
   val firstVetSections: List<FirstVetSection>,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
@@ -22,7 +22,6 @@ internal class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
         upcomingRenewals = null,
         enableNotifications = null,
       ),
-      showChatIcon = false,
       hasUnseenChatMessages = false,
       showHelpCenter = true,
       firstVetSections = listOf(),

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
@@ -53,6 +53,7 @@ internal class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
         ),
       ),
       travelBannerInfo = null,
+      showChatIcon = false
     ).right(),
   )
 }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -301,7 +301,7 @@ private fun HomeScreen(
           val actionsList = buildList {
             if (currentState.crossSellsAction != null) add(currentState.crossSellsAction)
             if (currentState.firstVetAction != null) add(currentState.firstVetAction)
-            add(currentState.chatAction)
+            if (currentState.chatAction != null) add(currentState.chatAction)
           }
           actionsList.forEach { action ->
             when (action) {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -301,7 +301,7 @@ private fun HomeScreen(
           val actionsList = buildList {
             if (currentState.crossSellsAction != null) add(currentState.crossSellsAction)
             if (currentState.firstVetAction != null) add(currentState.firstVetAction)
-            if (currentState.chatAction != null) add(currentState.chatAction)
+            add(currentState.chatAction)
           }
           actionsList.forEach { action ->
             when (action) {
@@ -883,7 +883,7 @@ private fun PreviewHomeScreenAllHomeTextTypes(
           hasUnseenChatMessages = false,
           crossSellsAction = null,
           firstVetAction = null,
-          chatAction = null,
+          chatAction = ChatAction,
           addonBannerInfo = null,
           isProduction = true,
         ),

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -85,6 +85,7 @@ import com.hedvig.android.design.system.hedvig.HedvigTooltip
 import com.hedvig.android.design.system.hedvig.LocalContentColor
 import com.hedvig.android.design.system.hedvig.NotificationDefaults
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority
+import com.hedvig.android.design.system.hedvig.StartClaimBottomSheet
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TooltipDefaults
 import com.hedvig.android.design.system.hedvig.TooltipDefaults.BeakDirection.TopEnd

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
@@ -134,7 +134,7 @@ internal class HomePresenter(
           },
           isHelpCenterEnabled = successData.showHelpCenter,
           hasUnseenChatMessages = successData.hasUnseenChatMessages,
-          chatAction = successData.chatAction,
+          chatAction = HomeTopBarAction.ChatAction,
           firstVetAction = successData.firstVetAction,
           crossSellsAction = successData.crossSellsAction,
           addonBannerInfo = successData.addonBannerInfo,
@@ -171,7 +171,7 @@ internal sealed interface HomeUiState {
     val claimStatusCardsData: HomeData.ClaimStatusCardsData?,
     val veryImportantMessages: List<HomeData.VeryImportantMessage>,
     val memberReminders: MemberReminders,
-    val chatAction: HomeTopBarAction.ChatAction?,
+    val chatAction: HomeTopBarAction.ChatAction,
     val firstVetAction: HomeTopBarAction.FirstVetAction?,
     val crossSellsAction: HomeTopBarAction.CrossSellsAction?,
     val addonBannerInfo: AddonBannerInfo?,
@@ -191,7 +191,6 @@ private data class SuccessData(
   val veryImportantMessages: List<HomeData.VeryImportantMessage>,
   val memberReminders: MemberReminders,
   val showHelpCenter: Boolean,
-  val chatAction: HomeTopBarAction.ChatAction?,
   val firstVetAction: HomeTopBarAction.FirstVetAction?,
   val crossSellsAction: HomeTopBarAction.CrossSellsAction?,
   val hasUnseenChatMessages: Boolean,
@@ -206,7 +205,6 @@ private data class SuccessData(
         veryImportantMessages = lastState.veryImportantMessages,
         memberReminders = lastState.memberReminders,
         showHelpCenter = lastState.isHelpCenterEnabled,
-        chatAction = lastState.chatAction,
         crossSellsAction = lastState.crossSellsAction,
         firstVetAction = lastState.firstVetAction,
         hasUnseenChatMessages = lastState.hasUnseenChatMessages,
@@ -226,7 +224,6 @@ private data class SuccessData(
         null
       }
 
-      val chatAction = if (homeData.showChatIcon) HomeTopBarAction.ChatAction else null
       val firstVetAction = if (homeData.firstVetSections.isNotEmpty()) {
         HomeTopBarAction.FirstVetAction(homeData.firstVetSections)
       } else {
@@ -254,7 +251,6 @@ private data class SuccessData(
           enableNotifications = null,
         ),
         showHelpCenter = homeData.showHelpCenter,
-        chatAction = chatAction,
         firstVetAction = firstVetAction,
         crossSellsAction = crossSellsAction,
         hasUnseenChatMessages = homeData.hasUnseenChatMessages,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
@@ -134,7 +134,7 @@ internal class HomePresenter(
           },
           isHelpCenterEnabled = successData.showHelpCenter,
           hasUnseenChatMessages = successData.hasUnseenChatMessages,
-          chatAction = HomeTopBarAction.ChatAction,
+          chatAction = successData.chatAction,
           firstVetAction = successData.firstVetAction,
           crossSellsAction = successData.crossSellsAction,
           addonBannerInfo = successData.addonBannerInfo,
@@ -171,7 +171,7 @@ internal sealed interface HomeUiState {
     val claimStatusCardsData: HomeData.ClaimStatusCardsData?,
     val veryImportantMessages: List<HomeData.VeryImportantMessage>,
     val memberReminders: MemberReminders,
-    val chatAction: HomeTopBarAction.ChatAction,
+    val chatAction: HomeTopBarAction.ChatAction?,
     val firstVetAction: HomeTopBarAction.FirstVetAction?,
     val crossSellsAction: HomeTopBarAction.CrossSellsAction?,
     val addonBannerInfo: AddonBannerInfo?,
@@ -191,6 +191,7 @@ private data class SuccessData(
   val veryImportantMessages: List<HomeData.VeryImportantMessage>,
   val memberReminders: MemberReminders,
   val showHelpCenter: Boolean,
+  val chatAction: HomeTopBarAction.ChatAction?,
   val firstVetAction: HomeTopBarAction.FirstVetAction?,
   val crossSellsAction: HomeTopBarAction.CrossSellsAction?,
   val hasUnseenChatMessages: Boolean,
@@ -209,6 +210,7 @@ private data class SuccessData(
         firstVetAction = lastState.firstVetAction,
         hasUnseenChatMessages = lastState.hasUnseenChatMessages,
         addonBannerInfo = lastState.addonBannerInfo,
+        chatAction = lastState.chatAction
       )
     }
 
@@ -255,6 +257,7 @@ private data class SuccessData(
         crossSellsAction = crossSellsAction,
         hasUnseenChatMessages = homeData.hasUnseenChatMessages,
         addonBannerInfo = homeData.travelBannerInfo,
+        chatAction = if (homeData.showChatIcon) HomeTopBarAction.ChatAction else null
       )
     }
   }

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
@@ -123,12 +123,13 @@ internal class GetHomeUseCaseTest {
           CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
         )
       },
-      HasAnyActiveConversationUseCase(apolloClient),
+
       testGetMemberRemindersUseCase,
       FakeFeatureManager(true),
       TestClock(),
       TimeZone.UTC,
       getTravelAddonBannerInfoUseCaseProvider = travelBannerProvider,
+      HasAnyActiveConversationUseCase(apolloClient),
     )
     val testId = "test"
 
@@ -172,12 +173,13 @@ internal class GetHomeUseCaseTest {
           CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
         )
       },
-      HasAnyActiveConversationUseCase(apolloClient),
+
       testGetMemberRemindersUseCase,
       FakeFeatureManager(true),
       TestClock(),
       TimeZone.UTC,
       travelBannerProvider,
+      HasAnyActiveConversationUseCase(apolloClient),
     )
 
     testGetMemberRemindersUseCase.memberReminders.add(MemberReminders())
@@ -495,9 +497,10 @@ internal class GetHomeUseCaseTest {
   ) = runTest {
     val featureManager = FakeFeatureManager(
       mapOf(
-        Feature.DISABLE_CHAT to false,
         Feature.HELP_CENTER to true,
         Feature.ENABLE_CLAIM_HISTORY to true,
+        // With the inbox-always-available kill switch off, the icon depends purely on existing conversations
+        Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT to false,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -553,16 +556,15 @@ internal class GetHomeUseCaseTest {
   }
 
   @Test
-  fun `showChatIcon depends on if there are existing messages, and on the help center and chat feature flags`(
-    @TestParameter chatIsKillSwitched: Boolean,
-    @TestParameter helpCenterIsEnabled: Boolean,
+  fun `showChatIcon is true when the inbox is always available, or when there are existing eligible messages`(
+    @TestParameter inboxAlwaysAvailable: Boolean,
     @TestParameter isEligibleToSeeTheChatButton: Boolean,
   ) = runTest {
     val featureManager = FakeFeatureManager(
       mapOf(
-        Feature.DISABLE_CHAT to chatIsKillSwitched,
-        Feature.HELP_CENTER to helpCenterIsEnabled,
+        Feature.HELP_CENTER to true,
         Feature.ENABLE_CLAIM_HISTORY to true,
+        Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT to inboxAlwaysAvailable,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -602,22 +604,14 @@ internal class GetHomeUseCaseTest {
       .isRight()
       .prop(HomeData::showChatIcon)
       .apply {
-        if (chatIsKillSwitched) {
-          // No matter what, if the chat is disabled, we do not show the chat button
-          isFalse()
+        if (inboxAlwaysAvailable) {
+          // When the inbox-always-available kill switch is on, we always show the chat button
+          isTrue()
+        } else if (isEligibleToSeeTheChatButton) {
+          // Otherwise we show it only when there is an active conversation to get back to
+          isTrue()
         } else {
-          if (isEligibleToSeeTheChatButton) {
-            // If they are eligible to see the chat button, we just show it
-            isTrue()
-          } else {
-            if (helpCenterIsEnabled) {
-              isFalse()
-            } else {
-              // Despite not being eligible to see the chat button, if the help center is disabled, we must show the
-              // chat button to allow them to still get to the chat in some way
-              isTrue()
-            }
-          }
+          isFalse()
         }
       }
   }
@@ -628,9 +622,9 @@ internal class GetHomeUseCaseTest {
   ) = runTest {
     val featureManager = FakeFeatureManager(
       mapOf(
-        Feature.DISABLE_CHAT to true,
         Feature.HELP_CENTER to helpCenterIsEnabled,
         Feature.ENABLE_CLAIM_HISTORY to true,
+        Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT to false,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -670,9 +664,10 @@ internal class GetHomeUseCaseTest {
   ) = runTest {
     val featureManager = FakeFeatureManager(
       mapOf(
-        Feature.DISABLE_CHAT to false,
         Feature.HELP_CENTER to true,
         Feature.ENABLE_CLAIM_HISTORY to true,
+        // Inbox-always-available off, so the icon reflects the conversation state being tested here
+        Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT to false,
       ),
     )
     val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager)
@@ -777,12 +772,13 @@ internal class GetHomeUseCaseTest {
   ): GetHomeDataUseCase {
     return GetHomeDataUseCaseImpl(
       apolloClient,
-      HasAnyActiveConversationUseCase(apolloClient),
+
       TestGetMemberRemindersUseCase().apply { memberReminders.add(MemberReminders()) },
       featureManager,
       testClock,
       timeZone,
       travelBannerProvider,
+      HasAnyActiveConversationUseCase(apolloClient),
     )
   }
 }

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -13,7 +13,6 @@ internal class UnleashFeatureFlagProvider(
     return hedvigUnleashClient.featureUpdatedFlow
       .map {
         when (feature) {
-          Feature.DISABLE_CHAT -> hedvigUnleashClient.client.isEnabled("disable_chat")
 
           Feature.MOVING_FLOW -> hedvigUnleashClient.client.isEnabled("moving_flow")
 

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -35,6 +35,8 @@ internal class UnleashFeatureFlagProvider(
           Feature.DISABLE_REDEEM_CAMPAIGN -> hedvigUnleashClient.client.isEnabled("disable_redeem_campaign")
 
           Feature.ENABLE_CLAIM_HISTORY -> hedvigUnleashClient.client.isEnabled("enable_claim_history")
+
+          Feature.ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT -> hedvigUnleashClient.client.isEnabled("enable_new_conversation_from_inbox")
         }
       }.distinctUntilChanged()
   }

--- a/app/featureflags/feature-flags/src/commonMain/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
+++ b/app/featureflags/feature-flags/src/commonMain/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
@@ -19,4 +19,7 @@ enum class Feature(
   ),
   DISABLE_REDEEM_CAMPAIGN("Disables the ability to redeem a campaign code"),
   ENABLE_CLAIM_HISTORY("Enables claim history"),
+  ALWAYS_AVAILABLE_INBOX_AND_NEW_CHAT("Enables inbox icon always available on the Home screen " +
+    "and New conversation button inside the inbox")
+
 }

--- a/app/featureflags/feature-flags/src/commonMain/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
+++ b/app/featureflags/feature-flags/src/commonMain/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
@@ -5,9 +5,6 @@ enum class Feature(
   @Suppress("unused") val explanation: String,
 ) {
   @Suppress("ktlint:standard:max-line-length")
-  DISABLE_CHAT(
-    "This flag determines if the chat feature inside the app should be disabled. This does not disable the ability to navigate to the chat, only that in the chat feature itself, some information should be shown describing that the chat is currently unavailable and they should check back later.",
-  ),
   MOVING_FLOW("Lets a user change their address and get a new offer"),
   PAYMENT_SCREEN("Controls whether the payment screen should be accessible from the profile tab"),
   TERMINATION_FLOW("Shows the button which enters the insurance termination flow from the insurance tab"),


### PR DESCRIPTION
- always visible Inbox icon on Home screen (under feature-flag)
- always available "New conversation button" in Inbox (under feature-flag)
- "honestly pledge" bottom sheet and navigation to Claim flow from Inbox

## a11y
- [ ] if these are UI changes - check for their accessibility