### PR TITLE
Gate the onboarding analytics-consent step behind a disable_analytics flag

### DIFF
--- a/app/feature/feature-onboarding/build.gradle.kts
+++ b/app/feature/feature-onboarding/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
   testImplementation(libs.coroutines.test)
   testImplementation(libs.junit)
   testImplementation(libs.turbine)
+  testImplementation(projects.featureFlagsTest)
   testImplementation(projects.loggingTest)
   testImplementation(projects.moleculeTest)
 }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingPath.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingPath.kt
@@ -6,24 +6,30 @@ import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
  * Computes which onboarding steps apply to this member, in presentation order. Pure so the skip
  * rules stay unit-testable. Welcome is not in the result: it is the flow root itself, occupying
  * progress position 0, so the progress bar renders `size + 1` segments.
+ *
+ * A step left out here is absent from the flow rather than skipped within it, so it also stops
+ * taking up a progress-bar segment. That is what [showAnalyticsConsent] relies on.
  */
-internal fun buildOnboardingPath(data: OnboardingData): List<OnboardingStepId> = buildList {
-  add(OnboardingStepId.AnalyticsConsent)
-  add(OnboardingStepId.PhoneNumber)
-  add(OnboardingStepId.Theme)
-  if (data.contractsMissingInsuredOrOwnerInfo.isNotEmpty()) {
-    add(OnboardingStepId.CoInsured)
+internal fun buildOnboardingPath(data: OnboardingData, showAnalyticsConsent: Boolean): List<OnboardingStepId> =
+  buildList {
+    if (showAnalyticsConsent) {
+      add(OnboardingStepId.AnalyticsConsent)
+    }
+    add(OnboardingStepId.PhoneNumber)
+    add(OnboardingStepId.Theme)
+    if (data.contractsMissingInsuredOrOwnerInfo.isNotEmpty()) {
+      add(OnboardingStepId.CoInsured)
+    }
+    if (data.contractsWithMissingPetId.isNotEmpty()) {
+      add(OnboardingStepId.PetIds)
+    }
+    if (data.referralInformation != null) {
+      add(OnboardingStepId.InviteFriend)
+    }
+    if (!data.hasConnectedPayinMethod) {
+      add(OnboardingStepId.ConnectPayment)
+    }
+    if (data.crossSells.isNotEmpty() && !data.hasOnlyAccidentContracts) {
+      add(OnboardingStepId.BundleDiscount)
+    }
   }
-  if (data.contractsWithMissingPetId.isNotEmpty()) {
-    add(OnboardingStepId.PetIds)
-  }
-  if (data.referralInformation != null) {
-    add(OnboardingStepId.InviteFriend)
-  }
-  if (!data.hasConnectedPayinMethod) {
-    add(OnboardingStepId.ConnectPayment)
-  }
-  if (data.crossSells.isNotEmpty() && !data.hasOnlyAccidentContracts) {
-    add(OnboardingStepId.BundleDiscount)
-  }
-}

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingSessionStore.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingSessionStore.kt
@@ -9,6 +9,8 @@ import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.coinsured.CoInsuredFlowType
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
+import com.hedvig.android.featureflags.FeatureManager
+import com.hedvig.android.featureflags.flags.Feature
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -47,6 +49,7 @@ internal class OnboardingMemberIdProviderImpl(
 internal class OnboardingSessionStore(
   private val onboardingRepository: OnboardingRepository,
   private val memberIdProvider: OnboardingMemberIdProvider,
+  private val featureManager: FeatureManager,
 ) {
   private val mutex = Mutex()
   private var cachedSession: OnboardingSession? = null
@@ -61,11 +64,14 @@ internal class OnboardingSessionStore(
       if (cached.memberId == currentMemberId) return@withLock cached.right()
     }
     cachedSession = null
+    // Read once, here, because this is the only place a path is built: it keeps the flag from
+    // reshuffling the path mid-flow, the same guarantee refreshData() upholds for the data.
+    val analyticsDisabled = featureManager.isFeatureEnabled(Feature.DISABLE_ANALYTICS).first()
     onboardingRepository.getOnboardingData().map { data ->
       OnboardingSession(
         memberId = currentMemberId,
         data = data,
-        path = buildOnboardingPath(data),
+        path = buildOnboardingPath(data, showAnalyticsConsent = !analyticsDisabled),
         // Capture which contracts each step owns from the first data, so completed rows stay pinned
         // as "done" instead of vanishing once a later refresh no longer lists them as missing.
         pinnedPetIdContractIds = data.contractsWithMissingPetId.map { it.id },

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/FakeOnboardingRepository.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/FakeOnboardingRepository.kt
@@ -10,6 +10,9 @@ import com.hedvig.android.feature.onboarding.data.OnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.data.OnboardingPayinStatus
 import com.hedvig.android.feature.onboarding.data.OnboardingReferralInformation
 import com.hedvig.android.feature.onboarding.data.OnboardingRepository
+import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
+import com.hedvig.android.featureflags.flags.Feature
+import com.hedvig.android.featureflags.test.FakeFeatureManager
 import kotlinx.coroutines.flow.flowOf
 
 internal class FakeOnboardingMemberIdProvider(var memberId: String? = "test-member-id") : OnboardingMemberIdProvider {
@@ -30,6 +33,20 @@ internal class FakeOnboardingRepository : OnboardingRepository {
     return updateContactInfoResponses.awaitItem()
   }
 }
+
+/**
+ * Builds a store with the feature flags a test rarely cares about already answered, so adding a
+ * dependency to [OnboardingSessionStore] does not mean touching every test that needs one.
+ */
+internal fun testSessionStore(
+  repository: OnboardingRepository,
+  memberIdProvider: OnboardingMemberIdProvider = FakeOnboardingMemberIdProvider(),
+  analyticsDisabled: Boolean = false,
+) = OnboardingSessionStore(
+  onboardingRepository = repository,
+  memberIdProvider = memberIdProvider,
+  featureManager = FakeFeatureManager(mapOf(Feature.DISABLE_ANALYTICS to analyticsDisabled)),
+)
 
 internal fun testOnboardingData(
   phoneNumber: String? = "070 990 12 32",

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingPathTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingPathTest.kt
@@ -4,6 +4,8 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsExactly
 import assertk.assertions.doesNotContain
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
 import com.hedvig.android.feature.onboarding.data.OnboardingPayinStatus
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import org.junit.Test
@@ -47,9 +49,12 @@ class OnboardingPathTest {
     crossSells = crossSells,
   )
 
+  private fun path(data: OnboardingData = data(), showAnalyticsConsent: Boolean = true) =
+    buildOnboardingPath(data, showAnalyticsConsent)
+
   @Test
   fun `consent, phone and theme are always present, in order, at the front`() {
-    val path = buildOnboardingPath(data())
+    val path = path(data())
     assertThat(path.take(3)).containsExactly(
       OnboardingStepId.AnalyticsConsent,
       OnboardingStepId.PhoneNumber,
@@ -58,8 +63,20 @@ class OnboardingPathTest {
   }
 
   @Test
+  fun `analytics consent step is left out entirely when analytics is disabled`() {
+    val path = path(showAnalyticsConsent = false)
+    assertThat(path).doesNotContain(OnboardingStepId.AnalyticsConsent)
+    assertThat(path.first()).isEqualTo(OnboardingStepId.PhoneNumber)
+  }
+
+  @Test
+  fun `disabling analytics shortens the path by exactly one step`() {
+    assertThat(path(showAnalyticsConsent = false)).hasSize(path().size - 1)
+  }
+
+  @Test
   fun `everything applicable produces the full path in canonical order`() {
-    val path = buildOnboardingPath(
+    val path = path(
       data(contracts = listOf(contract(missingCoInsuredCount = 1, isMissingPetId = true))),
     )
     assertThat(path).containsExactly(
@@ -76,49 +93,49 @@ class OnboardingPathTest {
 
   @Test
   fun `co-insured step is included when a contract is missing co-owner info`() {
-    val path = buildOnboardingPath(data(contracts = listOf(contract(missingCoOwnersCount = 1))))
+    val path = path(data(contracts = listOf(contract(missingCoOwnersCount = 1))))
     assertThat(path).contains(OnboardingStepId.CoInsured)
   }
 
   @Test
   fun `co-insured step is skipped when no contract has missing co-insured info`() {
-    val path = buildOnboardingPath(data(contracts = listOf(contract(missingCoInsuredCount = 0))))
+    val path = path(data(contracts = listOf(contract(missingCoInsuredCount = 0))))
     assertThat(path).doesNotContain(OnboardingStepId.CoInsured)
   }
 
   @Test
   fun `pet id step is skipped when no contract is missing a pet id`() {
-    val path = buildOnboardingPath(data(contracts = listOf(contract(isMissingPetId = false))))
+    val path = path(data(contracts = listOf(contract(isMissingPetId = false))))
     assertThat(path).doesNotContain(OnboardingStepId.PetIds)
   }
 
   @Test
   fun `invite step is skipped without referral information`() {
-    val path = buildOnboardingPath(data(referralInformation = null))
+    val path = path(data(referralInformation = null))
     assertThat(path).doesNotContain(OnboardingStepId.InviteFriend)
   }
 
   @Test
   fun `connect payment step is skipped when a payin method is already connected`() {
-    val path = buildOnboardingPath(data(hasConnectedPayinMethod = true))
+    val path = path(data(hasConnectedPayinMethod = true))
     assertThat(path).doesNotContain(OnboardingStepId.ConnectPayment)
   }
 
   @Test
   fun `bundle step is skipped when there are no cross sells`() {
-    val path = buildOnboardingPath(data(crossSells = emptyList()))
+    val path = path(data(crossSells = emptyList()))
     assertThat(path).doesNotContain(OnboardingStepId.BundleDiscount)
   }
 
   @Test
   fun `bundle step is skipped for accident-only members even with cross sells`() {
-    val path = buildOnboardingPath(data(contracts = listOf(contract(typeOfContract = "SE_ACCIDENT"))))
+    val path = path(data(contracts = listOf(contract(typeOfContract = "SE_ACCIDENT"))))
     assertThat(path).doesNotContain(OnboardingStepId.BundleDiscount)
   }
 
   @Test
   fun `bundle step is present for a mixed portfolio that includes accident`() {
-    val path = buildOnboardingPath(
+    val path = path(
       data(contracts = listOf(contract(typeOfContract = "SE_ACCIDENT"), contract(id = "c2"))),
     )
     assertThat(path).contains(OnboardingStepId.BundleDiscount)
@@ -126,7 +143,7 @@ class OnboardingPathTest {
 
   @Test
   fun `a member with nothing applicable gets exactly the mandatory steps`() {
-    val path = buildOnboardingPath(
+    val path = path(
       data(
         contracts = listOf(contract()),
         referralInformation = null,

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingSessionStoreTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingSessionStoreTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -13,7 +14,7 @@ internal class OnboardingSessionStoreTest {
   @Test
   fun `same member reuses the cached session without refetching`() = runTest {
     val repository = FakeOnboardingRepository()
-    val store = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider("member-a"))
+    val store = testSessionStore(repository, FakeOnboardingMemberIdProvider("member-a"))
 
     repository.onboardingDataResponses.add(testOnboardingData(phoneNumber = "111").right())
     val first = store.getOrFetchSession()
@@ -29,7 +30,7 @@ internal class OnboardingSessionStoreTest {
   fun `a member change discards the cache and fetches fresh`() = runTest {
     val repository = FakeOnboardingRepository()
     val memberIdProvider = FakeOnboardingMemberIdProvider("member-a")
-    val store = OnboardingSessionStore(repository, memberIdProvider)
+    val store = testSessionStore(repository, memberIdProvider)
 
     repository.onboardingDataResponses.add(testOnboardingData(phoneNumber = "111").right())
     val memberASession = store.getOrFetchSession()

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingNavigatorTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingNavigatorTest.kt
@@ -13,6 +13,7 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
 import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.navigation.common.HedvigNavKey
 import com.hedvig.android.navigation.compose.Backstack
@@ -36,8 +37,11 @@ internal class OnboardingNavigatorTest {
     }
   }
 
-  private suspend fun sessionStoreWithData(repository: FakeOnboardingRepository): OnboardingSessionStore {
-    val store = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+  private suspend fun sessionStoreWithData(
+    repository: FakeOnboardingRepository,
+    analyticsDisabled: Boolean = false,
+  ): OnboardingSessionStore {
+    val store = testSessionStore(repository, FakeOnboardingMemberIdProvider(), analyticsDisabled)
     repository.onboardingDataResponses.add(testOnboardingData().right())
     store.getOrFetchSession()
     return store
@@ -54,6 +58,24 @@ internal class OnboardingNavigatorTest {
     assertThat(backstack.entries).containsExactly(
       OnboardingKey,
       OnboardingStepKey(OnboardingStepId.AnalyticsConsent),
+    )
+  }
+
+  @Test
+  fun `continue from welcome skips straight past consent when analytics is disabled`() = runTest {
+    val backstack = TestBackstack().apply { entries.add(OnboardingKey) }
+    val repository = FakeOnboardingRepository()
+    val navigator = OnboardingNavigator(
+      backstack,
+      sessionStoreWithData(repository, analyticsDisabled = true),
+      FakeCompleteOnboardingUseCase(),
+    )
+
+    navigator.continueFrom(null)
+
+    assertThat(backstack.entries).containsExactly(
+      OnboardingKey,
+      OnboardingStepKey(OnboardingStepId.PhoneNumber),
     )
   }
 
@@ -110,7 +132,7 @@ internal class OnboardingNavigatorTest {
     val completeOnboarding = FakeCompleteOnboardingUseCase()
     val navigator = OnboardingNavigator(
       backstack,
-      OnboardingSessionStore(FakeOnboardingRepository(), FakeOnboardingMemberIdProvider()),
+      testSessionStore(FakeOnboardingRepository(), FakeOnboardingMemberIdProvider()),
       completeOnboarding,
     )
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/bundle/OnboardingBundlePresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/bundle/OnboardingBundlePresenterTest.kt
@@ -10,12 +10,12 @@ import assertk.assertions.isTrue
 import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingKey
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -51,7 +51,7 @@ internal class OnboardingBundlePresenterTest {
       entries.add(OnboardingStepKey(OnboardingStepId.BundleDiscount))
     }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingBundlePresenter(sessionStore, navigator)
 
@@ -74,7 +74,7 @@ internal class OnboardingBundlePresenterTest {
       entries.add(OnboardingStepKey(OnboardingStepId.BundleDiscount))
     }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, completeOnboarding)
     val presenter = OnboardingBundlePresenter(sessionStore, navigator)
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredPresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredPresenterTest.kt
@@ -13,11 +13,11 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
 import com.hedvig.android.feature.onboarding.data.OnboardingContract
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -43,7 +43,7 @@ internal class OnboardingCoInsuredPresenterTest {
   fun `rows are pinned from the contracts missing co-insured at load`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.CoInsured)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingCoInsuredPresenter(sessionStore, navigator)
 
@@ -63,7 +63,7 @@ internal class OnboardingCoInsuredPresenterTest {
   fun `add navigates to the edit co-insured flow`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.CoInsured)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingCoInsuredPresenter(sessionStore, navigator)
 
@@ -81,7 +81,7 @@ internal class OnboardingCoInsuredPresenterTest {
   fun `a co-owners contract yields a co-owners row and navigates into the co-owners flow`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.CoInsured)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingCoInsuredPresenter(sessionStore, navigator)
 
@@ -114,7 +114,7 @@ internal class OnboardingCoInsuredPresenterTest {
   fun `refresh marks completed rows instead of removing them`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.CoInsured)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingCoInsuredPresenter(sessionStore, navigator)
 
@@ -152,7 +152,7 @@ internal class OnboardingCoInsuredPresenterTest {
   fun `continue advances to InviteFriend (PetIds skipped for default data)`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.CoInsured)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingCoInsuredPresenter(sessionStore, navigator)
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/consent/OnboardingConsentPresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/consent/OnboardingConsentPresenterTest.kt
@@ -13,11 +13,11 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.FakeSettingsDataStore
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.feature.onboarding.ui.OnboardingProgress
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.MoleculePresenterTestContext
@@ -45,7 +45,7 @@ internal class OnboardingConsentPresenterTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.AnalyticsConsent)) }
     val repository = FakeOnboardingRepository()
     val settingsDataStore = FakeSettingsDataStore().apply { consent.value = storedConsent }
-    private val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    private val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val presenter = OnboardingConsentPresenter(
       sessionStore,
       OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase()),

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/invite/OnboardingInvitePresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/invite/OnboardingInvitePresenterTest.kt
@@ -9,12 +9,12 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
 import com.hedvig.android.feature.onboarding.data.OnboardingReferralInformation
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingForeverKey
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -40,7 +40,7 @@ internal class OnboardingInvitePresenterTest {
   fun `content carries the incentive`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.InviteFriend)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingInvitePresenter(sessionStore, navigator)
 
@@ -58,7 +58,7 @@ internal class OnboardingInvitePresenterTest {
   fun `invite friend pushes the standalone forever screen`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.InviteFriend)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingInvitePresenter(sessionStore, navigator)
 
@@ -76,7 +76,7 @@ internal class OnboardingInvitePresenterTest {
   fun `continue advances to connect payment`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.InviteFriend)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingInvitePresenter(sessionStore, navigator)
 
@@ -94,7 +94,7 @@ internal class OnboardingInvitePresenterTest {
   fun `step renders error state if the session has no referral information`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.InviteFriend)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingInvitePresenter(sessionStore, navigator)
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingPaymentPresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingPaymentPresenterTest.kt
@@ -12,11 +12,11 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
 import com.hedvig.android.feature.onboarding.data.OnboardingPayinStatus
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -42,7 +42,7 @@ internal class OnboardingPaymentPresenterTest {
   fun `not connected content when payin methods are missing`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.ConnectPayment)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPaymentPresenter(sessionStore, navigator)
 
@@ -60,7 +60,7 @@ internal class OnboardingPaymentPresenterTest {
   fun `connect payment pushes the trustly flow`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.ConnectPayment)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPaymentPresenter(sessionStore, navigator)
 
@@ -79,7 +79,7 @@ internal class OnboardingPaymentPresenterTest {
   fun `skip is offered only after entering the connect flow while still not connected`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.ConnectPayment)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPaymentPresenter(sessionStore, navigator)
 
@@ -100,7 +100,7 @@ internal class OnboardingPaymentPresenterTest {
   fun `refresh after returning with an active method flips to connected`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.ConnectPayment)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPaymentPresenter(sessionStore, navigator)
 
@@ -122,7 +122,7 @@ internal class OnboardingPaymentPresenterTest {
   fun `a pending method is shown as pending, not connected`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.ConnectPayment)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPaymentPresenter(sessionStore, navigator)
 
@@ -140,7 +140,7 @@ internal class OnboardingPaymentPresenterTest {
   fun `continue advances to BundleDiscount`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.ConnectPayment)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPaymentPresenter(sessionStore, navigator)
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdPresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdPresenterTest.kt
@@ -9,11 +9,11 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
 import com.hedvig.android.feature.onboarding.data.OnboardingContract
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -39,7 +39,7 @@ internal class OnboardingPetIdPresenterTest {
   fun `rows are pinned from the contracts missing pet id at load`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PetIds)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPetIdPresenter(sessionStore, navigator)
 
@@ -73,7 +73,7 @@ internal class OnboardingPetIdPresenterTest {
   fun `refresh marks completed rows instead of removing them`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PetIds)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPetIdPresenter(sessionStore, navigator)
 
@@ -125,7 +125,7 @@ internal class OnboardingPetIdPresenterTest {
   fun `continue advances to InviteFriend`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PetIds)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPetIdPresenter(sessionStore, navigator)
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhonePresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhonePresenterTest.kt
@@ -11,11 +11,11 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -41,7 +41,7 @@ internal class OnboardingPhonePresenterTest {
   fun `content pre-fills the member's phone number`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PhoneNumber)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPhonePresenter(sessionStore, navigator, repository)
 
@@ -58,7 +58,7 @@ internal class OnboardingPhonePresenterTest {
   fun `save success advances to the next step`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PhoneNumber)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPhonePresenter(sessionStore, navigator, repository)
 
@@ -81,7 +81,7 @@ internal class OnboardingPhonePresenterTest {
   fun `save failure shows inline error and does not advance`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PhoneNumber)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPhonePresenter(sessionStore, navigator, repository)
 
@@ -104,7 +104,7 @@ internal class OnboardingPhonePresenterTest {
   fun `do this later advances without calling the mutation`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.PhoneNumber)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingPhonePresenter(sessionStore, navigator, repository)
 

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemePresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemePresenterTest.kt
@@ -9,11 +9,11 @@ import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.FakeSettingsDataStore
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -40,7 +40,7 @@ internal class OnboardingThemePresenterTest {
   fun `selected theme defaults to SYSTEM_DEFAULT when nothing stored`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.Theme)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val settingsDataStore = FakeSettingsDataStore()
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingThemePresenter(sessionStore, navigator, settingsDataStore)
@@ -58,7 +58,7 @@ internal class OnboardingThemePresenterTest {
   fun `selecting a theme persists it and updates the selection`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.Theme)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val settingsDataStore = FakeSettingsDataStore()
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingThemePresenter(sessionStore, navigator, settingsDataStore)
@@ -78,7 +78,7 @@ internal class OnboardingThemePresenterTest {
   fun `continue advances to the next path step`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingStepKey(OnboardingStepId.Theme)) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val settingsDataStore = FakeSettingsDataStore()
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingThemePresenter(sessionStore, navigator, settingsDataStore)

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/welcome/OnboardingWelcomePresenterTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/ui/welcome/OnboardingWelcomePresenterTest.kt
@@ -10,12 +10,12 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
-import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.navigation.OnboardingKey
 import com.hedvig.android.feature.onboarding.navigation.OnboardingNavigator
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepKey
 import com.hedvig.android.feature.onboarding.testOnboardingData
+import com.hedvig.android.feature.onboarding.testSessionStore
 import com.hedvig.android.logger.TestLogcatLoggingRule
 import com.hedvig.android.molecule.test.test
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -40,7 +40,7 @@ internal class OnboardingWelcomePresenterTest {
   @Test
   fun `session fetch success shows content with the progress of the whole path`() = runTest {
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(TestBackstack(), sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingWelcomePresenter(sessionStore, navigator)
 
@@ -56,9 +56,25 @@ internal class OnboardingWelcomePresenterTest {
   }
 
   @Test
+  fun `disabling analytics costs the progress bar one segment`() = runTest {
+    val repository = FakeOnboardingRepository()
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider(), analyticsDisabled = true)
+    val navigator = OnboardingNavigator(TestBackstack(), sessionStore, NoopCompleteOnboardingUseCase())
+    val presenter = OnboardingWelcomePresenter(sessionStore, navigator)
+
+    presenter.test(OnboardingWelcomeUiState.Loading) {
+      skipItems(1)
+      repository.onboardingDataResponses.add(testOnboardingData().right())
+      val content = awaitItem()
+      assertThat(content).isInstanceOf<OnboardingWelcomeUiState.Content>()
+      assertThat((content as OnboardingWelcomeUiState.Content).progress.totalSteps).isEqualTo(7)
+    }
+  }
+
+  @Test
   fun `session fetch failure shows error, retry refetches`() = runTest {
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(TestBackstack(), sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingWelcomePresenter(sessionStore, navigator)
 
@@ -77,7 +93,7 @@ internal class OnboardingWelcomePresenterTest {
   fun `get started pushes the first path step onto the backstack`() = runTest {
     val backstack = TestBackstack().apply { entries.add(OnboardingKey) }
     val repository = FakeOnboardingRepository()
-    val sessionStore = OnboardingSessionStore(repository, FakeOnboardingMemberIdProvider())
+    val sessionStore = testSessionStore(repository, FakeOnboardingMemberIdProvider())
     val navigator = OnboardingNavigator(backstack, sessionStore, NoopCompleteOnboardingUseCase())
     val presenter = OnboardingWelcomePresenter(sessionStore, navigator)
 

--- a/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
+++ b/app/featureflags/feature-flags/FEATURE_FLAG_DEFAULTS.md
@@ -18,7 +18,7 @@ returns, etc.). Read this before adding a new flag.
      a `disable_x` flag reports "is the kill switch on"; the consumer inverts at the read site.
   2. **`neverFetchedDefaults`**, a map in `HedvigUnleashClient`, for the flags where polarity
      alone gives the wrong default.
-- `neverFetchedDefaults` holds three entries today. Adding others is usually noise and, for
+- `neverFetchedDefaults` holds four entries today. Adding others is usually noise and, for
   app-gating flags like `UPDATE_NECESSARY`, actively dangerous.
 
 ## The bug: Unleash Android SDK issue #141
@@ -101,7 +101,7 @@ The consequences are all silent:
 
 The symptom to recognise: a one-shot flag read (`.first()`) that runs during startup silently gets
 the wrong value, while `Flow`-based reads self-correct a second later and look fine. `OnboardingGate`
-is currently the app's only startup-time one-shot read.
+and `OnboardingSessionStore` are the app's startup-time one-shot reads.
 
 ## Never-fetched defaults: when and why
 
@@ -114,15 +114,21 @@ Today:
 
 ```kotlin
 private val neverFetchedDefaults: Map<Feature, Boolean> = mapOf(
+  Feature.DISABLE_ANALYTICS to true,
   Feature.DISABLE_PUPPY_GUIDE to true,
   Feature.DISABLE_TERMINATION_REDIRECTION to true,
   Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to true,
 )
 ```
 
-All three are kill switches, so their natural absent default is "feature on". Each instead needs to
+All four are kill switches, so their natural absent default is "feature on". Each instead needs to
 stay **hidden** until a fetch confirms it should show, which is what a rollout wants. Polarity gives
 the wrong default, so each gets an entry of `true` (kill switch on → feature hidden).
+
+`DISABLE_ANALYTICS` is the clearest illustration of why the entry is needed rather than optional: the
+step it hides must not appear at all, so letting polarity show it to a member whose first launch is
+offline would defeat the flag. Failing closed also fails safe here, since a member who is never asked
+leaves their analytics consent undecided, and undecided forwards no product analytics.
 
 ### Do NOT default app-gating flags to the "blocking" state
 

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/HedvigUnleashClient.kt
@@ -31,6 +31,7 @@ private const val APP_NAME = "android"
  * here: defaulting one into its blocking state locks out members who are offline on first launch.
  */
 private val neverFetchedDefaults: Map<Feature, Boolean> = mapOf(
+  Feature.DISABLE_ANALYTICS to true,
   Feature.DISABLE_PUPPY_GUIDE to true,
   Feature.DISABLE_TERMINATION_REDIRECTION to true,
   Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to true,

--- a/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/FeatureUnleashKey.kt
+++ b/app/featureflags/feature-flags/src/androidMain/kotlin/com/hedvig/android/featureflags/flags/FeatureUnleashKey.kt
@@ -2,6 +2,7 @@ package com.hedvig.android.featureflags.flags
 
 internal val Feature.unleashKey: String
   get() = when (this) {
+    Feature.DISABLE_ANALYTICS -> "disable_analytics"
     Feature.DISABLE_ONBOARDING -> "disable_onboarding"
     Feature.DISABLE_PUPPY_GUIDE -> "disable_puppy_guide"
     Feature.DISABLE_TERMINATION_REDIRECTION -> "disable_termination_redirection"

--- a/app/featureflags/feature-flags/src/commonMain/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
+++ b/app/featureflags/feature-flags/src/commonMain/kotlin/com/hedvig/android/featureflags/flags/Feature.kt
@@ -4,6 +4,10 @@ enum class Feature(
   // Used to easier get a context of what it's for.
   @Suppress("unused") val explanation: String,
 ) {
+  DISABLE_ANALYTICS(
+    "Kill switch for the analytics-consent step in onboarding. When the toggle is on, the step is left out " +
+      "of the onboarding path entirely, so it never shows and does not take up a progress-bar segment.",
+  ),
   DISABLE_ONBOARDING(
     "Kill switch for the post-login onboarding flow. When the toggle is on, onboarding is never shown.",
   ),


### PR DESCRIPTION
Notion: [Skip analytics screen until legal is done (done on iOS)](https://app.notion.com/p/hedviginsurance/Skip-analytics-screen-until-legal-is-done-done-on-iOS-3c2c3f71cb0a808f83c6e15b50203138)

## What

Adds a `DISABLE_ANALYTICS` kill switch (`disable_analytics`) and leaves the analytics-consent step out of the onboarding path entirely when it is on. The step is **absent from the flow**, not skipped inside it, so it also stops taking up a progress-bar segment.

## How

`buildOnboardingPath` takes `showAnalyticsConsent`. The flag is read once in `OnboardingSessionStore.getOrFetchSession`, the only place a path is built, which keeps it from reshuffling the path mid-flow (the same guarantee `refreshData` already upholds for the data). The progress bar needs no change since `totalSteps = path.size + 1`.

`OnboardingStepId.AnalyticsConsent` and its `entry<>` registration stay in place deliberately: the `when` over the enum is exhaustive, and a back stack saved by an older version can still contain `OnboardingStepKey(AnalyticsConsent)`, which serializes by name. Registered-but-never-entered costs nothing.

## The never-fetched default

`DISABLE_ANALYTICS` gets a `neverFetchedDefaults` entry of `true`. A `disable_*` flag's natural absent-toggle default is "feature on", which would show the step to a member whose first launch is offline and defeat the flag. Failing closed also fails safe here: a member who is never asked leaves analytics consent undecided, and undecided forwards no product analytics.

This is not the `UPDATE_NECESSARY` anti-pattern the doc warns about, since it gates one step rather than app access. `FEATURE_FLAG_DEFAULTS.md` is updated, including the entry count and the note about which classes do startup-time one-shot flag reads.

## Test churn

`OnboardingSessionStore` was constructed positionally at 33 call sites across 11 test files. Its dependencies now come from a shared `testSessionStore` factory, so the next added dependency does not mean touching all of them again.

## Verification

- `:feature-onboarding:test` 65 tests, 0 failures. New coverage: step absent, path one shorter, navigator skips straight to phone number, progress bar loses a segment.
- `:feature-onboarding:ktlintCheck`, `:feature-flags:ktlintCheck` clean.
- On device: with the flag off the flow is unchanged, 8 progress segments, consent step still at position 2.

> [!NOTE]
> The flag-on path is unit-tested but not yet verified on device: `disable_analytics` does not exist in the development Unleash project, so it currently resolves to `false`. **The toggle must exist and be on in both the development and production Unleash projects before release**, otherwise the step shows for anyone whose first fetch succeeds.