### PR TITLE
fix for remote files being shown but not submitted after regret

### DIFF
--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatViewModel.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ClaimChatViewModel.kt
@@ -906,13 +906,9 @@ internal class ClaimChatPresenter(
 
         is ClaimChatEvent.SubmitFile -> {
           val stepContent = currentStep?.stepContent as? StepContent.FileUpload ?: return@CollectEvents
-          val fileUris = stepContent.localFiles
-            .filter {
-              it.localPath != null
-            }
-            .map {
-              Uri.parse(it.localPath!!)
-            }
+          val fileUris = stepContent.localFiles.mapNotNull { file ->
+            file.localPath?.let { Uri.parse(it) }
+          }
           currentContinueButtonLoading = true
           launch {
             submitFileUploadUseCase

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/ClaimIntentExt.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/ClaimIntentExt.kt
@@ -73,10 +73,21 @@ private fun ClaimIntentFragment.CurrentStep.toClaimIntentStep(locale: CommonLoca
   return ClaimIntentStep(
     id = StepId(id),
     text = text,
-    stepContent = this.content.toStepContent(locale),
+    stepContent = this.content.toStepContent(locale).withoutAlreadyUploadedFiles(),
     isRegrettable = this.isRegrettable,
     hint = hint,
   )
+}
+
+/**
+ * Submitting a file upload step replaces its files with exactly the ones sent, and an already
+ * uploaded file comes back carrying only a url, never an id that could be sent again. Showing those
+ * files on the step the user is standing on would promise they are kept while continuing drops
+ * them, so the step the user can act on starts empty and they pick the whole set anew.
+ */
+private fun StepContent.withoutAlreadyUploadedFiles(): StepContent = when (this) {
+  is StepContent.FileUpload -> copy(localFiles = emptyList())
+  else -> this
 }
 
 context(raise: Raise<ClaimChatErrorMessage>)


### PR DESCRIPTION
Bug: 
when editing files step, we populate it with the remote files previously added, but we ignore them when submitting since their localPath is null. The solution is in the case of Regret not to use remote "currentFiles" at all.                                                                                                                    