### PR TITLE
Fix/cert path validator exception

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/SessionReconciler.kt
@@ -120,18 +120,7 @@ internal class SessionReconciler(
    */
   private suspend fun logoutOnInvalidCredentials() {
     val authStatusLog: (AuthStatus?) -> Unit = { authStatus ->
-      logcat {
-        buildString {
-          append("Owner: MainActivity | Received authStatus: ")
-          append(
-            when (authStatus) {
-              is AuthStatus.LoggedIn -> "LoggedIn"
-              AuthStatus.LoggedOut -> "LoggedOut"
-              null -> "null"
-            },
-          )
-        }
-      }
+      logcat { "Owner: MainActivity | Received authStatus: ${authStatus.logName()}" }
     }
     combine(
       authTokenService.authStatus.onEach(authStatusLog).filterNotNull().distinctUntilChanged(),
@@ -140,7 +129,7 @@ internal class SessionReconciler(
     ) { authStatus: AuthStatus, isDemoMode: Boolean, isLoggedIn: Boolean ->
       logcat {
         "SessionReconciler.logoutOnInvalidCredentials: " +
-          "authStatus:$authStatus | " +
+          "authStatus:${authStatus.logName()} | " +
           "isDemoMode:$isDemoMode | " +
           "isLoggedIn:$isLoggedIn"
       }
@@ -152,4 +141,14 @@ internal class SessionReconciler(
       }
     }.collect()
   }
+}
+
+/**
+ * Renders only the variant name. [AuthStatus.LoggedIn] holds the access and refresh tokens, and this
+ * value is logged at INFO, which reaches Datadog and Crashlytics breadcrumbs.
+ */
+private fun AuthStatus?.logName(): String = when (this) {
+  is AuthStatus.LoggedIn -> "LoggedIn"
+  AuthStatus.LoggedOut -> "LoggedOut"
+  null -> "null"
 }

--- a/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/AuthTokenServiceImpl.kt
+++ b/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/AuthTokenServiceImpl.kt
@@ -60,9 +60,22 @@ internal class AuthTokenServiceImpl(
   override suspend fun refreshAndGetAccessToken(): AccessToken? {
     val refreshToken = getRefreshToken() ?: return null
     return when (val result = authRepository.exchange(RefreshTokenGrant(refreshToken.token))) {
-      is AuthTokenResult.Error -> {
-        logcat { "Refreshing token failed. Invalidating present tokens" }
+      is AuthTokenResult.Error.BackendErrorResponse -> {
+        logcat { "Refreshing token was rejected by the backend. Invalidating present tokens" }
         logoutAndInvalidateTokens()
+        null
+      }
+
+      is AuthTokenResult.Error.IOError -> {
+        // The backend was never reached, so this says nothing about whether the tokens are still
+        // valid. Keeping them lets a later request retry the refresh; discarding them would force a
+        // full BankID re-login over the same network that just failed one small request.
+        logcat(LogPriority.WARN) { "Refreshing token could not reach the backend. Keeping present tokens" }
+        null
+      }
+
+      is AuthTokenResult.Error.UnknownError -> {
+        logcat(LogPriority.WARN) { "Refreshing token failed with an unknown error. Keeping present tokens" }
         null
       }
 

--- a/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/MemberIdService.kt
+++ b/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/MemberIdService.kt
@@ -46,21 +46,31 @@ class MemberIdService(
         .decodeToString()
       val payloadJsonObject: JsonObject = Json.parseToJsonElement(decodedPayload).jsonObject
       val subContent: JsonElement = payloadJsonObject.getOrElse("sub") {
-        logcat(LogPriority.ERROR) { "Failed to find `sub` in jsonElement for accessToken: $accessToken" }
+        logcat(LogPriority.ERROR) { "Failed to find `sub` in access token payload. ${accessToken.tokenShape()}" }
         return null
       }
       val subText = subContent.jsonPrimitive.content
       if (!subText.startsWith("mem_")) {
-        logcat(LogPriority.ERROR) { "Failed to find the `mem_` prefix for accessToken: $accessToken" }
+        logcat(LogPriority.ERROR) { "Access token `sub` lacks the `mem_` prefix. ${accessToken.tokenShape()}" }
         return null
       }
       subText.removePrefix("mem_")
     } catch (exception: SerializationException) {
-      logcat(LogPriority.ERROR, exception) { "Got serializationException for accessToken: $accessToken" }
+      logcat(LogPriority.ERROR, exception) {
+        "Got serializationException parsing access token. ${accessToken.tokenShape()}"
+      }
       null
     } catch (exception: IllegalArgumentException) {
-      logcat(LogPriority.ERROR, exception) { "Got illegalArgumentException for accessToken: $accessToken" }
+      logcat(LogPriority.ERROR, exception) {
+        "Got illegalArgumentException parsing access token. ${accessToken.tokenShape()}"
+      }
       null
     }
   }
 }
+
+/**
+ * Enough to tell a malformed token from a well-formed one, without putting a live bearer credential
+ * into logs that ship to Datadog and Crashlytics.
+ */
+private fun String.tokenShape(): String = "segments=${split(".").size}, length=$length"

--- a/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/token/LocalAccessToken.kt
+++ b/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/token/LocalAccessToken.kt
@@ -5,4 +5,10 @@ import kotlin.time.Instant
 data class LocalAccessToken(
   val token: String,
   val expiryDate: Instant,
-)
+) {
+  /**
+   * Redacted, so that interpolating this token, or anything holding it, can never publish a live
+   * bearer credential to a log sink.
+   */
+  override fun toString(): String = "LocalAccessToken(token=REDACTED, expiryDate=$expiryDate)"
+}

--- a/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/token/LocalRefreshToken.kt
+++ b/app/auth/auth-core-public/src/main/kotlin/com/hedvig/android/auth/token/LocalRefreshToken.kt
@@ -5,4 +5,10 @@ import kotlin.time.Instant
 data class LocalRefreshToken(
   val token: String,
   val expiryDate: Instant,
-)
+) {
+  /**
+   * Redacted, so that interpolating this token, or anything holding it, can never publish a live
+   * bearer credential to a log sink.
+   */
+  override fun toString(): String = "LocalRefreshToken(token=REDACTED, expiryDate=$expiryDate)"
+}

--- a/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/AuthTokenServiceImplTest.kt
+++ b/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/AuthTokenServiceImplTest.kt
@@ -3,6 +3,8 @@ package com.hedvig.android.auth
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.hedvig.android.auth.event.AuthEventStorage
 import com.hedvig.android.auth.storage.AuthTokenStorage
 import com.hedvig.android.auth.test.FakeAuthRepository
@@ -11,6 +13,8 @@ import com.hedvig.android.core.datastore.TestPreferencesDataStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.test.clock.TestClock
 import com.hedvig.authlib.AccessToken
+import com.hedvig.authlib.AuthRepository
+import com.hedvig.authlib.AuthTokenResult
 import com.hedvig.authlib.RefreshToken
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
@@ -78,14 +82,51 @@ internal class AuthTokenServiceImplTest {
     assertThat(status).isEqualTo(AuthStatus.LoggedOut)
   }
 
-  private fun TestScope.authTokenService(storage: AuthTokenStorage, clock: Clock): AuthTokenService =
-    AuthTokenServiceImpl(
-      storage,
-      FakeAuthRepository(),
-      AuthEventStorage(),
-      ApplicationScope(backgroundScope),
-      clock,
+  @Test
+  fun `a network error while refreshing keeps the stored tokens`() = runTest {
+    val clock = TestClock()
+    val storage = authTokenStorage(clock)
+    storage.updateTokens(
+      accessToken = AccessToken("access", expiryInSeconds = 60),
+      refreshToken = RefreshToken("refresh", expiryInSeconds = 6000),
     )
+    val authRepository = FakeAuthRepository()
+    val service = authTokenService(storage, clock, authRepository)
+    authRepository.exchangeResponse.add(AuthTokenResult.Error.IOError("no network"))
+
+    service.refreshAndGetAccessToken()
+
+    assertThat(storage.getTokens().first()).isNotNull()
+  }
+
+  @Test
+  fun `the backend rejecting the refresh token clears the stored tokens`() = runTest {
+    val clock = TestClock()
+    val storage = authTokenStorage(clock)
+    storage.updateTokens(
+      accessToken = AccessToken("access", expiryInSeconds = 60),
+      refreshToken = RefreshToken("refresh", expiryInSeconds = 6000),
+    )
+    val authRepository = FakeAuthRepository()
+    val service = authTokenService(storage, clock, authRepository)
+    authRepository.exchangeResponse.add(AuthTokenResult.Error.BackendErrorResponse("invalid_grant"))
+
+    service.refreshAndGetAccessToken()
+
+    assertThat(storage.getTokens().first()).isNull()
+  }
+
+  private fun TestScope.authTokenService(
+    storage: AuthTokenStorage,
+    clock: Clock,
+    authRepository: AuthRepository = FakeAuthRepository(),
+  ): AuthTokenService = AuthTokenServiceImpl(
+    storage,
+    authRepository,
+    AuthEventStorage(),
+    ApplicationScope(backgroundScope),
+    clock,
+  )
 
   private fun TestScope.authTokenStorage(clock: Clock) = AuthTokenStorage(
     TestPreferencesDataStore(

--- a/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/token/TokenRedactionTest.kt
+++ b/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/token/TokenRedactionTest.kt
@@ -1,0 +1,40 @@
+package com.hedvig.android.auth.token
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import com.hedvig.android.auth.AuthStatus
+import kotlin.time.Instant
+import org.junit.Test
+
+/**
+ * These values get interpolated into logs that ship to Datadog and Crashlytics, so a token surviving
+ * [toString] is a live credential leaving the device.
+ */
+internal class TokenRedactionTest {
+  private val accessToken = LocalAccessToken("access-token-secret", Instant.fromEpochSeconds(1))
+  private val refreshToken = LocalRefreshToken("refresh-token-secret", Instant.fromEpochSeconds(2))
+
+  @Test
+  fun `access token is not rendered by toString`() {
+    assertThat(accessToken.toString()).doesNotContain("access-token-secret")
+  }
+
+  @Test
+  fun `refresh token is not rendered by toString`() {
+    assertThat(refreshToken.toString()).doesNotContain("refresh-token-secret")
+  }
+
+  @Test
+  fun `expiry stays visible so the log remains useful`() {
+    assertThat(accessToken.toString()).contains("expiryDate")
+  }
+
+  @Test
+  fun `rendering the whole auth status leaks neither token`() {
+    val rendered = AuthStatus.LoggedIn(accessToken, refreshToken).toString()
+
+    assertThat(rendered).doesNotContain("access-token-secret")
+    assertThat(rendered).doesNotContain("refresh-token-secret")
+  }
+}

--- a/app/authlib/src/commonMain/kotlin/com/hedvig/authlib/AuthRepository.kt
+++ b/app/authlib/src/commonMain/kotlin/com/hedvig/authlib/AuthRepository.kt
@@ -51,7 +51,7 @@ public sealed interface AuthAttemptResult {
 
     public data class BackendErrorResponse(val message: String) : Error
 
-    public data class IOError(val message: String) : Error
+    public data class IOError(val message: String, val throwable: Throwable? = null) : Error
 
     public data class UnknownError(val message: String) : Error
   }

--- a/app/authlib/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt
+++ b/app/authlib/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt
@@ -93,7 +93,7 @@ public class NetworkAuthRepository(
       when (e) {
         is CancellationException -> throw e
 
-        is IOException -> AuthAttemptResult.Error.IOError("IO Error with message: ${e.message ?: "unknown message"}")
+        is IOException -> AuthAttemptResult.Error.IOError("IO Error with message: ${e.message ?: "unknown message"}", e)
 
         is NoTransformationFoundException -> AuthAttemptResult.Error.BackendErrorResponse(
           e.message ?: "unknown error",

--- a/app/feature/feature-login/build.gradle.kts
+++ b/app/feature/feature-login/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   implementation(projects.navigationCommon)
   implementation(projects.navigationCompose)
   implementation(projects.navigationCore)
+  implementation(projects.networkClients)
 
   testImplementation(libs.androidx.datastore.core)
   testImplementation(libs.androidx.junit)

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/BankIdState.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/BankIdState.kt
@@ -51,7 +51,8 @@ private class BankIdStateImpl(
 
   fun initialize() {
     canOpenBankId = context.canBankIdAppHandleUri(bankIdUri).also {
-      logcat { "Trying to resolve BankID app with bankIdUri:$bankIdUri | result: canOpenBankId=$it" }
+      // The URI carries a single-use autostart token, so log only what identifies the target.
+      logcat { "Trying to resolve BankID app for ${bankIdUri.host} | result: canOpenBankId=$it" }
     }
   }
 

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/BankIdState.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/BankIdState.kt
@@ -71,7 +71,7 @@ private class BankIdStateImpl(
       true
     } catch (e: PackageManager.NameNotFoundException) {
       logcat(LogPriority.WARN) {
-        "Could not resolve BankID app with bankIdUri:$uri + exception: $e"
+        "Could not resolve BankID app for ${uri.host} + exception: $e"
       }
       false
     }

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginPresenter.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginPresenter.kt
@@ -26,6 +26,8 @@ import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
+import com.hedvig.android.network.clients.TLS_DIAG_TAG
+import com.hedvig.android.network.clients.TlsDiagnostics
 import com.hedvig.authlib.AuthAttemptResult
 import com.hedvig.authlib.AuthRepository
 import com.hedvig.authlib.AuthTokenResult
@@ -40,6 +42,7 @@ internal class SwedishLoginPresenter(
   private val authTokenService: AuthTokenService,
   private val authRepository: AuthRepository,
   private val demoManager: DemoManager,
+  private val tlsDiagnostics: TlsDiagnostics,
   private val savedStateHandle: SavedStateHandle,
 ) : MoleculePresenter<SwedishLoginEvent, SwedishLoginUiState> {
   @Composable
@@ -123,7 +126,15 @@ internal class SwedishLoginPresenter(
         }
 
         is AuthAttemptResult.Error -> {
-          logcat(LogPriority.ERROR) { "Got Error when signing in with BankId: $result" }
+          val tlsFailure = (result as? AuthAttemptResult.Error.IOError)
+            ?.let { tlsDiagnostics.describe(it.throwable) }
+          if (tlsFailure != null) {
+            // Nothing reached us, so this is the member's network refusing the handshake rather than a
+            // fault of ours. WARN keeps it out of the app's error rate while the evidence stays greppable.
+            logcat(LogPriority.WARN, tag = TLS_DIAG_TAG) { "BankId login blocked by certificate trust. $tlsFailure" }
+          } else {
+            logcat(LogPriority.ERROR) { "Got Error when signing in with BankId: $result" }
+          }
           startLoginAttemptFailed = true
         }
 

--- a/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginViewModel.kt
+++ b/app/feature/feature-login/src/main/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginViewModel.kt
@@ -6,6 +6,7 @@ import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.HedvigViewModel
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.molecule.public.MoleculeViewModel
+import com.hedvig.android.network.clients.TlsDiagnostics
 import com.hedvig.authlib.AuthRepository
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
@@ -17,9 +18,10 @@ internal class SwedishLoginViewModel(
   authTokenService: AuthTokenService,
   authRepository: AuthRepository,
   demoManager: DemoManager,
+  tlsDiagnostics: TlsDiagnostics,
   @Assisted savedStateHandle: SavedStateHandle,
 ) : MoleculeViewModel<SwedishLoginEvent, SwedishLoginUiState>(
     SwedishLoginUiState(BankIdUiState.Loading, false),
-    SwedishLoginPresenter(authTokenService, authRepository, demoManager, savedStateHandle),
+    SwedishLoginPresenter(authTokenService, authRepository, demoManager, tlsDiagnostics, savedStateHandle),
     SharingStarted.WhileSubscribed(),
   )

--- a/app/feature/feature-login/src/test/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginPresenterTest.kt
+++ b/app/feature/feature-login/src/test/kotlin/com/hedvig/android/feature/login/swedishlogin/SwedishLoginPresenterTest.kt
@@ -17,6 +17,7 @@ import com.hedvig.android.auth.test.TestAuthTokenService
 import com.hedvig.android.core.demomode.DemoManager
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
+import com.hedvig.android.network.clients.TlsDiagnostics
 import com.hedvig.authlib.AccessToken
 import com.hedvig.authlib.AuthAttemptResult
 import com.hedvig.authlib.AuthRepository
@@ -302,6 +303,9 @@ class SwedishLoginPresenterTest {
         override fun isDemoMode(): Flow<Boolean> = flowOf(false)
 
         override suspend fun setDemoMode(demoMode: Boolean) {}
+      },
+      object : TlsDiagnostics {
+        override suspend fun describe(throwable: Throwable?): String? = null
       },
       savedStateHandle,
     )

--- a/app/network/network-clients/src/androidMain/kotlin/com/hedvig/android/network/clients/TlsDiagnostics.kt
+++ b/app/network/network-clients/src/androidMain/kotlin/com/hedvig/android/network/clients/TlsDiagnostics.kt
@@ -14,9 +14,7 @@ import java.security.KeyStore
 import java.security.cert.CertPathBuilderException
 import java.security.cert.CertPathValidatorException
 import java.security.cert.CertificateException
-import java.security.cert.X509Certificate
 import javax.net.ssl.SSLHandshakeException
-import javax.security.auth.x500.X500Principal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -47,19 +45,24 @@ internal class AndroidTlsDiagnostics(
     return withContext(Dispatchers.IO) {
       buildString {
         append("failure=").append(trustFailure::class.java.name)
-        append(" chain=").append(trustFailure.servedChain())
         append(" authHost=").append(resolvedAuthHost())
         append(" transport=").append(activeTransports())
         append(" userCaCount=").append(userInstalledCaCount())
         append(" api=").append(Build.VERSION.SDK_INT)
+        // Last, and quoted: it is the only field containing spaces, so the rest stay parseable.
+        append(" msg=\"").append(trustFailure.messageForLog()).append('"')
       }
     }
   }
 
   /**
-   * Which exception carries a trust failure varies by platform and provider — Android reports
-   * [CertPathValidatorException], the desktop JVM a [CertPathBuilderException] — so match on the
-   * message too rather than on one type.
+   * On Android the trust failure arrives as an [SSLHandshakeException] whose message merely names
+   * `CertPathValidatorException`, so the type checks below never match there and the message check is
+   * what identifies it. The type checks still hold on other providers, which report a
+   * [CertPathValidatorException] or [CertPathBuilderException] directly.
+   *
+   * Should the wording ever change, these stop being recognised and fall back to the pre-existing
+   * error log rather than disappearing, so the regression is visible in Datadog.
    */
   private fun Throwable.isTrustFailure(): Boolean {
     if (this is CertPathValidatorException || this is CertPathBuilderException) return true
@@ -72,18 +75,12 @@ internal class AndroidTlsDiagnostics(
   }
 
   /**
-   * Only [CertPathValidatorException] can carry the chain, and even then it may be absent, so the rest
-   * of the report has to stand on its own.
+   * The wording is what identifies a trust failure on Android, so record it verbatim: it is the only
+   * way to notice the provider changing it, or differing between OEMs and API levels.
    */
-  private fun Throwable.servedChain(): String {
-    val certificates = (this as? CertPathValidatorException)?.certPath?.certificates.orEmpty()
-      .filterIsInstance<X509Certificate>()
-    if (certificates.isEmpty()) return "unavailable"
-    return certificates.joinToString(
-      separator = " | ",
-      prefix = "[",
-      postfix = "]",
-    ) { "${it.subjectX500Principal.commonName()} issuedBy ${it.issuerX500Principal.commonName()}" }
+  private fun Throwable.messageForLog(): String {
+    val message = message ?: return "none"
+    return message.replace('\n', ' ').take(MAX_MESSAGE_CHARS)
   }
 
   /**
@@ -131,10 +128,8 @@ internal class AndroidTlsDiagnostics(
       .count { it.startsWith("user:") }
   }.getOrElse { -1 }
 
-  private fun X500Principal.commonName(): String = COMMON_NAME.find(name)?.groupValues?.get(1) ?: "?"
-
   private companion object {
     const val MAX_CAUSE_DEPTH = 10
-    val COMMON_NAME = Regex("CN=([^,]+)")
+    const val MAX_MESSAGE_CHARS = 200
   }
 }

--- a/app/network/network-clients/src/androidMain/kotlin/com/hedvig/android/network/clients/TlsDiagnostics.kt
+++ b/app/network/network-clients/src/androidMain/kotlin/com/hedvig/android/network/clients/TlsDiagnostics.kt
@@ -48,7 +48,7 @@ internal class AndroidTlsDiagnostics(
       buildString {
         append("failure=").append(trustFailure::class.java.name)
         append(" chain=").append(trustFailure.servedChain())
-        append(" resolvedIps=").append(resolvedAuthHostIps())
+        append(" authHost=").append(resolvedAuthHost())
         append(" transport=").append(activeTransports())
         append(" userCaCount=").append(userInstalledCaCount())
         append(" api=").append(Build.VERSION.SDK_INT)
@@ -86,10 +86,27 @@ internal class AndroidTlsDiagnostics(
     ) { "${it.subjectX500Principal.commonName()} issuedBy ${it.issuerX500Principal.commonName()}" }
   }
 
-  /** An address outside our hosting means the name was answered by something that isn't us. */
-  private fun resolvedAuthHostIps(): String = runCatching {
+  /**
+   * Reported as a category rather than raw addresses: our hosting answers from a rotating public pool,
+   * so a specific address proves nothing, whereas a loopback, unspecified or private answer means a
+   * filter on the device or the local network answered the name instead of us.
+   */
+  private fun resolvedAuthHost(): String = runCatching {
     val host = URI(buildConstants.urlAuthService).host ?: return@runCatching "unknown-host"
-    InetAddress.getAllByName(host).joinToString(",") { it.hostAddress ?: "?" }
+    val addresses = InetAddress.getAllByName(host)
+    if (addresses.isEmpty()) return@runCatching "no-addresses"
+    addresses
+      .map { address ->
+        when {
+          address.isAnyLocalAddress -> "unspecified"
+          address.isLoopbackAddress -> "loopback"
+          address.isSiteLocalAddress || address.isLinkLocalAddress -> "private"
+          else -> "public"
+        }
+      }
+      .distinct()
+      .sorted()
+      .joinToString("+")
   }.getOrElse { "unresolved(${it::class.simpleName})" }
 
   private fun activeTransports(): String = runCatching {

--- a/app/network/network-clients/src/androidMain/kotlin/com/hedvig/android/network/clients/TlsDiagnostics.kt
+++ b/app/network/network-clients/src/androidMain/kotlin/com/hedvig/android/network/clients/TlsDiagnostics.kt
@@ -1,0 +1,123 @@
+package com.hedvig.android.network.clients
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import com.hedvig.android.core.common.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import java.net.InetAddress
+import java.net.URI
+import java.security.KeyStore
+import java.security.cert.CertPathBuilderException
+import java.security.cert.CertPathValidatorException
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLHandshakeException
+import javax.security.auth.x500.X500Principal
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+const val TLS_DIAG_TAG = "TlsDiag"
+
+/**
+ * Evidence for why a TLS handshake was refused, gathered at the point of failure.
+ *
+ * A trust failure means a certificate did arrive and we declined it, so the questions worth answering
+ * are where the hostname pointed and whether this device trusts anything unusual. An address outside
+ * our hosting means something other than us answered the name; a non-zero count of added CAs means
+ * traffic is being intercepted on the device itself.
+ */
+interface TlsDiagnostics {
+  /** Null when [throwable] is not a certificate-trust failure, so callers can fall through. */
+  suspend fun describe(throwable: Throwable?): String?
+}
+
+@Inject
+@ContributesBinding(AppScope::class)
+internal class AndroidTlsDiagnostics(
+  private val context: Context,
+  private val buildConstants: HedvigBuildConstants,
+) : TlsDiagnostics {
+  override suspend fun describe(throwable: Throwable?): String? {
+    val causes = generateSequence(throwable) { it.cause }.take(MAX_CAUSE_DEPTH).toList()
+    val trustFailure = causes.firstOrNull { it.isTrustFailure() } ?: return null
+    return withContext(Dispatchers.IO) {
+      buildString {
+        append("failure=").append(trustFailure::class.java.name)
+        append(" chain=").append(trustFailure.servedChain())
+        append(" resolvedIps=").append(resolvedAuthHostIps())
+        append(" transport=").append(activeTransports())
+        append(" userCaCount=").append(userInstalledCaCount())
+        append(" api=").append(Build.VERSION.SDK_INT)
+      }
+    }
+  }
+
+  /**
+   * Which exception carries a trust failure varies by platform and provider — Android reports
+   * [CertPathValidatorException], the desktop JVM a [CertPathBuilderException] — so match on the
+   * message too rather than on one type.
+   */
+  private fun Throwable.isTrustFailure(): Boolean {
+    if (this is CertPathValidatorException || this is CertPathBuilderException) return true
+    if (this is SSLHandshakeException || this is CertificateException) {
+      val message = message ?: return false
+      return message.contains("certification path", ignoreCase = true) ||
+        message.contains("trust anchor", ignoreCase = true)
+    }
+    return false
+  }
+
+  /**
+   * Only [CertPathValidatorException] can carry the chain, and even then it may be absent, so the rest
+   * of the report has to stand on its own.
+   */
+  private fun Throwable.servedChain(): String {
+    val certificates = (this as? CertPathValidatorException)?.certPath?.certificates.orEmpty()
+      .filterIsInstance<X509Certificate>()
+    if (certificates.isEmpty()) return "unavailable"
+    return certificates.joinToString(
+      separator = " | ",
+      prefix = "[",
+      postfix = "]",
+    ) { "${it.subjectX500Principal.commonName()} issuedBy ${it.issuerX500Principal.commonName()}" }
+  }
+
+  /** An address outside our hosting means the name was answered by something that isn't us. */
+  private fun resolvedAuthHostIps(): String = runCatching {
+    val host = URI(buildConstants.urlAuthService).host ?: return@runCatching "unknown-host"
+    InetAddress.getAllByName(host).joinToString(",") { it.hostAddress ?: "?" }
+  }.getOrElse { "unresolved(${it::class.simpleName})" }
+
+  private fun activeTransports(): String = runCatching {
+    val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+    val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+      ?: return@runCatching "none"
+    listOfNotNull(
+      "vpn".takeIf { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) },
+      "wifi".takeIf { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) },
+      "cellular".takeIf { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) },
+    ).joinToString("+").ifEmpty { "other" }
+  }.getOrElse { "unknown" }
+
+  /**
+   * How many CAs the member or an MDM profile added. Count only — an alias can name an employer.
+   * A non-zero count is the strongest single signal that traffic is intercepted on the device.
+   */
+  private fun userInstalledCaCount(): Int = runCatching {
+    KeyStore.getInstance("AndroidCAStore").apply { load(null) }
+      .aliases()
+      .asSequence()
+      .count { it.startsWith("user:") }
+  }.getOrElse { -1 }
+
+  private fun X500Principal.commonName(): String = COMMON_NAME.find(name)?.groupValues?.get(1) ?: "?"
+
+  private companion object {
+    const val MAX_CAUSE_DEPTH = 10
+    val COMMON_NAME = Regex("CN=([^,]+)")
+  }
+}


### PR DESCRIPTION
## Background

We were seeing a steady stream of this in Datadog:

```
Got Error when signing in with BankId: IOError(message=IO Error with message:
java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.)
```

Three things came out of investigating it.

**Our TLS setup is fine.** No custom trust config anywhere in the app; `authlib` uses the default
platform trust manager. `auth.prod.hedvigit.com` and `apollo-router.prod.hedvigit.com` serve the same
certificate, rooted at `Amazon Root CA 1` cross-signed by `Starfield Services Root CA G2`, which has
been in the Android trust store since long before our `minSdk 23`. Not an infra incident, and not a
release regression.

**The volume was misleading.** 499 of 644 events over a month (77.5%) came from a *single device*:
one member, 24 sessions, six days, ~499 taps of Retry. Excluding them, the real member-facing rate is
about 4.8/day, flat. **Group by `@usr.device_id` before drawing conclusions from these counts.**

**We were making it much worse.** That member logged in successfully 14 times and was force-logged-out
13 times. Any network error during a background token refresh caused us to delete their tokens, which
dropped them at the BankID login screen and forced a full re-login over the same failing network.

## Practical gain of this release

**1. Members stop losing their session over a bad moment of network.**
The only change with real user impact. Previously one failed background token refresh destroyed the
session; now the session survives and the next request retries. Directly measurable — see the query
below.

**2. We stop writing members' access and refresh tokens into Datadog and Crashlytics.**
A log line was interpolating the whole `AuthStatus.LoggedIn`, which carries both tokens. Access tokens
live ~1h, refresh tokens ~24h, and a refresh token can mint new access tokens — so these were live
credentials in our log aggregators. Historical exposure has since expired. Invisible to users.

**3. Members' network problems no longer count as our app errors.**
Certificate-trust failures now log at WARN instead of ERROR, so the error rate reflects our bugs.

**4. We may learn what actually causes the certificate failures.** New diagnostic logging, below.

### What this release does *not* do

It does not fix the certificate error. Nobody who currently cannot log in will suddenly be able to.
The gain is that far fewer members get pushed into that state, and that we stop leaking credentials
while it happens.

## Queries to run

### The lockouts we are now preventing

```
env:prod service:android "could not reach the backend. Keeping present tokens"
```

Every hit is a forced logout that would have happened before this release and now doesn't. On the one
device we investigated, this was 13 occurrences in six days.

Legitimate logouts (server actually rejected the token) are unchanged:

```
env:prod service:android "was rejected by the backend. Invalidating present tokens"
```

The old message `"Refreshing token failed. Invalidating present tokens"` no longer exists, so it
should drop to zero.

### The new diagnostic

```
env:prod service:android status:warn "BankId login blocked by certificate trust"
```

Messages look like:

```
[TlsDiag] BankId login blocked by certificate trust. failure=javax.net.ssl.SSLHandshakeException
authHost=public transport=wifi userCaCount=1 api=28
msg="java.security.cert.CertPathValidatorException: Trust anchor for certification path not found."
```

That is a real line captured on device, not an illustration. `msg` comes last and is quoted because it
is the only field containing spaces, so the others stay cleanly parseable.

The fields are substrings in the message, so full-text search works but faceting does not. Count each:

```
"userCaCount=0"    "userCaCount=1"    "userCaCount=-1"
"transport=vpn"    "transport=wifi"   "transport=cellular"
"authHost=public"  "authHost=loopback"  "authHost=unspecified"  "authHost=private"
```

A Datadog grok parser on this message would give proper facets — ops change, no code needed.

### What should mostly disappear

```
env:prod service:android status:error "Got Error when signing in with BankId"
```

What remains here is non-TLS failure (the `Unable to resolve host` DNS cases), which still log at
ERROR deliberately.

## How to interpret the diagnostic

| What dominates | Conclusion | Next step |
| --- | --- | --- |
| `userCaCount` 1 or higher | A CA is installed on those devices — ad-blocker, antivirus, or work profile | Write the user-facing message; naming the cause is justified |
| `userCaCount=0` + `authHost=loopback` / `unspecified` / `private` | A local DNS filter is answering with a sinkhole | Message justified, worded about the network rather than an app |
| `userCaCount=0` + `authHost=public` + `transport=wifi` | Interception upstream — router, ISP, corporate wifi — invisible to the app | Inconclusive from our side; accept as environmental or take to infra |
| `userCaCount=-1` | The keystore probe threw | Fix the probe, not the app |
| Few `TlsDiag` lines while errors persist | Classification isn't matching in the field | Revisit the message-based fallback |

### Field reliability, established by testing

- **`userCaCount` — trustworthy.** Verified on an emulator: goes 0 → 1 when a CA is installed as a
  user certificate. This is the field that matters.
- **`transport` — trustworthy.** Returns real values. Note that on-device ad-blockers use Android's
  VPN API, so `vpn` here alongside a trust failure is a strong signal.
- **`authHost` — narrow.** Only catches DNS-level filtering (a local filter answering `0.0.0.0` or
  `127.0.0.1`). Our own lookup bypasses an HTTP proxy, so proxy-based interception reads `public`.
- **`failure` — expect `javax.net.ssl.SSLHandshakeException`, always.** Verified on device. The real
  `CertPathValidatorException` is never a link in the cause chain; Android only *names* it inside the
  handshake exception's message. Classification therefore matches on the message text ("trust anchor" /
  "certification path"), not on the exception type.
- **`msg` — the wording the classification depends on.** Captured verbatim (truncated at 200 chars) so
  we can spot the provider changing it, or it differing across OEMs and API levels. If that wording
  ever changes, these events stop being recognised and revert to the pre-existing `status:error` line
  we already monitor — so the regression is visible rather than silent.
- **No certificate chain is available.** We cannot name the intercepting CA. Android does not hand us
  the served chain on a trust failure, so `userCaCount` and `transport` are the only interception
  signals we get.

## Cautions when reading the results

1. Expect roughly 65 events over two weeks at the current baseline, minus staged-rollout lag — likely
   fewer in practice.
2. **Group by `@usr.device_id` first.** One stuck member produced 77% of the previous batch.
3. One screen entry produces exactly **one** login attempt. Verified on device: a single tap to reach
   the login screen, no further input, one event. The app never retries on its own, so every event
   beyond the first is a real Retry tap — event counts are a fair proxy for how hard somebody was
   trying, and sub-second gaps mean frantic tapping rather than a loop in our code.

## Known follow-ups, not in this release

- `observeLoginStatus` gives up on the first `IOException` mid-poll, so a brief network blip ends an
  in-progress BankID login permanently (26 occurrences on the investigated device).
- The token-refresh path (`AuthTokenResult.Error.IOError`) carries no diagnostics; only the login path
  is instrumented.
- No user-facing error message yet — deliberately withheld until the data says what to blame.