### PR TITLE
Own the onboarding step caption in OnboardingStepButtons

### DIFF
--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import com.hedvig.android.compose.ui.LocalSharedTransitionScope
@@ -237,7 +238,13 @@ internal fun OnboardingStepHeader(title: String, modifier: Modifier = Modifier, 
   }
 }
 
-/** Bottom-anchored button area with full-pill shapes. Primary and optional secondary buttons. */
+/**
+ * Bottom-anchored button area with full-pill shapes. Primary and optional secondary buttons, over an
+ * optional [caption].
+ *
+ * [caption] is a plain string rather than a slot on purpose: every step's caption is the same small
+ * translucent line, and owning the style here is what keeps it from being restyled per screen.
+ */
 @Composable
 internal fun ColumnScope.OnboardingStepButtons(
   primaryText: String,
@@ -246,7 +253,20 @@ internal fun ColumnScope.OnboardingStepButtons(
   secondaryText: String? = null,
   onSecondaryClick: (() -> Unit)? = null,
   secondaryAbovePrimary: Boolean = false,
+  caption: String? = null,
 ) {
+  if (caption != null) {
+    Spacer(Modifier.height(24.dp))
+    HedvigText(
+      text = caption,
+      style = HedvigTheme.typography.label,
+      color = HedvigTheme.colorScheme.textSecondaryTranslucent,
+      textAlign = TextAlign.Center,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+    )
+  }
   Spacer(Modifier.height(16.dp))
   val hapticFeedback = LocalHapticFeedback.current
   val primaryButton = @Composable {
@@ -317,6 +337,7 @@ private fun PreviewOnboardingStepScaffold() {
         onPrimaryClick = {},
         secondaryText = "Skip",
         onSecondaryClick = {},
+        caption = "You can add this information later",
       )
     }
   }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/coinsured/OnboardingCoInsuredDestination.kt
@@ -3,9 +3,7 @@ package com.hedvig.android.feature.onboarding.ui.coinsured
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -23,7 +20,6 @@ import com.hedvig.android.data.coinsured.CoInsuredFlowType
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.design.system.hedvig.HedvigPreview
-import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.feature.onboarding.ui.OnboardingContractCard
@@ -128,21 +124,12 @@ private fun OnboardingCoInsuredScreen(
           }
         }
         Spacer(Modifier.weight(1f))
-        Spacer(Modifier.height(24.dp))
-        HedvigText(
-          text = stringResource(Res.string.ONBOARDING_ADD_INFO_LATER_LABEL),
-          style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
-          textAlign = TextAlign.Center,
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        )
         OnboardingStepButtons(
           primaryText = stringResource(Res.string.general_continue_button),
           onPrimaryClick = onContinue,
           secondaryText = null,
           onSecondaryClick = null,
+          caption = stringResource(Res.string.ONBOARDING_ADD_INFO_LATER_LABEL),
         )
       }
     }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingPaymentDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/payment/OnboardingPaymentDestination.kt
@@ -2,7 +2,6 @@ package com.hedvig.android.feature.onboarding.ui.payment
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -23,7 +22,6 @@ import com.hedvig.android.core.common.di.HedvigViewModel
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.design.system.hedvig.HedvigPreview
-import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.feature.onboarding.data.OnboardingPayinStatus
@@ -225,19 +223,6 @@ private fun OnboardingPaymentScreen(
           modifier = Modifier.align(Alignment.CenterHorizontally),
         )
         Spacer(Modifier.weight(1f))
-        Spacer(Modifier.height(24.dp))
-        HedvigText(
-          text = if (isConnected) {
-            stringResource(Res.string.ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER)
-          } else {
-            stringResource(Res.string.ONBOARDING_CONNECT_PAYMENT_FOOTNOTE)
-          },
-          style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
-          modifier = Modifier
-            .align(Alignment.CenterHorizontally)
-            .padding(horizontal = 32.dp),
-        )
         OnboardingStepButtons(
           primaryText = if (isConnected) {
             stringResource(Res.string.general_continue_button)
@@ -247,6 +232,11 @@ private fun OnboardingPaymentScreen(
           onPrimaryClick = if (isConnected) onContinue else onConnectPayment,
           secondaryText = if (canSkip) stringResource(Res.string.ONBOARDING_DO_THIS_LATER_BUTTON) else null,
           onSecondaryClick = if (canSkip) onContinue else null,
+          caption = if (isConnected) {
+            stringResource(Res.string.ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER)
+          } else {
+            stringResource(Res.string.ONBOARDING_CONNECT_PAYMENT_FOOTNOTE)
+          },
         )
       }
     }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/petid/OnboardingPetIdDestination.kt
@@ -3,9 +3,7 @@ package com.hedvig.android.feature.onboarding.ui.petid
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -22,7 +19,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
 import com.hedvig.android.design.system.hedvig.HedvigPreview
-import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.feature.onboarding.ui.OnboardingContractCard
@@ -115,21 +111,12 @@ private fun OnboardingPetIdScreen(
           }
         }
         Spacer(Modifier.weight(1f))
-        Spacer(Modifier.height(24.dp))
-        HedvigText(
-          text = stringResource(Res.string.ONBOARDING_ADD_INFO_LATER_LABEL),
-          style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
-          textAlign = TextAlign.Center,
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        )
         OnboardingStepButtons(
           primaryText = stringResource(Res.string.general_continue_button),
           onPrimaryClick = onContinue,
           secondaryText = null,
           onSecondaryClick = null,
+          caption = stringResource(Res.string.ONBOARDING_ADD_INFO_LATER_LABEL),
         )
       }
     }

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemeDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/theme/OnboardingThemeDestination.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -135,19 +134,10 @@ private fun OnboardingThemeScreen(
           )
         }
         Spacer(Modifier.weight(1f))
-        Spacer(Modifier.height(24.dp))
-        HedvigText(
-          text = stringResource(Res.string.ONBOARDING_CHANGE_SETTINGS_LATER_LABEL),
-          style = HedvigTheme.typography.label,
-          color = HedvigTheme.colorScheme.textSecondaryTranslucent,
-          textAlign = TextAlign.Center,
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        )
         OnboardingStepButtons(
           primaryText = stringResource(Res.string.general_continue_button),
           onPrimaryClick = onContinueClick,
+          caption = stringResource(Res.string.ONBOARDING_CHANGE_SETTINGS_LATER_LABEL),
         )
       }
     }


### PR DESCRIPTION
## Problem

`OnboardingStepButtons` owns the bottom area of every onboarding step, but it had no caption parameter. So each screen wanting the small translucent line above the buttons wrote its own `HedvigText` immediately before the call. Four did: pets-ID, co-insured, theme, connect-payment.

Three were byte-identical copies of the same nine lines. Nothing connected them, which is how two ended up on `finePrint` (12sp) while the other two used `label` (14sp) until `cc6365c92b` corrected it. The duplication that allowed the drift is still there, so it can happen again.

The payment footnote was also diverging in a subtler way that is live today: same style and colour, but `.align(Alignment.CenterHorizontally)` with 32dp padding and **no** `textAlign`. On one line it looks like the others; as soon as it wraps, its lines are left-aligned inside a centred block while the other three centre every line at 16dp.

## Change

`OnboardingStepButtons` takes `caption: String?` and renders it with the one canonical style. The four call sites pass a string and delete their `HedvigText` plus their leading 24dp spacer.

A string rather than a `@Composable` slot on purpose: every caption is the same single line of text, and a slot would hand styling back to the caller, which is the hole this closes. The reasoning is in the KDoc so it does not get "improved" later.

Spacing is unchanged. The component now contributes the 24dp gap the call sites used to add, then the existing 16dp before the buttons. Screens with no caption are untouched.

## Behaviour

One intended visual change: the connect-payment footnote goes from 32dp to 16dp side padding and gains centred wrapping, matching the other three. Confirmed as wanted, the divergence was drift rather than intent.

Net 26 lines removed. Also adds the caption to the scaffold preview so the state is visible.

## Verification

`:feature-onboarding:ktlintCheck`, `:compileReleaseKotlin` and `:test` all green. Imports orphaned by the deletions were pruned by hand, since ktlint neither removes nor flags unused imports.