### PR TITLE
Fix the claim chat leave dialog's cancel label and pop semantics

### DIFF
--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/navigation/ClaimChatEntries.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/feature/claim/chat/navigation/ClaimChatEntries.kt
@@ -83,6 +83,7 @@ fun EntryProviderScope<HedvigNavKey>.claimChatEntries(
       appPackageId = appPackageId,
       imageLoader = imageLoader,
       navigateUp = backstack::navigateUp,
+      navigateBack = backstack::popBackstack,
       openPlayStore = openPlayStore,
     )
   }

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
@@ -140,6 +140,7 @@ internal fun ClaimChatDestination(
   imageLoader: ImageLoader,
   isDevelopmentFlow: Boolean,
   navigateUp: () -> Unit,
+  navigateBack: () -> Unit,
   openPlayStore: () -> Unit,
   resumeClaim: Boolean,
 ) {
@@ -165,6 +166,7 @@ internal fun ClaimChatDestination(
       appPackageId = appPackageId,
       imageLoader = imageLoader,
       navigateUp = navigateUp,
+      navigateBack = navigateBack,
       openPlayStore = openPlayStore,
     )
   }
@@ -181,6 +183,7 @@ internal fun ClaimChatScreenContent(
   appPackageId: String,
   imageLoader: ImageLoader,
   navigateUp: () -> Unit,
+  navigateBack: () -> Unit,
   openPlayStore: () -> Unit,
 ) {
   val uiState = claimChatViewModel.uiState.collectAsState().value
@@ -213,6 +216,7 @@ internal fun ClaimChatScreenContent(
           appPackageId = appPackageId,
           imageLoader = imageLoader,
           navigateUp = navigateUp,
+          navigateBack = navigateBack,
           openPlayStore = openPlayStore,
         )
       }
@@ -230,6 +234,7 @@ private fun ClaimChatScreen(
   appPackageId: String,
   imageLoader: ImageLoader,
   navigateUp: () -> Unit,
+  navigateBack: () -> Unit,
   openAppSettings: () -> Unit,
   openPlayStore: () -> Unit,
 ) {
@@ -260,6 +265,7 @@ private fun ClaimChatScreen(
         appPackageId = appPackageId,
         imageLoader = imageLoader,
         navigateUp = navigateUp,
+        navigateBack = navigateBack,
         openPlayStore = openPlayStore,
       )
     },
@@ -277,6 +283,7 @@ private fun ClaimChatScreenContent(
   appPackageId: String,
   imageLoader: ImageLoader,
   navigateUp: () -> Unit,
+  navigateBack: () -> Unit,
   openPlayStore: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -335,14 +342,14 @@ private fun ClaimChatScreenContent(
         text = stringResource(Res.string.RESUME_CLAIM_LEAVE_BODY),
         confirmButtonLabel = stringResource(Res.string.RESUME_CLAIM_LEAVE_CONFIRM),
         onDismissRequest = { showCloseFlowDialog = false },
-        onConfirmClick = navigateUp,
+        onConfirmClick = navigateBack,
       )
     } else {
       HedvigAlertDialog(
         title = stringResource(Res.string.GENERAL_ARE_YOU_SURE),
         text = stringResource(Res.string.claims_alert_body),
         onDismissRequest = { showCloseFlowDialog = false },
-        onConfirmClick = navigateUp,
+        onConfirmClick = navigateBack,
       )
     }
   }
@@ -424,7 +431,7 @@ private fun ClaimChatScreenContent(
           if (uiState.steps.size > 1 && showLeaveConfirmation) {
             showCloseFlowDialog = true
           } else {
-            navigateUp()
+            navigateBack()
           }
         },
       )

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/ui/ClaimChatDestination.kt
@@ -115,6 +115,7 @@ import hedvig.resources.EMBARK_UPDATE_APP_BUTTON
 import hedvig.resources.GENERAL_ARE_YOU_SURE
 import hedvig.resources.NETWORK_ERROR_ALERT_MESSAGE
 import hedvig.resources.RESUME_CLAIM_LEAVE_BODY
+import hedvig.resources.RESUME_CLAIM_LEAVE_CANCEL
 import hedvig.resources.RESUME_CLAIM_LEAVE_CONFIRM
 import hedvig.resources.RESUME_CLAIM_LEAVE_TITLE
 import hedvig.resources.Res
@@ -341,6 +342,7 @@ private fun ClaimChatScreenContent(
         title = stringResource(Res.string.RESUME_CLAIM_LEAVE_TITLE),
         text = stringResource(Res.string.RESUME_CLAIM_LEAVE_BODY),
         confirmButtonLabel = stringResource(Res.string.RESUME_CLAIM_LEAVE_CONFIRM),
+        dismissButtonLabel = stringResource(Res.string.RESUME_CLAIM_LEAVE_CANCEL),
         onDismissRequest = { showCloseFlowDialog = false },
         onConfirmClick = navigateBack,
       )


### PR DESCRIPTION
Two small fixes to the claim chat leave-confirmation dialog, found while reviewing the draft claim submission feature ahead of a test session.

### Label the cancel button "Stay"

`HedvigAlertDialog` defaults `dismissButtonLabel` to `GENERAL_NO`, so the button that keeps the member in the claim read **No** / **Nej**. Paired with **Leave** it mixes an answer to the title with an action, and nothing on the button says the member stays in the draft they were filling in.

`RESUME_CLAIM_LEAVE_CANCEL` ("Stay" / "Stanna kvar") shipped with the rest of the `RESUME_CLAIM_*` batch and was unreferenced on Android. iOS labels the same button with it (`SubmitClaimFlowNavigation`), so this is a parity gap: the Android design spec specified `GENERAL_NO` while the iOS PR it was written against was still in progress, and iOS settled on the dedicated string.

Only the resume-enabled branch changes. The legacy branch behind the flag asks "Are you sure?", where Yes/No is the correct pairing.

| before | after |
|---|---|
| No · Leave | Stay · Leave |
| Nej · Lämna | Stanna kvar · Lämna |

### Pop rather than navigate Up when leaving

The leave dialog and the in-content Close button both routed through `navigateUp`. That carries deep-link semantics: `BackstackController` overrides it to rebuild a synthetic parent stack for a key entered alone. Right for the top app bar's back arrow, wrong for a dialog button and an in-content close, where the user expects a plain temporal pop matching the system back gesture.

The dialog is opened from three affordances sharing one confirm handler: top app bar back, system back via `NavigationEventHandler`, and the content Close button. Two of the three require a plain pop, and matching predictive back is the consistency the rule protects, so the shared handler pops. The top app bar's own direct path keeps `navigateUp`.

**No behavior change today.** `navigateUp` only diverges from `popBackstack` when `entries.size == 1`, and `ClaimChatKey` carries no `DeepLinkAncestry`, so claim chat is always pushed on top of home or the inbox. This removes the latent divergence before a deep link into the flow makes it real.

### Testing

`:feature-claim-chat:assembleAndroidMain` and `ktlintCheck` pass. The module has no test source set.

To see the dialog: `enable_claim_intent_resume` on, a resumable claim intent, past the first step, then leave via the back arrow, the system back gesture, or a Close button in the flow.

### Not included

The draft card's fallback title (`RESUME_CLAIM_FALLBACK_TITLE`) currently resolves to "Continue" / "Fortsätt" and renders directly above a "Continue" button. iOS master carries the same value, so both platforms ship the duplicate. Fixing it means editing the value in Lokalise, which corrects Android and iOS together, so there is nothing to change in this PR.
