### PR TITLE
Feat: separate pledge screen for deplink

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
@@ -233,9 +233,6 @@ private fun EntryProviderScope<HedvigNavKey>.addHomeEntries(
     navigateToClaimChat = {
       backstack.add(ClaimChatKey(messageId = null, isDevelopmentFlow = false))
     },
-    navigateToClaimChatInDevMode = {
-      backstack.add(ClaimChatKey(messageId = null, isDevelopmentFlow = true))
-    },
     navigateToChipIdScreen = { backstack.add(ChipIdKey()) },
     openAppSettings = externalNavigator::openAppSettings,
     openUrl = openUrl,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
@@ -65,8 +65,8 @@ import com.hedvig.android.navigation.compose.add
 import com.hedvig.android.navigation.compose.navigateAndPopUpTo
 import com.hedvig.android.navigation.compose.popUpTo
 import com.hedvig.android.navigation.compose.removeAllOf
-import com.hedvig.feature.claim.chat.ClaimChatKey
-import com.hedvig.feature.claim.chat.claimChatEntries
+import com.hedvig.feature.claim.chat.navigation.ClaimChatKey
+import com.hedvig.feature.claim.chat.navigation.claimChatEntries
 import com.hedvig.feature.remove.addons.RemoveAddonsKey
 import com.hedvig.feature.remove.addons.removeAddonsEntries
 import kotlinx.coroutines.CoroutineScope

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
@@ -42,28 +42,41 @@ import org.jetbrains.compose.resources.stringResource
 fun StartClaimBottomSheet(
   state: HedvigBottomSheetState<Unit>,
   navigateToClaimChat: () -> Unit,
-  navigateToClaimChatInDevMode: () -> Unit,
-  isStagingEnvironment: Boolean,
 ) {
   HedvigBottomSheet(
     hedvigBottomSheetState = state,
     content = {
       StartClaimBottomSheetContent(
-        state,
-        navigateToClaimChat,
-        isStagingEnvironment,
-        navigateToClaimChatInDevMode,
-      )
-    },
+        dismiss = {
+          state.dismiss()
+        },
+        navigateToClaimChat = {
+          state.dismiss {
+            navigateToClaimChat()
+          }
+        })
+    }
   )
+}
+
+
+@Composable
+fun StartClaimPledgeScreen(
+  navigateUp: () -> Unit,
+  navigateToClaimChat: () -> Unit,
+  modifier: Modifier = Modifier) {
+  Column(modifier) {
+    StartClaimBottomSheetContent(
+      dismiss = navigateUp,
+      navigateToClaimChat = navigateToClaimChat,
+    )
+  }
 }
 
 @Composable
 private fun StartClaimBottomSheetContent(
-  state: HedvigBottomSheetState<Unit>,
+  dismiss: () -> Unit,
   navigateToClaimChat: () -> Unit,
-  isStagingEnvironment: Boolean,
-  navigateToClaimChatInDevMode: () -> Unit,
 ) {
   var isChecked by remember { mutableStateOf(false) }
   Column {
@@ -89,54 +102,22 @@ private fun StartClaimBottomSheetContent(
       text = stringResource(Res.string.general_continue_button),
       enabled = isChecked,
       onClick = dropUnlessResumed {
-        state.dismiss {
-          navigateToClaimChat()
-        }
+        navigateToClaimChat()
       },
       modifier = Modifier.fillMaxWidth(),
     )
-    if (isStagingEnvironment) {
-      StagingButtons(
-        state,
-        navigateToClaimChatInDevMode,
-      )
-    }
     Spacer(Modifier.height(16.dp))
     HedvigButton(
       text = stringResource(Res.string.general_cancel_button),
       enabled = true,
       buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
       onClick = {
-        state.dismiss()
+        dismiss()
       },
       modifier = Modifier.fillMaxWidth(),
     )
     Spacer(Modifier.height(8.dp))
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
-  }
-}
-
-@Composable
-private fun StagingButtons(state: HedvigBottomSheetState<Unit>, navigateToClaimChatInDevMode: () -> Unit) {
-  Column {
-    Spacer(Modifier.height(16.dp))
-    Row(
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-      modifier = Modifier.fillMaxWidth(),
-    ) {
-      HedvigButton(
-        text = "Claim Chat (Dev)",
-        enabled = true,
-        buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
-        buttonSize = ButtonDefaults.ButtonSize.Small,
-        onClick = dropUnlessResumed {
-          state.dismiss {
-            navigateToClaimChatInDevMode()
-          }
-        },
-        modifier = Modifier.weight(1f),
-      )
-    }
   }
 }
 
@@ -207,10 +188,8 @@ private fun PreviewStartClaimBottomSheetContent() {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       StartClaimBottomSheetContent(
-        state = rememberHedvigBottomSheetState(),
+        {},
         navigateToClaimChat = {},
-        isStagingEnvironment = true,
-        navigateToClaimChatInDevMode = {},
       )
     }
   }

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
@@ -72,9 +72,9 @@ fun StartClaimPledgeScreen(
   var isChecked by remember { mutableStateOf(false) }
   Column(modifier
     .verticalScroll(rememberScrollState())) {
-  //  Spacer(Modifier.height(16.dp))
     PledgeNotes()
     Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(8.dp))
     StartClaimBottomContent(
       isChecked = isChecked,
       onCheckedChange = {
@@ -83,7 +83,8 @@ fun StartClaimPledgeScreen(
       navigateToClaimChat = navigateToClaimChat,
       dismiss = navigateUp,
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }
 

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/StartClaimBottomSheet.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,8 +56,9 @@ fun StartClaimBottomSheet(
           state.dismiss {
             navigateToClaimChat()
           }
-        })
-    }
+        },
+      )
+    },
   )
 }
 
@@ -64,12 +67,23 @@ fun StartClaimBottomSheet(
 fun StartClaimPledgeScreen(
   navigateUp: () -> Unit,
   navigateToClaimChat: () -> Unit,
-  modifier: Modifier = Modifier) {
-  Column(modifier) {
-    StartClaimBottomSheetContent(
-      dismiss = navigateUp,
+  modifier: Modifier = Modifier,
+) {
+  var isChecked by remember { mutableStateOf(false) }
+  Column(modifier
+    .verticalScroll(rememberScrollState())) {
+  //  Spacer(Modifier.height(16.dp))
+    PledgeNotes()
+    Spacer(Modifier.weight(1f))
+    StartClaimBottomContent(
+      isChecked = isChecked,
+      onCheckedChange = {
+        isChecked = !isChecked
+      },
       navigateToClaimChat = navigateToClaimChat,
+      dismiss = navigateUp,
     )
+    Spacer(Modifier.height(16.dp))
   }
 }
 
@@ -91,11 +105,30 @@ private fun StartClaimBottomSheetContent(
     Spacer(Modifier.height(16.dp))
     PledgeNotes()
     Spacer(Modifier.height(16.dp))
-    ImportantInfoCheckBox(
+    StartClaimBottomContent(
       isChecked = isChecked,
       onCheckedChange = {
         isChecked = !isChecked
       },
+      navigateToClaimChat = navigateToClaimChat,
+      dismiss = dismiss,
+    )
+    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
+  }
+}
+
+@Composable
+private fun StartClaimBottomContent(
+  isChecked: Boolean,
+  onCheckedChange: () -> Unit,
+  navigateToClaimChat: () -> Unit,
+  dismiss: () -> Unit,
+) {
+  Column {
+    ImportantInfoCheckBox(
+      isChecked = isChecked,
+      onCheckedChange = onCheckedChange,
     )
     Spacer(Modifier.height(16.dp))
     HedvigButton(
@@ -116,8 +149,6 @@ private fun StartClaimBottomSheetContent(
       },
       modifier = Modifier.fillMaxWidth(),
     )
-    Spacer(Modifier.height(8.dp))
-    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
   }
 }
 

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/inbox/InboxDestination.kt
@@ -156,8 +156,6 @@ private fun InboxScreen(
       startClaimBottomSheetState.dismiss()
       navigateToClaimChat()
     },
-    navigateToClaimChatInDevMode = {},
-    isStagingEnvironment = false,
   )
   Surface(
     color = HedvigTheme.colorScheme.backgroundPrimary,

--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatEntries.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatEntries.kt
@@ -12,6 +12,7 @@ import com.hedvig.android.ui.force.upgrade.ForceUpgradeBlockingScreen
 import com.hedvig.feature.claim.chat.data.ClaimIntentOutcome
 import com.hedvig.feature.claim.chat.data.StepContent
 import com.hedvig.feature.claim.chat.ui.ClaimChatDestination
+import com.hedvig.feature.claim.chat.ui.StartClaimPledgeDestination
 import com.hedvig.feature.claim.chat.ui.outcome.ClaimOutcomeDeflectDestination
 import com.hedvig.feature.claim.chat.ui.outcome.ClaimOutcomeNewClaimDestination
 import kotlinx.serialization.Serializable
@@ -34,6 +35,9 @@ internal data class ClaimOutcomeNewClaimKey(
 
 @Serializable
 internal data object UpdateAppKey : HedvigNavKey
+
+@Serializable
+internal data object StartClaimPledgeKey: HedvigNavKey
 
 fun EntryProviderScope<HedvigNavKey>.claimChatEntries(
   backstack: Backstack,
@@ -96,6 +100,17 @@ fun EntryProviderScope<HedvigNavKey>.claimChatEntries(
   entry<UpdateAppKey> {
     ForceUpgradeBlockingScreen(
       goToPlayStore = tryOpenPlayStore,
+    )
+  }
+  entry<StartClaimPledgeKey> { _ ->
+    StartClaimPledgeDestination(
+      navigateUp = backstack::navigateUp,
+      navigateToClaimChat = {
+        backstack.navigateAndPopUpTo<StartClaimPledgeKey>(
+          ClaimChatKey(),
+          inclusive = true,
+        )
+      }
     )
   }
 }

--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/navigation/ClaimChatDeepLinks.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/navigation/ClaimChatDeepLinks.kt
@@ -1,4 +1,4 @@
-package com.hedvig.android.feature.home.home.navigation
+package com.hedvig.feature.claim.chat.navigation
 
 import androidx.navigation3.runtime.deeplink.DeepLinkMatcher
 import com.hedvig.android.core.common.di.AppScope
@@ -11,9 +11,9 @@ import dev.zacsweers.metro.Inject
 
 @ContributesIntoSet(AppScope::class)
 @Inject
-internal class HomeDeepLinkMatcherProvider(
+internal class ClaimChatDeepLinkMatcherProvider(
   private val container: HedvigDeepLinkContainer,
 ) : DeepLinkMatcherProvider {
   override fun matchers(): List<DeepLinkMatcher<out HedvigNavKey>> =
-    uriDeepLinkMatchers(container.home, HomeKey.serializer())
+    uriDeepLinkMatchers(container.claimFlow, StartClaimPledgeKey.serializer())
 }

--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/navigation/ClaimChatEntries.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/navigation/ClaimChatEntries.kt
@@ -1,4 +1,4 @@
-package com.hedvig.feature.claim.chat
+package com.hedvig.feature.claim.chat.navigation
 
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.compose.dropUnlessResumed

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/StartClaimPledgeScreen.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/StartClaimPledgeScreen.kt
@@ -8,13 +8,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
+import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.StartClaimPledgeScreen
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TopAppBar
 import com.hedvig.android.design.system.hedvig.TopAppBarActionType
+import com.hedvig.android.design.system.hedvig.rememberPreviewImageLoader
+import hedvig.resources.HONESTY_PLEDGE_HEADER
+import hedvig.resources.Res
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun StartClaimPledgeDestination(
@@ -27,7 +35,7 @@ internal fun StartClaimPledgeDestination(
     Column {
       val topAppbarInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
       TopAppBar(
-        title = "TODO", //todo
+        title = stringResource(Res.string.HONESTY_PLEDGE_HEADER),
         actionType = TopAppBarActionType.BACK,
         onActionClick = dropUnlessResumed(block = navigateUp),
         topAppBarActions = null,
@@ -37,7 +45,22 @@ internal fun StartClaimPledgeDestination(
       StartClaimPledgeScreen(
         navigateUp = navigateUp,
         navigateToClaimChat = navigateToClaimChat,
-        modifier = Modifier.padding(horizontal = 16.dp)
+        modifier = Modifier
+          .weight(1f)
+          .padding(horizontal = 16.dp)
+      )
+    }
+  }
+}
+
+
+@HedvigShortMultiScreenPreview
+@Composable
+private fun PreviewStartClaimPledgeDestination(
+) {
+  HedvigTheme {
+    Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
+      StartClaimPledgeDestination({},{}
       )
     }
   }

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/StartClaimPledgeScreen.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/StartClaimPledgeScreen.kt
@@ -1,0 +1,44 @@
+package com.hedvig.feature.claim.chat.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.hedvig.android.design.system.hedvig.HedvigTheme
+import com.hedvig.android.design.system.hedvig.StartClaimPledgeScreen
+import com.hedvig.android.design.system.hedvig.Surface
+import com.hedvig.android.design.system.hedvig.TopAppBar
+import com.hedvig.android.design.system.hedvig.TopAppBarActionType
+
+@Composable
+internal fun StartClaimPledgeDestination(
+  navigateUp: () -> Unit,
+  navigateToClaimChat: () -> Unit
+) {
+  Surface(
+    color = HedvigTheme.colorScheme.backgroundPrimary,
+  ) {
+    Column {
+      val topAppbarInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
+      TopAppBar(
+        title = "TODO", //todo
+        actionType = TopAppBarActionType.BACK,
+        onActionClick = dropUnlessResumed(block = navigateUp),
+        topAppBarActions = null,
+        windowInsets = topAppbarInsets,
+        customTopAppBarColors = null,
+      )
+      StartClaimPledgeScreen(
+        navigateUp = navigateUp,
+        navigateToClaimChat = navigateToClaimChat,
+        modifier = Modifier.padding(horizontal = 16.dp)
+      )
+    }
+  }
+}

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeEntries.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeEntries.kt
@@ -26,7 +26,6 @@ fun EntryProviderScope<HedvigNavKey>.homeEntries(
   navigateToMissingInfo: (String, CoInsuredFlowType) -> Unit,
   navigateToHelpCenter: () -> Unit,
   navigateToClaimChat: () -> Unit,
-  navigateToClaimChatInDevMode: () -> Unit,
   navigateToChipIdScreen: () -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
@@ -40,7 +39,6 @@ fun EntryProviderScope<HedvigNavKey>.homeEntries(
       onNavigateToInbox = dropUnlessResumed { onNavigateToInbox() },
       onNavigateToNewConversation = dropUnlessResumed { onNavigateToNewConversation() },
       navigateToClaimChat = dropUnlessResumed { navigateToClaimChat() },
-      navigateToClaimChatInDevMode = dropUnlessResumed { navigateToClaimChatInDevMode() },
       onClaimDetailCardClicked = dropUnlessResumed { claimId: String ->
         navigateToClaimDetails(claimId)
       },

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -156,7 +156,6 @@ internal fun HomeDestination(
   onNavigateToInbox: () -> Unit,
   onNavigateToNewConversation: () -> Unit,
   navigateToClaimChat: () -> Unit,
-  navigateToClaimChatInDevMode: () -> Unit,
   onClaimDetailCardClicked: (claimId: String) -> Unit,
   navigateToConnectPayment: () -> Unit,
   navigateToConnectPayout: () -> Unit,
@@ -179,7 +178,6 @@ internal fun HomeDestination(
     onNavigateToInbox = onNavigateToInbox,
     onNavigateToNewConversation = onNavigateToNewConversation,
     navigateToClaimChat = navigateToClaimChat,
-    navigateToClaimChatInDevMode = navigateToClaimChatInDevMode,
     onClaimDetailCardClicked = onClaimDetailCardClicked,
     navigateToConnectPayment = navigateToConnectPayment,
     navigateToConnectPayout = navigateToConnectPayout,
@@ -208,7 +206,6 @@ private fun HomeScreen(
   onNavigateToInbox: () -> Unit,
   onNavigateToNewConversation: () -> Unit,
   navigateToClaimChat: () -> Unit,
-  navigateToClaimChatInDevMode: () -> Unit,
   onClaimDetailCardClicked: (claimId: String) -> Unit,
   navigateToConnectPayment: () -> Unit,
   navigateToConnectPayout: () -> Unit,
@@ -244,8 +241,6 @@ private fun HomeScreen(
   StartClaimBottomSheet(
     state = startClaimBottomSheetState,
     navigateToClaimChat = navigateToClaimChat,
-    navigateToClaimChatInDevMode = navigateToClaimChatInDevMode,
-    isStagingEnvironment = (uiState as? Success)?.isProduction?.not() ?: false,
   )
   Box(Modifier.fillMaxSize()) {
     val toolbarHeight = 64.dp

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -817,7 +817,6 @@ private fun PreviewHomeScreen(
         navigateToChipIdScreen = {},
         setEpochDayWhenLastToolTipShown = {},
         imageLoader = rememberPreviewImageLoader(),
-        navigateToClaimChatInDevMode = {},
       )
     }
   }
@@ -850,7 +849,6 @@ private fun PreviewHomeScreenWithError() {
         navigateToChipIdScreen = {},
         setEpochDayWhenLastToolTipShown = {},
         imageLoader = rememberPreviewImageLoader(),
-        navigateToClaimChatInDevMode = {},
       )
     }
   }
@@ -904,7 +902,6 @@ private fun PreviewHomeScreenAllHomeTextTypes(
         navigateToChipIdScreen = {},
         setEpochDayWhenLastToolTipShown = {},
         imageLoader = rememberPreviewImageLoader(),
-        navigateToClaimChatInDevMode = {},
       )
     }
   }


### PR DESCRIPTION
Added a separate pledge screen to start a claim by deeplink avoiding the Home destination (instead of trying to open bottom sheet on deeplink)