### PR TITLE
Hide expired quote cards on home

### DIFF
--- a/app/feature/feature-home/src/main/graphql/QueryHome.graphql
+++ b/app/feature/feature-home/src/main/graphql/QueryHome.graphql
@@ -89,7 +89,9 @@ query Home($claimsHistoryFlag: Boolean!, $resumeClaimEnabled: Boolean!, $disable
           amount
           currencyCode
         }
+        lastActivityAt
         resumeUrl
+        validTo
         pillowImage {
           src
         }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -156,18 +156,22 @@ internal class GetHomeDataUseCaseImpl(
             val otherCrossSellsData = crossSellsData.otherCrossSells.map {
               it.toCrossSell()
             }
-            val ongoingShopSessions = homeQueryData.currentMember.ongoingShopSessions.orEmpty().map { session ->
-              OngoingShopSession(
-                id = session.id,
-                title = session.display.title,
-                subtitle = session.display.subtitle,
-                monthlyNet = session.display.monthlyNet?.let {
-                  UiMoney(it.amount, UiCurrencyCode.fromCurrencyCode(it.currencyCode))
-                },
-                resumeUrl = session.display.resumeUrl,
-                pillowImageUrl = session.display.pillowImage?.src,
-              )
-            }
+            val now = clock.now()
+            val ongoingShopSessions = homeQueryData.currentMember.ongoingShopSessions.orEmpty()
+              .filter { it.display.validTo > now }
+              .sortedByDescending { it.display.lastActivityAt }
+              .map { session ->
+                OngoingShopSession(
+                  id = session.id,
+                  title = session.display.title,
+                  subtitle = session.display.subtitle,
+                  monthlyNet = session.display.monthlyNet?.let {
+                    UiMoney(it.amount, UiCurrencyCode.fromCurrencyCode(it.currencyCode))
+                  },
+                  resumeUrl = session.display.resumeUrl,
+                  pillowImageUrl = session.display.pillowImage?.src,
+                )
+              }
             val recommendedAddon = crossSellsData.recommendedAddon?.let {
               RecommendedAddon(
                 id = it.id,

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
@@ -7,6 +7,7 @@ import assertk.Assert
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.extracting
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
@@ -923,6 +924,116 @@ internal class GetHomeUseCaseTest {
       .isRight()
       .prop(HomeData::ongoingShopSessions)
       .isEmpty()
+  }
+
+  @Test
+  fun `expired ongoing shop sessions are filtered out`() = runTest {
+    val featureManager = FakeFeatureManager(
+      mapOf(
+        Feature.ENABLE_NEW_CONVERSATION_FROM_INBOX to false,
+        Feature.ENABLE_CLAIM_INTENT_RESUME to false,
+        Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to false,
+      ),
+    )
+    val testClock = TestClock()
+    val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager, testClock)
+
+    apolloClient.registerTestResponse(
+      HomeQuery(true, false, false),
+      HomeQuery.Data(OctopusFakeResolver) {
+        currentMember = buildMember {
+          ongoingShopSessions = listOf(
+            buildShopSession {
+              id = "expired-session"
+              display = buildShopSessionDisplay {
+                title = "Expired quote"
+                validTo = testClock.now() - 1.days
+              }
+            },
+            buildShopSession {
+              id = "valid-session"
+              display = buildShopSessionDisplay {
+                title = "Valid quote"
+                validTo = testClock.now() + 1.days
+              }
+            },
+          )
+        }
+      },
+    )
+    apolloClient.registerTestResponse(UnreadMessageCountQuery(), UnreadMessageCountQuery.Data(OctopusFakeResolver))
+    apolloClient.registerTestResponse(
+      CbmNumberOfChatMessagesQuery(),
+      CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
+    )
+
+    val result = getHomeDataUseCase.invoke(true).first()
+
+    assertThat(result)
+      .isNotNull()
+      .isRight()
+      .prop(HomeData::ongoingShopSessions)
+      .single()
+      .prop(OngoingShopSession::id)
+      .isEqualTo("valid-session")
+  }
+
+  @Test
+  fun `ongoing shop sessions are sorted by most recent activity first`() = runTest {
+    val featureManager = FakeFeatureManager(
+      mapOf(
+        Feature.ENABLE_NEW_CONVERSATION_FROM_INBOX to false,
+        Feature.ENABLE_CLAIM_INTENT_RESUME to false,
+        Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to false,
+      ),
+    )
+    val testClock = TestClock()
+    val getHomeDataUseCase = testUseCaseWithoutReminders(featureManager, testClock)
+
+    apolloClient.registerTestResponse(
+      HomeQuery(true, false, false),
+      HomeQuery.Data(OctopusFakeResolver) {
+        currentMember = buildMember {
+          ongoingShopSessions = listOf(
+            buildShopSession {
+              id = "middle"
+              display = buildShopSessionDisplay {
+                lastActivityAt = testClock.now() - 2.days
+                validTo = testClock.now() + 1.days
+              }
+            },
+            buildShopSession {
+              id = "oldest"
+              display = buildShopSessionDisplay {
+                lastActivityAt = testClock.now() - 5.days
+                validTo = testClock.now() + 1.days
+              }
+            },
+            buildShopSession {
+              id = "newest"
+              display = buildShopSessionDisplay {
+                lastActivityAt = testClock.now() - 1.days
+                validTo = testClock.now() + 1.days
+              }
+            },
+          )
+        }
+      },
+    )
+    apolloClient.registerTestResponse(UnreadMessageCountQuery(), UnreadMessageCountQuery.Data(OctopusFakeResolver))
+    apolloClient.registerTestResponse(
+      CbmNumberOfChatMessagesQuery(),
+      CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
+    )
+
+    val result = getHomeDataUseCase.invoke(true).first()
+
+    assertThat(result)
+      .isNotNull()
+      .isRight()
+      .prop(HomeData::ongoingShopSessions)
+      .extracting(OngoingShopSession::id)
+      .containsExactly("newest", "middle", "oldest")
   }
 
   // Used as a convenience to get a use case without any enqueued apollo responses, but some sane defaults for the


### PR DESCRIPTION
Bottom of a two PR stack.

## What

The Your quotes section rendered whatever `ongoingShopSessions` the backend returned, in whatever order it returned them. Two consequences:

1. **Expired quotes stayed on screen.** `ShopSessionDisplay.validTo` documents itself as the client's tool for this:

   > Mirrors the underlying session's `validTo`. Clients can use this to hide cards that are expired.

   We never selected the field, so an expired session sat on home until the backend stopped returning it.

2. **Card order was arbitrary.** The mapping was a bare `.map {}`, so ordering was whatever the response happened to contain.

## How

Select `validTo` and `lastActivityAt`, drop sessions that are no longer valid, and put the most recently touched session first. Neither field is added to the `OngoingShopSession` model, since nothing reads them past the filter and sort.

## Testing

Two new tests in `GetHomeUseCaseTest`, both watched failing before the fix:

* the sorting test returned backend order (`middle, oldest, newest`) against the expected `newest, middle, oldest`
* the expiry test returned 2 sessions including `expired-session` where 1 was expected

The two pre-existing shop session tests still pass. `OctopusFakeResolver` resolves `DateTime` to `Instant.DISTANT_FUTURE`, so their unset `validTo` reads as not expired.

## Note for the reviewer

One assumption worth a second opinion: that the backend does return expired sessions. That follows from the schema telling clients to hide them (a server that filtered would not need to), but I did not confirm it against a live response.

## a11y
- [ ] if these are UI changes - check for their accessibility
