### PR TITLE
Fix co-owners copy in new home screen

### DIFF
--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -510,6 +510,7 @@
   <string name="HOME_QUICK_ACTIONS_EDIT_INSURANCE">Ändra försäkring</string>
   <string name="HOME_QUOTES_SECTION_TITLE">Dina prisförslag</string>
   <string name="HOME_TODO_ADD_COINSURED_TITLE">Lägg till medförsäkrad</string>
+  <string name="HOME_TODO_ADD_COOWNER_TITLE">Lägg till medägare</string>
   <string name="HOME_TODO_MISSING_CHIP_ID_TITLE">Chip-ID för husdjur saknas</string>
   <string name="HOME_TODO_MISSING_PAYMENT_METHOD_TITLE">Betalningsmetod saknas</string>
   <string name="HOME_TODO_MISSING_PAYOUT_METHOD_TITLE">Utbetalningsmetod saknas</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -510,6 +510,7 @@
   <string name="HOME_QUICK_ACTIONS_EDIT_INSURANCE">Edit insurance</string>
   <string name="HOME_QUOTES_SECTION_TITLE">Your quotes</string>
   <string name="HOME_TODO_ADD_COINSURED_TITLE">Add co-insured</string>
+  <string name="HOME_TODO_ADD_COOWNER_TITLE">Add co-owner</string>
   <string name="HOME_TODO_MISSING_CHIP_ID_TITLE">Missing pet chip-ID</string>
   <string name="HOME_TODO_MISSING_PAYMENT_METHOD_TITLE">Missing payment method</string>
   <string name="HOME_TODO_MISSING_PAYOUT_METHOD_TITLE">Missing payout method</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -509,6 +509,7 @@
   <string name="HOME_QUICK_ACTIONS_EDIT_INSURANCE">Ändra försäkring</string>
   <string name="HOME_QUOTES_SECTION_TITLE">Dina prisförslag</string>
   <string name="HOME_TODO_ADD_COINSURED_TITLE">Lägg till medförsäkrad</string>
+  <string name="HOME_TODO_ADD_COOWNER_TITLE">Lägg till medägare</string>
   <string name="HOME_TODO_MISSING_CHIP_ID_TITLE">Chip-ID för husdjur saknas</string>
   <string name="HOME_TODO_MISSING_PAYMENT_METHOD_TITLE">Betalningsmetod saknas</string>
   <string name="HOME_TODO_MISSING_PAYOUT_METHOD_TITLE">Utbetalningsmetod saknas</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -509,6 +509,7 @@
   <string name="HOME_QUICK_ACTIONS_EDIT_INSURANCE">Edit insurance</string>
   <string name="HOME_QUOTES_SECTION_TITLE">Your quotes</string>
   <string name="HOME_TODO_ADD_COINSURED_TITLE">Add co-insured</string>
+  <string name="HOME_TODO_ADD_COOWNER_TITLE">Add co-owner</string>
   <string name="HOME_TODO_MISSING_CHIP_ID_TITLE">Missing pet chip-ID</string>
   <string name="HOME_TODO_MISSING_PAYMENT_METHOD_TITLE">Missing payment method</string>
   <string name="HOME_TODO_MISSING_PAYOUT_METHOD_TITLE">Missing payout method</string>

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderToDoList.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderToDoList.kt
@@ -43,6 +43,7 @@ import com.hedvig.android.design.system.hedvig.icon.ProfileOutline
 import com.hedvig.android.design.system.hedvig.icon.WarningOutline
 import com.hedvig.android.memberreminders.MemberReminder
 import hedvig.resources.HOME_TODO_ADD_COINSURED_TITLE
+import hedvig.resources.HOME_TODO_ADD_COOWNER_TITLE
 import hedvig.resources.HOME_TODO_MISSING_CHIP_ID_TITLE
 import hedvig.resources.HOME_TODO_MISSING_PAYMENT_METHOD_TITLE
 import hedvig.resources.HOME_TODO_MISSING_PAYOUT_METHOD_TITLE
@@ -210,7 +211,10 @@ private fun MemberReminder.toToDoRowOrNull(
   is MemberReminder.CoInsuredInfo -> ToDoRowData(
     icon = HedvigIcons.ProfileOutline,
     iconTint = ToDoRowIconTint.Primary,
-    title = Res.string.HOME_TODO_ADD_COINSURED_TITLE,
+    title = when (coInsuredType) {
+      CoInsuredFlowType.CoInsured -> Res.string.HOME_TODO_ADD_COINSURED_TITLE
+      CoInsuredFlowType.CoOwners -> Res.string.HOME_TODO_ADD_COOWNER_TITLE
+    },
     onClick = { navigateToAddMissingInfo(contractId, coInsuredType) },
   )
 
@@ -318,6 +322,7 @@ private fun PreviewMemberReminderToDoList() {
           MemberReminder.PaymentReminder.ConnectPayout(),
           MemberReminder.MissingChipId(),
           MemberReminder.CoInsuredInfo("contractId", CoInsuredFlowType.CoInsured),
+          MemberReminder.CoInsuredInfo("contractId", CoInsuredFlowType.CoOwners),
           MemberReminder.ContactInfoUpdateNeeded,
         ),
         navigateToConnectPayment = {},


### PR DESCRIPTION
Was always saying "co-insured" in the "to-do" list in the home screen even for co-owner cases
Still navigates to the right flow