### PR TITLE
Simplify providing all the NotificationSenders to Metro

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationMetroProviders.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/di/ApplicationMetroProviders.kt
@@ -21,22 +21,9 @@ import coil3.svg.SvgDecoder
 import com.apollographql.apollo.ApolloClient
 import com.hedvig.android.app.apollo.LoggingInterceptor
 import com.hedvig.android.app.apollo.LogoutOnUnauthenticatedInterceptor
-import com.hedvig.android.app.navigation.CurrentDestinationHolder
-import com.hedvig.android.app.notification.senders.CarAddonSender
-import com.hedvig.android.app.notification.senders.ChatNotificationSender
-import com.hedvig.android.app.notification.senders.ClaimClosedNotificationSender
-import com.hedvig.android.app.notification.senders.ContactInfoSender
-import com.hedvig.android.app.notification.senders.CrossSellNotificationSender
-import com.hedvig.android.app.notification.senders.GenericNotificationSender
-import com.hedvig.android.app.notification.senders.InsuranceEvidenceNotificationSender
-import com.hedvig.android.app.notification.senders.InsuranceTabNotificationSender
-import com.hedvig.android.app.notification.senders.PaymentNotificationSender
-import com.hedvig.android.app.notification.senders.ReferralsNotificationSender
-import com.hedvig.android.app.notification.senders.TravelAddonSender
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.core.buildconstants.AppBuildConfig
 import com.hedvig.android.core.buildconstants.Flavor
-import com.hedvig.android.core.buildconstants.HedvigBuildConstants
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.common.di.BaseHttpClient
 import com.hedvig.android.core.common.di.DatabaseFile
@@ -44,14 +31,9 @@ import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.design.system.hedvig.pdfrenderer.PdfDecoder
 import com.hedvig.android.navigation.compose.DeepLinkMatcherProvider
 import com.hedvig.android.navigation.compose.HedvigDeepLinkMatcher
-import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.network.clients.ExtraApolloClientConfiguration
-import com.hedvig.android.notification.core.HedvigNotificationChannel
-import com.hedvig.android.notification.core.NotificationSender
-import com.hedvig.android.permission.PermissionManager
 import com.hedvig.app.BuildConfig
 import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
@@ -152,182 +134,6 @@ interface ApplicationMetroProviders {
           .build()
       }.build()
   }
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun providePaymentNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = PaymentNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Payments,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideCrossSellNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-  ): NotificationSender = CrossSellNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    HedvigNotificationChannel.CrossSell,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideReferralsNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = ReferralsNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Referrals,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideGenericNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = GenericNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Other,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideChatNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-    currentDestinationHolder: CurrentDestinationHolder,
-  ): NotificationSender = ChatNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Chat,
-    currentDestinationHolder,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideClaimClosedNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = ClaimClosedNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Payments,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideContactInfoSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = ContactInfoSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Other,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideInsuranceTabNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = InsuranceTabNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Other,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideTravelAddonSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = TravelAddonSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.CrossSell,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideCarAddonSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = CarAddonSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.CrossSell,
-  )
-
-  @Provides
-  @SingleIn(AppScope::class)
-  @IntoSet
-  fun provideInsuranceEvidenceNotificationSender(
-    applicationContext: Context,
-    permissionManager: PermissionManager,
-    buildConstants: HedvigBuildConstants,
-    deepLinkContainer: HedvigDeepLinkContainer,
-  ): NotificationSender = InsuranceEvidenceNotificationSender(
-    applicationContext,
-    permissionManager,
-    buildConstants,
-    deepLinkContainer,
-    HedvigNotificationChannel.Other,
-  )
 }
 
 private class AndroidBuildConfig : AppBuildConfig {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CarAddonSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CarAddonSender.kt
@@ -8,20 +8,28 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class CarAddonSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val deepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.CrossSell
+
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {
     val pendingIntent = PendingIntentCompat.getActivity(
       context,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ChatNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ChatNotificationSender.kt
@@ -21,6 +21,7 @@ import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.navigation.CurrentDestinationHolder
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.LogPriority.ERROR
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.common.SuppressesChatPushNotification
@@ -29,16 +30,23 @@ import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class ChatNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val hedvigDeepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
   private val currentDestinationHolder: CurrentDestinationHolder,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Chat
+
   override fun handlesNotificationType(notificationType: String) = notificationType == NOTIFICATION_TYPE_NEW_MESSAGE
 
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ClaimClosedNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ClaimClosedNotificationSender.kt
@@ -11,6 +11,7 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
@@ -18,15 +19,22 @@ import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class ClaimClosedNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val hedvigDeepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Payments
+
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {
     val claimId = remoteMessage.data.claimIdFromData()
     val intentUri = if (claimId != null) {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ContactInfoSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ContactInfoSender.kt
@@ -8,20 +8,28 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class ContactInfoSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val deepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Other
+
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {
     val pendingIntent = PendingIntentCompat.getActivity(
       context,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CrossSellNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/CrossSellNotificationSender.kt
@@ -9,20 +9,28 @@ import com.hedvig.android.app.notification.DATA_MESSAGE_BODY
 import com.hedvig.android.app.notification.DATA_MESSAGE_TITLE
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class CrossSellNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.CrossSell
+
   override fun handlesNotificationType(notificationType: String) = notificationType == NOTIFICATION_CROSS_SELL
 
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/GenericNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/GenericNotificationSender.kt
@@ -10,22 +10,29 @@ import com.hedvig.android.app.notification.DATA_MESSAGE_BODY
 import com.hedvig.android.app.notification.DATA_MESSAGE_TITLE
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 import java.util.concurrent.atomic.AtomicInteger
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class GenericNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val hedvigDeepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Other
   private val id = AtomicInteger(100)
 
   override fun handlesNotificationType(notificationType: String) =

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/InsuranceEvidenceNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/InsuranceEvidenceNotificationSender.kt
@@ -10,21 +10,29 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class InsuranceEvidenceNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val hedvigDeepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Other
+
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {
     val intentUri = hedvigDeepLinkContainer.insuranceEvidence.first().toUri()
     logcat { "InsuranceEvidenceNotificationSender sending notification with deeplink uri:$intentUri" }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/InsuranceTabNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/InsuranceTabNotificationSender.kt
@@ -8,6 +8,7 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
@@ -15,15 +16,22 @@ import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 internal class InsuranceTabNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val deepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Other
+
   override fun handlesNotificationType(notificationType: String): Boolean =
     NOTIFICATION_TYPE_OPEN_INSURANCE_TAB == notificationType
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/PaymentNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/PaymentNotificationSender.kt
@@ -8,20 +8,28 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class PaymentNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val deepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Payments
+
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {
     when (type) {
       NOTIFICATION_TYPE_CONNECT_DIRECT_DEBIT -> sendConnectDirectDebitNotification()

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ReferralsNotificationSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/ReferralsNotificationSender.kt
@@ -9,20 +9,28 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class ReferralsNotificationSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val deepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.Referrals
+
   override fun handlesNotificationType(notificationType: String) =
     notificationType == NOTIFICATION_TYPE_REFERRAL_SUCCESS
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/TravelAddonSender.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/notification/senders/TravelAddonSender.kt
@@ -8,20 +8,28 @@ import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.hedvig.android.app.notification.intentForNotification
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.navigation.core.HedvigDeepLinkContainer
 import com.hedvig.android.notification.core.HedvigNotificationChannel
 import com.hedvig.android.notification.core.NotificationSender
 import com.hedvig.android.notification.core.sendHedvigNotification
 import com.hedvig.android.permission.PermissionManager
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import hedvig.resources.R
 
+@ContributesIntoSet(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
 class TravelAddonSender(
   private val context: Context,
   private val permissionManager: PermissionManager,
   private val buildConstants: HedvigBuildConstants,
   private val deepLinkContainer: HedvigDeepLinkContainer,
-  private val notificationChannel: HedvigNotificationChannel,
 ) : NotificationSender {
+  private val notificationChannel = HedvigNotificationChannel.CrossSell
+
   override suspend fun sendNotification(type: String, remoteMessage: RemoteMessage) {
     val pendingIntent = PendingIntentCompat.getActivity(
       context,


### PR DESCRIPTION
Each sender's HedvigNotificationChannel was fixed but was provided from the outside. Moving it inside the class itself makes it possible to simply annotate them with @ContributesIntoSet and get the same result