### PR TITLE
Fix NoSuchMethodError: WindowMetrics.getDensity() crash on launch

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/MainActivity.kt
@@ -13,10 +13,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.ComposeFoundationFlags
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.retain.retain
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
@@ -254,7 +257,14 @@ class MainActivity : AppCompatActivity() {
       CompositionLocalProvider(
         LocalMetroViewModelFactory provides navRetainedViewModel.viewModelFactory,
       ) {
-        val windowSizeClass = calculateWindowSizeClass(this@MainActivity)
+        // Compute the window size class from Configuration. Do not switch this to
+        // calculateWindowSizeClass(activity) or LocalWindowInfo.containerSize: both route through
+        // androidx.window's WindowMetricsCalculator, which invokes WindowMetrics.getDensity(). That
+        // method is absent on some Android 14 builds, crashing at launch with NoSuchMethodError.
+        val configuration = LocalConfiguration.current
+        val windowSizeClass = WindowSizeClass.calculateFromSize(
+          DpSize(configuration.screenWidthDp.dp, configuration.screenHeightDp.dp),
+        )
         HedvigApp(
           backstackController = backstackController,
           deepLinkReadySignal = sessionReconciler.isReady,


### PR DESCRIPTION
## Problem

The app crashes on launch on some Android 14 devices, before the first frame:

```
Fatal Exception: java.lang.NoSuchMethodError: No virtual method getDensity()F
in class Landroid/view/WindowMetrics;
  at androidx.window.layout.util.DensityCompatHelperApi34Impl.density(DensityCompatHelper.kt:64)
  at androidx.window.layout.WindowMetricsCalculatorCompat.computeCurrentWindowMetrics(...)
  at androidx.compose.material3.windowsizeclass.calculateWindowSizeClass(AndroidWindowSizeClass_android.kt:44)
  at com.hedvig.android.app.MainActivity.onCreate$lambda$4$0(MainActivity.java:253)
```

`MainActivity` derived the window size class with material3's `calculateWindowSizeClass(activity)`. That routes through androidx.window's `WindowMetricsCalculator`, which calls `WindowMetrics.getDensity()`. That method is not present on some Android 14 platform builds, so the call links to nothing at runtime and throws `NoSuchMethodError` during initial composition. The library gates the call at API 34 but relies on a method only present in a later Android 14 revision.

`androidx.window:window:1.5.0` is pulled in transitively via `material3-window-size-class:1.5.0-alpha17` (from the `jetbrains-material3 = 1.11.0-alpha07` stack).

## Fix

Compute the `WindowSizeClass` from `Configuration` (`screenWidthDp` / `screenHeightDp`) via `WindowSizeClass.calculateFromSize`, which reads `Resources.getConfiguration()` and never touches androidx.window.

A guard comment at the call site documents why we avoid both `calculateWindowSizeClass(activity)` and `LocalWindowInfo.containerSize` (the latter routes through the same androidx.window density path in Compose UI 1.11.4).

## Verification

Built the R8-minified staging APK and inspected the shrunk dex + `mapping.txt`:

- material3's `AndroidWindowSizeClass_androidKt` (the crashing path) is stripped from the shipped app: the reported crash cannot recur.
- The only residual `WindowMetrics.getDensity()` reference is Compose UI's lazy `LocalWindowInfo.containerSize` path. It is computed only on read, and no app code reads `containerSize` (custom navigation, no material3 adaptive APIs), so it never executes.

## Scope note

This removes the live trigger of the buggy androidx.window code without pinning the dependency. If the app later adopts Compose adaptive-layout APIs that read `containerSize`, the underlying androidx.window bug would resurface and pinning `androidx.window` would then be warranted.

Firebase Crashlytics issue: `6a11e58b371ac16c7a6781fc95171530`
Affected version: 14.4.2 (1786360451)