### PR TITLE
Continue past an onboarding step a rebuilt path no longer contains

### DIFF
--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingKeys.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingKeys.kt
@@ -38,6 +38,9 @@ internal data object OnboardingForeverKey : HedvigNavKey
 /**
  * Identifies each onboarding step past welcome. The member's concrete path (which of these apply,
  * in order) is computed by buildOnboardingPath from the eagerly fetched OnboardingData.
+ *
+ * Declared in presentation order. buildOnboardingPath emits them in this order, and
+ * OnboardingNavigator relies on it to continue past a step a rebuilt path no longer contains.
  */
 enum class OnboardingStepId {
   AnalyticsConsent,

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingNavigator.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingNavigator.kt
@@ -37,7 +37,16 @@ internal class OnboardingNavigator(
       session.path.firstOrNull()
     } else {
       val currentIndex = session.path.indexOf(current)
-      if (currentIndex == -1) null else session.path.getOrNull(currentIndex + 1)
+      if (currentIndex == -1) {
+        // A path rebuilt after process death can legitimately lack the step being shown, once the
+        // condition that added it stopped holding (co-insured info since filled in, payment
+        // connected elsewhere, a gating flag flipped). [OnboardingStepId] is declared in
+        // presentation order, so the step to continue to is the first one past this in the path.
+        logcat { "Onboarding step $current missing from the rebuilt path, continuing past it" }
+        session.path.firstOrNull { it.ordinal > current.ordinal }
+      } else {
+        session.path.getOrNull(currentIndex + 1)
+      }
     }
     if (next == null) {
       exitOnboarding()

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingNavigatorTest.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/navigation/OnboardingNavigatorTest.kt
@@ -11,6 +11,8 @@ import assertk.assertions.isTrue
 import com.hedvig.android.feature.onboarding.FakeOnboardingMemberIdProvider
 import com.hedvig.android.feature.onboarding.FakeOnboardingRepository
 import com.hedvig.android.feature.onboarding.data.CompleteOnboardingUseCase
+import com.hedvig.android.feature.onboarding.data.OnboardingContract
+import com.hedvig.android.feature.onboarding.data.OnboardingData
 import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
 import com.hedvig.android.feature.onboarding.testOnboardingData
 import com.hedvig.android.feature.onboarding.testSessionStore
@@ -40,9 +42,10 @@ internal class OnboardingNavigatorTest {
   private suspend fun sessionStoreWithData(
     repository: FakeOnboardingRepository,
     analyticsDisabled: Boolean = false,
+    data: OnboardingData = testOnboardingData(),
   ): OnboardingSessionStore {
     val store = testSessionStore(repository, FakeOnboardingMemberIdProvider(), analyticsDisabled)
-    repository.onboardingDataResponses.add(testOnboardingData().right())
+    repository.onboardingDataResponses.add(data.right())
     store.getOrFetchSession()
     return store
   }
@@ -94,6 +97,48 @@ internal class OnboardingNavigatorTest {
   }
 
   @Test
+  fun `continue from a step the rebuilt path lacks pushes the next step that is still in it`() = runTest {
+    val backstack = TestBackstack().apply {
+      entries.add(OnboardingKey)
+      entries.add(OnboardingStepKey(OnboardingStepId.CoInsured))
+    }
+    val repository = FakeOnboardingRepository()
+    val completeOnboarding = FakeCompleteOnboardingUseCase()
+    // No contract needs co-insured info, so CoInsured is absent from the path the member stands on.
+    val navigator = OnboardingNavigator(
+      backstack,
+      sessionStoreWithData(repository, data = testOnboardingData(contracts = listOf(contractMissingNothing))),
+      completeOnboarding,
+    )
+
+    navigator.continueFrom(OnboardingStepId.CoInsured)
+
+    assertThat(backstack.entries.last()).isEqualTo(OnboardingStepKey(OnboardingStepId.InviteFriend))
+    assertThat(completeOnboarding.invoked).isFalse()
+  }
+
+  @Test
+  fun `continue from a missing step with nothing after it in the path exits the flow`() = runTest {
+    val backstack = TestBackstack().apply {
+      entries.add(OnboardingKey)
+      entries.add(OnboardingStepKey(OnboardingStepId.BundleDiscount))
+    }
+    val repository = FakeOnboardingRepository()
+    val completeOnboarding = FakeCompleteOnboardingUseCase()
+    // No cross-sells, so BundleDiscount is absent and it is the last step in declaration order.
+    val navigator = OnboardingNavigator(
+      backstack,
+      sessionStoreWithData(repository, data = testOnboardingData(crossSells = emptyList())),
+      completeOnboarding,
+    )
+
+    navigator.continueFrom(OnboardingStepId.BundleDiscount)
+
+    assertThat(completeOnboarding.invoked).isTrue()
+    assertThat(backstack.entries).isEmpty()
+  }
+
+  @Test
   fun `continue from the last step marks seen and removes all onboarding keys`() = runTest {
     val backstack = TestBackstack().apply {
       entries.add(OnboardingKey)
@@ -142,5 +187,15 @@ internal class OnboardingNavigatorTest {
     assertThat(completeOnboarding.invoked).isTrue()
   }
 }
+
+private val contractMissingNothing = OnboardingContract(
+  id = "contract-1",
+  displayName = "Home Insurance",
+  exposureName = "Bellmansgatan 19A",
+  typeOfContract = "SE_APARTMENT_RENT",
+  missingCoInsuredCount = 0,
+  missingCoOwnersCount = 0,
+  isMissingPetId = false,
+)
 
 private data object NonOnboardingKey : HedvigNavKey


### PR DESCRIPTION
## Problem

Two pieces of onboarding state have different lifetimes:

- the **current step** is a serialized back stack key (`OnboardingStepKey`), so it survives process death
- the **path** lives in `OnboardingSessionStore` (`ActivityRetainedScope`, in-memory), so it does not

After process death the key comes back and `getOrFetchSession()` rebuilds the path from fresh `OnboardingData` and a fresh `DISABLE_ANALYTICS` read. That rebuild can legitimately drop the step the member is standing on, once the condition that added it stopped holding:

- co-insured info filled in (often in the co-insured flow hosted on top of that very step)
- pet IDs filled in via the chip-ID flow
- payment connected on web meanwhile
- `referralInformation` gone null, or cross-sells emptied
- the analytics flag flipped (relevant again whenever we re-enable analytics)

`continueFrom` located the next step by index, and `indexOf == -1` fell into the same branch as "you finished the last step":

```kotlin
if (currentIndex == -1) null else session.path.getOrNull(currentIndex + 1)
...
if (next == null) exitOnboarding()
```

So the member tapped Continue, onboarding closed, `CompleteOnboardingUseCase` marked it done, and every remaining step was silently skipped forever. Nothing in the logs distinguished it from a normal finish.

Note `refreshData()` already pins the original path (the progress bar must not reshuffle mid-flow), so the in-session case was never exposed. Only the process-death rebuild was.

## Change

When the current step is absent from the path, continue to the first step past it rather than exiting. `OnboardingStepId` is declared in presentation order and `buildOnboardingPath` emits in that order, so the ordinal comparison lands on the correct next step. That invariant is now documented on the enum, since the navigator depends on it.

Exiting is now reserved for a step with genuinely nothing after it.

## Tests

`:feature-onboarding:test` green (8 `OnboardingNavigatorTest` cases). Two new ones, both of which fail on `develop`:

- a step missing from the rebuilt path continues to the next step still in it, and does not complete onboarding
- a missing step with nothing after it still exits

## Notes

Low frequency (needs real process death while parked on a step whose condition flipped) but the failure was silent and permanent, which is a poor pair. Found while reviewing the onboarding test-session tickets.