### PR TITLE
Payment protection: qualification period info on change amount summary

### DIFF
--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -152,6 +152,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Ange byggår</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Byggår</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">Du + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Det nya försäkringsbeloppet börjar gälla efter att kvalificeringstiden passerat. Ditt nuvarande belopp gäller som vanligt under tiden.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Ändra utbetalningskonto</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Ändra skyddsnivå</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Chatta med en specialist</string>
@@ -260,6 +261,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">Om du inte minns inköpsdatum behöver du inte fylla i något.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Saknas</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Hoppa över</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Ungefär hur länge stod barnvagnen där innan du märkte att den var borta?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">Ett dygn eller mer</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Över natten</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Var barnvagnen låst? Berätta gärna med egna ord, t.ex. vilket lås du använde.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Skicka in ditt skadeärende</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Gå till ärende</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Ditt ärende har skickats in</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -152,6 +152,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Please enter year of construction</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Year of construction</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">You + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Your updated amount will take effect after your qualification period. Your current amount remains active during this period.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Change payout account</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Change coverage level</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Talk to a human</string>
@@ -260,6 +261,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">If you don\'t remember the purchase date, you don\'t need to fill in anything.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Skipped</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Skip</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Roughly how long had the stroller been there before you noticed it was gone?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">A day or more</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Overnight</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Was the stroller locked? Tell us in your own words, e.g. what kind of lock you used.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Submit your claim</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Go to claim</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Your claim was submitted successfully</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -151,6 +151,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Ange byggår</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Byggår</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">Du + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Det nya försäkringsbeloppet börjar gälla efter att kvalificeringstiden passerat. Ditt nuvarande belopp gäller som vanligt under tiden.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Ändra utbetalningskonto</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Ändra skyddsnivå</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Chatta med en specialist</string>
@@ -259,6 +260,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">Om du inte minns inköpsdatum behöver du inte fylla i något.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Saknas</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Hoppa över</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Ungefär hur länge stod barnvagnen där innan du märkte att den var borta?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">Ett dygn eller mer</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Över natten</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Var barnvagnen låst? Berätta gärna med egna ord, t.ex. vilket lås du använde.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Skicka in ditt skadeärende</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Gå till ärende</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Ditt ärende har skickats in</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -151,6 +151,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Please enter year of construction</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Year of construction</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">You + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Your updated amount will take effect after your qualification period. Your current amount remains active during this period.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Change payout account</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Change coverage level</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Talk to a human</string>
@@ -259,6 +260,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">If you don't remember the purchase date, you don't need to fill in anything.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Skipped</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Skip</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Roughly how long had the stroller been there before you noticed it was gone?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">A day or more</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Overnight</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Was the stroller locked? Tell us in your own words, e.g. what kind of lock you used.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Submit your claim</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Go to claim</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Your claim was submitted successfully</string>

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryDestination.kt
@@ -48,6 +48,7 @@ import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedLinearProgress
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgress
 import com.hedvig.android.design.system.hedvig.HedvigMultiScreenPreview
+import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigScaffold
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTextButton
@@ -56,6 +57,7 @@ import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTa
 import com.hedvig.android.design.system.hedvig.Icon
 import com.hedvig.android.design.system.hedvig.IconButton
 import com.hedvig.android.design.system.hedvig.LocalTextStyle
+import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority.Info
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.a11y.getPerMonthDescription
 import com.hedvig.android.design.system.hedvig.icon.Close
@@ -70,6 +72,7 @@ import com.hedvig.ui.tiersandaddons.CostBreakdownEntry
 import com.hedvig.ui.tiersandaddons.DisplayDocument
 import com.hedvig.ui.tiersandaddons.QuoteCard
 import com.hedvig.ui.tiersandaddons.QuoteDisplayItem
+import hedvig.resources.CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO
 import hedvig.resources.CONFIRM_CHANGES_SUBTITLE
 import hedvig.resources.GENERAL_ARE_YOU_SURE
 import hedvig.resources.GENERAL_CONFIRM
@@ -229,6 +232,10 @@ private fun SummarySuccessScreen(
       Modifier
         .padding(horizontal = 16.dp),
     ) {
+      if (uiState.showQualificationPeriodInfo) {
+        HedvigNotificationCard(stringResource(Res.string.CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO), Info)
+        Spacer(Modifier.height(16.dp))
+      }
       HorizontalItemsWithMaximumSpaceTaken(
         modifier = Modifier.fillMaxWidth(),
         startSlot = {
@@ -382,75 +389,79 @@ private fun PreviewSummaryScreen(
 private class SummaryUiStateProvider :
   CollectionPreviewParameterProvider<SummaryState>(
     listOf(
-      Success(
-        currentContractData = ContractData(
-          contractGroup = ContractGroup.HOMEOWNER,
-          contractDisplayName = "Home Homeowner",
-          contractDisplaySubtitle = "Addressvägen 777",
-          activeDisplayPremium = UiMoney(449.0, SEK),
-        ),
-        activationDate = LocalDate(2024, 5, 1),
-        quote = TierDeductibleQuote(
-          id = "id4",
-          deductible = Deductible(
-            UiMoney(3500.0, SEK),
-            deductiblePercentage = 25,
-            description = "En fast del och en rörlig del om 25% av skadekostnaden",
-          ),
-          displayItems = listOf(),
-          tier = Tier(
-            "STANDARD",
-            tierLevel = 1,
-            tierDescription = "Vårt mellanpaket med hög ersättning.",
-            tierDisplayName = "Standard",
-          ),
-          productVariant = ProductVariant(
-            displayName = "Test",
-            contractGroup = ContractGroup.RENTAL,
-            contractType = ContractType.SE_APARTMENT_RENT,
-            partner = "test",
-            perils = listOf(),
-            insurableLimits = listOf(),
-            documents = listOf(),
-            displayTierName = "Standard",
-            tierDescription = "Our most standard coverage",
-            termsVersion = "SE_DOG_STANDARD-20230330-HEDVIG-null",
-          ),
-          addons = List(2) {
-            ChangeTierDeductibleAddonQuote(
-              addonVariant = AddonVariant(
-                displayName = "Addon Name",
-                perils = listOf(),
-                documents = listOf(
-                  InsuranceVariantDocument(
-                    "Document name",
-                    "",
-                    InsuranceVariantDocument.InsuranceDocumentType.TERMS_AND_CONDITIONS,
-                  ),
-                ),
-                termsVersion = "RESESKYDD-20230330-HEDVIG-null",
-                product = "product",
-              ),
-            )
-          },
-          currentTotalCost = TotalCost(
-            monthlyGross = UiMoney(175.0, SEK),
-            monthlyNet = UiMoney(150.0, SEK),
-          ),
-          newTotalCost = TotalCost(
-            monthlyGross = UiMoney(380.0, SEK),
-            monthlyNet = UiMoney(304.0, SEK),
-          ),
-          costBreakdown = listOf(
-            CostBreakdownEntry("Home Insurance Max", "300 kr/mo", false),
-            CostBreakdownEntry("Travel Plus", "80 kr/mo", true),
-            CostBreakdownEntry("Bundle discount 20%", "76 kr/mo", false),
-          ),
-          info = "Some important info",
-        ),
-      ),
+      previewSuccessState,
+      previewSuccessState.copy(showQualificationPeriodInfo = true),
       Failure,
       Loading,
       MakingChanges,
     ),
   )
+
+private val previewSuccessState = Success(
+  currentContractData = ContractData(
+    contractGroup = ContractGroup.HOMEOWNER,
+    contractDisplayName = "Home Homeowner",
+    contractDisplaySubtitle = "Addressvägen 777",
+    activeDisplayPremium = UiMoney(449.0, SEK),
+  ),
+  activationDate = LocalDate(2024, 5, 1),
+  quote = TierDeductibleQuote(
+    id = "id4",
+    deductible = Deductible(
+      UiMoney(3500.0, SEK),
+      deductiblePercentage = 25,
+      description = "En fast del och en rörlig del om 25% av skadekostnaden",
+    ),
+    displayItems = listOf(),
+    tier = Tier(
+      "STANDARD",
+      tierLevel = 1,
+      tierDescription = "Vårt mellanpaket med hög ersättning.",
+      tierDisplayName = "Standard",
+    ),
+    productVariant = ProductVariant(
+      displayName = "Test",
+      contractGroup = ContractGroup.RENTAL,
+      contractType = ContractType.SE_APARTMENT_RENT,
+      partner = "test",
+      perils = listOf(),
+      insurableLimits = listOf(),
+      documents = listOf(),
+      displayTierName = "Standard",
+      tierDescription = "Our most standard coverage",
+      termsVersion = "SE_DOG_STANDARD-20230330-HEDVIG-null",
+    ),
+    addons = List(2) {
+      ChangeTierDeductibleAddonQuote(
+        addonVariant = AddonVariant(
+          displayName = "Addon Name",
+          perils = listOf(),
+          documents = listOf(
+            InsuranceVariantDocument(
+              "Document name",
+              "",
+              InsuranceVariantDocument.InsuranceDocumentType.TERMS_AND_CONDITIONS,
+            ),
+          ),
+          termsVersion = "RESESKYDD-20230330-HEDVIG-null",
+          product = "product",
+        ),
+      )
+    },
+    currentTotalCost = TotalCost(
+      monthlyGross = UiMoney(175.0, SEK),
+      monthlyNet = UiMoney(150.0, SEK),
+    ),
+    newTotalCost = TotalCost(
+      monthlyGross = UiMoney(380.0, SEK),
+      monthlyNet = UiMoney(304.0, SEK),
+    ),
+    costBreakdown = listOf(
+      CostBreakdownEntry("Home Insurance Max", "300 kr/mo", false),
+      CostBreakdownEntry("Travel Plus", "80 kr/mo", true),
+      CostBreakdownEntry("Bundle discount 20%", "76 kr/mo", false),
+    ),
+    info = "Some important info",
+  ),
+  showQualificationPeriodInfo = false,
+)

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryViewModel.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepsummary/SummaryViewModel.kt
@@ -12,6 +12,7 @@ import com.hedvig.android.core.common.di.HedvigViewModel
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.data.changetier.data.ChangeTierRepository
 import com.hedvig.android.data.changetier.data.TierDeductibleQuote
+import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.feature.change.tier.data.GetCurrentContractDataUseCase
 import com.hedvig.android.feature.change.tier.navigation.ChooseTierKey
 import com.hedvig.android.feature.change.tier.navigation.SubmitFailureKey
@@ -53,7 +54,7 @@ internal class SummaryViewModel(
     ),
   )
 
-private class SummaryPresenter(
+internal class SummaryPresenter(
   private val params: SummaryParameters,
   private val tierRepository: ChangeTierRepository,
   private val getCurrentContractDataUseCase: GetCurrentContractDataUseCase,
@@ -129,6 +130,8 @@ private class SummaryPresenter(
                   quote = rightQuote,
                   currentContractData = currentContract,
                   activationDate = params.activationDate,
+                  showQualificationPeriodInfo = currentContract.contractGroup == ContractGroup.PAYMENT_PROTECTION &&
+                    rightQuote.tier.tierLevel > currentQuoteToChange.tier.tierLevel,
                 )
               }
             },
@@ -149,6 +152,11 @@ internal sealed interface SummaryState {
     val quote: TierDeductibleQuote,
     val currentContractData: ContractData,
     val activationDate: LocalDate,
+    /**
+     * Raising a payment protection amount only takes effect once a qualification period has passed. Its length varies
+     * per case, so the copy deliberately states no number of days.
+     */
+    val showQualificationPeriodInfo: Boolean,
   ) : SummaryState {
     val totalNet: UiMoney = quote.newTotalCost.monthlyNet
   }

--- a/app/feature/feature-choose-tier/src/test/kotlin/ui/stepsummary/SummaryPresenterTest.kt
+++ b/app/feature/feature-choose-tier/src/test/kotlin/ui/stepsummary/SummaryPresenterTest.kt
@@ -1,0 +1,110 @@
+package ui.stepsummary
+
+import FakeChangeTierRepository
+import TestBackstack
+import arrow.core.Either
+import arrow.core.raise.either
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.data.changetier.data.TierDeductibleQuote
+import com.hedvig.android.data.contract.ContractGroup
+import com.hedvig.android.feature.change.tier.data.CurrentContractData
+import com.hedvig.android.feature.change.tier.data.GetCurrentContractDataUseCase
+import com.hedvig.android.feature.change.tier.navigation.SummaryParameters
+import com.hedvig.android.feature.change.tier.ui.stepsummary.SummaryPresenter
+import com.hedvig.android.feature.change.tier.ui.stepsummary.SummaryState
+import com.hedvig.android.logger.TestLogcatLoggingRule
+import com.hedvig.android.molecule.test.test
+import currentQuote
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import org.junit.Rule
+import org.junit.Test
+import testQuote
+
+class SummaryPresenterTest {
+  @get:Rule
+  val testLogcatLogger = TestLogcatLoggingRule()
+
+  @Test
+  fun `when payment protection amount is increased show the qualification period info`() = runTest {
+    val tierRepo = FakeChangeTierRepository()
+    val presenter = SummaryPresenter(
+      params = params,
+      tierRepository = tierRepo,
+      getCurrentContractDataUseCase = FakeGetCurrentContractDataUseCase(),
+      backstack = TestBackstack(),
+    )
+    presenter.test(SummaryState.Loading) {
+      tierRepo.quoteTurbine.add(either { higherTierPaymentProtectionQuote })
+      tierRepo.quoteTurbine.add(either { currentPaymentProtectionQuote })
+      skipItems(1)
+      assertThat(awaitItem())
+        .isInstanceOf(SummaryState.Success::class)
+        .prop(SummaryState.Success::showQualificationPeriodInfo)
+        .isEqualTo(true)
+    }
+  }
+
+  @Test
+  fun `when the payment protection amount is not increased do not show the qualification period info`() = runTest {
+    val tierRepo = FakeChangeTierRepository()
+    val presenter = SummaryPresenter(
+      params = params,
+      tierRepository = tierRepo,
+      getCurrentContractDataUseCase = FakeGetCurrentContractDataUseCase(),
+      backstack = TestBackstack(),
+    )
+    presenter.test(SummaryState.Loading) {
+      tierRepo.quoteTurbine.add(either { currentPaymentProtectionQuote })
+      tierRepo.quoteTurbine.add(either { currentPaymentProtectionQuote })
+      skipItems(1)
+      assertThat(awaitItem())
+        .isInstanceOf(SummaryState.Success::class)
+        .prop(SummaryState.Success::showQualificationPeriodInfo)
+        .isEqualTo(false)
+    }
+  }
+
+  @Test
+  fun `when the contract is not payment protection do not show the qualification period info`() = runTest {
+    val tierRepo = FakeChangeTierRepository()
+    val presenter = SummaryPresenter(
+      params = params,
+      tierRepository = tierRepo,
+      getCurrentContractDataUseCase = FakeGetCurrentContractDataUseCase(),
+      backstack = TestBackstack(),
+    )
+    presenter.test(SummaryState.Loading) {
+      tierRepo.quoteTurbine.add(either { testQuote })
+      tierRepo.quoteTurbine.add(either { currentQuote })
+      skipItems(1)
+      assertThat(awaitItem())
+        .isInstanceOf(SummaryState.Success::class)
+        .prop(SummaryState.Success::showQualificationPeriodInfo)
+        .isEqualTo(false)
+    }
+  }
+}
+
+private fun TierDeductibleQuote.asPaymentProtection(): TierDeductibleQuote =
+  copy(productVariant = productVariant.copy(contractGroup = ContractGroup.PAYMENT_PROTECTION))
+
+private val currentPaymentProtectionQuote = currentQuote.asPaymentProtection()
+
+private val higherTierPaymentProtectionQuote = testQuote.asPaymentProtection()
+
+private class FakeGetCurrentContractDataUseCase : GetCurrentContractDataUseCase {
+  override suspend fun invoke(insuranceId: String): Either<ErrorMessage, CurrentContractData> {
+    return either { CurrentContractData("exposure name") }
+  }
+}
+
+private val params = SummaryParameters(
+  quoteIdToSubmit = "id0",
+  insuranceId = "testId",
+  activationDate = LocalDate(2025, 9, 11),
+)


### PR DESCRIPTION
Android side of [ugglan#2592](https://github.com/HedvigInsurance/ugglan/pull/2592). [GEN-5624](https://app.notion.com/p/hedviginsurance/App-If-increased-amount-in-change-amount-flow-Information-box-about-90-day-qualification-period-3c2c3f71cb0a80729756c7847c13419a)

When a member **increases** their payment protection amount, the change amount summary screen now shows an info card about the qualification period before the higher amount takes effect.

## Changes

- `SummaryState.Success` gains `showQualificationPeriodInfo`, computed in `SummaryPresenter` where both the selected and the current quote are already loaded. True only when the contract group is `PAYMENT_PROTECTION` **and** the selected quote's tier level is above the current one, so lowering or keeping the amount, and every other contract group, show nothing. Same predicate as iOS.
- `SummaryDestination` renders it as a `HedvigNotificationCard(..., Info)` directly above the `Total` row, matching how the moving flow places its "other insurances" notice (`feature-movingflow/.../summary/SummaryDestination.kt`), which is the treatment Richard asked for.
- The preview's `Success` fixture is extracted to a `previewSuccessState` val so the provider can add a second entry with the card visible without duplicating the 60-line quote.
- New `SummaryPresenterTest` covers the three cases from the iOS tests: payment protection + increase, payment protection + no increase, non-payment-protection + increase.

## Copy

Uses `CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO`, the renamed key, with both the English and Swedish copy in place:

> Your updated amount will take effect after your qualification period. Your current amount remains active during this period.

> Det nya försäkringsbeloppet börjar gälla efter att kvalificeringstiden passerat. Ditt nuvarande belopp gäller som vanligt under tiden.

Per Daniel's point that qualifying periods differ (sick leave, self-employed), the copy states no fixed number of days, so nothing in the app hardcodes 90.

**Note for iOS:** ugglan#2592 still references the old `CHANGE_TIER_PAYMENT_PROTECTION_INFO`, which no longer exists in Lokalise. It needs the same rename before it builds against current strings.

## Notes

- The first commit is a plain `./gradlew downloadStrings` run. Besides the key above it incidentally picks up the `CLAIM_CHAT_STROLLER_THEFT_*` keys that landed in Lokalise in the meantime.
