### PR TITLE
Fix/improve deep link race conditions

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -31,6 +31,7 @@ import com.hedvig.android.app.externalnavigator.ExternalNavigatorImpl
 import com.hedvig.android.app.navigation.CurrentDestinationHolder
 import com.hedvig.android.app.navigation.NavRetainedViewModel
 import com.hedvig.android.app.ui.HedvigApp
+import com.hedvig.android.app.urihandler.ExternalDeepLinkHandler
 import com.hedvig.android.auth.AuthTokenService
 import com.hedvig.android.auth.LogoutUseCase
 import com.hedvig.android.auth.MemberIdService
@@ -53,6 +54,7 @@ import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import java.util.Locale
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.modules.SerializersModule
 
@@ -122,11 +124,25 @@ class MainActivity : AppCompatActivity() {
   private val sessionReconciler get() = navRetainedViewModel.sessionReconciler
 
   /**
-   * External/notification VIEW intents are forwarded here as raw URI strings. [HedvigApp] collects them and routes
-   * each through the in-app deep-link matcher once the member is logged in. Replaces Nav2's automatic launch-intent
-   * deep-link handling on the (now removed) NavController.
+   * External/notification VIEW intents are forwarded here as raw URI strings. The per-Activity collector in
+   * [onCreate] routes each through [externalDeepLinkHandler] once the start scene is resolved. Replaces Nav2's
+   * automatic launch-intent deep-link handling on the (now removed) NavController.
    */
   private val deepLinkChannel = Channel<String>(Channel.UNLIMITED)
+
+  /**
+   * Per-Activity router for external/notification deep links. Lives outside composition because it is
+   * auth/navigation reconciliation — a sibling of [sessionReconciler] — not UI, and only mutates this Activity's
+   * back stack. Lazy because it reads @Inject fields, which are only populated after `appGraph.inject(this)`.
+   */
+  private val externalDeepLinkHandler: ExternalDeepLinkHandler by lazy {
+    ExternalDeepLinkHandler(
+      matcher = deepLinkMatcher,
+      backstackController = backstackController,
+      readySignal = sessionReconciler.isReady,
+      deepLinkHosts = hedvigBuildConstants.deepLinkHosts,
+    )
+  }
 
   /**
    * A channel to report whenever the splash screen has stopped showing. This is used to let `enableEdgeToEdge` be run
@@ -200,6 +216,11 @@ class MainActivity : AppCompatActivity() {
       sessionReconciler.reconcile()
       sessionReconciler.observeForcedLogout(lifecycle)
     }
+    lifecycleScope.launch {
+      deepLinkChannel.receiveAsFlow().collect { uri ->
+        externalDeepLinkHandler.handle(uri)
+      }
+    }
     setContent {
       CompositionLocalProvider(
         LocalMetroViewModelFactory provides navRetainedViewModel.viewModelFactory,
@@ -207,7 +228,6 @@ class MainActivity : AppCompatActivity() {
         val windowSizeClass = calculateWindowSizeClass(this@MainActivity)
         HedvigApp(
           backstackController = backstackController,
-          deepLinkChannel = deepLinkChannel,
           deepLinkReadySignal = sessionReconciler.isReady,
           windowSizeClass = windowSizeClass,
           settingsDataStore = settingsDataStore,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.ComposeFoundationFlags
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.retain.retain
 import androidx.core.content.getSystemService
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
@@ -176,6 +178,12 @@ class MainActivity : AppCompatActivity() {
     if (savedInstanceState == null) {
       handleDeepLinkIntent(intent)
     }
+    // onNewIntent fires (instead of a fresh onCreate) when the existing instance is reused: a caller
+    // sets FLAG_ACTIVITY_SINGLE_TOP while this Activity is top-of-task, or the launch config gains a
+    // singleTop/singleTask launchMode. None of our own callers (notification PendingIntents, App Link
+    // ACTION_VIEW) set that flag today, so those currently arrive via onCreate above — but an external
+    // caller can still trigger this path. Routed through the same handler either way so a deep link is
+    // never silently dropped.
     addOnNewIntentListener { newIntent -> handleDeepLinkIntent(newIntent) }
 
     attachBackstackTaskHooks()
@@ -200,6 +208,7 @@ class MainActivity : AppCompatActivity() {
         HedvigApp(
           backstackController = backstackController,
           deepLinkChannel = deepLinkChannel,
+          deepLinkReadySignal = sessionReconciler.isReady,
           windowSizeClass = windowSizeClass,
           settingsDataStore = settingsDataStore,
           featureManager = featureManager,
@@ -241,7 +250,6 @@ class MainActivity : AppCompatActivity() {
   private fun handleDeepLinkIntent(intent: Intent) {
     if (intent.action != Intent.ACTION_VIEW) return
     val uri = intent.data?.toString() ?: return
-    logcat { "MainActivity received deep-link intent for uri:$uri" }
     deepLinkChannel.trySend(uri)
   }
 }

--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -125,8 +125,7 @@ class MainActivity : AppCompatActivity() {
 
   /**
    * External/notification VIEW intents are forwarded here as raw URI strings. The per-Activity collector in
-   * [onCreate] routes each through [externalDeepLinkHandler] once the start scene is resolved. Replaces Nav2's
-   * automatic launch-intent deep-link handling on the (now removed) NavController.
+   * [onCreate] routes each through [externalDeepLinkHandler] once the start scene is resolved.
    */
   private val deepLinkChannel = Channel<String>(Channel.UNLIMITED)
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
@@ -180,7 +180,7 @@ internal class BackstackController(
   /**
    * Routes an in-app link tap (Compose `LocalUriHandler`). The member is navigating *within* a live
    * session, so we join the current task: logged out, stash it (consumed by [setLoggedIn] to land
-   * alone); logged in, dedup and append onto the live stack (Nav2 parity). External / notification
+   * alone); logged in, dedup and append onto the live stack. External / notification
    * deep links use [navigateToExternalDeepLink] instead — they must land alone.
    */
   fun navigateToInAppLink(key: HedvigNavKey) {

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
@@ -22,15 +22,11 @@ import com.hedvig.android.navigation.compose.LoneDeepLinkChrome
  * that Activity talks to — the UI via this concrete type, Presenters via the injected [Backstack]
  * interface (bound in the per-Activity `ActivityRetainedGraph`).
  *
- * Why activity-retained instead of composition: the state used to live in `rememberSerializable`
- * inside `MainActivity.setContent`, so a config change recreated the Activity and deserialized it into
- * a brand-new instance — while Metro ViewModels survive a config change as the same instance via their
- * per-entry `ViewModelStore`. Handing a long-lived Presenter a reference to the composition-scoped
- * stack would therefore go stale on the next rotation. The controller is instead built by
+ * Why activity-retained rather than composition-scoped: the controller is built by
  * [com.hedvig.android.app.navigation.NavRetainedViewModel] (a retained `ViewModel`), so it outlives
- * the composition and every screen ViewModel across a config change, yet — unlike the previous
- * app-singleton — dies with its Activity. Two `MainActivity` instances therefore get two independent
- * controllers instead of sharing one.
+ * the composition and every screen ViewModel across a config change — a long-lived Presenter can hold
+ * a reference to it without it going stale on rotation — yet it dies with its Activity. Two
+ * `MainActivity` instances therefore get two independent controllers instead of sharing one.
  *
  * Process-death persistence is bridged at the Activity seam: the retained instance is wiped when the
  * process dies, so `MainActivity` serializes the four holders into its `SavedStateRegistry` and
@@ -87,7 +83,7 @@ internal class BackstackController(
   val currentTopLevel: TopLevelTab
     get() = nearestTopLevelTab(entries) ?: TopLevelTab.Home
 
-  /** The destination on top of the rendered stack — replaces Nav2's `navController.currentDestination`. */
+  /** The destination on top of the rendered stack. */
   val currentDestination: HedvigNavKey?
     get() = entries.lastOrNull()
 

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
@@ -178,10 +178,12 @@ internal class BackstackController(
   }
 
   /**
-   * Routes a resolved deep-link key. Logged out: stash it (consumed by [setLoggedIn] to land alone).
-   * Logged in: dedup and append onto the live stack (join the current task — Nav2 parity).
+   * Routes an in-app link tap (Compose `LocalUriHandler`). The member is navigating *within* a live
+   * session, so we join the current task: logged out, stash it (consumed by [setLoggedIn] to land
+   * alone); logged in, dedup and append onto the live stack (Nav2 parity). External / notification
+   * deep links use [navigateToExternalDeepLink] instead — they must land alone.
    */
-  fun navigateToDeepLink(key: HedvigNavKey) {
+  fun navigateToInAppLink(key: HedvigNavKey) {
     if (!isLoggedIn) {
       pendingDeepLink = key
       return

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
@@ -195,6 +195,21 @@ internal class BackstackController(
   }
 
   /**
+   * Routes an external or notification deep link, which must land *alone* — it is an entry into the
+   * app from outside, not navigation within a live session. Logged out, stash it as [pendingDeepLink]
+   * so [setLoggedIn] still lands it alone after authentication; logged in, [reseed] to just this key.
+   * The ancestry is rebuilt on demand by [navigateUp] (the runs model and nav bar come back with it),
+   * so a lone deep link never sits on top of Home.
+   */
+  fun navigateToExternalDeepLink(key: HedvigNavKey) {
+    if (!isLoggedIn) {
+      pendingDeepLink = key
+      return
+    }
+    reseed(listOf(key))
+  }
+
+  /**
    * Task-aware Up. For a lone deep link it materializes the parent ancestry — `[Home]` for a lone
    * tab root, `[Home, Insurances]` for a lone contract detail — so Up behaves exactly like Back would
    * have inside the app. When we were launched into a foreign task ([isOwnTask] is false) that parent

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
@@ -30,10 +30,11 @@ import kotlinx.coroutines.launch
  *  1. [reconcile] picks the start scene (Home when logged in / in demo, Login otherwise) before the
  *     splash is dismissed, so the first frame is correct rather than the seeded Login root. This
  *     reconciler is 1:1 with its Activity's [BackstackController] (both [ActivityRetainedScope]-scoped),
- *     so [reconcile] runs once per Activity `onCreate` — a warm-process relaunch builds a fresh Activity
- *     and so a fresh controller + reconciler, which can't strand a logged-in member on the marketing
- *     screen. [isReady] gates the Activity's splash keep-condition: it drops to false while resolving
- *     and latches true again once the root matches the auth state.
+ *     so a warm-process relaunch builds a fresh Activity and so a fresh controller + reconciler, which
+ *     can't strand a logged-in member on the marketing screen. [isReady] gates the Activity's splash
+ *     keep-condition: it starts false, latches true once the root matches the auth state, and then
+ *     stays true for this reconciler's life — so a config change (which reuses the retained reconciler)
+ *     resolves nothing and never dips [isReady] back to false.
  *  2. [observeForcedLogout] keeps the root honest while running: log out when we leave demo mode and no
  *     longer hold tokens. It is lifecycle-gated so it only observes while the UI is STARTED.
  *
@@ -58,21 +59,19 @@ internal class SessionReconciler(
   private var lastKnownMemberId: String? = null
 
   /**
-   * Resolves the start scene for this Activity's [backstackController] before the splash is dismissed.
+   * Resolves the start scene for this Activity's [backstackController] before the splash is dismissed,
+   * then latches [isReady]. Runs its body at most once per instance — the early return makes a second
+   * call (e.g. after a config change reuses the retained instance) a no-op, so [isReady] never dips back
+   * to false and the content gate keyed on it never blanks.
    *
-   * Both this reconciler and the controller are [ActivityRetainedScope]-scoped, so they are 1:1 and
-   * [reconcile] is called once from the Activity's `onCreate`. A config change reuses the retained
-   * controller — whose root already matches the auth state — and a warm-process relaunch builds a fresh
-   * Activity, hence a fresh controller and reconciler; there is no process-wide instance that a
-   * once-per-process guard could wrongly skip and strand a still-logged-in member on the marketing
-   * screen. Re-running on the same controller (e.g. a config change) is harmless because
-   * [determineStartScene] is idempotent — it only touches the root on a genuine mismatch.
-   *
-   * [isReady] drops to false while resolving so the splash keep-condition holds, then latches true once
-   * the root matches the auth state.
+   * The guard is correct because this reconciler is [ActivityRetainedScope]-scoped, 1:1 with its
+   * Activity. A config change reuses the retained reconciler, whose [backstackController] root already
+   * matches the auth state, so re-resolving would be redundant. Anything that seeds a fresh `LoginKey`
+   * root — a cold start or a warm-process relaunch — builds a new Activity and therefore a new
+   * reconciler whose [isReady] starts false, so the guard never skips a root that still needs resolving.
    */
   suspend fun reconcile() {
-    isReadyState.value = false
+    if (isReadyState.value) return
     memberIdService.getMemberId().first()?.let { lastKnownMemberId = it }
     determineStartScene()
     isReadyState.value = true

--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
@@ -25,8 +25,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 /**
- * Owns the auth↔backstack reconciliation that used to live as loose effects in `HedvigApp`. Two jobs,
- * both narrowly about the rendered root:
+ * Owns the auth↔backstack reconciliation. Two jobs, both narrowly about the rendered root:
  *  1. [reconcile] picks the start scene (Home when logged in / in demo, Login otherwise) before the
  *     splash is dismissed, so the first frame is correct rather than the seeded Login root. This
  *     reconciler is 1:1 with its Activity's [BackstackController] (both [ActivityRetainedScope]-scoped),

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -49,6 +49,7 @@ import com.hedvig.android.app.navigation.hedvigEntryProvider
 import com.hedvig.android.app.navigation.shouldFadeThrough
 import com.hedvig.android.app.urihandler.AuthorizationCodeUriHandler
 import com.hedvig.android.app.urihandler.DeepLinkFirstUriHandler
+import com.hedvig.android.app.urihandler.ExternalDeepLinkHandler
 import com.hedvig.android.app.urihandler.SafeAndroidUriHandler
 import com.hedvig.android.auth.AuthStatus
 import com.hedvig.android.auth.AuthTokenService
@@ -79,6 +80,7 @@ import hedvig.resources.Res
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -89,6 +91,7 @@ import org.jetbrains.compose.resources.stringResource
 internal fun HedvigApp(
   backstackController: BackstackController,
   deepLinkChannel: Channel<String>,
+  deepLinkReadySignal: StateFlow<Boolean>,
   windowSizeClass: WindowSizeClass,
   settingsDataStore: SettingsDataStore,
   featureManager: FeatureManager,
@@ -146,9 +149,22 @@ internal fun HedvigApp(
           scope = scope,
         )
       }
-      LaunchedEffect(deepLinkFirstUriHandler, deepLinkChannel) {
+      val externalDeepLinkHandler = remember(
+        deepLinkMatcher,
+        backstackController,
+        deepLinkReadySignal,
+        hedvigBuildConstants,
+      ) {
+        ExternalDeepLinkHandler(
+          matcher = deepLinkMatcher,
+          backstackController = backstackController,
+          readySignal = deepLinkReadySignal,
+          deepLinkHosts = hedvigBuildConstants.deepLinkHosts,
+        )
+      }
+      LaunchedEffect(externalDeepLinkHandler, deepLinkChannel) {
         deepLinkChannel.receiveAsFlow().collect { uri ->
-          deepLinkFirstUriHandler.openUri(uri)
+          externalDeepLinkHandler.handle(uri)
         }
       }
       CrossSellSheet(

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -49,7 +49,6 @@ import com.hedvig.android.app.navigation.hedvigEntryProvider
 import com.hedvig.android.app.navigation.shouldFadeThrough
 import com.hedvig.android.app.urihandler.AuthorizationCodeUriHandler
 import com.hedvig.android.app.urihandler.DeepLinkFirstUriHandler
-import com.hedvig.android.app.urihandler.ExternalDeepLinkHandler
 import com.hedvig.android.app.urihandler.SafeAndroidUriHandler
 import com.hedvig.android.auth.AuthStatus
 import com.hedvig.android.auth.AuthTokenService
@@ -90,7 +89,6 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun HedvigApp(
   backstackController: BackstackController,
-  deepLinkChannel: Channel<String>,
   deepLinkReadySignal: StateFlow<Boolean>,
   windowSizeClass: WindowSizeClass,
   settingsDataStore: SettingsDataStore,
@@ -148,24 +146,6 @@ internal fun HedvigApp(
           delegate = deepLinkFirstUriHandler,
           scope = scope,
         )
-      }
-      val externalDeepLinkHandler = remember(
-        deepLinkMatcher,
-        backstackController,
-        deepLinkReadySignal,
-        hedvigBuildConstants,
-      ) {
-        ExternalDeepLinkHandler(
-          matcher = deepLinkMatcher,
-          backstackController = backstackController,
-          readySignal = deepLinkReadySignal,
-          deepLinkHosts = hedvigBuildConstants.deepLinkHosts,
-        )
-      }
-      LaunchedEffect(externalDeepLinkHandler, deepLinkChannel) {
-        deepLinkChannel.receiveAsFlow().collect { uri ->
-          externalDeepLinkHandler.handle(uri)
-        }
       }
       CrossSellSheet(
         isInScreenEligibleForCrossSells = hedvigAppState.isInScreenEligibleForCrossSells,

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -184,6 +184,11 @@ internal fun HedvigApp(
           )
           val density = LocalDensity.current
           val popSpec = hedvigPopTransitionSpec(backstackController, density)
+          // Hold the first frame on the themed background until SessionReconciler resolves the start
+          // scene. NavDisplay would otherwise render the seeded LoginKey root for a few frames before
+          // reconcile flips it — invisible behind the OS splash on a normal cold start, but exposed
+          // when launched via an App Link into another app's task (no splash is shown there).
+          val isReady by deepLinkReadySignal.collectAsStateWithLifecycle()
           Box(Modifier.fillMaxSize()) {
             Surface(
               color = com.hedvig.android.design.system.hedvig.HedvigTheme.colorScheme.backgroundPrimary,
@@ -191,32 +196,34 @@ internal fun HedvigApp(
             ) {
               Box(propagateMinConstraints = true, modifier = Modifier.fillMaxSize()) {
                 GlobalHedvigSnackBar(globalSnackBarState = globalSnackBarState)
-                NavDisplay(
-                  backStack = backstackController.entries,
-                  onBack = backstackController::popBackstack,
-                  entryDecorators = entryDecorators { backstackController.allLiveContentKeys },
-                  sharedTransitionScope = this@SharedTransitionLayout,
-                  sceneDecoratorStrategies = sceneDecoratorStrategies,
-                  transitionSpec = hedvigTransitionSpec(backstackController, density),
-                  popTransitionSpec = popSpec,
-                  predictivePopTransitionSpec = { popSpec() },
-                  entryProvider = entryProvider {
-                    hedvigEntryProvider(
-                      backstack = backstackController,
-                      scope = scope,
-                      windowSizeClass = windowSizeClass,
-                      memberIdService = memberIdService,
-                      globalSnackBarState = globalSnackBarState,
-                      externalNavigator = externalNavigator,
-                      androidAppHost = androidAppHost,
-                      openUrl = authorizationCodeUriHandler::openUri,
-                      openCrossSellUrl = authorizationCodeUriHandler::openUri,
-                      imageLoader = imageLoader,
-                      languageService = languageService,
-                      hedvigBuildConstants = hedvigBuildConstants,
-                    )
-                  },
-                )
+                if (isReady) {
+                  NavDisplay(
+                    backStack = backstackController.entries,
+                    onBack = backstackController::popBackstack,
+                    entryDecorators = entryDecorators { backstackController.allLiveContentKeys },
+                    sharedTransitionScope = this@SharedTransitionLayout,
+                    sceneDecoratorStrategies = sceneDecoratorStrategies,
+                    transitionSpec = hedvigTransitionSpec(backstackController, density),
+                    popTransitionSpec = popSpec,
+                    predictivePopTransitionSpec = { popSpec() },
+                    entryProvider = entryProvider {
+                      hedvigEntryProvider(
+                        backstack = backstackController,
+                        scope = scope,
+                        windowSizeClass = windowSizeClass,
+                        memberIdService = memberIdService,
+                        globalSnackBarState = globalSnackBarState,
+                        externalNavigator = externalNavigator,
+                        androidAppHost = androidAppHost,
+                        openUrl = authorizationCodeUriHandler::openUri,
+                        openCrossSellUrl = authorizationCodeUriHandler::openUri,
+                        imageLoader = imageLoader,
+                        languageService = languageService,
+                        hedvigBuildConstants = hedvigBuildConstants,
+                      )
+                    },
+                  )
+                }
               }
             }
             DemoModeOverlay(demoManager, logoutUseCase)

--- a/app/app/src/main/kotlin/com/hedvig/android/app/urihandler/DeepLinkFirstUriHandler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/urihandler/DeepLinkFirstUriHandler.kt
@@ -6,9 +6,12 @@ import com.hedvig.android.logger.logcat
 import com.hedvig.android.navigation.compose.HedvigDeepLinkMatcher
 
 /**
- * Tries to resolve a URI to an in-app [com.hedvig.android.navigation.common.HedvigNavKey] via [matcher] and navigate to
- * it via [backstackController]. Falls back to the [delegate] (e.g. the system browser) when the URI is not one of our
- * deep links.
+ * Handles *in-app* link taps (the Compose [UriHandler] behind `LocalUriHandler`). Tries to resolve a
+ * URI to an in-app [com.hedvig.android.navigation.common.HedvigNavKey] via [matcher] and navigate to
+ * it via [backstackController], appending onto the live stack. Falls back to the [delegate] (e.g. the
+ * system browser) when the URI is not one of our deep links — correct here because the member tapped a
+ * link inside the app. External / notification deep links are handled by [ExternalDeepLinkHandler],
+ * which lands alone and never falls back to the browser.
  */
 internal class DeepLinkFirstUriHandler(
   private val matcher: HedvigDeepLinkMatcher,
@@ -19,7 +22,7 @@ internal class DeepLinkFirstUriHandler(
     val destination = matcher.match(uri)
     if (destination != null) {
       logcat { "DeepLinkFirstUriHandler navigating to $destination for uri:$uri" }
-      backstackController.navigateToDeepLink(destination)
+      backstackController.navigateToInAppLink(destination)
     } else {
       logcat { "DeepLinkFirstUriHandler falling back to default UriHandler for uri:$uri" }
       delegate.openUri(uri)

--- a/app/app/src/main/kotlin/com/hedvig/android/app/urihandler/ExternalDeepLinkHandler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/urihandler/ExternalDeepLinkHandler.kt
@@ -1,0 +1,70 @@
+package com.hedvig.android.app.urihandler
+
+import com.hedvig.android.app.navigation.BackstackController
+import com.hedvig.android.feature.home.home.navigation.HomeKey
+import com.hedvig.android.logger.logcat
+import com.hedvig.android.navigation.compose.HedvigDeepLinkMatcher
+import java.net.URI
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+
+/**
+ * Handles deep links that enter the app from *outside*: external https App Links and notification
+ * taps, both forwarded as raw URI strings from `MainActivity` via the deep-link channel.
+ *
+ * Three deliberate differences from the in-app [DeepLinkFirstUriHandler]:
+ *  1. **Never falls back to the browser.** The host is one of our autoVerify'd App Link domains, so
+ *     opening it externally would bounce straight back into `MainActivity` as a fresh `ACTION_VIEW` —
+ *     an infinite self-relaunch. "Open it in the browser" is only ever correct for an in-app tap on a
+ *     link we don't handle.
+ *  2. **Unknown path on one of *our* hosts lands on Home.** A URI we can't match to a specific screen
+ *     but that targets one of [deepLinkHosts] (e.g. `.../home`, or any future path the backend sends
+ *     before the app learns it) lands the member on Home rather than being silently dropped. Only a
+ *     URI on a foreign host is ignored. This is the real "unknown deep link -> Home" behaviour the
+ *     matcher itself can't express (Nav3 patterns are exact, with no catch-all).
+ *  3. **Gated on [readySignal].** We wait for the [com.hedvig.android.app.navigation.SessionReconciler]
+ *     to resolve the start scene before routing, so the link reads a settled auth state and lands
+ *     deterministically — rather than racing the splash-gated reconciliation.
+ *
+ * A matched key (or the Home fallback) lands *alone* (see [BackstackController.navigateToExternalDeepLink]);
+ * the ancestry is rebuilt on demand by Up.
+ */
+internal class ExternalDeepLinkHandler(
+  private val matcher: HedvigDeepLinkMatcher,
+  private val backstackController: BackstackController,
+  private val readySignal: StateFlow<Boolean>,
+  private val deepLinkHosts: List<String>,
+) {
+  suspend fun handle(uri: String) {
+    readySignal.first { it }
+    val destination = matcher.match(uri)
+    if (destination != null) {
+      logcat { "ExternalDeepLinkHandler landing external deep link $destination for uri:$uri" }
+      backstackController.navigateToExternalDeepLink(destination)
+      return
+    }
+    if (targetsOwnDeepLink(uri)) {
+      logcat { "ExternalDeepLinkHandler no specific match for own-host uri:$uri — falling back to Home" }
+      backstackController.navigateToExternalDeepLink(HomeKey)
+      return
+    }
+    logcat { "ExternalDeepLinkHandler ignoring unmatched foreign-host external deep link uri:$uri" }
+  }
+
+  /**
+   * True when [uri] targets one of our deep-link hosts. [deepLinkHosts] entries are bare `host`
+   * (e.g. `link.hedvig.com`) or `host/pathPrefix` (e.g. `www.hedvig.com/deeplink`), matching the
+   * manifest's autoVerify filters — so we parse each entry as a URI too and require the host to match
+   * *and* the path to start with the entry's path prefix. An empty entry path matches any path.
+   */
+  private fun targetsOwnDeepLink(uri: String): Boolean {
+    val parsed = runCatching { URI(uri) }.getOrNull() ?: return false
+    val host = parsed.host ?: return false
+    val path = parsed.path ?: ""
+    return deepLinkHosts.any { entry ->
+      val entryUri = runCatching { URI("https://$entry") }.getOrNull() ?: return@any false
+      val entryHost = entryUri.host ?: return@any false
+      host.equals(entryHost, ignoreCase = true) && path.startsWith(entryUri.path ?: "")
+    }
+  }
+}

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/BackstackControllerTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/BackstackControllerTest.kt
@@ -312,9 +312,9 @@ internal class BackstackControllerTest {
   }
 
   @Test
-  fun `navigateToDeepLink while logged out stashes and leaves the stack untouched`() {
+  fun `navigateToInAppLink while logged out stashes and leaves the stack untouched`() {
     val controller = controllerWith(LoginKey)
-    controller.navigateToDeepLink(HelpCenterKey)
+    controller.navigateToInAppLink(HelpCenterKey)
     assertThat(controller.entries.toList()).containsExactly(LoginKey)
     assertThat(controller.pendingDeepLink).isEqualTo(HelpCenterKey)
   }
@@ -322,7 +322,7 @@ internal class BackstackControllerTest {
   @Test
   fun `setLoggedIn consumes the stash and lands the target alone`() {
     val controller = controllerWith(LoginKey)
-    controller.navigateToDeepLink(InsurancesKey)
+    controller.navigateToInAppLink(InsurancesKey)
     controller.setLoggedIn("mem-1")
     assertThat(controller.entries.toList()).containsExactly(InsurancesKey)
     assertThat(controller.pendingDeepLink).isEqualTo(null)
@@ -371,7 +371,7 @@ internal class BackstackControllerTest {
   fun `setLoggedIn lands a pending deep link alone even when a same-member stash exists`() {
     val controller = controllerWith(HomeKey, ProfileKey)
     controller.setLoggedOut("mem-1")
-    controller.navigateToDeepLink(HelpCenterKey) // logged out → stashed as pendingDeepLink
+    controller.navigateToInAppLink(HelpCenterKey) // logged out → stashed as pendingDeepLink
     controller.setLoggedIn("mem-1")
     assertThat(controller.entries.toList()).containsExactly(HelpCenterKey)
     assertThat(controller.parkedRuns).isEmpty()
@@ -379,9 +379,9 @@ internal class BackstackControllerTest {
   }
 
   @Test
-  fun `navigateToDeepLink while logged in appends onto the live stack`() {
+  fun `navigateToInAppLink while logged in appends onto the live stack`() {
     val controller = controllerWith(HomeKey, InsurancesKey)
-    controller.navigateToDeepLink(HelpCenterKey)
+    controller.navigateToInAppLink(HelpCenterKey)
     assertThat(controller.entries.toList())
       .containsExactly(HomeKey, InsurancesKey, HelpCenterKey)
     assertThat(controller.pendingDeepLink).isEqualTo(null)

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/BackstackControllerTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/BackstackControllerTest.kt
@@ -388,6 +388,23 @@ internal class BackstackControllerTest {
   }
 
   @Test
+  fun `navigateToExternalDeepLink while logged in lands the target alone`() {
+    val controller = controllerWith(HomeKey, InsurancesKey, HelpCenterKey)
+    controller.navigateToExternalDeepLink(HelpCenterKey)
+    assertThat(controller.entries.toList()).containsExactly(HelpCenterKey)
+    assertThat(controller.pendingDeepLink).isEqualTo(null)
+    assertThat(controller.parkedRuns).isEmpty()
+  }
+
+  @Test
+  fun `navigateToExternalDeepLink while logged out stashes and leaves the stack untouched`() {
+    val controller = controllerWith(LoginKey)
+    controller.navigateToExternalDeepLink(HelpCenterKey)
+    assertThat(controller.entries.toList()).containsExactly(LoginKey)
+    assertThat(controller.pendingDeepLink).isEqualTo(HelpCenterKey)
+  }
+
+  @Test
   fun `loneDeepLinkChrome is ShowUpBar for a lone tab root`() {
     assertThat(controllerWith(InsurancesKey).loneDeepLinkChrome).isEqualTo(LoneDeepLinkChrome.ShowUpBar)
   }

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/DeepLinkNavigationTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/DeepLinkNavigationTest.kt
@@ -12,7 +12,7 @@ import com.hedvig.android.navigation.common.HedvigNavKey
 import org.junit.Test
 
 /**
- * Guards [BackstackController.navigateToDeepLink] against re-introducing the value-equal
+ * Guards [BackstackController.navigateToInAppLink] against re-introducing the value-equal
  * duplicate-key crash: Nav3's `NavDisplay` renders every entry under `key.toString()`, so two
  * value-equal keys in the stack crash with "key … used multiple times". A deep link that resolves
  * to a key already on the stack must therefore never blind-append.
@@ -29,7 +29,7 @@ internal class DeepLinkNavigationTest {
   fun `deep link to the current tab root does not duplicate it`() {
     val controller = controllerWith(HomeKey)
 
-    controller.navigateToDeepLink(HomeKey)
+    controller.navigateToInAppLink(HomeKey)
 
     assertThat(controller.entries.toList()).containsExactly(HomeKey)
   }
@@ -38,7 +38,7 @@ internal class DeepLinkNavigationTest {
   fun `deep link to an already-present side tab does not duplicate it`() {
     val controller = controllerWith(HomeKey, InsurancesKey)
 
-    controller.navigateToDeepLink(InsurancesKey)
+    controller.navigateToInAppLink(InsurancesKey)
 
     assertThat(controller.entries.toList()).containsExactly(HomeKey, InsurancesKey)
   }
@@ -47,7 +47,7 @@ internal class DeepLinkNavigationTest {
   fun `deep link to a non-tab key already on the stack moves it to the top instead of duplicating`() {
     val controller = controllerWith(HomeKey, HelpCenterKey)
 
-    controller.navigateToDeepLink(HelpCenterKey)
+    controller.navigateToInAppLink(HelpCenterKey)
 
     assertThat(controller.entries.toList()).containsExactly(HomeKey, HelpCenterKey)
   }
@@ -56,7 +56,7 @@ internal class DeepLinkNavigationTest {
   fun `deep link to a new non-tab key appends it`() {
     val controller = controllerWith(HomeKey)
 
-    controller.navigateToDeepLink(HelpCenterKey)
+    controller.navigateToInAppLink(HelpCenterKey)
 
     assertThat(controller.entries.toList()).containsExactly(HomeKey, HelpCenterKey)
   }
@@ -65,7 +65,7 @@ internal class DeepLinkNavigationTest {
   fun `deep link to an absent side tab switches to it`() {
     val controller = controllerWith(HomeKey)
 
-    controller.navigateToDeepLink(InsurancesKey)
+    controller.navigateToInAppLink(InsurancesKey)
 
     assertThat(controller.entries.toList()).containsExactly(HomeKey, InsurancesKey)
   }

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/SessionReconcilerTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/SessionReconcilerTest.kt
@@ -83,10 +83,7 @@ internal class SessionReconcilerTest {
     mutableStateOf(null), // stashedSession
   )
 
-  private fun TestScope.sessionReconciler(
-    authStatus: AuthStatus,
-    controller: BackstackController,
-  ): SessionReconciler {
+  private fun TestScope.sessionReconciler(authStatus: AuthStatus, controller: BackstackController): SessionReconciler {
     val authTokenStorage = AuthTokenStorage(
       TestPreferencesDataStore(
         datastoreTestFileDirectory = testFolder.newFolder(),

--- a/app/app/src/test/kotlin/com/hedvig/android/app/urihandler/ExternalDeepLinkHandlerTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/urihandler/ExternalDeepLinkHandlerTest.kt
@@ -1,0 +1,68 @@
+package com.hedvig.android.app.urihandler
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.hedvig.android.app.navigation.BackstackController
+import com.hedvig.android.feature.home.home.navigation.HomeKey
+import com.hedvig.android.feature.insurances.navigation.InsurancesKey
+import com.hedvig.android.logger.TestLogcatLoggingRule
+import com.hedvig.android.navigation.common.HedvigNavKey
+import com.hedvig.android.navigation.compose.HedvigDeepLinkMatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+internal class ExternalDeepLinkHandlerTest {
+  @get:Rule
+  val testLogcatLogger = TestLogcatLoggingRule()
+
+  // Production-shaped hosts: a bare host, a host carrying a path prefix, and a legacy bare host.
+  private val deepLinkHosts = listOf("link.hedvig.com", "www.hedvig.com/deeplink", "hedvig.page.link")
+
+  // Empty matcher always returns null, so every uri exercises the host/path fallback rather than a match.
+  private fun handlerWith(controller: BackstackController) = ExternalDeepLinkHandler(
+    matcher = HedvigDeepLinkMatcher(emptyList()),
+    backstackController = controller,
+    readySignal = MutableStateFlow(true),
+    deepLinkHosts = deepLinkHosts,
+  )
+
+  private fun loggedInController(vararg keys: HedvigNavKey) = BackstackController(
+    mutableStateListOf(*keys),
+    mutableStateMapOf(),
+    mutableStateOf(null),
+    mutableStateOf(null),
+  )
+
+  @Test
+  fun `unmatched link on the path-prefixed own host falls back to Home alone`() = runTest {
+    val controller = loggedInController(HomeKey, InsurancesKey)
+    handlerWith(controller).handle("https://www.hedvig.com/deeplink/something-new")
+    assertThat(controller.entries.toList()).containsExactly(HomeKey)
+  }
+
+  @Test
+  fun `unmatched link on a bare own host falls back to Home alone`() = runTest {
+    val controller = loggedInController(HomeKey, InsurancesKey)
+    handlerWith(controller).handle("https://link.hedvig.com/something-new")
+    assertThat(controller.entries.toList()).containsExactly(HomeKey)
+  }
+
+  @Test
+  fun `own host but outside the path prefix is ignored`() = runTest {
+    val controller = loggedInController(HomeKey, InsurancesKey)
+    handlerWith(controller).handle("https://www.hedvig.com/not-a-deeplink")
+    assertThat(controller.entries.toList()).containsExactly(HomeKey, InsurancesKey)
+  }
+
+  @Test
+  fun `foreign host is ignored`() = runTest {
+    val controller = loggedInController(HomeKey, InsurancesKey)
+    handlerWith(controller).handle("https://evil.example.com/whatever")
+    assertThat(controller.entries.toList()).containsExactly(HomeKey, InsurancesKey)
+  }
+}

--- a/app/navigation/navigation-core/src/commonMain/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
+++ b/app/navigation/navigation-core/src/commonMain/kotlin/com/hedvig/android/navigation/core/HedvigDeepLinkContainer.kt
@@ -97,7 +97,10 @@ internal class HedvigDeepLinkContainerImpl(
 ) : HedvigDeepLinkContainer {
   private val baseDeepLinkDomains = hedvigBuildConstants.deepLinkHosts.map { "https://$it" }
 
-  // Home does not have some special text, acts as the fallback to all unknown deep links
+  // Home matches ONLY the bare deep-link domain (no path). It is not a catch-all: an unrecognised path
+  // (e.g. ".../home" or ".../something-new") matches no pattern and the matcher returns null. The real
+  // "unknown link on one of our hosts -> land on Home" fallback lives in ExternalDeepLinkHandler (:app),
+  // because Nav3 patterns are exact and cannot express a wildcard here.
   override val home: List<String> = baseDeepLinkDomains
   override val helpCenter: List<String> = baseDeepLinkDomains.map { baseDeepLinkDomain ->
     "$baseDeepLinkDomain/help-center"

--- a/docs/investigations/onnewintent-standard-launchmode.md
+++ b/docs/investigations/onnewintent-standard-launchmode.md
@@ -1,0 +1,190 @@
+# Can `onNewIntent` fire on a `standard` launchMode Activity?
+
+**Status:** Answered — **yes**, empirically confirmed.
+**Scope:** `MainActivity` in `:app` and its `addOnNewIntentListener` deep-link path.
+**Date of investigation:** 2026-06-17.
+
+---
+
+## The question
+
+`MainActivity` registers a listener:
+
+```kotlin
+addOnNewIntentListener { newIntent ->
+  handleDeepLinkIntent(newIntent)
+}
+```
+
+`MainActivity` uses the **default `standard` launch mode** (no `launchMode` attribute in the
+manifest). The open question was:
+
+> With `standard` launchMode, can the `addOnNewIntentListener` lambda ever actually fire,
+> or does every incoming intent just produce a brand-new Activity instance (`onCreate`)
+> instead of `onNewIntent`?
+
+Nobody had been able to reproduce the lambda firing in normal app usage. The hypothesis
+(credited to Adam Powell) was that `FLAG_ACTIVITY_SINGLE_TOP` set by the *caller* can route
+to `onNewIntent` even for a `standard` Activity.
+
+---
+
+## Background: when does `onNewIntent` fire?
+
+`Activity.onNewIntent` is delivered **instead of** a fresh `onCreate` only when the system
+decides to *reuse* an existing Activity instance that is already at the top of the target
+task, rather than instantiate a new one. For that reuse to happen, one of these must be true:
+
+1. The Activity declares `android:launchMode` = `singleTop`, `singleTask`, or `singleInstance`
+   in the manifest, **or**
+2. The **caller** sets `Intent.FLAG_ACTIVITY_SINGLE_TOP` (`0x20000000`) on the launching
+   intent **and** the target Activity instance is already at the top of the matched task,
+   with a matching component.
+
+For a `standard` Activity, condition (1) never applies, so the **only** path is (2): a caller
+explicitly setting `FLAG_ACTIVITY_SINGLE_TOP`.
+
+Important non-paths (these do **not** route to `onNewIntent` on a `standard` Activity):
+
+- `FLAG_ACTIVITY_CLEAR_TOP` **alone** → destroys and **recreates** the target (`onCreate`),
+  it does not reuse via `onNewIntent`. It only reuses the top instance when combined with
+  `FLAG_ACTIVITY_SINGLE_TOP` (`CLEAR_TOP | SINGLE_TOP`).
+- `FLAG_ACTIVITY_NEW_TASK` alone → new instance.
+
+---
+
+## Code findings
+
+### 1. `MainActivity` is `standard`
+
+`app/app/src/main/AndroidManifest.xml` — the `<activity>` for
+`com.hedvig.android.app.MainActivity` has **no** `android:launchMode`, so it defaults to
+`standard`.
+
+### 2. The app's own notification intents set NO reuse flags
+
+`app/app/src/main/kotlin/com/hedvig/android/app/notification/Util.kt`:
+
+```kotlin
+fun HedvigBuildConstants.intentForNotification(deepLinkUri: Uri?): Intent = Intent().apply {
+  action = Intent.ACTION_VIEW
+  data = deepLinkUri
+  component = ComponentName(this@intentForNotification.appPackageId, MainActivityFullyQualifiedName)
+}
+```
+
+No `FLAG_ACTIVITY_SINGLE_TOP`, no `FLAG_ACTIVITY_NEW_TASK`. Every notification sender
+(`ChatNotificationSender`, `PaymentNotificationSender`, `CrossSellNotificationSender`, etc.)
+wraps this in `PendingIntentCompat.getActivity(...)`. The platform implicitly adds
+`FLAG_ACTIVITY_NEW_TASK` for a PendingIntent activity launch, but it does **not** add
+`SINGLE_TOP`.
+
+**Consequence:** with the current code, notification taps on a `standard` `MainActivity`
+land in `onCreate`, never in the `addOnNewIntentListener` lambda. This is why the lambda
+appeared to be dead code and could not be reproduced through normal app usage — **no caller
+in the codebase sets `SINGLE_TOP`.**
+
+### 3. External `ACTION_VIEW` deep links (browser/links) also produce fresh `onCreate`
+
+Cold/warm deep links arriving via the manifest `<intent-filter>` for `ACTION_VIEW` are
+handled in `onCreate` (`if (savedInstanceState == null) handleDeepLinkIntent(intent)`),
+again because nothing sets `SINGLE_TOP`.
+
+---
+
+## The empirical test (no production-code change required to run)
+
+`am start` exposes a convenience flag, `--activity-single-top`, that simulates a caller
+setting `FLAG_ACTIVITY_SINGLE_TOP`. Existing log lines in `MainActivity.onCreate` are enough
+to tell the two paths apart:
+
+- `onCreate` logs `MainActivity@<identityHashCode> using BackstackController@<hash>`.
+  - **New instance** → a new log line with a **different** hashCode.
+  - **Reuse via `onNewIntent`** → **no** new `onCreate` log; same instance persists.
+
+### Steps
+
+1. Foreground the app with `MainActivity` at the top of its task.
+2. `adb logcat` for the `MainActivity@...` lines.
+3. Fire the intent **with** the flag:
+
+```bash
+adb shell am start -a android.intent.action.VIEW \
+  -d "<some-deeplink-uri>" \
+  -n com.hedvig.dev.app/com.hedvig.android.app.MainActivity \
+  --activity-single-top
+```
+
+Compare against the same command **without** `--activity-single-top` (expected: a fresh
+`onCreate` with a new hashCode).
+
+### Caveat
+
+Launching from the shell is a non-Activity context, so the system implicitly adds
+`FLAG_ACTIVITY_NEW_TASK`. As long as the app is already foregrounded with `MainActivity` on
+top, `NEW_TASK` resolves to the existing task and `SINGLE_TOP` does its job. If the intent
+ever lands in a *different* task you'd get a new instance instead — so always foreground the
+app first. Do **not** add `--activity-clear-top` for this isolation test (see the non-paths
+note above).
+
+---
+
+## Result (confirmed)
+
+A temporary log was added inside the listener purely to observe it:
+
+```kotlin
+addOnNewIntentListener { newIntent ->
+  logcat { "MainActivity@newIntent:$newIntent" }   // temporary instrumentation
+  handleDeepLinkIntent(newIntent)
+}
+```
+
+Observed logcat:
+
+```
+06:09:41.336  MainActivity@129065745 using BackstackController@211175504
+06:10:54.649  MainActivity@103329817 using BackstackController@44427708
+06:11:41.819  MainActivity@newIntent:Intent { act=android.intent.action.VIEW
+              dat=https://link.dev.hedvigit.com/... flg=0x30000000 xflg=0x4
+              cmp=com.hedvig.dev.app/com.hedvig.android.app.MainActivity }
+```
+
+Decoding the flags on the delivered intent:
+
+- `flg=0x30000000` = `FLAG_ACTIVITY_NEW_TASK (0x10000000)` `|` `FLAG_ACTIVITY_SINGLE_TOP (0x20000000)`.
+- The `--activity-single-top` test ran at `06:11:41` with **no preceding `onCreate` log**,
+  i.e. the existing instance was reused and the listener fired — exactly the `onNewIntent`
+  path.
+
+**Conclusion: yes.** On a `standard` launchMode Activity, `onNewIntent` (and therefore the
+`addOnNewIntentListener` lambda) *will* fire when a caller sets `FLAG_ACTIVITY_SINGLE_TOP`
+and the Activity is already at the top of the matched task. Adam Powell's recollection was
+correct.
+
+---
+
+## Implications for this codebase
+
+- The `addOnNewIntentListener` lambda is **not reachable through the app's own current code
+  paths**, because no caller (notification PendingIntents, external deep links) sets
+  `FLAG_ACTIVITY_SINGLE_TOP`. It is reachable only by an external caller that sets that flag,
+  or if `MainActivity` is ever given a `singleTop`/`singleTask` launchMode.
+- The listener is therefore a **defensive safety net**: routing `onNewIntent` through the
+  same `handleDeepLinkIntent(...)` handler means that if the launch config ever changes
+  (manifest `launchMode`, or we start setting `SINGLE_TOP` on notification intents to avoid
+  stacking duplicate Activities), deep links won't be silently dropped.
+- If we *want* notification taps to reuse the existing `MainActivity` instead of stacking a
+  new one, the change would be to add `FLAG_ACTIVITY_SINGLE_TOP` (likely together with
+  `FLAG_ACTIVITY_CLEAR_TOP`) to `intentForNotification` — at which point the listener becomes
+  a live, regularly-exercised path and needs corresponding test coverage.
+
+## Open follow-ups (for whoever picks this up)
+
+1. Decide whether the listener should stay as a safety net or whether we should deliberately
+   move notification/deep-link entry onto the `SINGLE_TOP` (reuse) model. The current
+   "always fresh `onCreate`" behavior means tapping multiple notifications can stack multiple
+   `MainActivity` instances — worth verifying whether that actually happens and whether it's
+   desirable given the single app-owned back stack.
+2. Remove the temporary `logcat { "MainActivity@newIntent:$newIntent" }` instrumentation if
+   it was committed — it was added only to observe this experiment.


### PR DESCRIPTION
This is an attempt to fix the race conditions around deep links by making sure reconcilation happens first, and then if a deep link is pending, it is handled appropriately, meaning taking over the entire backstack if required.

Need to test a bit more before merge

AI description of the reason the new timing corodingation which works well compared to letting the coroutines race each other:
```
1. The collector now waits. It calls externalDeepLinkHandler.handle(uri), which is suspend and whose first line is readySignal.first { it }. It cannot touch the back stack until isReady == true. (Before: synchronous openUri, no wait.)
2. navigateToExternalDeepLink lands alone in both auth states: logged out → pendingDeepLink = key (consumed later by setLoggedIn, which lands it alone); logged in → reseed(listOf(key)) → stack becomes exactly [destination]. Neither branch ever appends onto an existing root. (Before: logged-in branch did remove + add = append.)
3. reconcile() sets the root, then flips the gate: determineStartScene() settles the root first, and only then isReadyState.value = true. So the moment the gate opens, the root is already final. (Before: same internal order, but nothing downstream waited for it.)
4. The gate enforces the ordering the launch order only hinted at. MainActivity still launches reconcile() then setContent, but now even if the collector starts first and the auth/member-id flows suspend, handle() parks on readySignal.first { it } and yields back — it physically cannot run before reconcile finishes.

So the deciding factor from before — did the auth/member-id flows emit synchronously or suspend? — no longer changes the result:

- Flows suspend → handle() blocks on the gate until reconcile completes → reads the settled state → lands alone.
- Flows cached → reconcile completes first anyway → handle() reads the same settled state → lands alone.

Both timings now converge on one outcome: [destination] alone, Home never beneath it, system Back exits to Slack. The two random outcomes collapse into one. That’s
the determinism — it comes from the gate (point 1) removing the timing dependence, and reseed (point 2) removing the “append onto Home” outcome even in the logged-in
branch.
```