### PR TITLE
Emit on Unleash readiness, not only on toggle state change

### DIFF
--- a/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
+++ b/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
@@ -57,7 +57,12 @@ default:
 
 Reads are exposed as a `Flow`. `featureUpdatedFlow` emits on any toggle-state change, which
 includes the local backup being restored and not only a network fetch, so a collector that starts
-before the backup lands still sees the value update.
+before the backup lands still sees the value update. It also emits when the client becomes ready,
+which matters because the SDK sets `isReady()` from a coroutine independent of the one that
+notifies state listeners: the two race on the first cache write, and a collector that wins the race
+would read a `neverFetchedDefaults` value out of a cache that already holds real toggles. There is
+no second chance to correct that on its own, since an unchanged toggle set answers `304` and
+`doFetchToggles` writes the cache only on a successful fetch.
 
 ## When the "never fetched" default actually matters
 
@@ -93,9 +98,6 @@ The consequences are all silent:
   `false` until the first poll returns.
 - Offline launches lose last-known-good state entirely, since the backup can no longer load. The
   app has only the handful of values compiled into the bootstrap list.
-- A `304 NOT_MODIFIED` response never repopulates the cache (`doFetchToggles` emits toggles only on
-  success), while the OkHttp disk cache carries the ETag across process death. The near-empty
-  window can therefore outlast a single poll.
 
 The symptom to recognise: a one-shot flag read (`.first()`) that runs during startup silently gets
 the wrong value, while `Flow`-based reads self-correct a second later and look fine. `OnboardingGate`

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
@@ -56,11 +56,20 @@ class HedvigUnleashClient(
    * Emits whenever the toggle state changes for any reason, which includes the local backup being
    * restored and not just a network fetch, so a flag read while offline still updates once the
    * last-known-good state loads.
+   *
+   * It also emits on readiness, because the SDK flips `isReady()` from a coroutine independent of
+   * the one delivering [UnleashStateListener.onStateChanged]. A collector that observed the state
+   * change first would otherwise keep the [neverFetchedDefaults] value until the next cache write,
+   * which an unchanged toggle set never produces.
    */
   val featureUpdatedFlow: Flow<Unit> = callbackFlow {
     trySend(Unit)
-    val listener = object : UnleashStateListener {
+    val listener = object : UnleashStateListener, UnleashReadyListener {
       override fun onStateChanged() {
+        trySend(Unit)
+      }
+
+      override fun onReady() {
         trySend(Unit)
       }
     }


### PR DESCRIPTION
Stacked on #3058. Addresses the review comment on `featureUpdatedFlow`, plus one doc correction.

### The race

`valueOf()` branches on `client.isReady()`, but the SDK sets that flag from `readyOnFeaturesReceived()`, a coroutine independent of the one delivering `onStateChanged()` to state listeners. Both collect the same cache-updates `SharedFlow`, so they race on the first cache write with no ordering guarantee.

If the state listener wins, `featureUpdatedFlow` emits, `valueOf()` sees `isReady() == false`, and returns the `neverFetchedDefaults` value out of a cache that already holds real toggles.

On a fresh install nothing corrects that afterwards. `doFetchToggles` emits to `featuresReceivedFlow` only on a successful fetch, and once the fetcher holds an ETag the following polls answer `304`, so there is no further cache write and no further emission. The flag keeps its default for the rest of the process. When a backup exists on disk a second write follows shortly and papers over it, which is why this only bites the never-fetched case the defaults exist for.

### The fix

Register the same listener object as an `UnleashReadyListener` as well. `onReady()` runs after `readyOnFeaturesReceived()` has flipped the flag, so a re-read follows no matter which collector won. `distinctUntilChanged()` in `UnleashFeatureFlagProvider` absorbs the duplicate emission.

`addUnleashEventListener` registers a job per implemented interface into one list keyed by the listener instance, and `removeUnleashEventListener` cancels all of them, so nothing leaks. `onReady()` also cannot be missed if we register late: its job awaits `cache.getUpdatesFlow().first { it.toggles.isNotEmpty() }` over a `replay = 1` flow.

### Doc correction

Dropped the bullet claiming a `304` in a fresh process keeps the cache near-empty via an ETag carried across process death in the OkHttp disk cache. `UnleashFetcher.etag` is an in-memory `var`, so a fresh process sends no `If-None-Match` of its own, and OkHttp never surfaces a `304` to the caller: it merges and returns the stored `200`, which repopulates. Replaced with the race above, which is the real reason the ready emission is needed.

### Verification

`./gradlew :feature-flags:ktlintCheck :feature-flags:compileAndroidMain` passes. All SDK behaviour cited was read from the `unleash-android:3.3.1` sources.