### PR TITLE
Hold the Play Store review prompt until onboarding is left

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/BackstackController.kt
@@ -14,6 +14,7 @@ import com.hedvig.android.feature.login.navigation.LoginKey
 import com.hedvig.android.navigation.common.DeliberateLogoutOrigin
 import com.hedvig.android.navigation.common.HedvigNavKey
 import com.hedvig.android.navigation.common.StashedSession
+import com.hedvig.android.navigation.common.SuppressesAppStoreReviewRequest
 import com.hedvig.android.navigation.common.TopLevelTab
 import com.hedvig.android.navigation.compose.Backstack
 import com.hedvig.android.navigation.compose.LoneDeepLinkChrome
@@ -117,6 +118,14 @@ internal class BackstackController(
   /** The destination on top of the rendered stack. */
   val currentDestination: HedvigNavKey?
     get() = entries.lastOrNull()
+
+  /**
+   * Whether the member is anywhere inside a flow that must not be interrupted by the Play Store
+   * review prompt. Checks the whole stack, not just the top, because such a flow hosts the screens
+   * that earn the prompt on top of itself.
+   */
+  val suppressesAppStoreReviewRequest: Boolean
+    get() = entries.any { it is SuppressesAppStoreReviewRequest }
 
   /**
    * Every key whose decorator state must survive: the rendered stack plus all parked runs, mapped

--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -144,6 +144,7 @@ internal fun HedvigApp(
       TryShowAppStoreReviewDialogEffect(
         authTokenService,
         waitUntilAppReviewDialogShouldBeOpenedUseCase,
+        backstackController,
         androidAppHost::tryShowAppStoreReviewDialog,
       )
       TryShowOnboardingEffect(
@@ -368,6 +369,7 @@ private fun EnableEdgeToEdgeSideEffect(
 private fun TryShowAppStoreReviewDialogEffect(
   authTokenService: AuthTokenService,
   waitUntilAppReviewDialogShouldBeOpenedUseCase: WaitUntilAppReviewDialogShouldBeOpenedUseCase,
+  backstackController: BackstackController,
   tryShowAppStoreReviewDialog: () -> Unit,
 ) {
   val reviewDialogDelay = 2.seconds
@@ -376,6 +378,10 @@ private fun TryShowAppStoreReviewDialogEffect(
     lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
       authTokenService.authStatus.first { it is AuthStatus.LoggedIn }
       waitUntilAppReviewDialogShouldBeOpenedUseCase.invoke()
+      // Hold rather than return: awaiting above has already consumed the member's earned prompt, so
+      // giving up here would spend it on nothing. A flow completed inside onboarding still deserves
+      // the prompt, just once the member is out of onboarding and not mid-flow.
+      snapshotFlow { backstackController.suppressesAppStoreReviewRequest }.first { !it }
       delay(reviewDialogDelay)
       tryShowAppStoreReviewDialog()
     }

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/BackstackControllerTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/BackstackControllerTest.kt
@@ -16,6 +16,7 @@ import com.hedvig.android.feature.help.center.navigation.HelpCenterKey
 import com.hedvig.android.feature.home.home.navigation.HomeKey
 import com.hedvig.android.feature.insurances.navigation.InsurancesKey
 import com.hedvig.android.feature.login.navigation.LoginKey
+import com.hedvig.android.feature.onboarding.navigation.OnboardingKey
 import com.hedvig.android.feature.payments.navigation.PaymentsKey
 import com.hedvig.android.feature.profile.navigation.ProfileKey
 import com.hedvig.android.logger.TestLogcatLoggingRule
@@ -316,6 +317,20 @@ internal class BackstackControllerTest {
     val controller = controllerWith(HomeKey)
     assertThat(controller.navigateUp()).isFalse()
     assertThat(controller.entries.toList()).containsExactly(HomeKey)
+  }
+
+  @Test
+  fun `the review prompt is suppressed while onboarding sits below a hosted flow`() {
+    // HelpCenterKey stands in for any flow an onboarding step pushes on top of itself; what matters
+    // is that OnboardingKey is an ancestor rather than the top of the stack.
+    val controller = controllerWith(HomeKey, OnboardingKey, HelpCenterKey)
+    assertThat(controller.suppressesAppStoreReviewRequest).isTrue()
+  }
+
+  @Test
+  fun `the review prompt is allowed in the same flow reached outside onboarding`() {
+    val controller = controllerWith(HomeKey, HelpCenterKey)
+    assertThat(controller.suppressesAppStoreReviewRequest).isFalse()
   }
 
   @Test

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingKeys.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingKeys.kt
@@ -1,15 +1,19 @@
 package com.hedvig.android.feature.onboarding.navigation
 
 import com.hedvig.android.navigation.common.HedvigNavKey
+import com.hedvig.android.navigation.common.SuppressesAppStoreReviewRequest
 import kotlinx.serialization.Serializable
 
 /**
  * The onboarding flow root, rendering the welcome step. Pushed on top of Home by the onboarding
  * gate in `:app` for members who have not seen onboarding yet.
+ *
+ * It stays on the back stack for the whole flow, including while a step hosts a shared flow such as
+ * edit co-insured, which is what makes it the right place to hang [SuppressesAppStoreReviewRequest].
  */
 @androidx.annotation.Keep
 @Serializable
-data object OnboardingKey : HedvigNavKey
+data object OnboardingKey : HedvigNavKey, SuppressesAppStoreReviewRequest
 
 /**
  * One entry per onboarding step after welcome. Deliberately tiny: the eagerly-fetched flow data

--- a/app/navigation/navigation-common/src/commonMain/kotlin/com/hedvig/android/navigation/common/HedvigNavKey.kt
+++ b/app/navigation/navigation-common/src/commonMain/kotlin/com/hedvig/android/navigation/common/HedvigNavKey.kt
@@ -19,6 +19,15 @@ interface CrossSellEligibleDestination
 interface SuppressesChatPushNotification
 
 /**
+ * A flow during which the Play Store review prompt must not be asked for. Unlike the other markers
+ * here, this one is matched against **every** entry on the back stack rather than just the top: it
+ * marks a flow that hosts other flows on top of itself, and it is those hosted flows that complete
+ * and earn a review prompt. The prompt is held until the marked key leaves the stack, so the member
+ * still gets asked, just not mid-flow.
+ */
+interface SuppressesAppStoreReviewRequest
+
+/**
  * A destination from which reaching the logged-out state is treated as a deliberate "log me out now"
  * action, so the session is discarded rather than stashed for a same-member restore. Restoring the
  * nav back to this screen after a fresh login would be wrong. Replaces the dead


### PR DESCRIPTION
Notion: [Android showing rate](https://app.notion.com/p/hedviginsurance/android-showing-rate-3c2c3f71cb0a8052bb58f933fae72cb1)

## What

Completing the co-insured flow is the app's **only** "successful self-service" signal (`CommitMidtermChangeUseCase` is the single caller of `completedSelfServiceSuccessfully`), and onboarding hosts that same shared flow as one of its steps. So finishing it mid-onboarding interrupted the flow with a Play review prompt.

## How

A new `SuppressesAppStoreReviewRequest` marker, implemented by `OnboardingKey`, plus a derived property on `BackstackController`. `TryShowAppStoreReviewDialogEffect` now waits for the suppressing flow to leave the stack.

Two decisions worth calling out:

**It holds rather than returns early.** By the time suppression can be checked, `WaitUntilAppReviewDialogShouldBeOpenedUseCase` has already reset the counter (it resets inside `invoke()`), so an early `return` would spend the member's earned prompt on nothing and re-arm only on the next resume. Holding keeps the prompt and moves it to a moment where the member is not mid-flow. It also avoids burning a Play review request, which Google rate-limits per user, on a prompt that gets reflexively dismissed. So the member still gets asked, just on Home after onboarding rather than inside it.

**The marker is matched against the whole back stack, not the top.** `OnboardingKey` sits *below* the flows it hosts (the stack at trigger time is `[HomeKey, OnboardingKey, OnboardingStepKey(CoInsured), EditCoInsuredSuccessKey]`), so a `currentDestination is Marker` check cannot work. This is documented on the interface, since every other marker in that file is a top-of-stack check. `:app` already uses the same any-entry idiom in `TryShowOnboardingEffect`.

Hanging the marker on the key rather than threading a flag through the co-insured trigger means any future onboarding-hosted flow is covered without further plumbing, and `feature-edit-coinsured` needs no changes at all.

## Verification

- `:app:test` 110 tests, 0 failures, including new `BackstackControllerTest` coverage for onboarding-as-ancestor vs the same flow reached outside onboarding.
- `:app:ktlintCheck`, `:navigation-common:ktlintCheck`, `:feature-onboarding:ktlintCheck` clean.

> [!NOTE]
> Not verifiable on device: the Play in-app review dialog requires a Play-installed app and is rate-limited per user, so it does not surface on a sideloaded debug build. Covered by unit tests instead.

## Pre-existing bug found while investigating (not fixed here)

The review prompt is dropped entirely if the member backgrounds the app between completing a flow and the 2s delay elapsing, because of the `drop(1)` in `WaitUntilAppReviewDialogShouldBeOpenedUseCase` combined with the counter reset. Happy to fix in a follow-up if wanted.