### PR TITLE
chore: Gradle/AGP dependency bumps and deprecation cleanup

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -43,14 +43,14 @@ android {
   }
 
   buildTypes {
-    val debug by getting {
+    getByName("debug") {
       applicationIdSuffix = ".dev.app"
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = false
       isDebuggable = true
     }
 
-    val release by getting {
-//      signingConfig = debug.signingConfig // uncomment to run release build locally
+    getByName("release") {
+//      signingConfig = getByName("debug").signingConfig // uncomment to run release build locally
       applicationIdSuffix = ".app"
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = true
 
@@ -64,7 +64,7 @@ android {
       )
     }
 
-    val staging by creating {
+    create("staging") {
       applicationIdSuffix = ".app"
       manifestPlaceholders["firebaseCrashlyticsCollectionEnabled"] = true
       isMinifyEnabled = true

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/ExhaustiveBackStackSerializationTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/ExhaustiveBackStackSerializationTest.kt
@@ -121,7 +121,7 @@ internal class ExhaustiveBackstackSerializationTest {
 
   private fun invokeDefaultProviderMethod(interfaceClass: Class<*>, provideMethod: Method): SerializersModule {
     // The providers are Kotlin interfaces whose `provide*` method is a real JVM default method
-    // (the project compiles with -Xjvm-default). Invoke it via an `invokespecial` MethodHandle so we
+    // (the project compiles with -jvm-default). Invoke it via an `invokespecial` MethodHandle so we
     // don't depend on java.lang.reflect.InvocationHandler.invokeDefault, which the `:app` unit-test
     // classpath resolves against Android's stubbed reflection types that lack it.
     val proxy = Proxy.newProxyInstance(

--- a/app/network/network-clients/build.gradle.kts
+++ b/app/network/network-clients/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
       implementation(projects.coreDatastorePublic)
       implementation(projects.languageCore)
     }
-    val mobileMain by getting {
+    getByName("mobileMain") {
       dependencies {
         implementation(libs.datadog.sdk.ktor)
       }

--- a/build-logic/convention/src/main/kotlin/ApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ApplicationConventionPlugin.kt
@@ -15,7 +15,6 @@ class ApplicationConventionPlugin : Plugin<Project> {
       with(pluginManager) {
         apply(libs.plugins.androidApplication.get().pluginId)
         apply(libs.plugins.cacheFix.get().pluginId)
-        apply(libs.plugins.kotlin.get().pluginId)
       }
 
       extensions.configure<ApplicationExtension> {

--- a/build-logic/convention/src/main/kotlin/HedvigGradlePlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HedvigGradlePlugin.kt
@@ -128,7 +128,12 @@ private fun Project.configureMetro(libs: LibrariesForLibs) {
   pluginManager.withPlugin(libs.plugins.kotlinJvm.get().pluginId) {
     pluginManager.apply(metroPluginId)
   }
-  pluginManager.withPlugin(libs.plugins.kotlin.get().pluginId) {
+  // Android modules get their Kotlin compilation from AGP's built-in Kotlin support, so key off the
+  // AGP plugins rather than a standalone Kotlin plugin.
+  pluginManager.withPlugin(libs.plugins.androidApplication.get().pluginId) {
+    pluginManager.apply(metroPluginId)
+  }
+  pluginManager.withPlugin(libs.plugins.androidLibrary.get().pluginId) {
     pluginManager.apply(metroPluginId)
   }
 
@@ -161,7 +166,14 @@ private fun Project.configureCommonDependencies(libs: LibrariesForLibs) {
       configureCommonDependencies(project, libs)
     }
   }
-  pluginManager.withPlugin(libs.plugins.kotlin.get().pluginId) {
+  // Android modules use AGP's built-in Kotlin support, so key off the AGP plugins to attach the
+  // shared implementation dependencies (Compose BOM, logging, tracking).
+  pluginManager.withPlugin(libs.plugins.androidApplication.get().pluginId) {
+    dependencies {
+      configureCommonDependencies(project, libs)
+    }
+  }
+  pluginManager.withPlugin(libs.plugins.androidLibrary.get().pluginId) {
     dependencies {
       configureCommonDependencies(project, libs)
     }

--- a/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
@@ -17,7 +17,6 @@ class LibraryConventionPlugin : Plugin<Project> {
       with(pluginManager) {
         apply(libs.plugins.androidLibrary.get().pluginId)
         apply(libs.plugins.cacheFix.get().pluginId)
-        apply(libs.plugins.kotlin.get().pluginId)
       }
 
       extensions.configure<LibraryExtension> {

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/ConfigureKotlinCommonCompilerOptions.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/ConfigureKotlinCommonCompilerOptions.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 internal fun KotlinCommonCompilerOptions.configureKotlinCompilerOptions() {
   when (this) {
     is KotlinJvmCompilerOptions -> {
-      configureCommonKotlinCompilerOptions(listOf("-Xjvm-default=all"))
+      configureCommonKotlinCompilerOptions(listOf("-jvm-default=no-compatibility"))
       jvmTarget.set(JvmTarget.JVM_21)
     }
 

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/HedvigGradlePluginExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/HedvigGradlePluginExtension.kt
@@ -22,6 +22,7 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.compose.ComposeExtension
@@ -194,7 +195,7 @@ private abstract class ApolloHandler {
         this.packageName.set(packageName)
 
         @Suppress("OPT_IN_USAGE")
-        dependsOn(project.project(":apollo-octopus-public"), true)
+        dependsOn(project.dependencies.project(":apollo-octopus-public"), true)
         extraConfiguration.execute(this)
       }
     }
@@ -320,7 +321,7 @@ private abstract class NavKeysHandler {
     val isMultiplatform = project.extensions.findByType<KotlinMultiplatformExtension>() != null
     val kspConfiguration = if (isMultiplatform) "kspAndroid" else "ksp"
     project.dependencies {
-      add(kspConfiguration, project.project(":navigation-keys-processor"))
+      add(kspConfiguration, project(":navigation-keys-processor"))
     }
   }
 }
@@ -328,7 +329,7 @@ private abstract class NavKeysHandler {
 private abstract class ViewModelsHandler {
   fun configure(project: Project, pluginManager: PluginManager, libs: LibrariesForLibs) {
     pluginManager.apply(libs.plugins.ksp.get().pluginId)
-    val processor = project.project(":viewmodel-processor")
+    val processor = project.dependencies.project(":viewmodel-processor")
     val isMultiplatform = project.extensions.findByType<KotlinMultiplatformExtension>() != null
     if (!isMultiplatform) {
       project.dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
    alias(libs.plugins.doctor)
   alias(libs.plugins.googleServices) apply false
   alias(libs.plugins.kmpNativeCoroutines) apply false
-  alias(libs.plugins.kotlin) apply false
   alias(libs.plugins.kotlinJvm) apply false
   alias(libs.plugins.kotlinMultiplatform) apply false
   alias(libs.plugins.kotlinter) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,14 +38,10 @@ kotlin.internal.collectFUSMetrics=false
 metro.generateContributionProviders=true
 android.defaults.buildfeatures.resvalues=true
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
 android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.dependency.excludeLibraryComponentsFromConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
 
 kotlin.native.binary.forceNativeThreadStateForFunctions=org_jetbrains_skia_DirectContext__1nFlushAndSubmit;org_jetbrains_skia_Canvas__1nDrawPicture

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,5 +48,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 
-kotlin.native.cacheKind.iosSimulatorArm64=none
 kotlin.native.binary.forceNativeThreadStateForFunctions=org_jetbrains_skia_DirectContext__1nFlushAndSubmit;org_jetbrains_skia_Canvas__1nDrawPicture

--- a/micro-apps/design-showcase/build.gradle.kts
+++ b/micro-apps/design-showcase/build.gradle.kts
@@ -28,11 +28,10 @@ android {
   }
 
   buildTypes {
-    @Suppress("UNUSED_VARIABLE")
-    val debug by getting {
+    val debug = getByName("debug") {
       isDebuggable = true
     }
-    val release by getting {
+    getByName("release") {
       signingConfig = debug.signingConfig
       applicationIdSuffix = ".app"
       isMinifyEnabled = true


### PR DESCRIPTION
## What

Dependency-bump housekeeping plus the Gradle 9 / AGP 9 deprecation cleanup that the bump surfaced. This is the non-Apollo subset of Renovate PR #2886 (the Apollo 5.0 major bump is deliberately excluded, it deserves its own PR), followed by the deprecation fixes.

## Commits

- **Bump versions** — the non-Apollo dependency + GitHub Actions bumps from #2886 (kotlinter, jetbrainsMarkdown, classgraph, dependencyAnalysis, okio, develocity, and the workflow action versions). Apollo stays at 4.4.3.
- **Stop using deprecated gradle `by getting` api** — `by getting`/`by creating` → `getByName(...)`/`create(...)`.
- **Stop using deprecated Project-as-dependency-notation in convention plugin** — `project.project(":path")` → `DependencyHandler.project(String)`. (Fails in Gradle 10.)
- **Remove dead kotlin.native.cacheKind property** — no-op since Kotlin 2.3.20.
- **Use stabilized -jvm-default compiler flag** — `-Xjvm-default=all` → `-jvm-default=no-compatibility` (identical codegen).
- **Migrate Android modules to AGP built-in Kotlin** — stop applying `org.jetbrains.kotlin.android`; drop the AGP 9 transitional flags (`android.builtInKotlin`, `android.newDsl`, `android.enableAppCompileTimeRClass`, `android.uniquePackageNames`). The two `HedvigGradlePlugin` hooks that keyed off the standalone Kotlin plugin (Metro application + shared Compose BOM/logging/tracking deps) now trigger on the AGP plugins.

## Notes

- KMP modules use the separate `com.android.kotlin.multiplatform.library` plugin and are unaffected; iOS is unaffected (the removed flags are AGP-only).
- Checked against the AGP 9 upgrade skill: no `kotlinOptions`/`packagingOptions`/legacy variant API/kapt/custom BuildConfig to migrate; KSP is 2.3.10.

## Verification

- Full module graph compiles; `:app:assembleDebug` + `:app:testDebugUnitTest` pass; `:design-showcase:assembleDebug` passes.
- `./gradlew help` and `./gradlew build --dry-run` (Doctor temporarily disabled) both succeed.
- All targeted deprecation warnings (`by getting`, Project-as-dependency-notation, `org.jetbrains.kotlin.android`, `android.newDsl`/`builtInKotlin`, `-Xjvm-default`) are gone.

## Out of scope

- Apollo 4.4.3 → 5.0.1 (major, separate PR).
- `Project.getProperties` deprecation lives inside the third-party Gradle Doctor plugin (no upstream fix available).
