### PR TITLE
Fix: select Housing type

### DIFF
--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/enternewaddress/EnterNewAddressViewModel.kt
@@ -127,8 +127,7 @@ private class EnterNewAddressPresenter(
         Submit -> {
           @Suppress("NAME_SHADOWING")
           val content = content.getOrNull() ?: return@CollectEvents
-          val validContent = content.validate()
-          if (validContent == null) return@CollectEvents
+          val validContent = content.validate() ?: return@CollectEvents
           coroutineScope.launch {
             val movingFlowState = movingFlowRepository.updateWithPropertyInput(
               movingDate = validContent.movingDate,

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/start/HousingTypeViewModel.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/start/HousingTypeViewModel.kt
@@ -71,13 +71,14 @@ private class HousingTypePresenter(
     LaunchedEffect(Unit) {
       movingFlowRepository
         .movingFlowState()
-        .collectLatest {
+        .collectLatest { movingFlowState ->
           Snapshot.withMutableSnapshot {
             currentState = HousingTypeUiState.Content(
               possibleHousingTypes = HousingType.entries,
-              selectedHousingType = HousingType.entries.first(),
+              selectedHousingType = (currentState as? HousingTypeUiState.Content)?.selectedHousingType
+                ?: movingFlowState?.housingType
+                ?: HousingType.entries.first(),
             )
-            submittingHousingType = null
           }
         }
     }
@@ -85,14 +86,15 @@ private class HousingTypePresenter(
     val submittingHousingTypeValue = submittingHousingType
     LaunchedEffect(submittingHousingTypeValue) {
       if (submittingHousingTypeValue != null) {
-        val state = currentState as? HousingTypeUiState.Content ?: return@LaunchedEffect
-        currentState = state.copy(buttonLoading = true)
         movingFlowRepository.updateWithHousingType(submittingHousingTypeValue)
-        submittingHousingType = null
         backstack.add(EnterNewAddressKey(moveIntentId))
+        submittingHousingType = null
       }
     }
-    return currentState
+    return when (val state = currentState) {
+      is HousingTypeUiState.Content -> state.copy(buttonLoading = submittingHousingTypeValue != null)
+      else -> state
+    }
   }
 }
 


### PR DESCRIPTION
Bug: change housing type continue button sometimes gets stuck in loading state, also selection state clears when going back to this screen.

Fix: read selection from movingState and make buttonLoading depend on submitting.

[link to bug](https://app.notion.com/p/hedviginsurance/Android-check-Change-addressType-of-Home-continue-button-not-clearing-nav-state-sometimes-stuck-o-35ec3f71cb0a82c1a3f3814b0124bdf1?source=copy_link)