### PR TITLE
Bug: random fake logout — stuck on Marketing screen after resuming from background                                                                                        

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -241,7 +241,10 @@ dependencies {
 
   testImplementation(libs.assertK)
   testImplementation(libs.classgraph)
+  testImplementation(libs.coroutines.test)
   testImplementation(libs.junit)
+  testImplementation(projects.coreDatastoreTest)
+  testImplementation(projects.loggingTest)
 
   debugImplementation(libs.androidx.compose.uiTooling)
   debugImplementation(projects.featureImpersonation)

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
@@ -27,8 +27,11 @@ import kotlinx.coroutines.launch
  * Owns the auth↔backstack reconciliation that used to live as loose effects in `HedvigApp`. Two jobs,
  * both narrowly about the rendered root:
  *  1. [reconcile] picks the start scene (Home when logged in / in demo, Login otherwise) before the
- *     splash is dismissed, so the first frame is correct rather than the seeded Login root. [isReady]
- *     flips true once that resolves and drives the Activity's splash keep-condition.
+ *     splash is dismissed, so the first frame is correct rather than the seeded Login root. It runs for
+ *     every [BackstackController] handed in — not once per process — so a warm-process relaunch that
+ *     seeds a fresh Login root can't strand a logged-in member on the marketing screen. [isReady] gates
+ *     the Activity's splash keep-condition: it drops to false while resolving and latches true again
+ *     once the root matches the auth state.
  *  2. [observeForcedLogout] keeps the root honest while running: log out when we leave demo mode and no
  *     longer hold tokens. It is lifecycle-gated so it only observes while the UI is STARTED.
  *
@@ -51,11 +54,21 @@ internal class SessionReconciler(
   private var lastKnownMemberId: String? = null
 
   /**
-   * Resolves the start scene once, before the splash is dismissed. A no-op on subsequent calls because
-   * [isReady] has already latched true.
+   * Resolves the start scene for [backstackController] before the splash is dismissed, and re-runs for
+   * every controller instance handed in — not just the first.
+   *
+   * [BackstackController] is composition + saved-state scoped, so a new MainActivity launched into an
+   * already-warm process (the process — and therefore this singleton — is still alive, but there is no
+   * saved instance state to restore) seeds a fresh `LoginKey` root. A once-per-process guard would
+   * skip such a controller and strand a still-logged-in member on the marketing screen. Re-running is
+   * safe because [determineStartScene] is idempotent — it only touches the root on a genuine mismatch.
+   *
+   * [isReady] drops to false while resolving so the splash keep-condition holds for this controller too,
+   * then latches true once the root matches the auth state. The hosting `LaunchedEffect` is keyed on the
+   * controller, so this runs once per controller — [isReady] never flips back to false mid-session.
    */
   suspend fun reconcile(backstackController: BackstackController) {
-    if (isReadyState.value) return
+    isReadyState.value = false
     memberIdService.getMemberId().first()?.let { lastKnownMemberId = it }
     determineStartScene(backstackController)
     isReadyState.value = true

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/SessionReconcilerTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/SessionReconcilerTest.kt
@@ -1,0 +1,130 @@
+package com.hedvig.android.app.navigation
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.hedvig.android.auth.AuthStatus
+import com.hedvig.android.auth.AuthTokenService
+import com.hedvig.android.auth.MemberIdService
+import com.hedvig.android.auth.storage.AuthTokenStorage
+import com.hedvig.android.auth.token.AuthTokens
+import com.hedvig.android.auth.token.LocalAccessToken
+import com.hedvig.android.auth.token.LocalRefreshToken
+import com.hedvig.android.core.datastore.TestPreferencesDataStore
+import com.hedvig.android.core.demomode.DemoManager
+import com.hedvig.android.feature.home.home.navigation.HomeKey
+import com.hedvig.android.feature.login.navigation.LoginKey
+import com.hedvig.android.logger.TestLogcatLoggingRule
+import com.hedvig.android.navigation.common.HedvigNavKey
+import com.hedvig.authlib.AccessToken
+import com.hedvig.authlib.RefreshToken
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+internal class SessionReconcilerTest {
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  @get:Rule
+  val testLogcatLogger = TestLogcatLoggingRule()
+
+  @Test
+  fun `reconcile flips a freshly seeded Login root to Home when logged in`() = runTest {
+    val reconciler = sessionReconciler(authStatus = loggedIn())
+    val controller = controllerWith(LoginKey)
+
+    reconciler.reconcile(controller)
+
+    assertThat(controller.entries.toList()).containsExactly(HomeKey)
+  }
+
+  @Test
+  fun `reconcile leaves a logged-out seed on the Login root`() = runTest {
+    val reconciler = sessionReconciler(authStatus = AuthStatus.LoggedOut)
+    val controller = controllerWith(LoginKey)
+
+    reconciler.reconcile(controller)
+
+    assertThat(controller.entries.toList()).containsExactly(LoginKey)
+  }
+
+  // The regression: a new Activity launched into an already-warm process (same singleton reconciler, no
+  // saved state) seeds a fresh Login root. A once-per-process guard skipped it and stranded the member on
+  // the marketing screen; reconcile must resolve every controller it is handed.
+  @Test
+  fun `reconcile re-resolves a fresh Login seed for a second controller in a warm process`() = runTest {
+    val reconciler = sessionReconciler(authStatus = loggedIn())
+    // First Activity resolves to Home and latches readiness.
+    reconciler.reconcile(controllerWith(HomeKey))
+
+    // Second Activity in the same process, seeded to Login because there was no saved state to restore.
+    val secondController = controllerWith(LoginKey)
+    reconciler.reconcile(secondController)
+
+    assertThat(secondController.entries.toList()).containsExactly(HomeKey)
+  }
+
+  private fun controllerWith(vararg keys: HedvigNavKey) = BackstackController(
+    mutableStateListOf(*keys),
+    mutableStateMapOf(),
+    mutableStateOf(null), // pendingDeepLink
+    mutableStateOf(null), // stashedSession
+  )
+
+  private fun TestScope.sessionReconciler(authStatus: AuthStatus): SessionReconciler {
+    val authTokenStorage = AuthTokenStorage(
+      TestPreferencesDataStore(
+        datastoreTestFileDirectory = testFolder.newFolder(),
+        coroutineScope = backgroundScope,
+      ),
+    )
+    return SessionReconciler(
+      authTokenService = FakeAuthTokenService(authStatus),
+      demoManager = FakeDemoManager(),
+      memberIdService = MemberIdService(authTokenStorage),
+    )
+  }
+
+  private fun loggedIn(): AuthStatus.LoggedIn {
+    val expiry = Clock.System.now() + 1.hours
+    return AuthStatus.LoggedIn(
+      LocalAccessToken("access-token", expiry),
+      LocalRefreshToken("refresh-token", expiry),
+    )
+  }
+}
+
+private class FakeAuthTokenService(authStatus: AuthStatus) : AuthTokenService {
+  private val state = MutableStateFlow<AuthStatus?>(authStatus)
+  override val authStatus: StateFlow<AuthStatus?> = state.asStateFlow()
+
+  override suspend fun getTokens(): AuthTokens? = error("Not used in these tests")
+
+  override suspend fun refreshAndGetAccessToken(): AccessToken? = error("Not used in these tests")
+
+  override suspend fun loginWithTokens(accessToken: AccessToken, refreshToken: RefreshToken) =
+    error("Not used in these tests")
+
+  override suspend fun logoutAndInvalidateTokens() = error("Not used in these tests")
+}
+
+private class FakeDemoManager : DemoManager {
+  private val demoMode = MutableStateFlow(false)
+
+  override fun isDemoMode(): Flow<Boolean> = demoMode.asStateFlow()
+
+  override suspend fun setDemoMode(demoMode: Boolean) {
+    this.demoMode.value = demoMode
+  }
+}


### PR DESCRIPTION
Made by Claude. 
Initial prompt:

> "find the root of a bug. Sometimes I open the app, login, than the app is in background for a while, then I resume it - and I end up on this  screen MarketingDestination.kt#L67 which you are supposed to end on when you are not logged in. But I should be logged in yet; and indeed, when I press "Login" button here, I am not taken to SwedishLoginDestination (as it happens when I am logged out), but to HomeDestantion. It started to happen after we migrated from Nav2 to Navigation 3 recently. Look at determineStartScene"

**Root cause**
                                                                                                                                                                       
A scope mismatch in SessionReconciler:                                                                                                                               
                                                                                                                                                                       
  - `SessionReconciler` is a process-scoped singleton, so its `isReady` latch survives across Activity instances.                             
  - `BackstackController` is per-Activity / per-composition, and seeds its root to `LoginKey` whenever there's no saved instance state to restore.                         
                                                                                                                                                                       
`reconcile()` guarded its work with `if (isReadyState.value) return` — once per process. When a new MainActivity is created in an already-warm process with `savedInstanceState == null` (the system reclaimed the Activity but kept the process, then it relaunches fresh), the backstack is seeded to `[LoginKey]`, but `reconcile()` early-returns because `isReady` already latched true on the first launch. `determineStartScene()` never runs, the root is never corrected, and logoutOnInvalidCredentials bails out too (it sees isLoggedIn == false, computed purely from the LoginKey root). Result: Marketing, with valid tokens.                

**Fix**                                                                                                                                                                  
                                                                                                                                                                       
Decouple the splash gate from the once-only reconcile:                                                                                                               
                                                                                                                                                                       
  - `reconcile()` now runs `determineStartScene()` for every `BackstackController` it's handed, not just the first. It only changes the root on a genuine mismatch — so re-running is safe.                                                                                                                                    
  - `isReady` is now purely the splash keep-condition: it drops to false while resolving and latches true once the root matches auth state, so the splash holds across  warm-process relaunches too (no Marketing flash). The hosting `LaunchedEffect` is keyed on the controller, so this still runs once per controller and isReady never flips back mid-session.

**Testing**                                                                                                                                                              
                                                                                                                                                                       
Added `SessionReconcilerTest`.