### PR TITLE
chore: regenerate lint baselines with lint 9.3.1

### DIFF
--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-auth-listeners.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-auth-listeners.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-network-cache-manager.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-network-cache-manager.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-public.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-operation-error.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-operation-error.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-app.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-app.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-audio-player-data.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-audio-player-data.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-audio-player-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-audio-player-ui.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-core-api.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-core-api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-core-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-core-public.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-core-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-core-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-event-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-event-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-event-fake.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-event-fake.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-authlib.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-authlib.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-claim-status.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-claim-status.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-pager-indicator.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-pager-indicator.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-photo-capture-state.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-photo-capture-state.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-ui.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-webview.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-webview.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-app-review.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-app-review.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-build-constants.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-build-constants.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-common-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-common-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-common-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-common-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-datastore-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-datastore-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-datastore-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-datastore-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-demo-mode.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-demo-mode.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-design-system.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-design-system.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-file-upload.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-file-upload.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-icons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-icons.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-locale.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-locale.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.12.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.0)" variant="all" version="8.12.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-markdown.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-markdown.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-rive.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-rive.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.0.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0)" variant="all" version="9.0.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-ui-data.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-ui-data.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-ui.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-cross-sells.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-cross-sells.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-addons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-addons.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-changetier.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-changetier.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-chat.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-chat.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-claim-intent.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-claim-intent.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.1.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.1.1)" variant="all" version="9.1.1">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-coinsured.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-coinsured.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.0.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0)" variant="all" version="9.0.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-contract-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-contract-android.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-contract-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-contract-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-conversations.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-conversations.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-claim-closed.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-claim-closed.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.2)" variant="all" version="8.8.2">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-flow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-flow.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.2)" variant="all" version="8.8.2">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-display-items.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-display-items.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-paying-member.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-paying-member.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-android.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-public.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-public.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-termination.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-termination.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-database-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-database-android.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-database-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-database-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-database-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-database-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-datadog-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-datadog-android.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-datadog-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-datadog-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-datadog-demo-tracking.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-datadog-demo-tracking.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-showcase-desktop.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-showcase-desktop.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-showcase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-showcase.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-system-api.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-system-api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-system-hedvig.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-system-hedvig.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-system-internals.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-system-internals.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-addon-purchase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-addon-purchase.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-changeaddress.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-changeaddress.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-chat.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-chat.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-chip-id.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-chip-id.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.0.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0)" variant="all" version="9.0.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-choose-tier.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-choose-tier.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-claim-details.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-claim-details.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-claim-history.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-claim-history.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-connect-payment-trustly.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-connect-payment-trustly.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-cross-sell-after-flow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-cross-sell-after-flow.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-cross-sell-sheet.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-cross-sell-sheet.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.2)" variant="all" version="8.8.2">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-delete-account.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-delete-account.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-edit-coinsured.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-edit-coinsured.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-flags-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-flags-android.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.12.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.0)" variant="all" version="8.12.0">
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-flags-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-flags-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-flags-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-flags-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-force-upgrade.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-force-upgrade.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-forever.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-forever.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-help-center.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-help-center.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-home.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-home.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-image-viewer.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-image-viewer.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.0)" variant="all" version="8.8.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-impersonation.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-impersonation.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.0)" variant="all" version="8.8.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-insurance-certificate.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-insurance-certificate.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.2)" variant="all" version="8.8.2">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-insurances.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-insurances.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-login.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-login.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-movingflow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-movingflow.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-onboarding.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-onboarding.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
+
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-payments.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-payments.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-payout-account.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-payout-account.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.0.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0)" variant="all" version="9.0.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-profile.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-profile.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-remove-addons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-remove-addons.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.12.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.0)" variant="all" version="8.12.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-terminate-insurance.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-terminate-insurance.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-travel-certificate.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-travel-certificate.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-file-upload-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-file-upload-ui.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-forever-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-forever-ui.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-initializable.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-initializable.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-data.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-data.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-migration.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-migration.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-logging-device-model.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-logging-device-model.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.12.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.0)" variant="all" version="8.12.0">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-logging-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-logging-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-logging-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-logging-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-member-reminders-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-member-reminders-public.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-member-reminders-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-member-reminders-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-member-reminders-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-member-reminders-ui.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-molecule-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-molecule-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-molecule-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-molecule-test.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-activity.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-activity.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-common.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-common.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-compose-typed.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-compose-typed.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-compose.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-compose.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-badge-data-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-badge-data-public.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-firebase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-firebase.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-permission.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-permission.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-partners-deflect.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-partners-deflect.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.0.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0)" variant="all" version="9.0.0">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-placeholder.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-placeholder.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-pullrefresh.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-pullrefresh.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-shareddi.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-shareddi.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-test-clock.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-test-clock.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-theme.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-theme.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tier-comparison.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tier-comparison.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tracking-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tracking-core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tracking-datadog.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tracking-datadog.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tracking-firebase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tracking-firebase.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.1.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.1.1)" variant="all" version="9.1.1">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-ui-claim-flow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-ui-claim-flow.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-ui-claimflow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-ui-claimflow.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-ui-emergency.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-ui-emergency.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
 
 </issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-ui-tiers-and-addons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-ui-tiers-and-addons.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha09" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.8.0-alpha09">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-umbrella.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-umbrella.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
-
-</issues>


### PR DESCRIPTION
Stacked on top of #3048 (base branch is `chore/lint-baseline-9.3.1-cleanup`). Review/merge #3048 first.

Mechanical `updateLintBaseline` run to unify all module baselines on the current lint version. Baselines were spread across lint 8.8.0-alpha09 / 8.10.0 / 8.12.0 / 9.0.0 / 9.1.1; now all on 9.3.1.

**No new findings** — content is unchanged, only the version headers move to 9.3.1, and empty baselines are dropped. This is possible because the code fixes in #3048 resolved the only modules that had new lint-9.3.1 findings, so a fresh regeneration surfaces nothing.

The diff is large but mechanical: ~102 header-only bumps + removal of 33 empty baseline files.

Note: `core-resources` is a KMP-android module with no `updateLintBaseline` task, so its baseline can't be regenerated this way and is intentionally left as-is.