### PR TITLE
Feature: send claimId for closed-claim cross-sell flow

### DIFF
--- a/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
+++ b/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
@@ -122,20 +122,21 @@ internal class CrossSellSheetPresenter(
 }
 
 internal fun CrossSellInfoType.toCrossSellSource(): CrossSellInput {
-  val smartCrossSellInput: (FlowSource) -> CrossSellInput = { flowSource ->
+  val smartCrossSellInput: (flowSource: FlowSource, claimId: String?) -> CrossSellInput = { flowSource, claimId ->
     CrossSellInput(
       userFlow = UserFlow.SMART_X_SELL,
       flowSource = Optional.present(flowSource),
       experiments = emptyList(),
       contractId = Optional.presentIfNotNull(this.contractId),
+      claimId = Optional.presentIfNotNull(claimId),
     )
   }
   return when (this) {
-    CrossSellInfoType.Addon -> smartCrossSellInput(FlowSource.ADDON)
-    is CrossSellInfoType.ChangeTier -> smartCrossSellInput(FlowSource.CHANGE_TIER)
-    is CrossSellInfoType.ClosedClaim -> smartCrossSellInput(FlowSource.CLOSED_CLAIM)
-    CrossSellInfoType.EditCoInsured -> smartCrossSellInput(FlowSource.EDIT_COINSURED)
-    is CrossSellInfoType.MovingFlow -> smartCrossSellInput(FlowSource.MOVING)
+    CrossSellInfoType.Addon -> smartCrossSellInput(FlowSource.ADDON, null)
+    is CrossSellInfoType.ChangeTier -> smartCrossSellInput(FlowSource.CHANGE_TIER, null)
+    is CrossSellInfoType.ClosedClaim -> smartCrossSellInput(FlowSource.CLOSED_CLAIM, info.id)
+    CrossSellInfoType.EditCoInsured -> smartCrossSellInput(FlowSource.EDIT_COINSURED, null)
+    is CrossSellInfoType.MovingFlow -> smartCrossSellInput(FlowSource.MOVING, null)
   }
 }
 

--- a/app/feature/feature-cross-sell-sheet/src/test/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellInfoTypeToCrossSellInputTest.kt
+++ b/app/feature/feature-cross-sell-sheet/src/test/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellInfoTypeToCrossSellInputTest.kt
@@ -33,4 +33,28 @@ class CrossSellInfoTypeToCrossSellInputTest {
     assertThat(input.flowSource).isEqualTo(Optional.present(FlowSource.MOVING))
     assertThat(input.contractId).isEqualTo(Optional.absent())
   }
+
+  @Test
+  fun `a closed claim flow passes the claim id to the cross sell input`() {
+    val input = CrossSellInfoType.ClosedClaim(
+      info = CrossSellInfoType.ClosedClaim.ClaimInfo(
+        id = "claimId",
+        status = null,
+        type = null,
+        typeOfContract = null,
+      ),
+      contractId = "contractId",
+    ).toCrossSellSource()
+
+    assertThat(input.flowSource).isEqualTo(Optional.present(FlowSource.CLOSED_CLAIM))
+    assertThat(input.claimId).isEqualTo(Optional.present("claimId"))
+    assertThat(input.contractId).isEqualTo(Optional.present("contractId"))
+  }
+
+  @Test
+  fun `a flow that is not a closed claim leaves the claim id absent in the cross sell input`() {
+    val input = CrossSellInfoType.ChangeTier("contractId").toCrossSellSource()
+
+    assertThat(input.claimId).isEqualTo(Optional.absent())
+  }
 }


### PR DESCRIPTION
Thread the claim id into CrossSellInput.claimId for the CLOSED_CLAIM flow source. The backend added the optional claimId field to CrossSellInput (only allowed when flowSource is CLOSED_CLAIM) and asked clients to populate it for the closed-claim x-sell flow.