### PR TITLE
Bug/onboarding flag issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,22 +604,28 @@ dependencies {
 Feature flags are backed by Unleash. Before adding or changing a flag, read
 `app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md` — it explains why we never use
 the SDK's `defaultValue` parameter (Unleash Android SDK issue #141), how a flag's value is
-resolved when Unleash has never been fetched, and when bootstrap is required.
+resolved when Unleash has never been fetched, and when a never-fetched default is required.
 
 To add a new flag:
 1. Add the enum value to `Feature` (commonMain), named to mirror its Unleash key polarity
    (`ENABLE_X` for `enable_x`, `DISABLE_X` for `disable_x`), with a short explanation.
 2. Map it to its raw Unleash key in `Feature.unleashKey` (androidMain).
-3. `UnleashFeatureFlagProvider` needs no change — it returns the raw `isEnabled(key)` for
-   every flag. At the read site, use the value directly for a positive flag, or invert it
-   (`if (!disableX)`) for a kill switch.
+3. `UnleashFeatureFlagProvider` needs no change — every flag resolves through
+   `HedvigUnleashClient.valueOf(feature)`. At the read site, use the value directly for a
+   positive flag, or invert it (`if (!disableX)`) for a kill switch.
 
-**IMPORTANT — always reconsider bootstrap when adding a feature:** Decide what the flag
-should resolve to when it has *never been fetched* (offline first launch / fresh install
-before the first poll returns). If the natural polarity default is acceptable, do nothing.
-If a rollout needs the opposite default, add a `Toggle(...)` to the bootstrap list in
-`HedvigUnleashClient.start(...)`. Never bootstrap an app-gating flag (e.g.
+**IMPORTANT — always reconsider the never-fetched default when adding a feature:** Decide
+what the flag should resolve to when it has *never been fetched* (offline first launch /
+fresh install before the first poll returns). If the natural polarity default is
+acceptable, do nothing. If a rollout needs the opposite default, add an entry to
+`neverFetchedDefaults` in `HedvigUnleashClient`. Never default an app-gating flag (e.g.
 `UPDATE_NECESSARY`) into its blocking state — that can brick the app for offline users.
+
+**Never pass `bootstrap` to `client.start(...)`.** It is the SDK's own seeding mechanism and
+it looks like the right tool, but a bootstrapped toggle set makes the client report ready
+before any real toggle data exists and permanently suppresses the on-disk backup, so every
+flag without a bootstrap entry silently reads `false` at startup. `FEATURE_FLAG_DEFAULTS.md`
+documents the mechanism.
 
 ### Working with Translations
 

--- a/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
+++ b/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
@@ -9,13 +9,16 @@ returns, etc.). Read this before adding a new flag.
 
 - We **only** call `client.isEnabled(name)`. We **never** call the
   `isEnabled(name, defaultValue)` overload — it's broken with the Frontend API.
+- We **never** pass `bootstrap` to `client.start()`. It looks like the natural place to seed
+  defaults, and it silently breaks readiness and the local backup — see
+  [Why we don't use the SDK's `bootstrap` parameter](#why-we-dont-use-the-sdks-bootstrap-parameter).
 - An absent toggle reads as `false`. We control the real default through two levers:
   1. **Flag naming polarity** (`enable_x` vs `disable_x`). Each `Feature` enum value is
-     named to mirror its underlying Unleash key, and `UnleashFeatureFlagProvider` returns
-     the raw `isEnabled(key)` value with no per-flag negation. A `disable_x` flag therefore
-     reports "is the kill switch on"; the consumer inverts at the read site.
-  2. **Bootstrap** — only for the one flag where polarity alone gives the wrong default.
-- Only `DISABLE_PUPPY_GUIDE` is bootstrapped today. Adding others is usually noise and, for
+     named to mirror its underlying Unleash key, and there is no per-flag negation anywhere, so
+     a `disable_x` flag reports "is the kill switch on"; the consumer inverts at the read site.
+  2. **`neverFetchedDefaults`**, a map in `HedvigUnleashClient`, for the flags where polarity
+     alone gives the wrong default.
+- `neverFetchedDefaults` holds three entries today. Adding others is usually noise and, for
   app-gating flags like `UPDATE_NECESSARY`, actively dangerous.
 
 ## The bug: Unleash Android SDK issue #141
@@ -32,9 +35,14 @@ hasn't seen. As long as we never pass a `defaultValue`, we're not exposed to #14
 
 ## How a flag resolves to a value
 
-`isEnabled(name)` returns `false` for an absent toggle. `UnleashFeatureFlagProvider`
-returns that raw value unchanged — the `Feature` name mirrors the key's polarity, so the
-toggle value *is* the flag value. The polarity convention then determines the default:
+`UnleashFeatureFlagProvider` resolves every read through `HedvigUnleashClient.valueOf(feature)`:
+
+- once the client holds real toggle state (`isReady()`), it returns `client.isEnabled(key)`;
+- before that, it returns the flag's `neverFetchedDefaults` entry, or `false` if it has none.
+
+`isEnabled(name)` returns `false` for an absent toggle, and a `Feature`'s name mirrors its key's
+polarity, so the toggle value *is* the flag value. The polarity convention then determines the
+default:
 
 - **Positive flags** (`enable_x`, `update_necessary`…) read `isEnabled(key)`. Absent →
   `false` → feature **off**. Good default for new features: they stay off until we
@@ -47,6 +55,10 @@ toggle value *is* the flag value. The polarity convention then determines the de
   it stays off and the feature stays on — an inherent and acceptable property of a kill
   switch.
 
+Reads are exposed as a `Flow`. `featureUpdatedFlow` emits on any toggle-state change, which
+includes the local backup being restored and not only a network fetch, so a collector that starts
+before the backup lands still sees the value update.
+
 ## When the "never fetched" default actually matters
 
 Thanks to `LocalBackup`, the SDK persists the last successfully-fetched toggle state and
@@ -57,42 +69,75 @@ window:
 - Fresh install while fully offline.
 
 After any successful fetch, an offline launch uses the last-known remote state, not the
-bootstrap/absent default.
+never-fetched default.
 
-## Bootstrap: when and why
+This holds only because we leave `bootstrap` unset. Seeding it stops the backup from ever loading,
+which widens that narrow window to every cold start.
 
-`HedvigUnleashClient.start(bootstrap = …)` seeds toggle state before the first fetch.
-Bootstrap is only needed when the **desired** never-fetched default differs from the
-**natural** polarity default.
+## Why we don't use the SDK's `bootstrap` parameter
 
-Today the only entry is:
+`DefaultUnleash.start(bootstrap = …)` looks like the obvious place to seed never-fetched defaults.
+It isn't, because of how the SDK defines readiness (verified against `unleash-android:3.3.1`):
+
+- `start()` writes the bootstrap toggles into the toggle cache as an ordinary cache update,
+  indistinguishable from fetched data.
+- `readyOnFeaturesReceived()` marks the client ready on the first **non-empty** cache update.
+  Bootstrap satisfies that on its own, so `isReady()` becomes true before any real data exists.
+- `initializeLocalBackup()` only attempts to load the on-disk backup *while the client is not
+  ready*. Once bootstrap has made it ready, the backup is never loaded at all.
+
+The consequences are all silent:
+
+- `awaitReady()` returns immediately with only the bootstrapped toggles in cache, so it reports
+  "we have flag values" when we effectively don't. Every flag without a bootstrap entry reads
+  `false` until the first poll returns.
+- Offline launches lose last-known-good state entirely, since the backup can no longer load. The
+  app has only the handful of values compiled into the bootstrap list.
+- A `304 NOT_MODIFIED` response never repopulates the cache (`doFetchToggles` emits toggles only on
+  success), while the OkHttp disk cache carries the ETag across process death. The near-empty
+  window can therefore outlast a single poll.
+
+The symptom to recognise: a one-shot flag read (`.first()`) that runs during startup silently gets
+the wrong value, while `Flow`-based reads self-correct a second later and look fine. `OnboardingGate`
+is currently the app's only startup-time one-shot read.
+
+## Never-fetched defaults: when and why
+
+`neverFetchedDefaults` in `HedvigUnleashClient` supplies a flag's value for the window before the
+client holds real toggle state. It is consulted only while `!client.isReady()`; once a fetch or the
+local backup lands, the real value takes over. An entry is only needed when the **desired**
+never-fetched default differs from the **natural** polarity default.
+
+Today:
 
 ```kotlin
-client.start(bootstrap = listOf(Toggle(name = Feature.DISABLE_PUPPY_GUIDE.unleashKey, enabled = true)))
+private val neverFetchedDefaults: Map<Feature, Boolean> = mapOf(
+  Feature.DISABLE_PUPPY_GUIDE to true,
+  Feature.DISABLE_TERMINATION_REDIRECTION to true,
+  Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to true,
+)
 ```
 
-`disable_puppy_guide` is a kill switch, so its natural absent default is "feature on".
-But during rollout we want the puppy guide **hidden** until the first fetch confirms it
-should show. Polarity gives the wrong default, so we bootstrap `enabled = true` (kill
-switch on → feature hidden). Once toggles are fetched, the remote value takes over —
-the bootstrap is discarded wholesale on the first successful fetch.
+All three are kill switches, so their natural absent default is "feature on". Each instead needs to
+stay **hidden** until a fetch confirms it should show, which is what a rollout wants. Polarity gives
+the wrong default, so each gets an entry of `true` (kill switch on → feature hidden).
 
-### Do NOT bootstrap app-gating flags to the "blocking" state
+### Do NOT default app-gating flags to the "blocking" state
 
 `UPDATE_NECESSARY` is the cautionary example. `update_necessary` is positive, so absent →
 `false` → the app does **not** force an update → offline users can still use the app.
-That's the safe direction. Bootstrapping it to `true` would brick the app for anyone who
+That's the safe direction. Giving it an entry of `true` would brick the app for anyone who
 is offline on first launch. Leave it alone.
 
 ## Adding a new flag — checklist
 
 1. Add the enum value to `Feature` (commonMain), named to mirror its Unleash key polarity
    (`ENABLE_X` for `enable_x`, `DISABLE_X` for `disable_x`), with a short explanation.
-2. Add its raw Unleash key to `Feature.unleashKey` (androidMain). `UnleashFeatureFlagProvider`
-   needs no change — it returns `isEnabled(key)` for every flag.
-3. At the read site, use the value directly for a positive flag, or invert it
-   (`if (!disableX)`) for a kill switch.
+2. Add its raw Unleash key to `Feature.unleashKey` (androidMain).
+3. `UnleashFeatureFlagProvider` needs no change — every flag resolves through
+   `HedvigUnleashClient.valueOf(feature)`. At the read site, use the value directly for a
+   positive flag, or invert it (`if (!disableX)`) for a kill switch.
 4. Ask: **what should this be when never fetched / offline on first launch?**
-   - If the natural polarity default is acceptable → done, no bootstrap.
-   - If you need the opposite default during rollout → add a `Toggle(...)` to the
-     bootstrap list. Double-check you're not gating the whole app into a blocked state.
+   - If the natural polarity default is acceptable → done, no entry needed.
+   - If you need the opposite default during rollout → add an entry to `neverFetchedDefaults`.
+     Double-check you're not gating the whole app into a blocked state.

--- a/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
+++ b/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
@@ -57,7 +57,12 @@ default:
 
 Reads are exposed as a `Flow`. `featureUpdatedFlow` emits on any toggle-state change, which
 includes the local backup being restored and not only a network fetch, so a collector that starts
-before the backup lands still sees the value update.
+before the backup lands still sees the value update. It also emits when the client becomes ready,
+which matters because the SDK sets `isReady()` from a coroutine independent of the one that
+notifies state listeners: the two race on the first cache write, and a collector that wins the race
+would read a `neverFetchedDefaults` value out of a cache that already holds real toggles. There is
+no second chance to correct that on its own, since an unchanged toggle set answers `304` and
+`doFetchToggles` writes the cache only on a successful fetch.
 
 ## When the "never fetched" default actually matters
 
@@ -93,9 +98,6 @@ The consequences are all silent:
   `false` until the first poll returns.
 - Offline launches lose last-known-good state entirely, since the backup can no longer load. The
   app has only the handful of values compiled into the bootstrap list.
-- A `304 NOT_MODIFIED` response never repopulates the cache (`doFetchToggles` emits toggles only on
-  success), while the OkHttp disk cache carries the ETag across process death. The near-empty
-  window can therefore outlast a single poll.
 
 The symptom to recognise: a one-shot flag read (`.first()`) that runs during startup silently gets
 the wrong value, while `Flow`-based reads self-correct a second later and look fine. `OnboardingGate`

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
@@ -7,11 +7,9 @@ import com.hedvig.android.featureflags.flags.unleashKey
 import com.hedvig.android.logger.logcat
 import io.getunleash.android.DefaultUnleash
 import io.getunleash.android.UnleashConfig
-import io.getunleash.android.data.Toggle
 import io.getunleash.android.data.UnleashContext
-import io.getunleash.android.events.HeartbeatEvent
-import io.getunleash.android.events.UnleashFetcherHeartbeatListener
 import io.getunleash.android.events.UnleashReadyListener
+import io.getunleash.android.events.UnleashStateListener
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
@@ -26,6 +24,18 @@ private const val DEVELOPMENT_CLIENT_KEY = "*:development.f2455340ac9d599b5816fa
 private const val UNLEASH_URL = "https://eu.app.unleash-hosted.com/eubb1047/api/frontend"
 private const val APP_NAME = "android"
 
+/**
+ * Values used until the client holds real toggle state, for the flags whose natural absent-toggle
+ * default is wrong. These are kill switches that must read as on, keeping their feature hidden,
+ * until a fetch or the local backup says otherwise. An app-gating flag must never get an entry
+ * here: defaulting one into its blocking state locks out members who are offline on first launch.
+ */
+private val neverFetchedDefaults: Map<Feature, Boolean> = mapOf(
+  Feature.DISABLE_PUPPY_GUIDE to true,
+  Feature.DISABLE_TERMINATION_REDIRECTION to true,
+  Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to true,
+)
+
 class HedvigUnleashClient(
   private val androidContext: Context,
   private val isProduction: Boolean,
@@ -33,7 +43,7 @@ class HedvigUnleashClient(
   coroutineScope: CoroutineScope,
   private val memberIdService: MemberIdService,
 ) {
-  val client = DefaultUnleash(
+  private val client = DefaultUnleash(
     androidContext = androidContext,
     unleashConfig = createConfig(),
     unleashContext = createContext(
@@ -41,16 +51,16 @@ class HedvigUnleashClient(
       memberId = null,
     ),
   )
+
+  /**
+   * Emits whenever the toggle state changes for any reason, which includes the local backup being
+   * restored and not just a network fetch, so a flag read while offline still updates once the
+   * last-known-good state loads.
+   */
   val featureUpdatedFlow: Flow<Unit> = callbackFlow {
     trySend(Unit)
-    val listener = object : UnleashFetcherHeartbeatListener {
-      override fun onError(event: HeartbeatEvent) {
-      }
-
-      override fun togglesChecked() {
-      }
-
-      override fun togglesUpdated() {
+    val listener = object : UnleashStateListener {
+      override fun onStateChanged() {
         trySend(Unit)
       }
     }
@@ -62,9 +72,27 @@ class HedvigUnleashClient(
   }
 
   /**
+   * The current value of [feature], falling back to [neverFetchedDefaults] until the client holds
+   * real toggle state. An absent toggle reads as false, so the fallback is what gives a flag whose
+   * natural polarity default is wrong the value it needs in that window.
+   */
+  fun valueOf(feature: Feature): Boolean {
+    return if (client.isReady()) {
+      client.isEnabled(feature.unleashKey)
+    } else {
+      neverFetchedDefaults[feature] ?: false
+    }
+  }
+
+  /**
    * Suspends until Unleash reports isReady(), which it sets on the first non-empty toggle set from
    * either the on-disk backup or a network fetch, returning immediately if it already has. Never
    * completes while the app has never fetched and cannot reach Unleash, so callers must impose a timeout.
+   *
+   * Any toggle state seeded through the SDK's `bootstrap` parameter would also satisfy this, since
+   * readiness is just "the toggle cache became non-empty". Seeding it would additionally stop the
+   * on-disk backup from ever loading, which the SDK only attempts while not yet ready. Defaults for
+   * the never-fetched window therefore live in [neverFetchedDefaults], outside the SDK's cache.
    */
   suspend fun awaitReady() {
     if (client.isReady()) return
@@ -93,15 +121,7 @@ class HedvigUnleashClient(
         )
       }
     }
-    // Bootstrap these kill switches to on, so the features stay hidden until the first successful
-    // fetch. Once toggles are fetched, the remote value takes over.
-    client.start(
-      bootstrap = listOf(
-        Toggle(name = Feature.DISABLE_PUPPY_GUIDE.unleashKey, enabled = true),
-        Toggle(name = Feature.DISABLE_TERMINATION_REDIRECTION.unleashKey, enabled = true),
-        Toggle(name = Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS.unleashKey, enabled = true),
-      ),
-    )
+    client.start()
   }
 
   private fun createConfig(): UnleashConfig {

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
@@ -56,11 +56,20 @@ class HedvigUnleashClient(
    * Emits whenever the toggle state changes for any reason, which includes the local backup being
    * restored and not just a network fetch, so a flag read while offline still updates once the
    * last-known-good state loads.
+   *
+   * It also emits on readiness, because the SDK flips `isReady()` from a coroutine independent of
+   * the one delivering [UnleashStateListener.onStateChanged]. A collector that observed the state
+   * change first would otherwise keep the [neverFetchedDefaults] value until the next cache write,
+   * which an unchanged toggle set never produces.
    */
   val featureUpdatedFlow: Flow<Unit> = callbackFlow {
     trySend(Unit)
-    val listener = object : UnleashStateListener {
+    val listener = object : UnleashStateListener, UnleashReadyListener {
       override fun onStateChanged() {
+        trySend(Unit)
+      }
+
+      override fun onReady() {
         trySend(Unit)
       }
     }

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/UnleashFeatureFlagProvider.kt
@@ -20,7 +20,7 @@ internal class UnleashFeatureFlagProvider(
     // Each Feature's name mirrors the polarity of its underlying Unleash key (enable_* / disable_*),
     // so the raw toggle value is the feature value. Callers of a disable_* flag invert at the read site.
     return hedvigUnleashClient.featureUpdatedFlow
-      .map { hedvigUnleashClient.client.isEnabled(feature.unleashKey) }
+      .map { hedvigUnleashClient.valueOf(feature) }
       .distinctUntilChanged()
   }
 


### PR DESCRIPTION
Fix for the bug where onboarding showed on every cold start regardless of the disable_onboarding F flag.

Seems like it was an existing bug that never surfaced since we don't have any other flag that is needed only once on start and is never re-fetched again.

The cause description from Claude:

>     Root cause was our own bootstrap list. DefaultUnleash.start(bootstrap = …) writes the seeded                                                                      
>      toggles into the cache like any other state; readyOnFeaturesReceived() flips ready on the first                                                                   
>      non-empty cache update, so bootstrap alone made isReady() true instantly; and                                                                                     
>      initializeLocalBackup() only loads the on-disk backup while !ready, so seeding bootstrap also                                                                     
>      meant the backup could never load. Net effect: awaitReady() returned immediately with only the                                                                    
>      three bootstrapped toggles in cache, and every other flag read false until the first poll landed                                                                  
>      ~1s later. OnboardingGate is the app's only one-shot (.first()) flag read that runs at startup,                                                                   
>      so it was the only place the defect was visible.                                                                                                                  

So the fix mainly removed bootstrap from isReady(), and did adjustments: added 3 existing defaults for 3 flags to neverFetchedDefaults map consulted only while !client.isReady(), added valueOf(feature), switched featureUpdatedFlow to UnleashStateListener.onStateChanged().  

