### PR TITLE
feat(x-sells): send ONBOARDING userFlow for onboarding cross-sells

### DIFF
--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
@@ -1736,7 +1736,7 @@ input CrossSellExperimentInput {
 input CrossSellInput {
   userFlow: UserFlow!
   """
-  REQUIRED for SMART_X_SELL, must be NULL for HOME_X_SELL and INSURANCES
+  REQUIRED for SMART_X_SELL, must be NULL for HOME_X_SELL, INSURANCES and ONBOARDING
   """
   flowSource: FlowSource
   """
@@ -1773,6 +1773,11 @@ type CrossSellV2 {
   Other available cross-sells (behavior varies by userFlow)
   """
   otherCrossSells: [CrossSell!]!
+  """
+  Whether otherCrossSells should be presented as promoted offers (the highlighted "save" treatment).
+  A flow can apply a discount without promoting it, so this may be false while items still carry discount
+  copy in their description. Independent of recommendedCrossSell, which carries its own discount fields.
+  """
   discountAvailable: Boolean!
 }
 enum CurrencyCode {
@@ -2722,6 +2727,8 @@ type Member {
   - INSURANCES: All options in otherCrossSells, no recommendation
   - HOME_X_SELL: Recommendation + other options
   - SMART_X_SELL (requires flowSource): Focused recommendation OR all options
+  - ONBOARDING: All options in otherCrossSells led by the recommendation, no separate recommendation
+  otherCrossSells carry discount copy for every flow except SMART_X_SELL.
   """
   crossSellV2(input: CrossSellInput!): CrossSellV2!
   """
@@ -5704,6 +5711,10 @@ enum UserFlow {
   Smart cross-sell - focused recommendation OR all options
   """
   SMART_X_SELL
+  """
+  End of onboarding - all options led by the recommendation
+  """
+  ONBOARDING
 }
 scalar UUID
 type ValueArray {

--- a/app/feature/feature-onboarding/src/main/graphql/OnboardingQuery.graphql
+++ b/app/feature/feature-onboarding/src/main/graphql/OnboardingQuery.graphql
@@ -38,7 +38,7 @@ query Onboarding {
         status
       }
     }
-    crossSellV2(input: { userFlow: HOME_X_SELL, flowSource: null, experiments: [] }) {
+    crossSellV2(input: { userFlow: ONBOARDING, flowSource: null, experiments: [] }) {
       otherCrossSells {
         id
         title


### PR DESCRIPTION
## What this does

Switches the end-of-onboarding cross-sell query from `HOME_X_SELL` to the new dedicated `ONBOARDING` userFlow, so onboarding cross-sells can be tuned independently of Home. `ONBOARDING` returns all options as one recommendation-led list, with the discount described in each row's subtitle but no promoted "save" button (that stays the Insurances tab only).

Two commits:
- `chore: sync Octopus schema (adds ONBOARDING userFlow)`: real introspection sync from dev, which now serves `ONBOARDING` plus the accompanying cross-sell description updates. (Replaces the earlier temporary stub.)
- `feat: send ONBOARDING userFlow for onboarding cross-sells`: the query change.

No cross-sell UI code changes. Home and onboarding already render the server `description` as the row subtitle with a neutral button, so the discount subtext now appears purely from the backend. (An earlier "discount copy on Home" attempt was reverted for that reason and is not part of this branch.)

## Verification

- Backend `ONBOARDING` is deployed to dev: `apollo-router.dev.hedvigit.com` `UserFlow` now exposes `INSURANCES`, `HOME_X_SELL`, `SMART_X_SELL`, `ONBOARDING`.
- `:feature-onboarding:compileReleaseKotlin` is green against the synced schema.

## a11y
- [ ] if these are UI changes - check for their accessibility (no new UI; the onboarding cross-sell rows are unchanged, only their data source and copy change)
