### PR TITLE
Onboarding: tighten Figma fidelity across the flow

### DIFF
--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -639,12 +639,12 @@
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">Det gör det lättare att hjälpa dig om något händer</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">Så att vi vet vilka som omfattas av din försäkring</string>
   <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
-    <item quantity="one">%1$s medförsäkrad</item>
-    <item quantity="other">%1$s medförsäkrade</item>
+    <item quantity="one">%d medförsäkrad</item>
+    <item quantity="other">%d medförsäkrade</item>
   </plurals>
   <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
-    <item quantity="one">%1$s delägare</item>
-    <item quantity="other">%1$s delägare</item>
+    <item quantity="one">%d delägare</item>
+    <item quantity="other">%d delägare</item>
   </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Öppnas i din webbläsare</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Kunde inte spara, försök igen</string>

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -624,6 +624,7 @@
   <string name="ONBOARDING_ANALYTICS_SUBTITLE">Vi använder tekniska verktyg för att se hur du använder appen, så att vi kan göra den bättre.\n\nProduktanalys är helt frivilligt och kan när som helst stängas av i inställningarna. Denna data används aldrig för marknadsföring.</string>
   <string name="ONBOARDING_ANALYTICS_TITLE">Hjälp oss göra appen bättre</string>
   <string name="ONBOARDING_CHANGE_SETTINGS_LATER_LABEL">Du kan ändra inställningarna senare</string>
+  <string name="ONBOARDING_CONNECT_PAYMENT_BANK_LABEL">Bank</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_FOOTNOTE">Du behöver lägga till ett betalsätt för att din försäkring ska fortsätta gälla</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SUBTITLE">Lägg till ett betalsätt för att aktivera din försäkring</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER">Du kan byta konto senare i inställningar</string>
@@ -637,6 +638,14 @@
   <string name="ONBOARDING_INVITE_FRIEND_TITLE">Bjud in en vän</string>
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">Det gör det lättare att hjälpa dig om något händer</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">Så att vi vet vilka som omfattas av din försäkring</string>
+  <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
+    <item quantity="one">%1$s medförsäkrad</item>
+    <item quantity="other">%1$s medförsäkrade</item>
+  </plurals>
+  <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
+    <item quantity="one">%1$s delägare</item>
+    <item quantity="other">%1$s delägare</item>
+  </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Öppnas i din webbläsare</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Kunde inte spara, försök igen</string>
   <string name="ONBOARDING_PHONE_SUBTITLE">Lägg till ditt telefonnummer så att vi kan nå dig om något händer</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -639,12 +639,12 @@
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">This makes it easier to help you if something happens</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">So we know who\'s covered by your insurance</string>
   <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
-    <item quantity="one">%1$s co-insured</item>
-    <item quantity="other">%1$s co-insured</item>
+    <item quantity="one">%d co-insured</item>
+    <item quantity="other">%d co-insured</item>
   </plurals>
   <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
-    <item quantity="one">%1$s co-owner</item>
-    <item quantity="other">%1$s co-owners</item>
+    <item quantity="one">%d co-owner</item>
+    <item quantity="other">%d co-owners</item>
   </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Opens in your browser</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Could not save, please try again</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -624,6 +624,7 @@
   <string name="ONBOARDING_ANALYTICS_SUBTITLE">We use technical tools to see how you use the app, so we can make it better.\n\nProduct analytics is completely optional and can be turned off any time in settings. This data is never used for marketing.</string>
   <string name="ONBOARDING_ANALYTICS_TITLE">Help us make the app better</string>
   <string name="ONBOARDING_CHANGE_SETTINGS_LATER_LABEL">You can change these settings later</string>
+  <string name="ONBOARDING_CONNECT_PAYMENT_BANK_LABEL">Bank</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_FOOTNOTE">Adding a payment method is required to keep your insurance active</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SUBTITLE">Add a payment method to activate your insurance</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER">You can switch accounts later in settings</string>
@@ -637,6 +638,14 @@
   <string name="ONBOARDING_INVITE_FRIEND_TITLE">Invite a friend</string>
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">This makes it easier to help you if something happens</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">So we know who\'s covered by your insurance</string>
+  <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
+    <item quantity="one">%1$s co-insured</item>
+    <item quantity="other">%1$s co-insured</item>
+  </plurals>
+  <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
+    <item quantity="one">%1$s co-owner</item>
+    <item quantity="other">%1$s co-owners</item>
+  </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Opens in your browser</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Could not save, please try again</string>
   <string name="ONBOARDING_PHONE_SUBTITLE">Add your phone number so we can reach you if something happens</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -623,6 +623,7 @@
   <string name="ONBOARDING_ANALYTICS_SUBTITLE">Vi använder tekniska verktyg för att se hur du använder appen, så att vi kan göra den bättre.\n\nProduktanalys är helt frivilligt och kan när som helst stängas av i inställningarna. Denna data används aldrig för marknadsföring.</string>
   <string name="ONBOARDING_ANALYTICS_TITLE">Hjälp oss göra appen bättre</string>
   <string name="ONBOARDING_CHANGE_SETTINGS_LATER_LABEL">Du kan ändra inställningarna senare</string>
+  <string name="ONBOARDING_CONNECT_PAYMENT_BANK_LABEL">Bank</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_FOOTNOTE">Du behöver lägga till ett betalsätt för att din försäkring ska fortsätta gälla</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SUBTITLE">Lägg till ett betalsätt för att aktivera din försäkring</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER">Du kan byta konto senare i inställningar</string>
@@ -636,6 +637,14 @@
   <string name="ONBOARDING_INVITE_FRIEND_TITLE">Bjud in en vän</string>
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">Det gör det lättare att hjälpa dig om något händer</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">Så att vi vet vilka som omfattas av din försäkring</string>
+  <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
+    <item quantity="one">%1$s medförsäkrad</item>
+    <item quantity="other">%1$s medförsäkrade</item>
+  </plurals>
+  <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
+    <item quantity="one">%1$s delägare</item>
+    <item quantity="other">%1$s delägare</item>
+  </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Öppnas i din webbläsare</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Kunde inte spara, försök igen</string>
   <string name="ONBOARDING_PHONE_SUBTITLE">Lägg till ditt telefonnummer så att vi kan nå dig om något händer</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -638,12 +638,12 @@
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">Det gör det lättare att hjälpa dig om något händer</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">Så att vi vet vilka som omfattas av din försäkring</string>
   <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
-    <item quantity="one">%1$s medförsäkrad</item>
-    <item quantity="other">%1$s medförsäkrade</item>
+    <item quantity="one">%1$d medförsäkrad</item>
+    <item quantity="other">%1$d medförsäkrade</item>
   </plurals>
   <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
-    <item quantity="one">%1$s delägare</item>
-    <item quantity="other">%1$s delägare</item>
+    <item quantity="one">%1$d delägare</item>
+    <item quantity="other">%1$d delägare</item>
   </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Öppnas i din webbläsare</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Kunde inte spara, försök igen</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -623,6 +623,7 @@
   <string name="ONBOARDING_ANALYTICS_SUBTITLE">We use technical tools to see how you use the app, so we can make it better.\n\nProduct analytics is completely optional and can be turned off any time in settings. This data is never used for marketing.</string>
   <string name="ONBOARDING_ANALYTICS_TITLE">Help us make the app better</string>
   <string name="ONBOARDING_CHANGE_SETTINGS_LATER_LABEL">You can change these settings later</string>
+  <string name="ONBOARDING_CONNECT_PAYMENT_BANK_LABEL">Bank</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_FOOTNOTE">Adding a payment method is required to keep your insurance active</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SUBTITLE">Add a payment method to activate your insurance</string>
   <string name="ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER">You can switch accounts later in settings</string>
@@ -636,6 +637,14 @@
   <string name="ONBOARDING_INVITE_FRIEND_TITLE">Invite a friend</string>
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">This makes it easier to help you if something happens</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">So we know who's covered by your insurance</string>
+  <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
+    <item quantity="one">%1$s co-insured</item>
+    <item quantity="other">%1$s co-insured</item>
+  </plurals>
+  <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
+    <item quantity="one">%1$s co-owner</item>
+    <item quantity="other">%1$s co-owners</item>
+  </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Opens in your browser</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Could not save, please try again</string>
   <string name="ONBOARDING_PHONE_SUBTITLE">Add your phone number so we can reach you if something happens</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -638,12 +638,12 @@
   <string name="ONBOARDING_MISSING_INFO_PET_SUBTITLE">This makes it easier to help you if something happens</string>
   <string name="ONBOARDING_MISSING_INFO_SUBTITLE">So we know who's covered by your insurance</string>
   <plurals name="ONBOARDING_NUMBER_OF_COINSURED">
-    <item quantity="one">%1$s co-insured</item>
-    <item quantity="other">%1$s co-insured</item>
+    <item quantity="one">%1$d co-insured</item>
+    <item quantity="other">%1$d co-insured</item>
   </plurals>
   <plurals name="ONBOARDING_NUMBER_OF_COOWNERS">
-    <item quantity="one">%1$s co-owner</item>
-    <item quantity="other">%1$s co-owners</item>
+    <item quantity="one">%1$d co-owner</item>
+    <item quantity="other">%1$d co-owners</item>
   </plurals>
   <string name="ONBOARDING_OPENS_IN_BROWSER_HINT">Opens in your browser</string>
   <string name="ONBOARDING_PHONE_SAVE_ERROR">Could not save, please try again</string>

--- a/app/feature/feature-onboarding/src/main/graphql/OnboardingQuery.graphql
+++ b/app/feature/feature-onboarding/src/main/graphql/OnboardingQuery.graphql
@@ -10,10 +10,12 @@ query Onboarding {
       supportsCoInsured
       supportsCoOwners
       coInsured {
+        firstName
         hasMissingInfo
         terminatesOn
       }
       coOwners {
+        firstName
         hasMissingInfo
         terminatesOn
       }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingData.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingData.kt
@@ -47,6 +47,12 @@ internal data class OnboardingContract(
   val missingCoInsuredCount: Int,
   val missingCoOwnersCount: Int,
   val isMissingPetId: Boolean,
+  // Total (non-terminating) people plus their first names, used to summarise a contract's row on the
+  // co-insured step: the count while info is still missing, the names once the row is complete.
+  val coInsuredCount: Int = 0,
+  val coInsuredNames: List<String> = emptyList(),
+  val coOwnerCount: Int = 0,
+  val coOwnerNames: List<String> = emptyList(),
 ) {
   /**
    * Which edit flow this contract's missing info needs, or null when nothing is missing. Co-owners

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingRepository.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingRepository.kt
@@ -55,6 +55,26 @@ internal class OnboardingRepositoryImpl(
             0
           },
           isMissingPetId = contract.isMissingPetId,
+          coInsuredCount = if (contract.supportsCoInsured) {
+            contract.coInsured.orEmpty().count { it.terminatesOn == null }
+          } else {
+            0
+          },
+          coInsuredNames = if (contract.supportsCoInsured) {
+            contract.coInsured.orEmpty().filter { it.terminatesOn == null }.mapNotNull { it.firstName }
+          } else {
+            emptyList()
+          },
+          coOwnerCount = if (contract.supportsCoOwners) {
+            contract.coOwners.orEmpty().count { it.terminatesOn == null }
+          } else {
+            0
+          },
+          coOwnerNames = if (contract.supportsCoOwners) {
+            contract.coOwners.orEmpty().filter { it.terminatesOn == null }.mapNotNull { it.firstName }
+          } else {
+            emptyList()
+          },
         )
       },
       referralInformation = member.referralInformation.let { referralInformation ->

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
@@ -24,7 +24,6 @@ import com.hedvig.android.design.system.hedvig.HedvigCard
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Icon
-import com.hedvig.android.design.system.hedvig.hedvigDropShadow
 import com.hedvig.android.design.system.hedvig.icon.Checkmark
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import hedvig.resources.ONBOARDING_ADD_BUTTON
@@ -46,8 +45,7 @@ internal fun OnboardingContractCard(
     color = HedvigTheme.colorScheme.surfacePrimary,
     modifier = modifier
       .fillMaxWidth()
-      .padding(horizontal = 16.dp)
-      .hedvigDropShadow(HedvigTheme.shapes.cornerLarge),
+      .padding(horizontal = 16.dp),
   ) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
@@ -62,12 +60,12 @@ internal fun OnboardingContractCard(
       Column(Modifier.weight(1f)) {
         HedvigText(
           text = displayName,
-          style = HedvigTheme.typography.bodySmall,
+          style = HedvigTheme.typography.label,
         )
         HedvigText(
           text = exposureName,
           style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondary,
+          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
         )
       }
       Spacer(Modifier.width(12.dp))

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
@@ -34,7 +34,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun OnboardingContractCard(
   displayName: String,
-  exposureName: String,
+  secondaryText: String,
   typeOfContract: String,
   isComplete: Boolean,
   onAddClick: () -> Unit,
@@ -63,7 +63,7 @@ internal fun OnboardingContractCard(
           style = HedvigTheme.typography.label,
         )
         HedvigText(
-          text = exposureName,
+          text = secondaryText,
           style = HedvigTheme.typography.label,
           color = HedvigTheme.colorScheme.textSecondaryTranslucent,
         )

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/bundle/OnboardingBundleDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/bundle/OnboardingBundleDestination.kt
@@ -219,7 +219,7 @@ private fun OnboardingCrossSellRow(
     verticalAlignment = Alignment.CenterVertically,
     modifier = Modifier
       .fillMaxWidth()
-      .padding(horizontal = 16.dp),
+      .padding(horizontal = 16.dp, vertical = 8.dp),
   ) {
     if (crossSell.pillowImageUrl != null) {
       val placeholder = crossSellPainterFallback()
@@ -242,7 +242,7 @@ private fun OnboardingCrossSellRow(
       HedvigText(
         crossSell.description,
         style = HedvigTheme.typography.label,
-        color = HedvigTheme.colorScheme.textSecondary,
+        color = HedvigTheme.colorScheme.textSecondaryTranslucent,
         maxLines = 1,
         softWrap = false,
         modifier = Modifier.autoScrollingMarquee(),

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -118,7 +118,7 @@ private fun OnboardingCoInsuredScreen(
           for (row in content.rows) {
             OnboardingContractCard(
               displayName = row.displayName,
-              exposureName = row.exposureName,
+              secondaryText = row.secondaryText(),
               typeOfContract = row.typeOfContract,
               isComplete = row.isComplete,
               onAddClick = { onAddCoInsured(row.contractId, row.flowType) },
@@ -145,6 +145,22 @@ private fun OnboardingCoInsuredScreen(
       }
     }
   }
+}
+
+// A complete row lists the people's names; while info is still missing it shows how many there are.
+// TODO: Add "%1$d co-insured" / "%1$d medförsäkrade" and "%1$d co-owners" / "%1$d delägare" to Lokalise
+private fun CoInsuredRow.secondaryText(): String = if (isComplete && insuredNames.isNotEmpty()) {
+  insuredNames.toReadableList()
+} else {
+  val noun = if (flowType == CoInsuredFlowType.CoOwners) "co-owners" else "co-insured"
+  "$insuredCount $noun"
+}
+
+/** Joins names the way the design shows them: "A", "A & B", "A, B & C". */
+private fun List<String>.toReadableList(): String = when (size) {
+  0 -> ""
+  1 -> single()
+  else -> "${dropLast(1).joinToString(", ")} & ${last()}"
 }
 
 @HedvigPreview
@@ -177,18 +193,19 @@ private class OnboardingCoInsuredUiStateProvider : CollectionPreviewParameterPro
         CoInsuredRow(
           contractId = "contract-1",
           displayName = "Home Insurance",
-          exposureName = "Storgatan 1",
           typeOfContract = "SE_APARTMENT_RENT",
           flowType = CoInsuredFlowType.CoInsured,
           isComplete = false,
+          insuredCount = 5,
         ),
         CoInsuredRow(
           contractId = "contract-2",
           displayName = "Car Insurance",
-          exposureName = "ABC 123",
           typeOfContract = "SE_CAR_FULL",
           flowType = CoInsuredFlowType.CoInsured,
           isComplete = true,
+          insuredCount = 3,
+          insuredNames = listOf("Sladan", "Mariia", "Sonny"),
         ),
       ),
     ),
@@ -198,18 +215,18 @@ private class OnboardingCoInsuredUiStateProvider : CollectionPreviewParameterPro
         CoInsuredRow(
           contractId = "contract-3",
           displayName = "Villa Insurance",
-          exposureName = "Villavägen 5",
           typeOfContract = "SE_VILLA",
           flowType = CoInsuredFlowType.CoOwners,
           isComplete = false,
+          insuredCount = 2,
         ),
         CoInsuredRow(
           contractId = "contract-4",
           displayName = "Cottage Insurance",
-          exposureName = "Sommarvägen 12",
           typeOfContract = "SE_VILLA",
           flowType = CoInsuredFlowType.CoOwners,
           isComplete = false,
+          insuredCount = 3,
         ),
       ),
     ),

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -129,8 +129,8 @@ private fun OnboardingCoInsuredScreen(
         Spacer(Modifier.height(24.dp))
         HedvigText(
           text = stringResource(Res.string.ONBOARDING_ADD_INFO_LATER_LABEL),
-          style = HedvigTheme.typography.finePrint,
-          color = HedvigTheme.colorScheme.textSecondary,
+          style = HedvigTheme.typography.label,
+          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
           textAlign = TextAlign.Center,
           modifier = Modifier
             .fillMaxWidth()

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -37,8 +37,11 @@ import hedvig.resources.ONBOARDING_ADD_COOWNERS_TITLE
 import hedvig.resources.ONBOARDING_ADD_INFO_LATER_LABEL
 import hedvig.resources.ONBOARDING_DO_THIS_LATER_BUTTON
 import hedvig.resources.ONBOARDING_MISSING_INFO_SUBTITLE
+import hedvig.resources.ONBOARDING_NUMBER_OF_COINSURED
+import hedvig.resources.ONBOARDING_NUMBER_OF_COOWNERS
 import hedvig.resources.Res
 import hedvig.resources.general_continue_button
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -147,17 +150,17 @@ private fun OnboardingCoInsuredScreen(
   }
 }
 
-// A complete row lists the people's names; while info is still missing it shows how many there are.
-// TODO: Add "%1$d co-insured" / "%1$d medförsäkrade" and "%1$d co-owners" / "%1$d delägare" to Lokalise
+// A complete row lists the people by name; while info is still missing it shows how many there are.
+@Composable
 private fun CoInsuredRow.secondaryText(): String = if (isComplete && insuredNames.isNotEmpty()) {
   insuredNames.toReadableList()
 } else {
-  val noun = when {
-    flowType == CoInsuredFlowType.CoOwners && insuredCount == 1 -> "co-owner"
-    flowType == CoInsuredFlowType.CoOwners -> "co-owners"
-    else -> "co-insured"
+  val plural = if (flowType == CoInsuredFlowType.CoOwners) {
+    Res.plurals.ONBOARDING_NUMBER_OF_COOWNERS
+  } else {
+    Res.plurals.ONBOARDING_NUMBER_OF_COINSURED
   }
-  "$insuredCount $noun"
+  pluralStringResource(plural, insuredCount, insuredCount)
 }
 
 /** Joins names the way the design shows them: "A", "A & B", "A, B & C". */

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -152,7 +152,11 @@ private fun OnboardingCoInsuredScreen(
 private fun CoInsuredRow.secondaryText(): String = if (isComplete && insuredNames.isNotEmpty()) {
   insuredNames.toReadableList()
 } else {
-  val noun = if (flowType == CoInsuredFlowType.CoOwners) "co-owners" else "co-insured"
+  val noun = when {
+    flowType == CoInsuredFlowType.CoOwners && insuredCount == 1 -> "co-owner"
+    flowType == CoInsuredFlowType.CoOwners -> "co-owners"
+    else -> "co-insured"
+  }
   "$insuredCount $noun"
 }
 

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredViewModel.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredViewModel.kt
@@ -51,13 +51,15 @@ internal class OnboardingCoInsuredPresenter(
         progress = session.progressFor(OnboardingStepId.CoInsured),
         rows = pinned.mapNotNull { (id, flowType) ->
           val contract = session.data.contracts.firstOrNull { it.id == id } ?: return@mapNotNull null
+          val forCoOwners = flowType == CoInsuredFlowType.CoOwners
           CoInsuredRow(
             contractId = contract.id,
             displayName = contract.displayName,
-            exposureName = contract.exposureName,
             typeOfContract = contract.typeOfContract,
             flowType = flowType,
             isComplete = contract.coInsuredFlowType == null,
+            insuredCount = if (forCoOwners) contract.coOwnerCount else contract.coInsuredCount,
+            insuredNames = if (forCoOwners) contract.coOwnerNames else contract.coInsuredNames,
           )
         },
       )
@@ -96,10 +98,13 @@ internal class OnboardingCoInsuredPresenter(
 internal data class CoInsuredRow(
   val contractId: String,
   val displayName: String,
-  val exposureName: String,
   val typeOfContract: String,
   val flowType: CoInsuredFlowType,
   val isComplete: Boolean,
+  // Total people on the contract and their first names. The row summarises as a count while info is
+  // still missing, then switches to the names once complete.
+  val insuredCount: Int = 0,
+  val insuredNames: List<String> = emptyList(),
 )
 
 internal sealed interface OnboardingCoInsuredUiState {

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/invite/OnboardingInviteDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/invite/OnboardingInviteDestination.kt
@@ -110,7 +110,7 @@ private fun OnboardingInviteScreen(
         Box(
           modifier = Modifier
             .align(Alignment.CenterHorizontally)
-            .fillMaxWidth(0.72f),
+            .fillMaxWidth(0.62f),
           contentAlignment = Alignment.Center,
         ) {
           ExampleReferralsCard(
@@ -155,8 +155,8 @@ private fun ExampleReferralsCard(
     onAnimationCompleted()
   }
   Surface(
-    modifier = modifier.hedvigDropShadow(HedvigTheme.shapes.cornerLarge),
-    shape = HedvigTheme.shapes.cornerLarge,
+    modifier = modifier.hedvigDropShadow(HedvigTheme.shapes.cornerXXLarge),
+    shape = HedvigTheme.shapes.cornerXXLarge,
     color = HedvigTheme.colorScheme.backgroundPrimary,
     border = HedvigTheme.colorScheme.borderPrimary,
   ) {
@@ -205,7 +205,8 @@ private fun ExampleReferralRow(name: String, incentiveDisplay: String, modifier:
     // ballooning on wide (e.g. landscape) layouts.
     HedvigText(text = name, style = HedvigTheme.typography.bodySmall, modifier = Modifier.weight(1f))
     Spacer(Modifier.width(8.dp))
-    HedvigText(text = "-$incentiveDisplay", style = HedvigTheme.typography.bodySmall)
+    // en dash (–) rather than a hyphen, matching the design.
+    HedvigText(text = "–$incentiveDisplay", style = HedvigTheme.typography.bodySmall)
   }
 }
 

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingConnectingPaymentSymbol.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingConnectingPaymentSymbol.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -21,8 +22,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
@@ -85,19 +93,42 @@ private fun ConnectingGraphic(checkVisible: Boolean, modifier: Modifier = Modifi
 @Composable
 private fun BankCard() {
   Surface(
-    shape = HedvigTheme.shapes.cornerXLarge,
+    shape = HedvigTheme.shapes.cornerXXLarge,
     color = HedvigTheme.colorScheme.backgroundPrimary,
-    border = HedvigTheme.colorScheme.borderSecondary,
     modifier = Modifier
       .size(SymbolSize)
-      .hedvigDropShadow(HedvigTheme.shapes.cornerXLarge),
+      .hedvigDropShadow(HedvigTheme.shapes.cornerXXLarge)
+      .dashedBorder(
+        color = HedvigTheme.colorScheme.borderSecondary,
+        shape = HedvigTheme.shapes.cornerXXLarge,
+        strokeWidth = 1.dp,
+        dashOn = 4.dp,
+        dashOff = 4.dp,
+      ),
   ) {
-    Box(contentAlignment = Alignment.Center) {
+    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
       // TODO: Add "Bank" / "Bank" to Lokalise
-      HedvigText(text = "Bank", style = HedvigTheme.typography.bodySmall)
+      HedvigText(
+        text = "Bank",
+        style = HedvigTheme.typography.bodySmall.copy(fontFamily = HedvigTheme.typography.serif),
+      )
     }
   }
 }
+
+/** Draws a dashed outline that follows [shape], on top of the content so it is not clipped. */
+private fun Modifier.dashedBorder(color: Color, shape: Shape, strokeWidth: Dp, dashOn: Dp, dashOff: Dp): Modifier =
+  drawWithContent {
+    drawContent()
+    drawOutline(
+      outline = shape.createOutline(size, layoutDirection, this),
+      color = color,
+      style = Stroke(
+        width = strokeWidth.toPx(),
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(dashOn.toPx(), dashOff.toPx())),
+      ),
+    )
+  }
 
 @Composable
 private fun HedvigSymbolWithCheck(checkVisible: Boolean) {

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingConnectingPaymentSymbol.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingConnectingPaymentSymbol.kt
@@ -42,11 +42,13 @@ import com.hedvig.android.design.system.hedvig.hedvigDropShadow
 import com.hedvig.android.design.system.hedvig.icon.Checkmark
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.tokens.MotionTokens
+import hedvig.resources.ONBOARDING_CONNECT_PAYMENT_BANK_LABEL
 import hedvig.resources.Res
 import hedvig.resources.pillow_hedvig
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 
 private val SymbolSize = 74.dp
 private val CheckBadgeSize = 24.dp
@@ -107,9 +109,8 @@ private fun BankCard() {
       ),
   ) {
     Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-      // TODO: Add "Bank" / "Bank" to Lokalise
       HedvigText(
-        text = "Bank",
+        text = stringResource(Res.string.ONBOARDING_CONNECT_PAYMENT_BANK_LABEL),
         style = HedvigTheme.typography.bodySmall.copy(fontFamily = HedvigTheme.typography.serif),
       )
     }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingPaymentDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingPaymentDestination.kt
@@ -233,7 +233,7 @@ private fun OnboardingPaymentScreen(
             stringResource(Res.string.ONBOARDING_CONNECT_PAYMENT_FOOTNOTE)
           },
           style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondary,
+          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
           modifier = Modifier
             .align(Alignment.CenterHorizontally)
             .padding(horizontal = 32.dp),

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
@@ -108,7 +108,7 @@ private fun OnboardingPetIdScreen(
           for (row in content.rows) {
             OnboardingContractCard(
               displayName = row.displayName,
-              exposureName = row.exposureName,
+              secondaryText = row.exposureName,
               typeOfContract = row.typeOfContract,
               isComplete = row.isComplete,
               onAddClick = { onAddPetId(row.contractId) },

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
@@ -119,8 +119,8 @@ private fun OnboardingPetIdScreen(
         Spacer(Modifier.height(24.dp))
         HedvigText(
           text = stringResource(Res.string.ONBOARDING_ADD_INFO_LATER_LABEL),
-          style = HedvigTheme.typography.finePrint,
-          color = HedvigTheme.colorScheme.textSecondary,
+          style = HedvigTheme.typography.label,
+          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
           textAlign = TextAlign.Center,
           modifier = Modifier
             .fillMaxWidth()

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemeDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemeDestination.kt
@@ -139,7 +139,7 @@ private fun OnboardingThemeScreen(
         HedvigText(
           text = stringResource(Res.string.ONBOARDING_CHANGE_SETTINGS_LATER_LABEL),
           style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondary,
+          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
           textAlign = TextAlign.Center,
           modifier = Modifier
             .fillMaxWidth()
@@ -188,7 +188,7 @@ private fun ThemeOptionRow(
         HedvigText(
           text = description,
           style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondary,
+          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
         )
       }
       ThemeSelectionIndicator(selected)


### PR DESCRIPTION
## What

Tightens the onboarding flow's fidelity to the updated Figma ("App P2 2026"), after a screen-by-screen comparison. Mostly typography, spacing, and token corrections, plus two content/behaviour changes on the co-insured and connect-payment steps.

## Changes

**Shared step card (`OnboardingContractCard`, used by co-insured + pet ID)**
- Row title 18sp → 14sp (`label`), secondary line → `textSecondaryTranslucent`, and dropped the shadow the design doesn't have.
- Renamed the generic `exposureName` param to `secondaryText`.

**Co-insured step**
- Row now summarises the contract's people instead of the exposure name: a **count** while info is still missing ("1 co-owner", "5 co-insured"), switching to the **names** once complete ("Sladan, Mariia & Sonny").
- Data comes from widening the existing `Onboarding` query with `coInsured/coOwners.firstName` (no backend change) and carrying counts + names through `OnboardingData` → repository → `CoInsuredRow`.
- Count uses the new `ONBOARDING_NUMBER_OF_COINSURED` / `ONBOARDING_NUMBER_OF_COOWNERS` plurals (correct singular/plural per language).

**Connect payment**
- Bank card: 24dp corners, **dashed** border (new local `dashedBorder` modifier), and the "Bank" label in the serif face via `ONBOARDING_CONNECT_PAYMENT_BANK_LABEL`.
- Kept the pillow symbol for now (no reusable flat app-icon asset in a feature-reachable module).

**Other steps**
- Invite: card corner 24dp, card width 72% → 62%, en dash on the incentive.
- Bundle: 8dp vertical row padding so pillow-to-pillow spacing matches the design (works with the equal-height/wrap layout).
- Theme + payment footnote + "you can add this later" helpers: → `textSecondaryTranslucent`, helper size `finePrint` → `label`.

## Deliberately NOT changed (iOS-only styling, accepted by design)
- Liquid Glass circular nav buttons + separately-centered progress bar (Android keeps the flat inline treatment).
- Theme picker stays a radio (Figma shows a checkbox).
- Pet-ID number on completed rows is not shown (the number isn't returned by any query; would need a new backend field). Row stays name-only.
- Connect-payment "connected" state keeps the header (anti layout-shift) vs Figma dropping it.

## Verification
- Compile, ktlint, and `:feature-onboarding` unit tests green.
- Walked the whole flow on a physical Pixel 6 Pro in both light and dark: welcome, consent, phone, theme, co-insured (count + names states), invite, connect payment (dashed card + serif "Bank"), bundle. All render as intended and the localized "1 co-owner" is correct.

## Notes
- No backend change required.
- `dashedBorder` is local to the payment file; can be promoted to the design system if reused.
