### PR TITLE
Bug: submitting wrong step

### DIFF
--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Button.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Button.kt
@@ -61,6 +61,11 @@ import hedvig.resources.Res
 import hedvig.resources.TALKBACK_LOADING_STATE_BUTTON
 import org.jetbrains.compose.resources.stringResource
 
+/**
+ * @param isLoading Swaps the label for a loading indicator and stops the button accepting clicks, so an in-flight
+ *  action cannot be triggered a second time. Colors keep following [enabled], leaving a loading button's fill
+ *  unchanged.
+ */
 @Composable
 fun HedvigButton(
   text: String,
@@ -85,6 +90,7 @@ fun HedvigButton(
     border = border,
     onClickLabel = onClickLabel,
     shape = shape,
+    isLoading = isLoading,
   ) {
     val buttonColors = buttonStyle.style.buttonColors
     val loadingTransition = updateTransition(isLoading, label = "loading transition")
@@ -126,6 +132,7 @@ fun HedvigButton(
   border: Color? = null,
   onClickLabel: String? = null,
   shape: Shape? = null,
+  isLoading: Boolean = false,
   content: @Composable RowScope.() -> Unit,
 ) {
   @Suppress("NAME_SHADOWING")
@@ -157,7 +164,9 @@ fun HedvigButton(
     },
     onClickLabel = onClickLabel,
     role = Role.Button,
-    enabled = enabled,
+    // Colors above are already resolved from `enabled`, so withholding the click while loading leaves the
+    // button's appearance untouched.
+    enabled = enabled && !isLoading,
     shape = shape,
     border = border,
     // The rim shadows have to sit on top of the container fill, which is only reachable from outside

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatViewModel.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatViewModel.kt
@@ -754,7 +754,9 @@ internal class ClaimChatPresenter(
               currentContent.freeTextMinLength > it
             } ?: true
             steps.updateStepWithSuccess<StepContent.AudioRecording>(currentStep!!.id) { step, content ->
-              val canSubmit = !currentContinueButtonLoading && !event.text.isNullOrEmpty() && !textTooShort
+              // Validity of the text only. This is captured when the text last changed, so it must not fold in
+              // transient submission state, which the UI applies at the moment the button is composed.
+              val canSubmit = !event.text.isNullOrEmpty() && !textTooShort
               step.copy(
                 stepContent = content.copy(
                   recordingState = recordingState.copy(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatViewModel.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatViewModel.kt
@@ -726,8 +726,8 @@ internal class ClaimChatPresenter(
                   logcat { "ClaimChatEvent.Skip $it" }
                 },
                 ifRight = { claimIntent ->
-                  if (!steps.updateStepWithSuccess(event.id) { step -> step.clearContent() }) return@launch
                   currentSkipButtonLoading = false
+                  if (!steps.updateStepWithSuccess(event.id) { step -> step.clearContent() }) return@launch
                   handleNext(
                     steps,
                     setOutcome,
@@ -1239,13 +1239,6 @@ private fun onTaskSubmissionFailed(
     step.copy(stepContent = content.copy(failedToSubmit = true))
   }
   setErrorMessage(errorMessage)
-}
-
-private fun <T> MutableList<T>.removeLastIf(predicate: (T) -> Boolean) {
-  val last = lastOrNull() ?: return
-  if (predicate(last)) {
-    removeAt(this.lastIndex)
-  }
 }
 
 private fun validateField(field: Field): Field {

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/ClaimIntent.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/ClaimIntent.kt
@@ -215,6 +215,7 @@ enum class InformationSeverity {
 sealed interface AudioRecordingStepState {
   data class FreeTextDescription(
     val errorType: FreeTextErrorType?,
+    /** Whether [freeText] passes the step's length requirements. Says nothing about a submission being in flight. */
     val canSubmit: Boolean,
     val hasError: Boolean = false,
     val freeText: String? = null,

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
@@ -945,14 +945,16 @@ private fun StepBottomContent(
       }
 
       is StepContent.Information -> {
-        Column {
+        // Only the current step may be answered; a past step's notice keeps its top content but loses its button.
+        if (isCurrentStep) {
           HedvigButton(
-            modifier = modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             text = stepItem.stepContent.buttonTitle,
             onClick = dropUnlessResumed {
               onEvent(SubmitInformation(stepItem.id))
             },
             enabled = !currentContinueButtonLoading,
+            isLoading = currentContinueButtonLoading,
           )
         }
       }

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
@@ -934,7 +934,7 @@ private fun StepBottomContent(
 
       is StepContent.DeflectMessage -> {
         HedvigButton(
-          modifier = modifier.fillMaxWidth(),
+          modifier = Modifier.fillMaxWidth(),
           text = stringResource(Res.string.general_close_button),
           onClick = dropUnlessResumed {
             closeFlow()

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/ContentSelectStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/ContentSelectStep.kt
@@ -50,6 +50,8 @@ internal fun ContentSelectStep(
   skipButtonLoading: Boolean,
   modifier: Modifier = Modifier,
 ) {
+  // Confirming and skipping both answer the same step, so either one being in flight has to lock the other out.
+  val isSubmitting = currentContinueButtonLoading || skipButtonLoading
   Column(modifier) {
     AnimatedContent(
       isCurrentStep,
@@ -62,7 +64,7 @@ internal fun ContentSelectStep(
           ContentSelectChips(
             options = options,
             onOptionClick = { option ->
-              if (!currentContinueButtonLoading) {
+              if (!isSubmitting) {
                 onEvent(
                   ClaimChatEvent.Select(
                     itemId,
@@ -87,7 +89,7 @@ internal fun ContentSelectStep(
                 }
               },
               isLoading = currentContinueButtonLoading,
-              enabled = !currentContinueButtonLoading && selectedOptionId != null,
+              enabled = !isSubmitting && selectedOptionId != null,
               modifier = Modifier.fillMaxWidth(),
             )
             if (canSkip) {
@@ -95,7 +97,7 @@ internal fun ContentSelectStep(
                 stringResource(Res.string.claims_skip_button),
                 onClick = onSkip,
                 isLoading = skipButtonLoading,
-                enabled = !skipButtonLoading,
+                enabled = !isSubmitting,
                 modifier = Modifier.fillMaxWidth(),
                 buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
               )

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/FormStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/FormStep.kt
@@ -181,6 +181,8 @@ private fun FormContent(
   modifier: Modifier = Modifier,
 ) {
   val errorDescription = firstFieldWithError?.let { "${getErrorText(it)}: ${it.title}" }
+  // Continuing and skipping both answer the same step, so either one being in flight has to lock the other out.
+  val isSubmitting = continueButtonLoading || skipButtonLoading
   Column(modifier) {
     if (isCurrentStep) {
       Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -342,7 +344,7 @@ private fun FormContent(
       Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         HedvigButton(
           text = stringResource(Res.string.general_continue_button),
-          enabled = !continueButtonLoading,
+          enabled = !isSubmitting,
           isLoading = continueButtonLoading,
           onClick = onSubmit,
           modifier = Modifier.fillMaxWidth().semantics {
@@ -354,7 +356,7 @@ private fun FormContent(
         if (canSkip) {
           HedvigButton(
             text = stringResource(Res.string.claims_skip_button),
-            enabled = !skipButtonLoading,
+            enabled = !isSubmitting,
             onClick = onSkip,
             isLoading = skipButtonLoading,
             modifier = Modifier.fillMaxWidth(),

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/FormStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/FormStep.kt
@@ -181,7 +181,6 @@ private fun FormContent(
   modifier: Modifier = Modifier,
 ) {
   val errorDescription = firstFieldWithError?.let { "${getErrorText(it)}: ${it.title}" }
-  // Continuing and skipping both answer the same step, so either one being in flight has to lock the other out.
   val isSubmitting = continueButtonLoading || skipButtonLoading
   Column(modifier) {
     if (isCurrentStep) {

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/UploadFilesStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/UploadFilesStep.kt
@@ -73,7 +73,6 @@ internal fun UploadFilesStep(
   onNavigateToImageViewer: (imageUrl: String, cacheKey: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  // Continuing and skipping both answer the same step, so either one being in flight has to lock the other out.
   val isSubmitting = continueButtonLoading || skipButtonLoading
   Box(modifier) {
     if (isCurrentStep) {

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/UploadFilesStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/UploadFilesStep.kt
@@ -73,6 +73,8 @@ internal fun UploadFilesStep(
   onNavigateToImageViewer: (imageUrl: String, cacheKey: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  // Continuing and skipping both answer the same step, so either one being in flight has to lock the other out.
+  val isSubmitting = continueButtonLoading || skipButtonLoading
   Box(modifier) {
     if (isCurrentStep) {
       Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -101,7 +103,7 @@ internal fun UploadFilesStep(
         if (stepContent.localFiles.isNotEmpty()) {
           HedvigButton(
             text = stringResource(Res.string.claims_continue_button),
-            enabled = !continueButtonLoading,
+            enabled = !isSubmitting,
             onClick = {
               onEvent(
                 ClaimChatEvent.SubmitFile(
@@ -116,7 +118,7 @@ internal fun UploadFilesStep(
         if (stepContent.isSkippable && stepContent.localFiles.isEmpty()) {
           HedvigButton(
             text = stringResource(Res.string.claims_skip_button),
-            enabled = !skipButtonLoading,
+            enabled = !isSubmitting,
             onClick = {
               onEvent(ClaimChatEvent.Skip(itemId))
             },

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
@@ -263,7 +263,7 @@ internal fun AudioRecorderBubble(
                 submitAudioFile = submitAudioFile,
                 redo = redoRecording,
                 openAppSettings = openAppSettings,
-                continueButtonLoading = continueButtonLoading,
+                isSubmitting = isSubmitting,
                 bottomSheetState = state,
               )
               HedvigButton(
@@ -334,7 +334,7 @@ private fun AudioRecordingBottomSheet(
   submitAudioFile: () -> Unit,
   redo: () -> Unit,
   openAppSettings: () -> Unit,
-  continueButtonLoading: Boolean,
+  isSubmitting: Boolean,
   modifier: Modifier = Modifier,
 ) {
   var showPermissionDialog by remember { mutableStateOf(false) }
@@ -387,7 +387,7 @@ private fun AudioRecordingBottomSheet(
       clock = clock,
       submitAudioFile = submitAudioFile,
       redo = redo,
-      continueButtonLoading = continueButtonLoading,
+      isSubmitting = isSubmitting,
       audioPlayer = audioPlayer,
       audioRecordingState = audioRecordingState,
       stopRecording = stopRecording,
@@ -402,7 +402,7 @@ private fun AudioRecordingSheetContent(
   clock: Clock,
   submitAudioFile: () -> Unit,
   redo: () -> Unit,
-  continueButtonLoading: Boolean,
+  isSubmitting: Boolean,
   audioPlayer: AudioPlayer?,
   audioRecordingState: AudioRecordingStepState.AudioRecording,
   stopRecording: () -> Unit,
@@ -492,7 +492,7 @@ private fun AudioRecordingSheetContent(
       StartOverButton(
         modifier = Modifier.weight(1f),
         onStartOver = redo,
-        isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !continueButtonLoading,
+        isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !isSubmitting,
       )
       Spacer(Modifier.width(4.dp))
       ControlButton(
@@ -506,13 +506,13 @@ private fun AudioRecordingSheetContent(
         },
         onStopRecording = stopRecording,
         audioRecordingState = audioRecordingState,
-        isEnabled = !continueButtonLoading,
+        isEnabled = !isSubmitting,
       )
       Spacer(Modifier.width(4.dp))
       SendButton(
         modifier = Modifier.weight(1f),
         onSend = submitAudioFile,
-        isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !continueButtonLoading,
+        isEnabled = audioRecordingState is AudioRecordingStepState.AudioRecording.Playback && !isSubmitting,
       )
     }
     Spacer(Modifier.height(16.dp))
@@ -1149,7 +1149,7 @@ private fun PreviewAudioRecordingSheetContent(
         clock = Clock.System,
         submitAudioFile = {},
         redo = {},
-        continueButtonLoading = false,
+        isSubmitting = false,
         audioPlayer = null,
         audioRecordingState = state,
         stopRecording = {},

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
@@ -220,6 +220,8 @@ internal fun AudioRecorderBubble(
   skipButtonLoading: Boolean,
   modifier: Modifier = Modifier,
 ) {
+  // Submitting and skipping both answer the same step, so either one being in flight has to lock the other out.
+  val isSubmitting = continueButtonLoading || skipButtonLoading
   AnimatedContent(
     recordingState,
     contentKey = { s ->
@@ -242,7 +244,9 @@ internal fun AudioRecorderBubble(
             errorType = recordingState.errorType,
             isCurrentStep = isCurrentStep,
             continueButtonLoading = continueButtonLoading,
-            canSubmit = recordingState.canSubmit,
+            // recordingState.canSubmit only reports whether the text itself is valid, so the in-flight state has
+            // to be folded in here to keep the button from firing a second submission for the same step.
+            canSubmit = recordingState.canSubmit && !isSubmitting,
           )
         }
 
@@ -311,7 +315,7 @@ internal fun AudioRecorderBubble(
           stringResource(Res.string.claims_skip_button),
           onClick = onSkip,
           isLoading = skipButtonLoading,
-          enabled = !skipButtonLoading,
+          enabled = !isSubmitting,
           modifier = Modifier.fillMaxWidth(),
           buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
         )

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/step/audiorecording/AudioRecordingStepSections.kt
@@ -220,7 +220,6 @@ internal fun AudioRecorderBubble(
   skipButtonLoading: Boolean,
   modifier: Modifier = Modifier,
 ) {
-  // Submitting and skipping both answer the same step, so either one being in flight has to lock the other out.
   val isSubmitting = continueButtonLoading || skipButtonLoading
   AnimatedContent(
     recordingState,


### PR DESCRIPTION
since we have some amount of `Cannot complete other than the current step` error on BE: [datadog](https://app.datadoghq.eu/logs?query=env%3Aprod%20%22Cannot%20complete%20other%20than%20the%20current%20step%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Casc&viz=stream&from_ts=1672670284296&to_ts=1675262284296&live=true) , and some of them as I checked originate on Android, adding safeguards for some possible weak points.