### PR TITLE
Fix: onboarding UI test session 

### DIFF
--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
@@ -62,7 +62,6 @@ internal fun OnboardingContractCard(
       Column(Modifier.weight(1f)) {
         HedvigText(
           text = displayName,
-          style = HedvigTheme.typography.label,
         )
         HedvigText(
           text = secondaryText,

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
@@ -1,5 +1,6 @@
 package com.hedvig.android.feature.onboarding.ui
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,7 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.data.contract.pillowResource
 import com.hedvig.android.data.contract.toContractGroup
 import com.hedvig.android.design.system.hedvig.ButtonDefaults
@@ -70,30 +73,40 @@ internal fun OnboardingContractCard(
         )
       }
       Spacer(Modifier.width(12.dp))
-      if (isComplete) {
-        Box(
-          contentAlignment = Alignment.Center,
-          modifier = Modifier
-            .size(24.dp)
-            .clip(HedvigTheme.shapes.cornerXSmall)
-            .background(HedvigTheme.colorScheme.signalGreenElement),
-        ) {
-          Icon(
-            imageVector = HedvigIcons.Checkmark,
-            contentDescription = null,
-            tint = HedvigTheme.colorScheme.fillWhite,
-            modifier = Modifier.size(16.dp),
+      // The checkmark is only animated in when the row becomes complete while it is on screen. A row that is
+      // already complete on its first composition renders it without motion.
+      // Aligned to the end so that the width change between the button and the checkmark is absorbed on the
+      // trailing edge, leaving the text column beside it untouched.
+      AnimatedContent(
+        targetState = isComplete,
+        contentAlignment = Alignment.Center,
+        label = "contract card completion",
+      ) { complete ->
+        if (complete) {
+          Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+              .size(24.dp)
+              .clip(HedvigTheme.shapes.cornerXSmall)
+              .background(HedvigTheme.colorScheme.signalGreenElement),
+          ) {
+            Icon(
+              imageVector = HedvigIcons.Checkmark,
+              contentDescription = null,
+              tint = HedvigTheme.colorScheme.fillWhite,
+              modifier = Modifier.size(16.dp),
+            )
+          }
+        } else {
+          HedvigButton(
+            text = stringResource(Res.string.ONBOARDING_ADD_BUTTON),
+            onClick = onAddClick,
+            enabled = true,
+            buttonStyle = ButtonDefaults.ButtonStyle.Primary,
+            buttonSize = ButtonDefaults.ButtonSize.Small,
+            modifier = Modifier.clip(CircleShape),
           )
         }
-      } else {
-        HedvigButton(
-          text = stringResource(Res.string.ONBOARDING_ADD_BUTTON),
-          onClick = onAddClick,
-          enabled = true,
-          buttonStyle = ButtonDefaults.ButtonStyle.Primary,
-          buttonSize = ButtonDefaults.ButtonSize.Small,
-          modifier = Modifier.clip(CircleShape),
-        )
       }
     }
   }
@@ -101,14 +114,16 @@ internal fun OnboardingContractCard(
 
 @HedvigPreview
 @Composable
-private fun PreviewOnboardingContractCard() {
+private fun PreviewOnboardingContractCard(
+  @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) isComplete: Boolean,
+) {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       OnboardingContractCard(
         displayName = "displayName",
         secondaryText = "secondaryText",
         typeOfContract = "SE_HOUSE",
-        isComplete = false,
+        isComplete = isComplete,
         onAddClick = {},
         modifier = Modifier,
       )

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
@@ -267,7 +267,10 @@ internal fun ColumnScope.OnboardingStepButtons(
     @Composable {
       HedvigButton(
         text = secondaryText,
-        onClick = onSecondaryClick,
+        onClick = {
+          hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+          onSecondaryClick()
+        },
         enabled = true,
         buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
         modifier = Modifier

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
@@ -34,6 +34,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
@@ -246,10 +248,14 @@ internal fun ColumnScope.OnboardingStepButtons(
   secondaryAbovePrimary: Boolean = false,
 ) {
   Spacer(Modifier.height(16.dp))
+  val hapticFeedback = LocalHapticFeedback.current
   val primaryButton = @Composable {
     HedvigButton(
       text = primaryText,
-      onClick = onPrimaryClick,
+      onClick = {
+        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+        onPrimaryClick()
+      },
       enabled = primaryEnabled,
       modifier = Modifier
         .fillMaxWidth()

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -35,7 +35,6 @@ import com.hedvig.android.feature.onboarding.ui.OnboardingStepScaffold
 import hedvig.resources.ONBOARDING_ADD_COINSURED_TITLE
 import hedvig.resources.ONBOARDING_ADD_COOWNERS_TITLE
 import hedvig.resources.ONBOARDING_ADD_INFO_LATER_LABEL
-import hedvig.resources.ONBOARDING_DO_THIS_LATER_BUTTON
 import hedvig.resources.ONBOARDING_MISSING_INFO_SUBTITLE
 import hedvig.resources.ONBOARDING_NUMBER_OF_COINSURED
 import hedvig.resources.ONBOARDING_NUMBER_OF_COOWNERS
@@ -150,7 +149,7 @@ private fun OnboardingCoInsuredScreen(
   }
 }
 
-// A complete row lists the people by name; while info is still missing it shows how many there are.
+// Names are listed once they are all known; until then they are followed by a count of the people still missing.
 @Composable
 private fun CoInsuredRow.secondaryText(): String {
   val plural = if (flowType == CoInsuredFlowType.CoOwners) {
@@ -163,7 +162,7 @@ private fun CoInsuredRow.secondaryText(): String {
   } else if (insuredNames.isNotEmpty()) {
     val count = insuredCount - insuredNames.size
     "${insuredNames.toReadableList()} + ${pluralStringResource(plural, count, count)}"
-  }  else {
+  } else {
     pluralStringResource(plural, insuredCount, insuredCount)
   }
 }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -142,8 +142,8 @@ private fun OnboardingCoInsuredScreen(
         OnboardingStepButtons(
           primaryText = stringResource(Res.string.general_continue_button),
           onPrimaryClick = onContinue,
-          secondaryText = stringResource(Res.string.ONBOARDING_DO_THIS_LATER_BUTTON),
-          onSecondaryClick = onContinue,
+          secondaryText = null,
+          onSecondaryClick = null,
         )
       }
     }
@@ -152,15 +152,20 @@ private fun OnboardingCoInsuredScreen(
 
 // A complete row lists the people by name; while info is still missing it shows how many there are.
 @Composable
-private fun CoInsuredRow.secondaryText(): String = if (isComplete && insuredNames.isNotEmpty()) {
-  insuredNames.toReadableList()
-} else {
+private fun CoInsuredRow.secondaryText(): String {
   val plural = if (flowType == CoInsuredFlowType.CoOwners) {
     Res.plurals.ONBOARDING_NUMBER_OF_COOWNERS
   } else {
     Res.plurals.ONBOARDING_NUMBER_OF_COINSURED
   }
-  pluralStringResource(plural, insuredCount, insuredCount)
+  return if (insuredNames.isNotEmpty() && isComplete) {
+    insuredNames.toReadableList()
+  } else if (insuredNames.isNotEmpty()) {
+    val count = insuredCount - insuredNames.size
+    "${insuredNames.toReadableList()} + ${pluralStringResource(plural, count, count)}"
+  }  else {
+    pluralStringResource(plural, insuredCount, insuredCount)
+  }
 }
 
 /** Joins names the way the design shows them: "A", "A & B", "A, B & C". */

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredViewModel.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredViewModel.kt
@@ -101,8 +101,8 @@ internal data class CoInsuredRow(
   val typeOfContract: String,
   val flowType: CoInsuredFlowType,
   val isComplete: Boolean,
-  // Total people on the contract and their first names. The row summarises as a count while info is
-  // still missing, then switches to the names once complete.
+  // Total people on the contract, and the first names of those already known. The two are independent:
+  // [insuredNames] can be shorter than [insuredCount] while details are still missing.
   val insuredCount: Int = 0,
   val insuredNames: List<String> = emptyList(),
 )

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
@@ -33,7 +33,6 @@ import com.hedvig.android.feature.onboarding.ui.OnboardingStepHeader
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepScaffold
 import hedvig.resources.ONBOARDING_ADD_INFO_LATER_LABEL
 import hedvig.resources.ONBOARDING_ADD_PET_CHIP_IDS_TITLE
-import hedvig.resources.ONBOARDING_DO_THIS_LATER_BUTTON
 import hedvig.resources.ONBOARDING_MISSING_INFO_PET_SUBTITLE
 import hedvig.resources.Res
 import hedvig.resources.general_continue_button

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
@@ -129,8 +129,8 @@ private fun OnboardingPetIdScreen(
         OnboardingStepButtons(
           primaryText = stringResource(Res.string.general_continue_button),
           onPrimaryClick = onContinue,
-          secondaryText = stringResource(Res.string.ONBOARDING_DO_THIS_LATER_BUTTON),
-          onSecondaryClick = onContinue,
+          secondaryText = null,
+          onSecondaryClick = null,
         )
       }
     }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
@@ -123,8 +123,11 @@ private fun OnboardingPhoneScreen(
           errorState = if (content.showSubmissionError != null) {
             val text = when (content.showSubmissionError) {
               GeneralError -> stringResource(Res.string.ONBOARDING_PHONE_SAVE_ERROR)
-              is NumberTooShort -> stringResource(Res.string.CLAIM_CHAT_FORM_TEXT_MIN_CHAR,
-                content.showSubmissionError.minLength)
+
+              NumberTooShort -> stringResource(
+                Res.string.CLAIM_CHAT_FORM_TEXT_MIN_CHAR,
+                MINIMUM_PHONE_NUMBER_LENGTH,
+              )
             }
             HedvigTextFieldDefaults.ErrorState.Error.WithMessage(text)
           } else {
@@ -179,7 +182,7 @@ private class OnboardingPhoneUiStateProvider : CollectionPreviewParameterProvide
     OnboardingPhoneUiState.Content(
       progress = OnboardingProgress(totalSteps = 5, currentIndex = 3),
       phoneNumber = "070 123 45 67",
-      showSubmissionError = NumberTooShort(),
+      showSubmissionError = NumberTooShort,
     ),
   ),
 )

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
@@ -123,7 +123,8 @@ private fun OnboardingPhoneScreen(
           errorState = if (content.showSubmissionError != null) {
             val text = when (content.showSubmissionError) {
               GeneralError -> stringResource(Res.string.ONBOARDING_PHONE_SAVE_ERROR)
-              is NumberTooShort -> stringResource(Res.string.CLAIM_CHAT_FORM_TEXT_MIN_CHAR, content.showSubmissionError.minLength)
+              is NumberTooShort -> stringResource(Res.string.CLAIM_CHAT_FORM_TEXT_MIN_CHAR,
+                content.showSubmissionError.minLength)
             }
             HedvigTextFieldDefaults.ErrorState.Error.WithMessage(text)
           } else {

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
@@ -105,7 +107,9 @@ private fun OnboardingPhoneScreen(
               placeCursorAtEnd()
             }
           },
-          modifier = Modifier.align(Alignment.CenterHorizontally),
+          modifier = Modifier.align(Alignment.CenterHorizontally).semantics {
+            hideFromAccessibility()
+          },
         )
         Spacer(Modifier.weight(1f))
         Spacer(Modifier.height(24.dp))

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
@@ -33,6 +33,9 @@ import com.hedvig.android.feature.onboarding.ui.OnboardingProgressBarAnimation
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepButtons
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepHeader
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepScaffold
+import com.hedvig.android.feature.onboarding.ui.phone.SubmissionError.GeneralError
+import com.hedvig.android.feature.onboarding.ui.phone.SubmissionError.NumberTooShort
+import hedvig.resources.CLAIM_CHAT_FORM_TEXT_MIN_CHAR
 import hedvig.resources.ONBOARDING_DO_THIS_LATER_BUTTON
 import hedvig.resources.ONBOARDING_PHONE_SAVE_ERROR
 import hedvig.resources.ONBOARDING_PHONE_SUBTITLE
@@ -117,10 +120,12 @@ private fun OnboardingPhoneScreen(
           state = phoneNumberState,
           labelText = stringResource(Res.string.ONBOARDING_PHONE_TITLE),
           textFieldSize = HedvigTextFieldDefaults.TextFieldSize.Medium,
-          errorState = if (content.showSubmissionError) {
-            HedvigTextFieldDefaults.ErrorState.Error.WithMessage(
-              stringResource(Res.string.ONBOARDING_PHONE_SAVE_ERROR),
-            )
+          errorState = if (content.showSubmissionError != null) {
+            val text = when (content.showSubmissionError) {
+              GeneralError -> stringResource(Res.string.ONBOARDING_PHONE_SAVE_ERROR)
+              is NumberTooShort -> stringResource(Res.string.CLAIM_CHAT_FORM_TEXT_MIN_CHAR, content.showSubmissionError.minLength)
+            }
+            HedvigTextFieldDefaults.ErrorState.Error.WithMessage(text)
           } else {
             HedvigTextFieldDefaults.ErrorState.NoError
           },
@@ -173,7 +178,7 @@ private class OnboardingPhoneUiStateProvider : CollectionPreviewParameterProvide
     OnboardingPhoneUiState.Content(
       progress = OnboardingProgress(totalSteps = 5, currentIndex = 3),
       phoneNumber = "070 123 45 67",
-      showSubmissionError = true,
+      showSubmissionError = NumberTooShort(),
     ),
   ),
 )

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.style.LineHeightStyle
@@ -115,6 +117,7 @@ private fun KeypadKey(label: String, highlighted: Boolean, onKeypadClick: (Strin
     animationSpec = tween(MotionTokens.DurationLong1.toInt(), easing = MotionTokens.EasingEmphasizedCubicBezier),
     label = "keypad scale",
   )
+  val hapticFeedback = LocalHapticFeedback.current
   Box(
     modifier = Modifier
       .size(KeySize)
@@ -124,6 +127,7 @@ private fun KeypadKey(label: String, highlighted: Boolean, onKeypadClick: (Strin
       }
       .clip(HedvigTheme.shapes.cornerLarge)
       .clickable(clickEnabled) {
+        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
         onKeypadClick(label)
       }
       .background(containerColor, HedvigTheme.shapes.cornerLarge),

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
@@ -39,7 +39,7 @@ import com.hedvig.android.design.system.hedvig.tokens.MotionTokens
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 
-private val KeySize = 36.dp
+private val KeySize = 48.dp
 private val HorizontalGap = 11.dp
 private val VerticalGap = 9.dp
 private val GlyphFontSize = 20.sp

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneViewModel.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneViewModel.kt
@@ -24,6 +24,8 @@ import com.hedvig.android.molecule.public.MoleculeViewModel
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.launch
 
+internal const val MINIMUM_PHONE_NUMBER_LENGTH = 6
+
 @Inject
 @HedvigViewModel(ActivityRetainedScope::class)
 internal class OnboardingPhoneViewModel(
@@ -97,8 +99,8 @@ internal class OnboardingPhonePresenter(
 
         is OnboardingPhoneEvent.Save -> {
           val content = currentState as? OnboardingPhoneUiState.Content ?: return@CollectEvents
-          if (event.phoneNumber.length < 6) {
-            currentState = content.copy(showSubmissionError = NumberTooShort())
+          if (event.phoneNumber.length < MINIMUM_PHONE_NUMBER_LENGTH) {
+            currentState = content.copy(showSubmissionError = NumberTooShort)
           } else {
             phoneNumberToSubmit = event.phoneNumber
             submitIteration++
@@ -134,10 +136,10 @@ internal sealed interface OnboardingPhoneUiState {
 }
 
 internal sealed interface SubmissionError {
-  data class NumberTooShort(val minLength: Int = 6): SubmissionError
-  data object GeneralError: SubmissionError
-}
+  data object NumberTooShort : SubmissionError
 
+  data object GeneralError : SubmissionError
+}
 
 internal sealed interface OnboardingPhoneEvent {
   data object Retry : OnboardingPhoneEvent

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneViewModel.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneViewModel.kt
@@ -15,6 +15,8 @@ import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.ui.OnboardingProgress
 import com.hedvig.android.feature.onboarding.ui.OnboardingProgressBarAnimation
+import com.hedvig.android.feature.onboarding.ui.phone.SubmissionError.GeneralError
+import com.hedvig.android.feature.onboarding.ui.phone.SubmissionError.NumberTooShort
 import com.hedvig.android.feature.onboarding.ui.progressFor
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
@@ -66,14 +68,14 @@ internal class OnboardingPhonePresenter(
       if (submitIteration == 0) return@LaunchedEffect
       val content = currentState as? OnboardingPhoneUiState.Content ?: return@LaunchedEffect
       val session = sessionStore.currentSession ?: return@LaunchedEffect
-      currentState = content.copy(isSubmitting = true, showSubmissionError = false)
+      currentState = content.copy(isSubmitting = true, showSubmissionError = null)
       onboardingRepository.updateContactInfo(
         email = session.data.email,
         phoneNumber = phoneNumberToSubmit,
       ).fold(
         ifLeft = {
           currentState = (currentState as? OnboardingPhoneUiState.Content ?: content)
-            .copy(isSubmitting = false, showSubmissionError = true)
+            .copy(isSubmitting = false, showSubmissionError = GeneralError)
         },
         ifRight = {
           // Reset before navigating so returning to this retained entry does not leave Save disabled.
@@ -94,8 +96,13 @@ internal class OnboardingPhonePresenter(
         }
 
         is OnboardingPhoneEvent.Save -> {
-          phoneNumberToSubmit = event.phoneNumber
-          submitIteration++
+          val content = currentState as? OnboardingPhoneUiState.Content ?: return@CollectEvents
+          if (event.phoneNumber.length < 6) {
+            currentState = content.copy(showSubmissionError = NumberTooShort())
+          } else {
+            phoneNumberToSubmit = event.phoneNumber
+            submitIteration++
+          }
         }
 
         OnboardingPhoneEvent.DoThisLater -> {
@@ -104,7 +111,7 @@ internal class OnboardingPhonePresenter(
 
         OnboardingPhoneEvent.ClearSubmissionError -> {
           val content = currentState as? OnboardingPhoneUiState.Content ?: return@CollectEvents
-          currentState = content.copy(showSubmissionError = false)
+          currentState = content.copy(showSubmissionError = null)
         }
       }
     }
@@ -122,9 +129,15 @@ internal sealed interface OnboardingPhoneUiState {
     val progress: OnboardingProgress,
     val phoneNumber: String,
     val isSubmitting: Boolean = false,
-    val showSubmissionError: Boolean = false,
+    val showSubmissionError: SubmissionError? = null,
   ) : OnboardingPhoneUiState
 }
+
+internal sealed interface SubmissionError {
+  data class NumberTooShort(val minLength: Int = 6): SubmissionError
+  data object GeneralError: SubmissionError
+}
+
 
 internal sealed interface OnboardingPhoneEvent {
   data object Retry : OnboardingPhoneEvent

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemeDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemeDestination.kt
@@ -168,6 +168,7 @@ private fun ThemeOptionRow(
     color = HedvigTheme.colorScheme.surfacePrimary,
     modifier = modifier
       .fillMaxWidth()
+      .clip(HedvigTheme.shapes.cornerLarge)
       .selectable(selected = selected, role = Role.RadioButton, onClick = onClick),
   ) {
     Row(

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhonePresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhonePresenterTest.kt
@@ -6,7 +6,6 @@ import arrow.core.right
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isTrue
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
@@ -95,7 +94,8 @@ internal class OnboardingPhonePresenterTest {
       awaitItem() // isSubmitting = true
       val state = awaitItem()
       assertThat(state).isInstanceOf<OnboardingPhoneUiState.Content>()
-      assertThat((state as OnboardingPhoneUiState.Content).showSubmissionError).isTrue()
+      assertThat((state as OnboardingPhoneUiState.Content).showSubmissionError)
+        .isEqualTo(SubmissionError.GeneralError)
       assertThat(backstack.entries.last()).isEqualTo(OnboardingStepKey(OnboardingStepId.PhoneNumber))
     }
   }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoDestination.kt
@@ -213,7 +213,8 @@ private fun ColumnScope.SuccessState(
   Spacer(Modifier.height(16.dp))
   HedvigButton(
     text = stringResource(Res.string.general_save_button),
-    enabled = uiState.canSubmit || uiState.submittingUpdatedInfo,
+    // Invalid input is reported as an error on the offending field on submission, rather than by blocking the button.
+    enabled = true,
     onClick = {
       focusManager.clearFocus()
       updateEmailAndPhoneNumber()

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoViewModel.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.text.TextRange
 import arrow.core.Either
 import arrow.core.getOrElse
+import arrow.core.right
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.HedvigViewModel
@@ -58,40 +59,33 @@ internal sealed interface ContactInfoUiState {
   data class Content(
     val phoneNumberState: TextFieldState,
     val emailState: TextFieldState,
-    val uploadedPhoneNumber: PhoneNumber?,
+    val uploadedPhoneNumber: String?,
     val uploadedEmail: Email?,
     val submittingUpdatedInfo: Boolean,
     val showSuccessSnackBar: Boolean = false,
     val errorSnackBarText: ErrorSnackBarText? = null,
+    val hasAttemptedSubmission: Boolean = false,
   ) : ContactInfoUiState {
+    /**
+     * Validated with the same rules the submission uses, so that an input can never look valid but be rejected on
+     * submit. An empty field only counts as an error once submission has been attempted, since the member has not
+     * had the chance to fill it in before that.
+     */
     private val phoneNumber: Either<ErrorMessage, PhoneNumber?>
-      get() = PhoneNumber.fromStringAfterTrimmingWhitespaces(phoneNumberState.text.toString())
+      get() = when {
+        phoneNumberState.text.isBlank() && !hasAttemptedSubmission -> null.right()
+        else -> PhoneNumber.notNullFromStringAfterTrimmingWhitespaces(phoneNumberState.text.toString())
+      }
     private val email: Either<ErrorMessage, Email?>
-      get() = Email.fromString(emailState.text.toString())
+      get() = when {
+        emailState.text.isBlank() && !hasAttemptedSubmission -> null.right()
+        else -> Email.fromStringNotNull(emailState.text.toString())
+      }
 
     val phoneNumberHasError: Boolean
       get() = phoneNumber.isLeft()
     val emailHasError: Boolean
       get() = email.isLeft()
-
-    private val emailIsDeletingKnownInfo: Boolean
-      get() = when (uploadedEmail) {
-        null -> false
-        else -> emailState.text.isBlank()
-      }
-    private val phoneNumberIsDeletingKnownInfo: Boolean
-      get() = when (uploadedPhoneNumber) {
-        null -> false
-        else -> phoneNumberState.text.isBlank()
-      }
-
-    val canSubmit: Boolean
-      get() = !(phoneNumberState.text.isBlank() || emailState.text.isBlank()) &&
-        !emailIsDeletingKnownInfo &&
-        !phoneNumberIsDeletingKnownInfo &&
-        !emailHasError &&
-        !phoneNumberHasError &&
-        !submittingUpdatedInfo
 
     val phoneNumberInputTransformation = InputTransformation.byValue { _, proposed ->
       proposed.filterNot { it.isWhitespace() }.trim()
@@ -125,11 +119,12 @@ internal class ContactInfoPresenter(
       TextFieldState(lastEmailState?.text?.toString() ?: "", lastEmailState?.selection ?: TextRange(0))
     }
     var uploadedEmail: Email? by remember { mutableStateOf(lastState.content?.uploadedEmail) }
-    var uploadedPhoneNumber: PhoneNumber? by remember { mutableStateOf(lastState.content?.uploadedPhoneNumber) }
+    var uploadedPhoneNumber: String? by remember { mutableStateOf(lastState.content?.uploadedPhoneNumber) }
 
     var refetchDataIteration by remember { mutableIntStateOf(0) }
 
     var submittingData: Pair<PhoneNumber, Email>? by remember { mutableStateOf(null) }
+    var hasAttemptedSubmission by remember { mutableStateOf(lastState.content?.hasAttemptedSubmission == true) }
     var errorSnackBarText by remember { mutableStateOf<ErrorSnackBarText?>(null) }
     var showSuccessToast by remember { mutableStateOf<Boolean>(false) }
 
@@ -148,7 +143,7 @@ internal class ContactInfoPresenter(
       uploadedEmail = contactInformation.email
       uploadedPhoneNumber = contactInformation.phoneNumber
       email.setTextAndPlaceCursorAtEnd(contactInformation.email.valueForTextField)
-      phoneNumber.setTextAndPlaceCursorAtEnd(contactInformation.phoneNumber.valueForTextField)
+      phoneNumber.setTextAndPlaceCursorAtEnd(contactInformation.phoneNumber ?: "")
     }
 
     LaunchedEffect(refetchDataIteration) {
@@ -219,7 +214,9 @@ internal class ContactInfoPresenter(
         }
 
         SubmitData -> {
-          if (phoneNumber.text.isBlank() || email.text.isBlank()) return@CollectEvents
+          // Marked before validating, so that invalid input the member has now submitted starts showing its error.
+          hasAttemptedSubmission = true
+          if (submittingData != null) return@CollectEvents
           val trimmedPhoneNumber = PhoneNumber
             .notNullFromStringAfterTrimmingWhitespaces(phoneNumber.text.toString())
             .getOrElse {
@@ -253,6 +250,7 @@ internal class ContactInfoPresenter(
         submittingUpdatedInfo = submittingData != null,
         errorSnackBarText = errorSnackBarText,
         showSuccessSnackBar = showSuccessToast,
+        hasAttemptedSubmission = hasAttemptedSubmission,
       )
     }
   }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepository.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepository.kt
@@ -15,7 +15,11 @@ internal interface ContactInfoRepository {
 }
 
 data class ContactInformation(
-  val phoneNumber: PhoneNumber?,
+  /**
+   * The stored number exactly as the backend holds it, which is not necessarily a valid [PhoneNumber]. It is shown to
+   * the member so that they can correct it, and validated again on submission.
+   */
+  val phoneNumber: String?,
   val email: Email?,
 ) {
   @JvmInline
@@ -67,6 +71,8 @@ data class ContactInformation(
     }
 
     companion object {
+      const val MINIMUM_NUMBER_OF_DIGITS = 6
+
       private val phoneNumberRegex = Regex("""([+]?\d+)""")
       private val invalidInputErrorMessage = { phoneNumber: String ->
         "Phone number [$phoneNumber] must contain only numbers with an optional '+' in the beginning"
@@ -76,12 +82,8 @@ data class ContactInformation(
         "Phone number [$phoneNumber] cannot contain whitespaces"
       }
 
-      /**
-       * for the phone number we get from the backend, can be null
-       */
-      fun fromStringAfterTrimmingWhitespaces(input: String?): Either<ErrorMessage, PhoneNumber?> {
-        val inputWithoutWhitespaces = input?.filterNot { it.isWhitespace() }
-        return fromString(inputWithoutWhitespaces)
+      private val tooShortInputErrorMessage = { phoneNumber: String ->
+        "Phone number [$phoneNumber] must contain at least $MINIMUM_NUMBER_OF_DIGITS digits"
       }
 
       /**
@@ -93,28 +95,17 @@ data class ContactInformation(
       }
 
       /**
-       * returns [Either.Left] with an [ErrorMessage] if the input is an invalid phone number
-       * returns [Either.Right] with a [PhoneNumber] if the input is a valid phone number
-       * returns [Either.Right] with a [null] [PhoneNumber] if the input is null or empty
-       */
-      fun fromString(input: String?): Either<ErrorMessage, PhoneNumber?> {
-        return when {
-          input.isNullOrBlank() -> null.right()
-          input.any { it.isWhitespace() } -> ErrorMessage(whitespacesInInputErrorMessage(input)).left()
-          input.matches(phoneNumberRegex) -> PhoneNumber(input).right()
-          else -> ErrorMessage(invalidInputErrorMessage(input)).left()
-        }
-      }
-
-      /**
-       * returns [Either.Left] with an [ErrorMessage] if the input is an invalid phone number or blank string
+       * returns [Either.Left] with an [ErrorMessage] if the input is an invalid phone number, a blank string, or
+       * holds fewer than [MINIMUM_NUMBER_OF_DIGITS] digits
        * returns [Either.Right] with a [PhoneNumber] if the input is a valid phone number
        */
       fun notNullFromString(input: String): Either<ErrorMessage, PhoneNumber> {
+        val numberOfDigits = input.count { it.isDigit() }
         return when {
           input.any { it.isWhitespace() } -> ErrorMessage(whitespacesInInputErrorMessage(input)).left()
-          !input.isBlank() && input.matches(phoneNumberRegex) -> PhoneNumber(input).right()
-          else -> ErrorMessage(invalidInputErrorMessage(input)).left()
+          input.isBlank() || !input.matches(phoneNumberRegex) -> ErrorMessage(invalidInputErrorMessage(input)).left()
+          numberOfDigits < MINIMUM_NUMBER_OF_DIGITS -> ErrorMessage(tooShortInputErrorMessage(input)).left()
+          else -> PhoneNumber(input).right()
         }
       }
     }
@@ -125,10 +116,4 @@ data class ContactInformation(
  * Defaults to an empty [String] since a textField needs to have at least an empty input if the [Email] is null
  */
 internal val Email?.valueForTextField: String
-  get() = this?.value ?: ""
-
-/**
- * Defaults to an empty [String] since a textField needs to have at least an empty input if the [PhoneNumber] is null
- */
-internal val PhoneNumber?.valueForTextField: String
   get() = this?.value ?: ""

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryDemo.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryDemo.kt
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.Inject
 @Inject
 internal class ContactInfoRepositoryDemo : ContactInfoRepository {
   private var contactInformation = ContactInformation(
-    PhoneNumber("072102103"),
+    "072102103",
     Email("google@gmail.com"),
   )
 
@@ -21,7 +21,7 @@ internal class ContactInfoRepositoryDemo : ContactInfoRepository {
   override suspend fun updateInfo(phoneNumber: PhoneNumber, email: Email): Either<ErrorMessage, ContactInformation> {
     contactInformation = contactInformation.copy(
       email = email,
-      phoneNumber = phoneNumber,
+      phoneNumber = phoneNumber.value,
     )
     return contactInformation.right()
   }

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryImpl.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/ContactInfoRepositoryImpl.kt
@@ -29,9 +29,8 @@ internal class ContactInfoRepositoryImpl(
         .safeExecute(::ErrorMessage)
         .bind()
         .currentMember
-      val phoneNumber = PhoneNumber.fromStringAfterTrimmingWhitespaces(member.phoneNumber).bind()
       val email = Email.fromString(member.email).bind()
-      ContactInformation(phoneNumber, email)
+      ContactInformation(member.phoneNumber.takeIfStoredNumber(), email)
     }
   }
 
@@ -56,9 +55,15 @@ internal class ContactInfoRepositoryImpl(
       }
       networkCacheManager.clearCache()
       ContactInformation(
-        PhoneNumber.fromStringAfterTrimmingWhitespaces(member.phoneNumber).bind(),
+        member.phoneNumber.takeIfStoredNumber(),
         Email.fromString(member.email).bind(),
       )
     }
   }
 }
+
+/**
+ * A blank number is the backend's way of saying there is none stored, which needs to stay apart from a number the
+ * member has actually got.
+ */
+private fun String?.takeIfStoredNumber(): String? = this?.takeIf { it.isNotBlank() }

--- a/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoPresenterTest.kt
+++ b/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/contactinfo/ContactInfoPresenterTest.kt
@@ -21,7 +21,6 @@ import com.hedvig.android.apollo.test.registerSuspendingTestResponse
 import com.hedvig.android.feature.NoopNetworkCacheManager
 import com.hedvig.android.feature.profile.data.ContactInfoRepositoryImpl
 import com.hedvig.android.feature.profile.data.ContactInformation.Email
-import com.hedvig.android.feature.profile.data.ContactInformation.PhoneNumber
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import kotlinx.coroutines.test.runTest
@@ -50,7 +49,7 @@ class ContactInfoPresenterTest {
     val repository = ContactInfoRepositoryImpl(apolloClient, NoopNetworkCacheManager)
     val presenter = ContactInfoPresenter(repository)
     val originalEmail = "test@hedvig.com"
-    val originalPhoneNumber = "+123"
+    val originalPhoneNumber = "+1234567"
     val alteredEmail = "test2@hedvig.com"
     val alteredPhoneNumber = "+123456"
     apolloClient.registerSuspendingTestResponse(
@@ -67,22 +66,21 @@ class ContactInfoPresenterTest {
       with(awaitItem()) {
         assertThat(this.content!!.phoneNumberState.text).isEqualTo(originalPhoneNumber)
         assertThat(this.content!!.emailState.text).isEqualTo(originalEmail)
-        assertThat(this.content!!.uploadedPhoneNumber).isEqualTo(PhoneNumber(originalPhoneNumber))
+        assertThat(this.content!!.uploadedPhoneNumber).isEqualTo(originalPhoneNumber)
         assertThat(this.content!!.uploadedEmail).isEqualTo(Email(originalEmail))
         assertThat(this.content!!.submittingUpdatedInfo).isEqualTo(false)
-        assertThat(this.content!!.canSubmit).isEqualTo(true)
+        assertThat(this.content!!.phoneNumberHasError).isFalse()
+        assertThat(this.content!!.emailHasError).isFalse()
         content!!.phoneNumberState.setTextAndPlaceCursorAtEnd(alteredPhoneNumber)
         content!!.emailState.setTextAndPlaceCursorAtEnd(alteredEmail)
-        assertThat(this.content!!.uploadedPhoneNumber).isEqualTo(PhoneNumber(originalPhoneNumber))
+        assertThat(this.content!!.uploadedPhoneNumber).isEqualTo(originalPhoneNumber)
         assertThat(this.content!!.uploadedEmail).isEqualTo(Email(originalEmail))
-        assertThat(this.content!!.canSubmit).isEqualTo(true)
       }
       sendEvent(ContactInfoEvent.SubmitData)
       with(awaitItem().content!!) {
         assertThat(emailHasError).isFalse()
         assertThat(phoneNumberHasError).isFalse()
         assertThat(submittingUpdatedInfo).isTrue()
-        assertThat(canSubmit).isFalse()
       }
       apolloClient.registerSuspendingTestResponse(
         MemberUpdateContactInfoMutation(alteredEmail, originalPhoneNumber),
@@ -111,29 +109,27 @@ class ContactInfoPresenterTest {
       with(awaitItem().content!!) {
         assertThat(this.content!!.phoneNumberState.text).isEqualTo(alteredPhoneNumber)
         assertThat(this.content!!.emailState.text).isEqualTo(alteredEmail)
-        assertThat(this.content!!.uploadedPhoneNumber).isEqualTo(PhoneNumber(alteredPhoneNumber))
+        assertThat(this.content!!.uploadedPhoneNumber).isEqualTo(alteredPhoneNumber)
         assertThat(this.content!!.uploadedEmail).isEqualTo(Email(alteredEmail))
         assertThat(this.content!!.submittingUpdatedInfo).isFalse()
-        assertThat(this.content!!.canSubmit).isTrue()
+        assertThat(this.content!!.phoneNumberHasError).isFalse()
+        assertThat(this.content!!.emailHasError).isFalse()
       }
     }
   }
 
   @Test
-  fun `Allowing submission should depend on if the input is valid`() = runTest {
+  fun `Each field reports its own validity once submission has been attempted`() = runTest {
     val repository = ContactInfoRepositoryImpl(apolloClient, NoopNetworkCacheManager)
     val presenter = ContactInfoPresenter(repository)
     val originalEmail = "test@hedvig.com"
-    val originalPhoneNumber = "+123"
+    val originalPhoneNumber = "+123456"
     val validEmails = listOf(
       "test@hedvig.co",
       "a@hedvig.c",
       "a@h.c",
     )
     val validPhoneNumbers = listOf(
-      "+1234",
-      "+1",
-      "1",
       "+1234567890123",
       "1234567890123",
       "+123 456 789 0123",
@@ -152,38 +148,102 @@ class ContactInfoPresenterTest {
       "+",
       "",
       " ",
+      "+1",
+      "1",
+      "+12345",
+      "12345",
     )
     presenter.test(
       ContactInfoUiState.Content(
         phoneNumberState = TextFieldState(originalPhoneNumber),
         emailState = TextFieldState(originalEmail),
-        uploadedPhoneNumber = PhoneNumber(originalPhoneNumber),
+        uploadedPhoneNumber = originalPhoneNumber,
         uploadedEmail = Email(originalEmail),
         submittingUpdatedInfo = false,
+        hasAttemptedSubmission = true,
       ),
     ) {
       with(expectMostRecentItem().content!!) {
-        assertThat(canSubmit).isTrue()
-        phoneNumberState.setTextAndPlaceCursorAtEnd(validPhoneNumbers.first())
-        assertThat(canSubmit).isTrue()
-        for (invalidEmail in invalidEmails) {
-          emailState.setTextAndPlaceCursorAtEnd(invalidEmail)
-          assertThat(canSubmit).isFalse()
+        assertThat(phoneNumberHasError).isFalse()
+        assertThat(emailHasError).isFalse()
+        for (validPhoneNumber in validPhoneNumbers) {
+          phoneNumberState.setTextAndPlaceCursorAtEnd(validPhoneNumber)
+          assertThat(phoneNumberHasError).isFalse()
         }
-        emailState.setTextAndPlaceCursorAtEnd(validEmails.first())
-        assertThat(canSubmit).isTrue()
         for (invalidPhoneNumber in invalidPhoneNumbers) {
           phoneNumberState.setTextAndPlaceCursorAtEnd(invalidPhoneNumber)
-          assertThat(canSubmit).isFalse()
+          assertThat(phoneNumberHasError).isTrue()
+          assertThat(emailHasError).isFalse()
         }
-        phoneNumberState.setTextAndPlaceCursorAtEnd(validPhoneNumbers.first())
-        assertThat(canSubmit).isTrue()
-        emailState.setTextAndPlaceCursorAtEnd(originalEmail)
-        assertThat(canSubmit).isTrue()
-        phoneNumberState.setTextAndPlaceCursorAtEnd(originalPhoneNumber)
-        assertThat(canSubmit).isTrue()
+        for (validEmail in validEmails) {
+          emailState.setTextAndPlaceCursorAtEnd(validEmail)
+          assertThat(emailHasError).isFalse()
+        }
+        for (invalidEmail in invalidEmails) {
+          emailState.setTextAndPlaceCursorAtEnd(invalidEmail)
+          assertThat(emailHasError).isTrue()
+        }
       }
       expectNoEvents()
+    }
+  }
+
+  @Test
+  fun `An invalid phone number from the backend is shown as an editable error instead of failing the screen`(
+    @TestParameter("+12345", "12", "+1234a") backendPhoneNumber: String,
+  ) = runTest {
+    val repository = ContactInfoRepositoryImpl(apolloClient, NoopNetworkCacheManager)
+    val presenter = ContactInfoPresenter(repository)
+    val backendEmail = "test@hedvig.com"
+    apolloClient.registerSuspendingTestResponse(
+      ContactInformationQuery(),
+      ContactInformationQuery.Data(OctopusFakeResolver) {
+        this.currentMember = this.buildMember {
+          this.phoneNumber = backendPhoneNumber
+          this.email = backendEmail
+        }
+      },
+    )
+    presenter.test(ContactInfoUiState.Loading) {
+      assertThat(awaitItem()).isEqualTo(ContactInfoUiState.Loading)
+      with(awaitItem().content!!) {
+        assertThat(phoneNumberState.text).isEqualTo(backendPhoneNumber)
+        assertThat(phoneNumberHasError).isTrue()
+        phoneNumberState.setTextAndPlaceCursorAtEnd("+123456")
+        assertThat(phoneNumberHasError).isFalse()
+      }
+    }
+  }
+
+  @Test
+  fun `Submitting invalid input shows the field error instead of uploading it`() = runTest {
+    val repository = ContactInfoRepositoryImpl(apolloClient, NoopNetworkCacheManager)
+    val presenter = ContactInfoPresenter(repository)
+    val email = "test@hedvig.com"
+    presenter.test(
+      ContactInfoUiState.Content(
+        phoneNumberState = TextFieldState(""),
+        emailState = TextFieldState(email),
+        uploadedPhoneNumber = null,
+        uploadedEmail = Email(email),
+        submittingUpdatedInfo = false,
+      ),
+    ) {
+      // An empty field is not an error until the member has tried to submit it
+      assertThat(expectMostRecentItem().content!!.phoneNumberHasError).isFalse()
+      sendEvent(ContactInfoEvent.SubmitData)
+      val content = awaitItem().content!!
+      assertThat(content.phoneNumberHasError).isTrue()
+      assertThat(content.submittingUpdatedInfo).isFalse()
+      // A number with too few digits is not uploaded either
+      content.phoneNumberState.setTextAndPlaceCursorAtEnd("+12345")
+      assertThat(content.phoneNumberHasError).isTrue()
+      sendEvent(ContactInfoEvent.SubmitData)
+      expectNoEvents()
+      content.phoneNumberState.setTextAndPlaceCursorAtEnd("+123456")
+      assertThat(content.phoneNumberHasError).isFalse()
+      sendEvent(ContactInfoEvent.SubmitData)
+      assertThat(awaitItem().content!!.submittingUpdatedInfo).isTrue()
     }
   }
 
@@ -237,7 +297,8 @@ class ContactInfoPresenterTest {
         assertThat(this.content!!.uploadedPhoneNumber).isNull()
         assertThat(this.content!!.uploadedEmail).isNull()
         assertThat(this.content!!.submittingUpdatedInfo).isEqualTo(false)
-        assertThat(this.content!!.canSubmit).isEqualTo(false)
+        assertThat(this.content!!.phoneNumberHasError).isFalse()
+        assertThat(this.content!!.emailHasError).isFalse()
       }
     }
   }
@@ -264,7 +325,12 @@ class ContactInfoPresenterTest {
         content!!.emailState.setTextAndPlaceCursorAtEnd("")
         assertThat(this.content!!.uploadedPhoneNumber).isNotNull()
         assertThat(this.content!!.uploadedEmail).isNotNull()
-        assertThat(this.content!!.canSubmit).isEqualTo(false)
+      }
+      sendEvent(ContactInfoEvent.SubmitData)
+      with(awaitItem().content!!) {
+        assertThat(phoneNumberHasError).isTrue()
+        assertThat(emailHasError).isTrue()
+        assertThat(submittingUpdatedInfo).isFalse()
       }
     }
   }


### PR DESCRIPTION
fixes for test session: [notion](https://app.notion.com/p/hedviginsurance/Onboarding-3c2c3f71cb0a80ce97cddd8937206d9f?v=bdb280f8734047399f5a4e29efd329d6)

also, contact phone number in Profile behaves now differently: if malformed number comes from BE, we show it (instead of erroring out the whole screen) together with error message