### PR TITLE
Let members dismiss a quote card on home

### DIFF
--- a/app/feature/feature-home/build.gradle.kts
+++ b/app/feature/feature-home/build.gradle.kts
@@ -18,6 +18,8 @@ android {
 dependencies {
   implementation(libs.accompanist.permissions)
   implementation(libs.androidx.compose.foundation)
+  implementation(libs.androidx.datastore.core)
+  implementation(libs.androidx.datastore.preferencesCore)
   implementation(libs.apollo.normalizedCache)
   implementation(libs.apollo.runtime)
   implementation(libs.arrow.core)
@@ -69,6 +71,7 @@ dependencies {
   testImplementation(projects.apolloOctopusTest)
   testImplementation(projects.apolloTest)
   testImplementation(projects.coreCommonTest)
+  testImplementation(projects.coreDatastoreTest)
   testImplementation(projects.featureFlagsTest)
   testImplementation(projects.languageTest)
   testImplementation(projects.loggingTest)

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/DismissedShopSessionsStorage.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/DismissedShopSessionsStorage.kt
@@ -1,0 +1,51 @@
+package com.hedvig.android.feature.home.home.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import com.hedvig.android.core.common.di.AppScope
+import com.hedvig.android.logger.LogPriority
+import com.hedvig.android.logger.logcat
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+/**
+ * Remembers, per install, which ongoing shop sessions the member closed on the home screen. A
+ * dismissed session stays hidden for as long as the backend keeps returning it.
+ */
+internal interface DismissedShopSessionsStorage {
+  fun observeDismissedSessionIds(): Flow<Set<String>>
+
+  suspend fun dismiss(sessionId: String)
+}
+
+@ContributesBinding(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
+internal class DismissedShopSessionsStorageImpl(
+  private val dataStore: DataStore<Preferences>,
+) : DismissedShopSessionsStorage {
+  override fun observeDismissedSessionIds(): Flow<Set<String>> = dataStore.data
+    .map { it[KEY].orEmpty() }
+    .catch { error ->
+      // Home must still render if this local-only preference can't be read.
+      logcat(LogPriority.ERROR, error) { "Reading dismissed shop sessions failed; treating none as dismissed" }
+      emit(emptySet())
+    }
+
+  override suspend fun dismiss(sessionId: String) {
+    dataStore.edit { preferences ->
+      preferences[KEY] = preferences[KEY].orEmpty() + sessionId
+    }
+  }
+
+  companion object {
+    internal const val KEY_NAME = "com.hedvig.android.feature.home.dismissed_shop_session_ids"
+    private val KEY = stringSetPreferencesKey(KEY_NAME)
+  }
+}

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -68,9 +68,23 @@ internal class GetHomeDataUseCaseImpl(
   private val timeZone: TimeZone,
   private val getAddonBannerInfoUseCase: GetAddonBannerInfoUseCase,
   private val hasAnyActiveConversationUseCase: HasAnyActiveConversationUseCase,
+  private val dismissedShopSessionsStorage: DismissedShopSessionsStorage,
 ) : GetHomeDataUseCase {
-  @OptIn(ExperimentalCoroutinesApi::class)
   override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> {
+    return combine(
+      backendHomeData(forceNetworkFetch),
+      dismissedShopSessionsStorage.observeDismissedSessionIds(),
+    ) { homeDataResult, dismissedSessionIds ->
+      homeDataResult.map { homeData ->
+        homeData.copy(
+          ongoingShopSessions = homeData.ongoingShopSessions.filterNot { it.id in dismissedSessionIds },
+        )
+      }
+    }
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private fun backendHomeData(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> {
     return combine(
       featureManager.isFeatureEnabled(Feature.ENABLE_CLAIM_INTENT_RESUME),
       featureManager.isFeatureEnabled(Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS),

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCaseDemo.kt
@@ -12,67 +12,75 @@ import com.hedvig.android.data.contract.ImageAsset
 import com.hedvig.android.memberreminders.MemberReminders
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 @Inject
-internal class GetHomeDataUseCaseDemo : GetHomeDataUseCase {
-  override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> = flowOf(
-    HomeData(
-      contractStatus = HomeData.ContractStatus.Active,
-      claimStatusCardsData = null,
-      veryImportantMessages = listOf(),
-      memberReminders = MemberReminders(
-        connectPayment = null,
-        upcomingRenewals = null,
-        enableNotifications = null,
-      ),
-      hasUnseenChatMessages = false,
-      showHelpCenter = true,
-      firstVetSections = listOf(),
-      crossSells = CrossSellSheetData(
-        recommendedCrossSell =
-          RecommendedCrossSell(
-            crossSell = CrossSell(
-              "rh",
-              "Car Insurance",
-              "For you and your car",
-              "",
-              ImageAsset("", "", ""),
-              ImageAsset("", "", ""),
-            ),
-            bannerText = "50% discount the first year",
-            discountText = "-50%",
-            buttonText = "Explore offer",
-            buttonDescription = "Limited time offer",
-            backgroundPillowImages = null,
-            bundleProgress = null,
-          ),
-        otherCrossSells = listOf(
-          CrossSell(
-            "rf",
-            "Pet insurance",
-            "For your dog or cat",
-            "",
-            ImageAsset("", "", ""),
-            ImageAsset("", "", ""),
-          ),
-        ),
-        recommendedAddon = null,
-      ),
-      ongoingShopSessions = listOf(
-        OngoingShopSession(
-          id = "demo-session-1",
-          title = "Home + Accident",
-          subtitle = "Studio apartment, Stockholm",
-          monthlyNet = UiMoney(199.0, UiCurrencyCode.SEK),
-          resumeUrl = "https://www.hedvig.com",
-          pillowImageUrl = null,
-        ),
-      ),
-      addonBannerInfos = emptyList(),
-      showChatIcon = false,
-      firstName = "Demo",
-      draftClaim = null,
-    ).right(),
-  )
+internal class GetHomeDataUseCaseDemo(
+  private val dismissedShopSessionsStorage: DismissedShopSessionsStorage,
+) : GetHomeDataUseCase {
+  override fun invoke(forceNetworkFetch: Boolean): Flow<Either<ApolloOperationError, HomeData>> {
+    return dismissedShopSessionsStorage.observeDismissedSessionIds().map { dismissedSessionIds ->
+      demoHomeData.copy(
+        ongoingShopSessions = demoHomeData.ongoingShopSessions.filterNot { it.id in dismissedSessionIds },
+      ).right()
+    }
+  }
 }
+
+private val demoHomeData = HomeData(
+  contractStatus = HomeData.ContractStatus.Active,
+  claimStatusCardsData = null,
+  veryImportantMessages = listOf(),
+  memberReminders = MemberReminders(
+    connectPayment = null,
+    upcomingRenewals = null,
+    enableNotifications = null,
+  ),
+  hasUnseenChatMessages = false,
+  showHelpCenter = true,
+  firstVetSections = listOf(),
+  crossSells = CrossSellSheetData(
+    recommendedCrossSell =
+      RecommendedCrossSell(
+        crossSell = CrossSell(
+          "rh",
+          "Car Insurance",
+          "For you and your car",
+          "",
+          ImageAsset("", "", ""),
+          ImageAsset("", "", ""),
+        ),
+        bannerText = "50% discount the first year",
+        discountText = "-50%",
+        buttonText = "Explore offer",
+        buttonDescription = "Limited time offer",
+        backgroundPillowImages = null,
+        bundleProgress = null,
+      ),
+    otherCrossSells = listOf(
+      CrossSell(
+        "rf",
+        "Pet insurance",
+        "For your dog or cat",
+        "",
+        ImageAsset("", "", ""),
+        ImageAsset("", "", ""),
+      ),
+    ),
+    recommendedAddon = null,
+  ),
+  ongoingShopSessions = listOf(
+    OngoingShopSession(
+      id = "demo-session-1",
+      title = "Home + Accident",
+      subtitle = "Studio apartment, Stockholm",
+      monthlyNet = UiMoney(199.0, UiCurrencyCode.SEK),
+      resumeUrl = "https://www.hedvig.com",
+      pillowImageUrl = null,
+    ),
+  ),
+  addonBannerInfos = emptyList(),
+  showChatIcon = false,
+  firstName = "Demo",
+  draftClaim = null,
+)

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -1116,6 +1116,9 @@ private fun MemberRemindersSection(
 
 private val PillowSize = 48.dp
 
+/** Keeps card text clear of the dismiss button pinned to the top-right corner. */
+private val DismissButtonReservedWidth = 40.dp
+
 @Composable
 private fun QuotesSection(
   sessions: List<OngoingShopSession>,
@@ -1166,53 +1169,61 @@ private fun QuoteCard(
       .fillMaxWidth()
       .hedvigDropShadow(HedvigTheme.shapes.cornerXLarge),
   ) {
-    Column(Modifier.padding(16.dp)) {
-      Row(verticalAlignment = Alignment.CenterVertically) {
-        if (session.pillowImageUrl != null) {
-          val pillowPx = with(LocalDensity.current) { PillowSize.roundToPx() }
-          AsyncImage(
-            model = storyblokResized(session.pillowImageUrl, pillowPx),
-            contentDescription = null,
-            imageLoader = imageLoader,
-            contentScale = ContentScale.Fit,
-            modifier = Modifier.size(PillowSize),
-          )
-          Spacer(Modifier.width(12.dp))
-        }
-        Column(Modifier.weight(1f)) {
-          HedvigText(text = session.title, style = HedvigTheme.typography.bodySmall)
-          val secondary = session.monthlyNet?.let {
-            stringResource(
-              Res.string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,
-              it,
+    Box(Modifier.fillMaxWidth()) {
+      IconButton(
+        onClick = { onDismiss(session.id) },
+        modifier = Modifier.align(Alignment.TopEnd),
+      ) {
+        Icon(
+          imageVector = HedvigIcons.Close,
+          contentDescription = stringResource(Res.string.ongoing_shop_session_dismiss_offer),
+        )
+      }
+      Column(Modifier.padding(16.dp)) {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.padding(end = DismissButtonReservedWidth),
+        ) {
+          if (session.pillowImageUrl != null) {
+            val pillowPx = with(LocalDensity.current) { PillowSize.roundToPx() }
+            AsyncImage(
+              model = storyblokResized(session.pillowImageUrl, pillowPx),
+              contentDescription = null,
+              imageLoader = imageLoader,
+              contentScale = ContentScale.Fit,
+              modifier = Modifier.size(PillowSize),
             )
-          } ?: session.subtitle
+            Spacer(Modifier.width(12.dp))
+          }
+          Column(Modifier.weight(1f)) {
+            HedvigText(text = session.title, style = HedvigTheme.typography.bodySmall)
+            val secondary = session.monthlyNet?.let {
+              stringResource(
+                Res.string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,
+                it,
+              )
+            } ?: session.subtitle
 
-          if (secondary != null) {
-            HedvigText(
-              text = secondary,
-              style = HedvigTheme.typography.label,
-              color = HedvigTheme.colorScheme.textSecondary,
-            )
+            if (secondary != null) {
+              HedvigText(
+                text = secondary,
+                style = HedvigTheme.typography.label,
+                color = HedvigTheme.colorScheme.textSecondary,
+              )
+            }
           }
         }
-        IconButton(onClick = { onDismiss(session.id) }) {
-          Icon(
-            imageVector = HedvigIcons.Close,
-            contentDescription = stringResource(Res.string.ongoing_shop_session_dismiss_offer),
-          )
-        }
+        Spacer(Modifier.height(12.dp))
+        HedvigButton(
+          text = stringResource(Res.string.general_continue_button),
+          onClick = { onResumeClick(session.resumeUrl) },
+          buttonStyle = Secondary,
+          buttonSize = ButtonSize.Medium,
+          enabled = true,
+          shape = HedvigTheme.shapes.cornerFull,
+          modifier = Modifier.fillMaxWidth(),
+        )
       }
-      Spacer(Modifier.height(12.dp))
-      HedvigButton(
-        text = stringResource(Res.string.general_continue_button),
-        onClick = { onResumeClick(session.resumeUrl) },
-        buttonStyle = Secondary,
-        buttonSize = ButtonSize.Medium,
-        enabled = true,
-        shape = HedvigTheme.shapes.cornerFull,
-        modifier = Modifier.fillMaxWidth(),
-      )
     }
   }
 }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -122,6 +122,7 @@ import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HedvigTooltip
 import com.hedvig.android.design.system.hedvig.Icon
+import com.hedvig.android.design.system.hedvig.IconButton
 import com.hedvig.android.design.system.hedvig.StartClaimBottomSheet
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.TooltipDefaults
@@ -130,6 +131,7 @@ import com.hedvig.android.design.system.hedvig.TooltipDefaults.TooltipStyle.Inbo
 import com.hedvig.android.design.system.hedvig.TopAppBarLayoutForActions
 import com.hedvig.android.design.system.hedvig.api.HedvigBottomSheetState
 import com.hedvig.android.design.system.hedvig.hedvigDropShadow
+import com.hedvig.android.design.system.hedvig.icon.Close
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.HelipadOutline
 import com.hedvig.android.design.system.hedvig.icon.Reload
@@ -206,6 +208,7 @@ import hedvig.resources.general_continue_button
 import hedvig.resources.home_tab_claim_button_text
 import hedvig.resources.home_tab_get_help
 import hedvig.resources.home_tab_welcome_title_without_name
+import hedvig.resources.ongoing_shop_session_dismiss_offer
 import kotlin.math.roundToInt
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -262,6 +265,9 @@ internal fun HomeDestination(
     navigateToMissingInfo = navigateToMissingInfo,
     markMessageAsSeen = { viewModel.emit(HomeEvent.MarkMessageAsSeen(it)) },
     deleteDraftClaim = { draftId -> viewModel.emit(HomeEvent.DeleteDraftClaim(draftId)) },
+    dismissOngoingShopSession = { sessionId ->
+      viewModel.emit(HomeEvent.DismissOngoingShopSession(sessionId))
+    },
     navigateToFirstVet = navigateToFirstVet,
     markCrossSellsNotificationAsSeen = { viewModel.emit(HomeEvent.MarkCardCrossSellsAsSeen) },
     navigateToContactInfo = navigateToContactInfo,
@@ -292,6 +298,7 @@ private fun HomeScreen(
   openCrossSellUrl: (String) -> Unit,
   markMessageAsSeen: (String) -> Unit,
   deleteDraftClaim: (String) -> Unit,
+  dismissOngoingShopSession: (String) -> Unit,
   openAppSettings: () -> Unit,
   navigateToMissingInfo: (String, CoInsuredFlowType) -> Unit,
   navigateToFirstVet: (List<FirstVetSection>) -> Unit,
@@ -435,6 +442,7 @@ private fun HomeScreen(
             navigateToMissingInfo = navigateToMissingInfo,
             onNavigateToNewConversation = onNavigateToNewConversation,
             markMessageAsSeen = markMessageAsSeen,
+            dismissOngoingShopSession = dismissOngoingShopSession,
             navigateToContactInfo = navigateToContactInfo,
             navigateToChipIdScreen = navigateToChipIdScreen,
             navigateToUsageData = navigateToUsageData,
@@ -587,6 +595,7 @@ private fun HomeScreenSuccess(
   openClaimFlowSheet: () -> Unit,
   onContinueDraftClaim: () -> Unit,
   onDeleteDraftClaim: (String) -> Unit,
+  dismissOngoingShopSession: (String) -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
   markMessageAsSeen: (String) -> Unit,
@@ -896,6 +905,7 @@ private fun HomeScreenSuccess(
               QuotesSection(
                 sessions = sessions,
                 onResumeClick = openUrl,
+                onDismiss = dismissOngoingShopSession,
                 imageLoader = imageLoader,
                 horizontalInsets = horizontalInsets,
               )
@@ -1110,6 +1120,7 @@ private val PillowSize = 48.dp
 private fun QuotesSection(
   sessions: List<OngoingShopSession>,
   onResumeClick: (String) -> Unit,
+  onDismiss: (String) -> Unit,
   imageLoader: ImageLoader,
   horizontalInsets: PaddingValues,
 ) {
@@ -1131,6 +1142,7 @@ private fun QuotesSection(
       QuoteCard(
         session = session,
         onResumeClick = onResumeClick,
+        onDismiss = onDismiss,
         imageLoader = imageLoader,
         modifier = cardModifier,
       )
@@ -1142,6 +1154,7 @@ private fun QuotesSection(
 private fun QuoteCard(
   session: OngoingShopSession,
   onResumeClick: (String) -> Unit,
+  onDismiss: (String) -> Unit,
   imageLoader: ImageLoader,
   modifier: Modifier = Modifier,
 ) {
@@ -1182,6 +1195,12 @@ private fun QuoteCard(
               color = HedvigTheme.colorScheme.textSecondary,
             )
           }
+        }
+        IconButton(onClick = { onDismiss(session.id) }) {
+          Icon(
+            imageVector = HedvigIcons.Close,
+            contentDescription = stringResource(Res.string.ongoing_shop_session_dismiss_offer),
+          )
         }
       }
       Spacer(Modifier.height(12.dp))
@@ -1614,6 +1633,7 @@ private fun PreviewHomeScreen(
         navigateToMissingInfo = { _, _ -> },
         markMessageAsSeen = {},
         deleteDraftClaim = {},
+        dismissOngoingShopSession = {},
         navigateToFirstVet = {},
         markCrossSellsNotificationAsSeen = {},
         navigateToContactInfo = {},
@@ -1650,6 +1670,7 @@ private fun PreviewHomeScreenWithError() {
         navigateToMissingInfo = { _, _ -> },
         markMessageAsSeen = {},
         deleteDraftClaim = {},
+        dismissOngoingShopSession = {},
         navigateToFirstVet = {},
         markCrossSellsNotificationAsSeen = {},
         navigateToContactInfo = {},
@@ -1709,6 +1730,7 @@ private fun PreviewHomeScreenAllHomeTextTypes(
         navigateToMissingInfo = { _, _ -> },
         markMessageAsSeen = {},
         deleteDraftClaim = {},
+        dismissOngoingShopSession = {},
         navigateToFirstVet = {},
         markCrossSellsNotificationAsSeen = {},
         navigateToContactInfo = {},

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -1116,9 +1117,6 @@ private fun MemberRemindersSection(
 
 private val PillowSize = 48.dp
 
-/** Keeps card text clear of the dismiss button pinned to the top-right corner. */
-private val DismissButtonReservedWidth = 40.dp
-
 @Composable
 private fun QuotesSection(
   sessions: List<OngoingShopSession>,
@@ -1169,21 +1167,9 @@ private fun QuoteCard(
       .fillMaxWidth()
       .hedvigDropShadow(HedvigTheme.shapes.cornerXLarge),
   ) {
-    Box(Modifier.fillMaxWidth()) {
-      IconButton(
-        onClick = { onDismiss(session.id) },
-        modifier = Modifier.align(Alignment.TopEnd),
-      ) {
-        Icon(
-          imageVector = HedvigIcons.Close,
-          contentDescription = stringResource(Res.string.ongoing_shop_session_dismiss_offer),
-        )
-      }
-      Column(Modifier.padding(16.dp)) {
-        Row(
-          verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier.padding(end = DismissButtonReservedWidth),
-        ) {
+    Box(Modifier.fillMaxWidth().padding(16.dp)) {
+      Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
           if (session.pillowImageUrl != null) {
             val pillowPx = with(LocalDensity.current) { PillowSize.roundToPx() }
             AsyncImage(
@@ -1211,6 +1197,18 @@ private fun QuoteCard(
                 color = HedvigTheme.colorScheme.textSecondary,
               )
             }
+          }
+          IconButton(
+            onClick = { onDismiss(session.id) },
+            modifier = Modifier
+              .align(Alignment.Top)
+              .size(24.dp)
+              .wrapContentSize(unbounded = true),
+          ) {
+            Icon(
+              imageVector = HedvigIcons.Close,
+              contentDescription = stringResource(Res.string.ongoing_shop_session_dismiss_offer),
+            )
           }
         }
         Spacer(Modifier.height(12.dp))
@@ -1714,6 +1712,16 @@ private fun PreviewHomeScreenAllHomeTextTypes(
             enableNotifications = null,
             coInsuredInfo = null,
             updateContactInfo = null,
+          ),
+          ongoingShopSessions = listOf(
+            OngoingShopSession(
+              id = "session-id",
+              title = "Title",
+              subtitle = null,
+              monthlyNet = null,
+              resumeUrl = "",
+              pillowImageUrl = null,
+            ),
           ),
           isHelpCenterEnabled = false,
           quickActions = previewQuickActions,

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -212,6 +212,7 @@ import hedvig.resources.home_tab_welcome_title_without_name
 import hedvig.resources.ongoing_shop_session_dismiss_offer
 import kotlin.math.roundToInt
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.delay
@@ -543,8 +544,8 @@ private fun ColumnScope.CrossSellsTooltip(uiState: Success, setEpochDayWhenLastT
       if (shouldSetEpochDayWhenLastToolTipShown) {
         val today = Clock.System.now().toLocalDateTime(
           TimeZone.currentSystemDefault(),
-        ).date.toEpochDays().toLong()
-        delay(5000)
+        ).date.toEpochDays()
+        delay(5000.milliseconds)
         setEpochDayWhenLastToolTipShown(today)
       }
     }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenter.kt
@@ -17,6 +17,7 @@ import com.hedvig.android.crosssells.CrossSellSheetData
 import com.hedvig.android.data.addons.data.AddonBannerInfo
 import com.hedvig.android.data.claimintent.DeleteClaimIntentDraftUseCase
 import com.hedvig.android.data.contract.CrossSell
+import com.hedvig.android.feature.home.home.data.DismissedShopSessionsStorage
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
 import com.hedvig.android.feature.home.home.data.HomeData
 import com.hedvig.android.feature.home.home.data.OngoingShopSession
@@ -48,6 +49,7 @@ internal class HomePresenter(
   private val isProduction: Boolean,
   private val deleteClaimIntentDraftUseCase: DeleteClaimIntentDraftUseCase,
   private val getMemberQuickActionsUseCase: GetMemberQuickActionsUseCase,
+  private val dismissedShopSessionsStorage: DismissedShopSessionsStorage,
 ) : MoleculePresenter<HomeEvent, HomeUiState> {
   @Composable
   override fun MoleculePresenterScope<HomeEvent>.present(lastState: HomeUiState): HomeUiState {
@@ -77,6 +79,12 @@ internal class HomePresenter(
 
         is HomeEvent.CrossSellToolTipShown -> {
           crossSellToolTipShownEpochDay = homeEvent.epochDay
+        }
+
+        is HomeEvent.DismissOngoingShopSession -> {
+          applicationScope.launch {
+            dismissedShopSessionsStorage.dismiss(homeEvent.sessionId)
+          }
         }
 
         is HomeEvent.DeleteDraftClaim -> {
@@ -193,6 +201,8 @@ internal sealed interface HomeEvent {
   data class CrossSellToolTipShown(val epochDay: Long) : HomeEvent
 
   data class DeleteDraftClaim(val draftId: String) : HomeEvent
+
+  data class DismissOngoingShopSession(val sessionId: String) : HomeEvent
 }
 
 internal sealed interface HomeUiState {

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeViewModel.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeViewModel.kt
@@ -5,6 +5,7 @@ import com.hedvig.android.core.common.ApplicationScope
 import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.HedvigViewModel
 import com.hedvig.android.data.claimintent.DeleteClaimIntentDraftUseCase
+import com.hedvig.android.feature.home.home.data.DismissedShopSessionsStorage
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
 import com.hedvig.android.feature.home.home.data.SeenImportantMessagesStorage
 import com.hedvig.android.memberquickactions.GetMemberQuickActionsUseCase
@@ -22,6 +23,7 @@ internal class HomeViewModel(
   hedvigBuildConstants: HedvigBuildConstants,
   deleteClaimIntentDraftUseCase: DeleteClaimIntentDraftUseCase,
   getMemberQuickActionsUseCase: GetMemberQuickActionsUseCase,
+  dismissedShopSessionsStorage: DismissedShopSessionsStorage,
 ) : MoleculeViewModel<HomeEvent, HomeUiState>(
     HomeUiState.Loading,
     HomePresenter(
@@ -32,5 +34,6 @@ internal class HomeViewModel(
       hedvigBuildConstants.isProduction,
       deleteClaimIntentDraftUseCase,
       getMemberQuickActionsUseCase,
+      dismissedShopSessionsStorage,
     ),
   )

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/DismissedShopSessionsStorageTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/DismissedShopSessionsStorageTest.kt
@@ -1,0 +1,76 @@
+package com.hedvig.android.feature.home.home.data
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEmpty
+import com.hedvig.android.core.datastore.TestPreferencesDataStore
+import com.hedvig.android.logger.TestLogcatLoggingRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DismissedShopSessionsStorageTest {
+  @get:Rule
+  val testLogcatLogger = TestLogcatLoggingRule()
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  @Test
+  fun `nothing is dismissed to begin with`() = runTest {
+    val storage = DismissedShopSessionsStorageImpl(testDataStore())
+
+    assertThat(storage.observeDismissedSessionIds().first()).isEmpty()
+  }
+
+  @Test
+  fun `a dismissed session id is observable`() = runTest {
+    val storage = DismissedShopSessionsStorageImpl(testDataStore())
+
+    storage.dismiss("session-1")
+
+    assertThat(storage.observeDismissedSessionIds().first()).containsExactlyInAnyOrder("session-1")
+  }
+
+  @Test
+  fun `dismissing a second session keeps the first one`() = runTest {
+    val storage = DismissedShopSessionsStorageImpl(testDataStore())
+
+    storage.dismiss("session-1")
+    storage.dismiss("session-2")
+
+    assertThat(storage.observeDismissedSessionIds().first())
+      .containsExactlyInAnyOrder("session-1", "session-2")
+  }
+
+  @Test
+  fun `dismissals are kept in the data store rather than in memory`() = runTest {
+    val dataStore = testDataStore()
+    DismissedShopSessionsStorageImpl(dataStore).dismiss("session-1")
+
+    val freshStorage = DismissedShopSessionsStorageImpl(dataStore)
+
+    assertThat(freshStorage.observeDismissedSessionIds().first()).containsExactlyInAnyOrder("session-1")
+  }
+
+  @Test
+  fun `a value of the wrong type under the key reads as nothing dismissed`() = runTest {
+    val dataStore = testDataStore()
+    // An older build of this feature stored a String under a key of this name.
+    dataStore.edit { it[stringPreferencesKey(DismissedShopSessionsStorageImpl.KEY_NAME)] = "not-a-set" }
+
+    val dismissed = DismissedShopSessionsStorageImpl(dataStore).observeDismissedSessionIds().first()
+
+    assertThat(dismissed).isEmpty()
+  }
+
+  private fun TestScope.testDataStore() = TestPreferencesDataStore(
+    datastoreTestFileDirectory = testFolder.newFolder("datastoreTempFolder"),
+    coroutineScope = backgroundScope,
+  )
+}

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/FakeDismissedShopSessionsStorage.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/FakeDismissedShopSessionsStorage.kt
@@ -1,0 +1,21 @@
+package com.hedvig.android.feature.home.home.data
+
+import app.cash.turbine.Turbine
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+internal class FakeDismissedShopSessionsStorage(
+  dismissedSessionIds: Set<String> = emptySet(),
+) : DismissedShopSessionsStorage {
+  val dismissedSessionIds = MutableStateFlow(dismissedSessionIds)
+  val dismissedIdsTurbine = Turbine<String>()
+
+  override fun observeDismissedSessionIds(): Flow<Set<String>> = dismissedSessionIds.asStateFlow()
+
+  override suspend fun dismiss(sessionId: String) {
+    dismissedSessionIds.update { it + sessionId }
+    dismissedIdsTurbine.add(sessionId)
+  }
+}

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/data/GetHomeUseCaseTest.kt
@@ -127,6 +127,7 @@ internal class GetHomeUseCaseTest {
       TimeZone.UTC,
       getAddonBannerInfoUseCase = travelBannerUseCase,
       HasAnyActiveConversationUseCase(apolloClient),
+      FakeDismissedShopSessionsStorage(),
     )
     val testId = "test"
 
@@ -176,6 +177,7 @@ internal class GetHomeUseCaseTest {
       TimeZone.UTC,
       travelBannerUseCase,
       HasAnyActiveConversationUseCase(apolloClient),
+      FakeDismissedShopSessionsStorage(),
     )
 
     testGetMemberRemindersUseCase.memberReminders.add(MemberReminders())
@@ -925,12 +927,55 @@ internal class GetHomeUseCaseTest {
       .isEmpty()
   }
 
+  @Test
+  fun `dismissed ongoing shop sessions are filtered out`() = runTest {
+    val featureManager = FakeFeatureManager(
+      mapOf(
+        Feature.ENABLE_NEW_CONVERSATION_FROM_INBOX to false,
+        Feature.ENABLE_CLAIM_INTENT_RESUME to false,
+        Feature.DISABLE_RESUMING_ONGOING_SHOP_SESSIONS to false,
+      ),
+    )
+    val getHomeDataUseCase = testUseCaseWithoutReminders(
+      featureManager = featureManager,
+      dismissedShopSessionsStorage = FakeDismissedShopSessionsStorage(setOf("dismissed-session")),
+    )
+
+    apolloClient.registerTestResponse(
+      HomeQuery(true, false, false),
+      HomeQuery.Data(OctopusFakeResolver) {
+        currentMember = buildMember {
+          ongoingShopSessions = listOf(
+            buildShopSession { id = "dismissed-session" },
+            buildShopSession { id = "kept-session" },
+          )
+        }
+      },
+    )
+    apolloClient.registerTestResponse(UnreadMessageCountQuery(), UnreadMessageCountQuery.Data(OctopusFakeResolver))
+    apolloClient.registerTestResponse(
+      CbmNumberOfChatMessagesQuery(),
+      CbmNumberOfChatMessagesQuery.Data(OctopusFakeResolver),
+    )
+
+    val result = getHomeDataUseCase.invoke(true).first()
+
+    assertThat(result)
+      .isNotNull()
+      .isRight()
+      .prop(HomeData::ongoingShopSessions)
+      .single()
+      .prop(OngoingShopSession::id)
+      .isEqualTo("kept-session")
+  }
+
   // Used as a convenience to get a use case without any enqueued apollo responses, but some sane defaults for the
   // other dependencies
   private fun testUseCaseWithoutReminders(
     featureManager: FeatureManager = FakeFeatureManager(true),
     testClock: TestClock = TestClock(),
     timeZone: TimeZone = TimeZone.UTC,
+    dismissedShopSessionsStorage: DismissedShopSessionsStorage = FakeDismissedShopSessionsStorage(),
   ): GetHomeDataUseCase {
     return GetHomeDataUseCaseImpl(
       apolloClient,
@@ -940,6 +985,7 @@ internal class GetHomeUseCaseTest {
       timeZone,
       travelBannerUseCase,
       HasAnyActiveConversationUseCase(apolloClient),
+      dismissedShopSessionsStorage,
     )
   }
 }

--- a/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenterTest.kt
+++ b/app/feature/feature-home/src/test/kotlin/com/hedvig/android/feature/home/home/ui/HomePresenterTest.kt
@@ -25,6 +25,7 @@ import com.hedvig.android.crosssells.RecommendedCrossSell
 import com.hedvig.android.data.claimintent.DeleteClaimIntentDraftUseCase
 import com.hedvig.android.data.contract.CrossSell
 import com.hedvig.android.data.contract.ImageAsset
+import com.hedvig.android.feature.home.home.data.FakeDismissedShopSessionsStorage
 import com.hedvig.android.feature.home.home.data.GetHomeDataUseCase
 import com.hedvig.android.feature.home.home.data.HomeData
 import com.hedvig.android.feature.home.home.data.OngoingShopSession
@@ -107,6 +108,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -136,6 +138,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -163,6 +166,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -244,6 +248,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     val addonOnlyCrossSells = CrossSellSheetData(null, listOf(), testAddon)
 
@@ -288,6 +293,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -344,6 +350,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -370,6 +377,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -410,6 +418,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     homePresenter.test(HomeUiState.Loading) {
@@ -462,6 +471,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     val firstVet = FirstVetSection(
       buttonTitle = "ButtonTitle",
@@ -521,6 +531,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     val crossSell = CrossSell(
       id = "id",
@@ -587,6 +598,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
@@ -638,6 +650,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
@@ -689,6 +702,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     val otherCrossSell = CrossSell(
       id = "other",
@@ -729,6 +743,7 @@ internal class HomePresenterTest {
       false,
       deleteClaimIntentDraftUseCase,
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
@@ -758,6 +773,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
@@ -786,6 +802,7 @@ internal class HomePresenterTest {
       false,
       deleteClaimIntentDraftUseCase,
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
@@ -827,6 +844,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(quickActions.right()),
+      FakeDismissedShopSessionsStorage(),
     )
     homePresenter.test(HomeUiState.Loading) {
       assertThat(awaitItem()).isInstanceOf<HomeUiState.Loading>()
@@ -891,6 +909,7 @@ internal class HomePresenterTest {
       false,
       TestDeleteClaimIntentDraftUseCase(),
       FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      FakeDismissedShopSessionsStorage(),
     )
 
     val session = OngoingShopSession(
@@ -912,6 +931,30 @@ internal class HomePresenterTest {
         .isInstanceOf<HomeUiState.Success>()
         .prop(HomeUiState.Success::ongoingShopSessions)
         .containsExactly(session)
+    }
+  }
+
+  @Test
+  fun `dismissing an ongoing shop session persists the dismissal`() = runTest {
+    val dismissedShopSessionsStorage = FakeDismissedShopSessionsStorage()
+    val homePresenter = HomePresenter(
+      TestGetHomeDataUseCase(),
+      SeenImportantMessagesStorageImpl(),
+      FakeCrossSellHomeNotificationService(),
+      ApplicationScope(backgroundScope),
+      false,
+      TestDeleteClaimIntentDraftUseCase(),
+      FakeGetMemberQuickActionsUseCase(emptyList<QuickAction>().right()),
+      dismissedShopSessionsStorage,
+    )
+
+    homePresenter.test(HomeUiState.Loading) {
+      assertThat(awaitItem()).isEqualTo(HomeUiState.Loading)
+
+      sendEvent(HomeEvent.DismissOngoingShopSession("session-1"))
+
+      assertThat(dismissedShopSessionsStorage.dismissedIdsTurbine.awaitItem()).isEqualTo("session-1")
+      cancelAndIgnoreRemainingEvents()
     }
   }
 


### PR DESCRIPTION
## What

Adds a close button to each Your quotes card. A dismissed session id is kept in DataStore, so the card stays gone across restarts for as long as the backend keeps returning that session.

This revives work from `makerdays/expose-existing-shop-sessions`, which predates the Metro and Nav3 migration and cannot be rebased (1184 commits behind, 17 conflicts, five of them against files the migration deleted). The Your quotes section itself already landed separately; dismissal was the one capability that never did.

Previously this sat on top of #3094, which added client side expiry filtering and ordering. That is closed: storefront already filters expired sessions and orders most recent first, so it was redundant.

## How

The dismissed set is applied by combining it with the backend home data rather than becoming a seventh arm of the query `combine`, which already needed a local 6 arity helper. This keeps a local only concern separate from what the backend returned, so the existing `invoke` body moved unchanged into a private `backendHomeData()`.

`stringSetPreferencesKey` means no JSON encoding of the id set, so the original branch's serializer and decode handling are unnecessary.

Dismissals are not pruned. They are a handful of UUIDs per member, so cleanup would be speculative.

Dismissal is permanent per install, with no undo. That is a settled product decision, not an oversight.

## Two things a device found that tests could not

Worth a reviewer's attention, because green tests said nothing about either.

An earlier build of this feature stored a `String` under a preference key of a very similar name. On a device that had run it, reading a key of that name as a typed `Set` threw `ClassCastException`, that exception propagated through the `combine`, and it took down the whole home screen: no Home query, blank content, ANR. So the key here is deliberately named `dismissed_shop_session_ids`, and **the old `dismissed_ongoing_shop_sessions` name must not be reused**. An unreadable value is also treated as nothing dismissed, so a local only preference can never break home again.

A clean install was fine throughout, which is why the unit tests and a passing DI check all missed it.

Note the trade in that guard: `catch` terminates the upstream, so after a read failure the flow emits `emptySet()` once and completes. Home keeps rendering, which is the point, but dismissals would not visibly apply again until the flow is re-collected.

## Testing

`DismissedShopSessionsStorageTest` covers the DataStore round trip, accumulation, that state lives in the store rather than in memory, and the wrong type case above (which reproduces the exact device `ClassCastException`). `GetHomeUseCaseTest` covers filtering out a dismissed session, `HomePresenterTest` covers persistence on the event. 108 tests green in `feature-home`.

Verified on a physical device with two synthetic sessions injected into the real path, since my account returns no ongoing shop sessions:

* card renders in the carousel with title, price, close button and Continue
* tapping close removes that card and leaves the other, and does not trigger the card's own resume tap
* after `force-stop` and relaunch it is still dismissed, and the id is in the DataStore file

## Dismiss button placement

Settled: the button is pinned to the card's top-right corner (second commit).

Worth noting for anyone reading the diff, since I got this wrong first time round: aligning it to the top of the header row does nothing, because its 48dp interactive size already matches the 48dp pillow image that drives the row's height. It has to come out of the row into a `Box` aligned `TopEnd`, with horizontal room reserved so a long title cannot run under it. Verified on device with and without a pillow image, and it now sits in the same place either way.

Not covered by tests: the button itself, since this module has no Compose tests.

## a11y
- [x] if these are UI changes - check for their accessibility

The close button is a design system `IconButton`, so it gets the 48dp minimum touch target, and its `contentDescription` is the existing Lokalise string `ongoing_shop_session_dismiss_offer`.
