### PR TITLE
Restrict the onboarding phone field to a single line of digits

### DIFF
--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneDestination.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.byValue
 import androidx.compose.foundation.text.input.placeCursorAtEnd
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
@@ -134,6 +137,8 @@ private fun OnboardingPhoneScreen(
             HedvigTextFieldDefaults.ErrorState.NoError
           },
           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+          inputTransformation = PhoneNumberInputTransformation,
+          lineLimits = TextFieldLineLimits.SingleLine,
           modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
@@ -148,6 +153,15 @@ private fun OnboardingPhoneScreen(
       }
     }
   }
+}
+
+/**
+ * The in-app keypad only ever emits digits, but tapping the field opens the system IME, whose phone
+ * layout also offers separators, a plus sign and a newline key. Filtering to digits keeps what is
+ * submitted independent of which of the two the member typed on.
+ */
+private val PhoneNumberInputTransformation = InputTransformation.byValue { _, proposed ->
+  proposed.filter { it.isDigit() }
 }
 
 @HedvigPreview


### PR DESCRIPTION
## Problem

The phone step draws its own keypad, whose `*` and `#` keys are already inert (`clickEnabled` excludes them), so it only ever emits digits. But tapping the text field opens the **system IME** instead, and its phone layout offers a separator row (`-`, space, `.`), a plus sign, and a return key.

So the field accepted all of those, and pressing return inserted a newline and grew the field to a second line:

```
0701234567
88
```

Reproduced on device before the fix.

## Change

Two arguments at the call site:

- `lineLimits = TextFieldLineLimits.SingleLine`. `TextFieldLineLimits.Default` is multiline, which is what allowed the second line. This also turns the IME's return key into a **done** action, so there is no newline key to press in the first place.
- `inputTransformation` filtering to digits, so the value is identical regardless of which of the two keyboards produced it.

The design system's state-based `HedvigTextField` already exposed both; this call site just passed neither.

## Verified on device

Debug build on a Pixel 6 Pro, driving the real flow:

- Before: `0701234567` + return + `88` produced two lines.
- After: return dismisses the keyboard instead of inserting a newline, and the IME's return key renders as a checkmark rather than `↵`.
- After: typing `07ab+1-2.3` yields `07123`.
- `:feature-onboarding:ktlintFormat`, `:compileReleaseKotlin` and `:test` all green.

## Two things worth a reviewer's opinion

1. **A leading `+` is stripped.** A member (or a prefilled backend value) using `+46 70 …` becomes `4670…`, which changes the meaning of the number. Strictly numeric is what was asked for, but if we want international entry to survive, the filter should allow a leading `+`. One-line change either way.
2. **A prefilled value is sanitized on first edit.** `InputTransformation.byValue` sees the whole proposed value, so a backend number containing separators (the preview in this file uses `"070 123 45 67"`) collapses to digits as soon as the member types. Arguably the point of the change, but it is a visible jump.

Also noting for consistency: Profile's contact-info screen uses `InputTransformation.byValue { _, proposed -> proposed.filterNot { it.isWhitespace() }.trim() }`, which strips whitespace but still permits letters and `+`. Two screens editing the same field now have different rules. Happy to unify in a follow-up, but I did not want to change Profile's behaviour unasked.