### PR TITLE
chore: update CODEOWNERS to domain group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @HedvigInsurance/android
+*       @HedvigInsurance/mobile


### PR DESCRIPTION
## Why
Engineering ownership is being reorganised into domain groups on the GitHub org. CODEOWNERS should point at the owning domain team so reviews route to the right group.

## What
Set the CODEOWNERS owner for this repo to its domain group (@HedvigInsurance/mobile).