### PR TITLE
chore: shorten quick action tile copy on home screen

### DIFF
--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -1218,7 +1218,7 @@ private fun QuickActionTilesSection(
       quickActions.forEach { action ->
         HomeActionTile(
           icon = action.homeIcon(),
-          text = stringResource(action.titleRes),
+          text = stringResource(action.shortTitleRes),
           onClick = {
             when (action) {
               is QuickAction.StandaloneQuickLink -> onQuickLink(action.quickLinkDestination)

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
@@ -107,7 +107,7 @@ private fun PreviewOnboardingContractCard() {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       OnboardingContractCard(
         displayName = "displayName",
-        exposureName = "exposureName",
+        secondaryText = "secondaryText",
         typeOfContract = "SE_HOUSE",
         isComplete = false,
         onAddClick = {},

--- a/app/shared/member-quick-actions/src/commonMain/kotlin/com/hedvig/android/memberquickactions/GetMemberQuickActionsUseCase.kt
+++ b/app/shared/member-quick-actions/src/commonMain/kotlin/com/hedvig/android/memberquickactions/GetMemberQuickActionsUseCase.kt
@@ -8,7 +8,6 @@ import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.featureflags.FeatureManager
-import com.hedvig.android.featureflags.flags.Feature
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
 import com.hedvig.android.memberquickactions.QuickLinkDestination.OuterDestination.ChooseInsuranceForEditCoInsured
@@ -40,8 +39,9 @@ import hedvig.resources.HC_QUICK_ACTIONS_TRAVEL_CERTIFICATE
 import hedvig.resources.HC_QUICK_ACTIONS_TRAVEL_CERTIFICATE_SUBTITLE
 import hedvig.resources.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_SUBTITLE
 import hedvig.resources.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_TITLE
+import hedvig.resources.HOME_QUICK_ACTIONS_CHANGE_ADDRESS
+import hedvig.resources.HOME_QUICK_ACTIONS_EDIT_INSURANCE
 import hedvig.resources.Res
-import kotlinx.coroutines.flow.first
 import octopus.AvailableSelfServiceOnContractsQuery
 
 interface GetMemberQuickActionsUseCase {
@@ -110,6 +110,7 @@ internal class GetMemberQuickActionsUseCaseImpl(
             links = linksToExpand,
             titleRes = Res.string.HC_QUICK_ACTIONS_EDIT_INSURANCE_TITLE,
             hintTextRes = Res.string.HC_QUICK_ACTIONS_EDIT_INSURANCE_SUBTITLE,
+            shortTitleRes = Res.string.HOME_QUICK_ACTIONS_EDIT_INSURANCE,
           ),
         )
       }
@@ -119,6 +120,7 @@ internal class GetMemberQuickActionsUseCaseImpl(
             quickLinkDestination = QuickLinkDestination.OuterDestination.QuickLinkChangeAddress,
             titleRes = Res.string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_TITLE,
             hintTextRes = Res.string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_SUBTITLE,
+            shortTitleRes = Res.string.HOME_QUICK_ACTIONS_CHANGE_ADDRESS,
           ),
         )
       }

--- a/app/shared/member-quick-actions/src/commonMain/kotlin/com/hedvig/android/memberquickactions/QuickAction.kt
+++ b/app/shared/member-quick-actions/src/commonMain/kotlin/com/hedvig/android/memberquickactions/QuickAction.kt
@@ -6,15 +6,20 @@ sealed interface QuickAction {
   val titleRes: StringResource
   val hintTextRes: StringResource
 
+  /** Shorter title for the compact home tile; falls back to [titleRes] when no shorter copy exists. */
+  val shortTitleRes: StringResource
+
   data class StandaloneQuickLink(
     override val titleRes: StringResource,
     override val hintTextRes: StringResource,
     val quickLinkDestination: QuickLinkDestination,
+    override val shortTitleRes: StringResource = titleRes,
   ) : QuickAction
 
   data class MultiSelectExpandedLink(
     override val titleRes: StringResource,
     override val hintTextRes: StringResource,
     val links: List<StandaloneQuickLink>,
+    override val shortTitleRes: StringResource = titleRes,
   ) : QuickAction
 }


### PR DESCRIPTION
## What

The home screen quick action tiles are laid out three-across, so long titles like "Edit your insurance" and "Move to new address" wrap to two lines and read loose (matching the Figma request to tighten them).

This adds a `shortTitleRes` to `QuickAction` (falling back to `titleRes`), so the compact tile can show a tighter label while the Help Center and the "Edit insurance" bottom sheet keep the full descriptive title.

Wired to the two short keys that already exist in Lokalise (confirmed live via `downloadStrings`):

| Action | Help Center title | Home tile now |
|---|---|---|
| Edit insurance | Edit your insurance | **Edit insurance** |
| Change address | Move to new address | **Change address** |

Every other top-level tile (Travel certificate, Payments, FirstVet, Sick abroad) is already one or two short words, so no new strings were needed.

## Notes

- No new Lokalise strings added; both `HOME_QUICK_ACTIONS_*` keys were added on the iOS side and survive `downloadStrings`.
- Sheet sub-items (co-insured, co-owner, change coverage, cancellation) are full-width rows and keep their descriptive titles.