### PR TITLE
Feat/add analytics member reminder

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
@@ -54,6 +54,7 @@ import com.hedvig.android.feature.payments.navigation.paymentsEntries
 import com.hedvig.android.feature.payoutaccount.navigation.PayoutAccountKey
 import com.hedvig.android.feature.payoutaccount.navigation.payoutAccountEntries
 import com.hedvig.android.feature.profile.navigation.ContactInfoKey
+import com.hedvig.android.feature.profile.navigation.UsageDataKey
 import com.hedvig.android.feature.profile.tab.profileEntries
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceKey
 import com.hedvig.android.feature.terminateinsurance.navigation.terminateInsuranceEntries
@@ -291,6 +292,7 @@ private fun EntryProviderScope<HedvigNavKey>.addHomeEntries(
       )
     },
     navigateToChipIdScreen = { backstack.add(ChipIdKey()) },
+    navigateToUsageData = { backstack.add(UsageDataKey) },
     openAppSettings = externalNavigator::openAppSettings,
     openUrl = openUrl,
     openCrossSellUrl = openCrossSellUrl,

--- a/app/app/src/test/kotlin/com/hedvig/android/app/navigation/ExhaustiveBackStackSerializationTest.kt
+++ b/app/app/src/test/kotlin/com/hedvig/android/app/navigation/ExhaustiveBackStackSerializationTest.kt
@@ -22,6 +22,7 @@ import com.hedvig.android.feature.payments.navigation.PaymentsKey
 import com.hedvig.android.feature.payoutaccount.navigation.PayoutAccountKey
 import com.hedvig.android.feature.profile.navigation.ContactInfoKey
 import com.hedvig.android.feature.profile.navigation.ProfileKey
+import com.hedvig.android.feature.profile.navigation.UsageDataKey
 import com.hedvig.android.feature.terminateinsurance.navigation.TerminateInsuranceKey
 import com.hedvig.android.feature.travelcertificate.navigation.TravelCertificateKey
 import com.hedvig.android.navigation.common.HedvigNavKey
@@ -270,6 +271,7 @@ internal class ExhaustiveBackstackSerializationTest {
       PaymentsKey,
       ProfileKey,
       ContactInfoKey,
+      UsageDataKey,
       LoginKey,
       HelpCenterKey,
       DeleteAccountKey,

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -152,6 +152,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Ange byggår</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Byggår</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">Du + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Det nya försäkringsbeloppet börjar gälla efter att kvalificeringstiden passerat. Ditt nuvarande belopp gäller som vanligt under tiden.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Ändra utbetalningskonto</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Ändra skyddsnivå</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Chatta med en specialist</string>
@@ -260,6 +261,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">Om du inte minns inköpsdatum behöver du inte fylla i något.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Saknas</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Hoppa över</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Ungefär hur länge stod barnvagnen där innan du märkte att den var borta?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">Ett dygn eller mer</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Över natten</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Var barnvagnen låst? Berätta gärna med egna ord, t.ex. vilket lås du använde.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Skicka in ditt skadeärende</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Gå till ärende</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Ditt ärende har skickats in</string>
@@ -517,6 +524,7 @@
   <string name="HOME_TODO_PAYMENT_OVERDUE_TITLE">Din betalning är försenad</string>
   <string name="HOME_TODO_REQUIRES_ACTION_SUBTITLE">Kräver åtgärd</string>
   <string name="HOME_TODO_SECTION_TITLE">Att göra</string>
+  <string name="HOME_TODO_SELECT_USAGE_DATA_TITLE">Välj hantering av användningsdata</string>
   <string name="HOME_TODO_UPDATE_CONTACT_DETAILS_TITLE">Uppdatera kontaktuppgifter</string>
   <string name="HONESTY_PLEDGE_DESCRIPTION">Hedvig bygger på tillit. Jag lovar att berätta vad som hände precis som det var och bara begära den ersättning jag har rätt till.</string>
   <string name="HONESTY_PLEDGE_HEADER">Anmäl skada</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -152,6 +152,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Please enter year of construction</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Year of construction</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">You + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Your updated amount will take effect after your qualification period. Your current amount remains active during this period.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Change payout account</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Change coverage level</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Talk to a human</string>
@@ -260,6 +261,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">If you don\'t remember the purchase date, you don\'t need to fill in anything.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Skipped</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Skip</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Roughly how long had the stroller been there before you noticed it was gone?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">A day or more</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Overnight</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Was the stroller locked? Tell us in your own words, e.g. what kind of lock you used.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Submit your claim</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Go to claim</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Your claim was submitted successfully</string>
@@ -517,6 +524,7 @@
   <string name="HOME_TODO_PAYMENT_OVERDUE_TITLE">Your payment is overdue</string>
   <string name="HOME_TODO_REQUIRES_ACTION_SUBTITLE">Requires action</string>
   <string name="HOME_TODO_SECTION_TITLE">To do</string>
+  <string name="HOME_TODO_SELECT_USAGE_DATA_TITLE">Select usage data handling</string>
   <string name="HOME_TODO_UPDATE_CONTACT_DETAILS_TITLE">Update contact details</string>
   <string name="HONESTY_PLEDGE_DESCRIPTION">Hedvig is based on trust. I solemnly swear to recite the event as it was and only claim the compensation I’m entitled to.</string>
   <string name="HONESTY_PLEDGE_HEADER">Make a claim</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -151,6 +151,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Ange byggår</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Byggår</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">Du + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Det nya försäkringsbeloppet börjar gälla efter att kvalificeringstiden passerat. Ditt nuvarande belopp gäller som vanligt under tiden.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Ändra utbetalningskonto</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Ändra skyddsnivå</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Chatta med en specialist</string>
@@ -259,6 +260,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">Om du inte minns inköpsdatum behöver du inte fylla i något.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Saknas</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Hoppa över</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Ungefär hur länge stod barnvagnen där innan du märkte att den var borta?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">Ett dygn eller mer</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Över natten</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 timmar</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Var barnvagnen låst? Berätta gärna med egna ord, t.ex. vilket lås du använde.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Skicka in ditt skadeärende</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Gå till ärende</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Ditt ärende har skickats in</string>
@@ -516,6 +523,7 @@
   <string name="HOME_TODO_PAYMENT_OVERDUE_TITLE">Din betalning är försenad</string>
   <string name="HOME_TODO_REQUIRES_ACTION_SUBTITLE">Kräver åtgärd</string>
   <string name="HOME_TODO_SECTION_TITLE">Att göra</string>
+  <string name="HOME_TODO_SELECT_USAGE_DATA_TITLE">Välj hantering av användningsdata</string>
   <string name="HOME_TODO_UPDATE_CONTACT_DETAILS_TITLE">Uppdatera kontaktuppgifter</string>
   <string name="HONESTY_PLEDGE_DESCRIPTION">Hedvig bygger på tillit. Jag lovar att berätta vad som hände precis som det var och bara begära den ersättning jag har rätt till.</string>
   <string name="HONESTY_PLEDGE_HEADER">Anmäl skada</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -151,6 +151,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR">Please enter year of construction</string>
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Year of construction</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">You + %1$d</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Your updated amount will take effect after your qualification period. Your current amount remains active during this period.</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Change payout account</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Change coverage level</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Talk to a human</string>
@@ -259,6 +260,12 @@
   <string name="CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT">If you don't remember the purchase date, you don't need to fill in anything.</string>
   <string name="CLAIM_CHAT_SKIPPED_STEP">Skipped</string>
   <string name="CLAIM_CHAT_SKIP_STEP">Skip</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE">Roughly how long had the stroller been there before you noticed it was gone?</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE">A day or more</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT">Overnight</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS">2-8 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS">Under 2 hours</string>
+  <string name="CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE">Was the stroller locked? Tell us in your own words, e.g. what kind of lock you used.</string>
   <string name="CLAIM_CHAT_SUBMIT_CLAIM">Submit your claim</string>
   <string name="CLAIM_CHAT_SUCCESS_GO_TO_CLAIM">Go to claim</string>
   <string name="CLAIM_CHAT_SUCCESS_MESSAGE">Your claim was submitted successfully</string>
@@ -516,6 +523,7 @@
   <string name="HOME_TODO_PAYMENT_OVERDUE_TITLE">Your payment is overdue</string>
   <string name="HOME_TODO_REQUIRES_ACTION_SUBTITLE">Requires action</string>
   <string name="HOME_TODO_SECTION_TITLE">To do</string>
+  <string name="HOME_TODO_SELECT_USAGE_DATA_TITLE">Select usage data handling</string>
   <string name="HOME_TODO_UPDATE_CONTACT_DETAILS_TITLE">Update contact details</string>
   <string name="HONESTY_PLEDGE_DESCRIPTION">Hedvig is based on trust. I solemnly swear to recite the event as it was and only claim the compensation I’m entitled to.</string>
   <string name="HONESTY_PLEDGE_HEADER">Make a claim</string>

--- a/app/data/data-settings-datastore/data-settings-datastore-public/build.gradle.kts
+++ b/app/data/data-settings-datastore/data-settings-datastore-public/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   implementation(libs.androidx.datastore.preferencesCore)
   implementation(libs.coroutines.core)
   implementation(projects.coreCommonPublic)
+  implementation(projects.featureFlags)
   implementation(projects.theme)
   testImplementation(libs.assertK)
   testImplementation(libs.coroutines.test)

--- a/app/data/data-settings-datastore/data-settings-datastore-public/src/main/kotlin/com/hedvig/android/data/settings/datastore/GetAnalyticsConsentUseCase.kt
+++ b/app/data/data-settings-datastore/data-settings-datastore-public/src/main/kotlin/com/hedvig/android/data/settings/datastore/GetAnalyticsConsentUseCase.kt
@@ -1,0 +1,37 @@
+package com.hedvig.android.data.settings.datastore
+
+import com.hedvig.android.core.common.di.AppScope
+import com.hedvig.android.featureflags.FeatureManager
+import com.hedvig.android.featureflags.flags.Feature
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+/**
+ * The single read path for the member's analytics consent, so every screen that surfaces the
+ * decision is gated by the same kill switch instead of each one remembering to check the flag.
+ */
+interface GetAnalyticsConsentUseCase {
+  /**
+   * The member's [AnalyticsConsent], or null while [Feature.DISABLE_ANALYTICS] is on: the member is
+   * never asked for a decision then, so there is nothing to show or act on.
+   */
+  fun invoke(): Flow<AnalyticsConsent?>
+}
+
+@ContributesBinding(AppScope::class)
+@Inject
+internal class GetAnalyticsConsentUseCaseImpl(
+  private val settingsDataStore: SettingsDataStore,
+  private val featureManager: FeatureManager,
+) : GetAnalyticsConsentUseCase {
+  override fun invoke(): Flow<AnalyticsConsent?> {
+    return combine(
+      featureManager.isFeatureEnabled(Feature.DISABLE_ANALYTICS),
+      settingsDataStore.observeAnalyticsConsent(),
+    ) { analyticsDisabled, consent ->
+      consent.takeIf { !analyticsDisabled }
+    }
+  }
+}

--- a/app/data/data-settings-datastore/data-settings-datastore-test/src/main/kotlin/com/hedvig/android/data/settings/datastore/FakeGetAnalyticsConsentUseCase.kt
+++ b/app/data/data-settings-datastore/data-settings-datastore-test/src/main/kotlin/com/hedvig/android/data/settings/datastore/FakeGetAnalyticsConsentUseCase.kt
@@ -1,0 +1,14 @@
+package com.hedvig.android.core.datastore
+
+import com.hedvig.android.data.settings.datastore.AnalyticsConsent
+import com.hedvig.android.data.settings.datastore.GetAnalyticsConsentUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeGetAnalyticsConsentUseCase(
+  initialConsent: AnalyticsConsent? = AnalyticsConsent.NOT_DECIDED,
+) : GetAnalyticsConsentUseCase {
+  val consent = MutableStateFlow(initialConsent)
+
+  override fun invoke(): Flow<AnalyticsConsent?> = consent
+}

--- a/app/feature/feature-chip-id/src/main/kotlin/com/hedvig/android/feature/chip/id/ui/selectinsurance/SelectInsuranceForChipIdDestination.kt
+++ b/app/feature/feature-chip-id/src/main/kotlin/com/hedvig/android/feature/chip/id/ui/selectinsurance/SelectInsuranceForChipIdDestination.kt
@@ -103,7 +103,7 @@ private fun SelectInsuranceForChipIdScreen(
       HedvigScaffold(
         navigateUp = navigateUp,
       ) {
-        HedvigErrorSection(onButtonClick = reload, modifier = Modifier.padding(16.dp))
+        HedvigErrorSection(onButtonClick = reload, modifier = Modifier.weight(1f))
       }
     }
 

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeEntries.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/navigation/HomeEntries.kt
@@ -31,6 +31,7 @@ fun EntryProviderScope<HedvigNavKey>.homeEntries(
   navigateToQuickLink: (QuickLinkDestination) -> Unit,
   navigateToClaimChat: (resumeClaim: Boolean) -> Unit,
   navigateToChipIdScreen: () -> Unit,
+  navigateToUsageData: () -> Unit,
   openAppSettings: () -> Unit,
   openUrl: (String) -> Unit,
   openCrossSellUrl: (String) -> Unit,
@@ -69,6 +70,7 @@ fun EntryProviderScope<HedvigNavKey>.homeEntries(
       },
       imageLoader = imageLoader,
       navigateToChipId = navigateToChipIdScreen,
+      navigateToUsageData = dropUnlessResumed { navigateToUsageData() },
       navigateToAddonPurchaseFlow = dropUnlessResumed { ids -> navigateToAddonPurchaseFlow(ids) },
     )
   }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -238,6 +238,7 @@ internal fun HomeDestination(
   navigateToFirstVet: (List<FirstVetSection>) -> Unit,
   navigateToContactInfo: () -> Unit,
   navigateToChipId: () -> Unit,
+  navigateToUsageData: () -> Unit,
   imageLoader: ImageLoader,
   navigateToAddonPurchaseFlow: (List<String>) -> Unit,
 ) {
@@ -265,6 +266,7 @@ internal fun HomeDestination(
     markCrossSellsNotificationAsSeen = { viewModel.emit(HomeEvent.MarkCardCrossSellsAsSeen) },
     navigateToContactInfo = navigateToContactInfo,
     navigateToChipIdScreen = navigateToChipId,
+    navigateToUsageData = navigateToUsageData,
     setEpochDayWhenLastToolTipShown = { epochDay ->
       viewModel.emit(HomeEvent.CrossSellToolTipShown(epochDay))
     },
@@ -295,6 +297,7 @@ private fun HomeScreen(
   navigateToFirstVet: (List<FirstVetSection>) -> Unit,
   navigateToContactInfo: () -> Unit,
   navigateToChipIdScreen: () -> Unit,
+  navigateToUsageData: () -> Unit,
   markCrossSellsNotificationAsSeen: () -> Unit,
   setEpochDayWhenLastToolTipShown: (Long) -> Unit,
   imageLoader: ImageLoader,
@@ -434,6 +437,7 @@ private fun HomeScreen(
             markMessageAsSeen = markMessageAsSeen,
             navigateToContactInfo = navigateToContactInfo,
             navigateToChipIdScreen = navigateToChipIdScreen,
+            navigateToUsageData = navigateToUsageData,
             openCrossSellUrl = openCrossSellUrl,
             imageLoader = imageLoader,
             navigateToAddonPurchaseFlow = navigateToAddonPurchaseFlow,
@@ -590,6 +594,7 @@ private fun HomeScreenSuccess(
   onNavigateToNewConversation: () -> Unit,
   navigateToContactInfo: () -> Unit,
   navigateToChipIdScreen: () -> Unit,
+  navigateToUsageData: () -> Unit,
   openCrossSellUrl: (String) -> Unit,
   imageLoader: ImageLoader,
   navigateToAddonPurchaseFlow: (List<String>) -> Unit,
@@ -883,6 +888,7 @@ private fun HomeScreenSuccess(
               onNavigateToNewConversation = onNavigateToNewConversation,
               navigateToContactInfo = navigateToContactInfo,
               navigateToChipIdScreen = navigateToChipIdScreen,
+              navigateToUsageData = navigateToUsageData,
               horizontalInsets = horizontalInsets,
             )
 
@@ -1065,6 +1071,7 @@ private fun MemberRemindersSection(
   onNavigateToNewConversation: () -> Unit,
   navigateToContactInfo: () -> Unit,
   navigateToChipIdScreen: () -> Unit,
+  navigateToUsageData: () -> Unit,
   horizontalInsets: PaddingValues,
 ) {
   val toDoReminders = applicableReminders.homeActionRequiredReminders()
@@ -1090,6 +1097,7 @@ private fun MemberRemindersSection(
           onNavigateToNewConversation = onNavigateToNewConversation,
           navigateToContactInfo = navigateToContactInfo,
           navigateToChipId = navigateToChipIdScreen,
+          navigateToUsageData = navigateToUsageData,
         )
       }
     }
@@ -1610,6 +1618,7 @@ private fun PreviewHomeScreen(
         markCrossSellsNotificationAsSeen = {},
         navigateToContactInfo = {},
         navigateToChipIdScreen = {},
+        navigateToUsageData = {},
         setEpochDayWhenLastToolTipShown = {},
         imageLoader = rememberPreviewImageLoader(),
         navigateToAddonPurchaseFlow = {},
@@ -1645,6 +1654,7 @@ private fun PreviewHomeScreenWithError() {
         markCrossSellsNotificationAsSeen = {},
         navigateToContactInfo = {},
         navigateToChipIdScreen = {},
+        navigateToUsageData = {},
         setEpochDayWhenLastToolTipShown = {},
         imageLoader = rememberPreviewImageLoader(),
         navigateToAddonPurchaseFlow = {},
@@ -1703,6 +1713,7 @@ private fun PreviewHomeScreenAllHomeTextTypes(
         markCrossSellsNotificationAsSeen = {},
         navigateToContactInfo = {},
         navigateToChipIdScreen = {},
+        navigateToUsageData = {},
         setEpochDayWhenLastToolTipShown = {},
         imageLoader = rememberPreviewImageLoader(),
         navigateToAddonPurchaseFlow = {},

--- a/app/feature/feature-onboarding/build.gradle.kts
+++ b/app/feature/feature-onboarding/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
   testImplementation(libs.coroutines.test)
   testImplementation(libs.junit)
   testImplementation(libs.turbine)
+  testImplementation(projects.dataSettingsDatastoreTest)
   testImplementation(projects.featureFlagsTest)
   testImplementation(projects.loggingTest)
   testImplementation(projects.moleculeTest)

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingSessionStore.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingSessionStore.kt
@@ -8,9 +8,8 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.coinsured.CoInsuredFlowType
+import com.hedvig.android.data.settings.datastore.GetAnalyticsConsentUseCase
 import com.hedvig.android.feature.onboarding.navigation.OnboardingStepId
-import com.hedvig.android.featureflags.FeatureManager
-import com.hedvig.android.featureflags.flags.Feature
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -49,7 +48,7 @@ internal class OnboardingMemberIdProviderImpl(
 internal class OnboardingSessionStore(
   private val onboardingRepository: OnboardingRepository,
   private val memberIdProvider: OnboardingMemberIdProvider,
-  private val featureManager: FeatureManager,
+  private val getAnalyticsConsentUseCase: GetAnalyticsConsentUseCase,
 ) {
   private val mutex = Mutex()
   private var cachedSession: OnboardingSession? = null
@@ -64,14 +63,15 @@ internal class OnboardingSessionStore(
       if (cached.memberId == currentMemberId) return@withLock cached.right()
     }
     cachedSession = null
+    // A null consent means analytics consent is switched off, so the step has nothing to ask.
     // Read once, here, because this is the only place a path is built: it keeps the flag from
     // reshuffling the path mid-flow, the same guarantee refreshData() upholds for the data.
-    val analyticsDisabled = featureManager.isFeatureEnabled(Feature.DISABLE_ANALYTICS).first()
+    val analyticsConsentEnabled = getAnalyticsConsentUseCase.invoke().first() != null
     onboardingRepository.getOnboardingData().map { data ->
       OnboardingSession(
         memberId = currentMemberId,
         data = data,
-        path = buildOnboardingPath(data, showAnalyticsConsent = !analyticsDisabled),
+        path = buildOnboardingPath(data, showAnalyticsConsent = analyticsConsentEnabled),
         // Capture which contracts each step owns from the first data, so completed rows stay pinned
         // as "done" instead of vanishing once a later refresh no longer lists them as missing.
         pinnedPetIdContractIds = data.contractsWithMissingPetId.map { it.id },

--- a/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/FakeOnboardingRepository.kt
+++ b/app/feature/feature-onboarding/src/test/kotlin/com/hedvig/android/feature/onboarding/FakeOnboardingRepository.kt
@@ -3,6 +3,8 @@ package com.hedvig.android.feature.onboarding
 import app.cash.turbine.Turbine
 import arrow.core.Either
 import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.core.datastore.FakeGetAnalyticsConsentUseCase
+import com.hedvig.android.data.settings.datastore.AnalyticsConsent
 import com.hedvig.android.feature.onboarding.data.OnboardingContract
 import com.hedvig.android.feature.onboarding.data.OnboardingCrossSell
 import com.hedvig.android.feature.onboarding.data.OnboardingData
@@ -11,8 +13,6 @@ import com.hedvig.android.feature.onboarding.data.OnboardingPayinStatus
 import com.hedvig.android.feature.onboarding.data.OnboardingReferralInformation
 import com.hedvig.android.feature.onboarding.data.OnboardingRepository
 import com.hedvig.android.feature.onboarding.data.OnboardingSessionStore
-import com.hedvig.android.featureflags.flags.Feature
-import com.hedvig.android.featureflags.test.FakeFeatureManager
 import kotlinx.coroutines.flow.flowOf
 
 internal class FakeOnboardingMemberIdProvider(var memberId: String? = "test-member-id") : OnboardingMemberIdProvider {
@@ -45,7 +45,9 @@ internal fun testSessionStore(
 ) = OnboardingSessionStore(
   onboardingRepository = repository,
   memberIdProvider = memberIdProvider,
-  featureManager = FakeFeatureManager(mapOf(Feature.DISABLE_ANALYTICS to analyticsDisabled)),
+  getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(
+    initialConsent = AnalyticsConsent.NOT_DECIDED.takeIf { !analyticsDisabled },
+  ),
 )
 
 internal fun testOnboardingData(

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/navigation/ProfileDestinations.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/navigation/ProfileDestinations.kt
@@ -30,4 +30,4 @@ internal data object LicensesKey : HedvigNavKey
 internal data object SettingsKey : HedvigNavKey
 
 @Serializable
-internal data object UsageDataKey : HedvigNavKey
+data object UsageDataKey : HedvigNavKey

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsDestination.kt
@@ -178,23 +178,26 @@ private fun SettingsScreen(
           enabled = true,
           hasError = uiState.emailSubscriptionPreferenceError,
         )
-        Spacer(Modifier.height(4.dp))
-        HedvigBigCard(
-          onClick = onNavigateToUsageData,
-          inputText = when (uiState.analyticsConsent) {
-            AnalyticsConsent.GRANTED -> stringResource(Res.string.GENERAL_ENABLED)
+        val analyticsConsent = uiState.analyticsConsent
+        if (analyticsConsent != null) {
+          Spacer(Modifier.height(4.dp))
+          HedvigBigCard(
+            onClick = onNavigateToUsageData,
+            inputText = when (analyticsConsent) {
+              AnalyticsConsent.GRANTED -> stringResource(Res.string.GENERAL_ENABLED)
 
-            AnalyticsConsent.DENIED -> stringResource(Res.string.GENERAL_DISABLED)
+              AnalyticsConsent.DENIED -> stringResource(Res.string.GENERAL_DISABLED)
 
-            // No explicit choice made yet: nothing is forwarded to Firebase, but this is shown
-            // as distinct from an explicit "Disabled".
-            AnalyticsConsent.NOT_DECIDED, null -> stringResource(Res.string.not_selected)
-          },
-          labelText = stringResource(Res.string.SETTINGS_USAGE_DATA_TITLE),
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        )
+              // No explicit choice made yet: nothing is forwarded to Firebase, but this is shown
+              // as distinct from an explicit "Disabled".
+              AnalyticsConsent.NOT_DECIDED -> stringResource(Res.string.not_selected)
+            },
+            labelText = stringResource(Res.string.SETTINGS_USAGE_DATA_TITLE),
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(horizontal = 16.dp),
+          )
+        }
         Spacer(Modifier.height(16.dp))
 
         AnimatedVisibility(

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsPresenter.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsPresenter.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import com.hedvig.android.apollo.NetworkCacheManager
 import com.hedvig.android.apollo.auth.listeners.UploadLanguagePreferenceToBackendUseCase
 import com.hedvig.android.data.settings.datastore.AnalyticsConsent
+import com.hedvig.android.data.settings.datastore.GetAnalyticsConsentUseCase
 import com.hedvig.android.data.settings.datastore.SettingsDataStore
 import com.hedvig.android.feature.profile.data.ChangeEmailSubscriptionPreferencesUseCase
 import com.hedvig.android.language.Language
@@ -26,6 +27,7 @@ internal class SettingsPresenter(
   private val cacheManager: NetworkCacheManager,
   private val changeEmailSubscriptionPreferencesUseCase: ChangeEmailSubscriptionPreferencesUseCase,
   private val uploadLanguagePreferenceToBackendUseCase: UploadLanguagePreferenceToBackendUseCase,
+  private val getAnalyticsConsentUseCase: GetAnalyticsConsentUseCase,
 ) : MoleculePresenter<SettingsEvent, SettingsUiState> {
   @Composable
   override fun MoleculePresenterScope<SettingsEvent>.present(lastState: SettingsUiState): SettingsUiState {
@@ -39,7 +41,7 @@ internal class SettingsPresenter(
       .timeToShowNotificationReminder()
       .collectAsState(lastState.showNotificationReminder)
       .value
-    val analyticsConsent = settingsDataStore.observeAnalyticsConsent()
+    val analyticsConsent = getAnalyticsConsentUseCase.invoke()
       .collectAsState(lastState.analyticsConsent).value
 
     CollectEvents { event ->
@@ -97,6 +99,8 @@ sealed interface SettingsUiState {
   val selectedTheme: Theme?
   val isSubscribedToEmails: Boolean?
   val showNotificationReminder: Boolean?
+
+  /** Null while analytics consent is switched off, in which case the usage data row is not offered. */
   val analyticsConsent: AnalyticsConsent?
   val languageOptions: List<Language>
     get() = Language.entries

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsViewModel.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import com.hedvig.android.apollo.NetworkCacheManager
 import com.hedvig.android.apollo.auth.listeners.UploadLanguagePreferenceToBackendUseCase
 import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.HedvigViewModel
+import com.hedvig.android.data.settings.datastore.GetAnalyticsConsentUseCase
 import com.hedvig.android.data.settings.datastore.SettingsDataStore
 import com.hedvig.android.feature.profile.data.ChangeEmailSubscriptionPreferencesUseCase
 import com.hedvig.android.language.LanguageService
@@ -20,6 +21,7 @@ internal class SettingsViewModel(
   enableNotificationsReminderSnoozeManager: EnableNotificationsReminderSnoozeManager,
   cacheManager: NetworkCacheManager,
   uploadLanguagePreferenceToBackendUseCase: UploadLanguagePreferenceToBackendUseCase,
+  getAnalyticsConsentUseCase: GetAnalyticsConsentUseCase,
 ) : MoleculeViewModel<SettingsEvent, SettingsUiState>(
     SettingsUiState.Loading(selectedLanguage = languageService.getLanguage()),
     SettingsPresenter(
@@ -29,5 +31,6 @@ internal class SettingsViewModel(
       cacheManager = cacheManager,
       uploadLanguagePreferenceToBackendUseCase = uploadLanguagePreferenceToBackendUseCase,
       changeEmailSubscriptionPreferencesUseCase = changeEmailSubscriptionPreferencesUseCase,
+      getAnalyticsConsentUseCase = getAnalyticsConsentUseCase,
     ),
   )

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/ProfileDestination.kt
@@ -73,6 +73,7 @@ import com.hedvig.android.design.system.hedvig.icon.Settings
 import com.hedvig.android.design.system.hedvig.placeholder.hedvigPlaceholder
 import com.hedvig.android.design.system.hedvig.placeholder.shimmer
 import com.hedvig.android.memberreminders.ui.MemberReminderCards
+import com.hedvig.android.memberreminders.ui.cardReminders
 import com.hedvig.android.notification.permission.NotificationPermissionDialog
 import com.hedvig.android.notification.permission.rememberNotificationPermissionState
 import com.hedvig.android.placeholder.PlaceholderHighlight
@@ -216,8 +217,9 @@ private fun ProfileScreen(
       NotificationPermissionDialog(notificationPermissionState, openAppSettings)
       val consumedWindowInsets = remember { MutableWindowInsets() }
       if (uiState is ProfileUiState.Success) {
-        val memberReminders =
-          uiState.memberReminders.onlyApplicableReminders(notificationPermissionState.status.isGranted)
+        val memberReminders = uiState.memberReminders
+          .onlyApplicableReminders(notificationPermissionState.status.isGranted)
+          .cardReminders()
         val padding = PaddingValues(horizontal = 16.dp) + WindowInsets.safeDrawing
           .exclude(consumedWindowInsets)
           .only(WindowInsetsSides.Horizontal)

--- a/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/settings/SettingsPresenterTest.kt
+++ b/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/settings/SettingsPresenterTest.kt
@@ -7,7 +7,9 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.hedvig.android.apollo.auth.listeners.UploadLanguagePreferenceToBackendUseCase
+import com.hedvig.android.core.datastore.FakeGetAnalyticsConsentUseCase
 import com.hedvig.android.core.datastore.FakeSettingsDataStore
+import com.hedvig.android.data.settings.datastore.AnalyticsConsent
 import com.hedvig.android.feature.NoopNetworkCacheManager
 import com.hedvig.android.feature.profile.data.ChangeEmailSubscriptionPreferencesUseCase
 import com.hedvig.android.feature.profile.data.SubPrefError
@@ -31,6 +33,7 @@ class SettingsPresenterTest {
       NoopNetworkCacheManager,
       uploadLanguagePreferenceToBackendUseCase = NoopUploadLanguagePreferenceToBackendUseCase(),
       changeEmailSubscriptionPreferencesUseCase = NoopChangeEmailSubscriptionPreferencesUseCase(),
+      getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(),
     )
 
     settingsPresenter.test(
@@ -54,6 +57,7 @@ class SettingsPresenterTest {
       NoopNetworkCacheManager,
       uploadLanguagePreferenceToBackendUseCase = NoopUploadLanguagePreferenceToBackendUseCase(),
       changeEmailSubscriptionPreferencesUseCase = NoopChangeEmailSubscriptionPreferencesUseCase(),
+      getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(),
     )
 
     settingsPresenter.test(
@@ -63,7 +67,7 @@ class SettingsPresenterTest {
         Theme.SYSTEM_DEFAULT,
         false,
         isSubscribedToEmails = false,
-        analyticsConsent = null,
+        analyticsConsent = AnalyticsConsent.NOT_DECIDED,
       ),
     ) {
       assertThat(awaitItem().showNotificationReminder).isEqualTo(false)
@@ -82,6 +86,7 @@ class SettingsPresenterTest {
       NoopNetworkCacheManager,
       uploadLanguagePreferenceToBackendUseCase = NoopUploadLanguagePreferenceToBackendUseCase(),
       changeEmailSubscriptionPreferencesUseCase = NoopChangeEmailSubscriptionPreferencesUseCase(),
+      getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(),
     )
 
     settingsPresenter.test(
@@ -91,7 +96,7 @@ class SettingsPresenterTest {
         Theme.SYSTEM_DEFAULT,
         false,
         isSubscribedToEmails = false,
-        analyticsConsent = null,
+        analyticsConsent = AnalyticsConsent.NOT_DECIDED,
       ),
     ) {
       assertThat(awaitItem().showNotificationReminder).isEqualTo(false)
@@ -110,6 +115,7 @@ class SettingsPresenterTest {
       NoopNetworkCacheManager,
       uploadLanguagePreferenceToBackendUseCase = NoopUploadLanguagePreferenceToBackendUseCase(),
       changeEmailSubscriptionPreferencesUseCase = NoopChangeEmailSubscriptionPreferencesUseCase(),
+      getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(),
     )
 
     settingsPresenter.test(
@@ -119,7 +125,7 @@ class SettingsPresenterTest {
         Theme.entries.first(),
         false,
         isSubscribedToEmails = false,
-        analyticsConsent = null,
+        analyticsConsent = AnalyticsConsent.NOT_DECIDED,
       ),
     ) {
       enableNotificationsReminderManager.snoozeNotificationReminderCalls.expectNoEvents()
@@ -140,6 +146,7 @@ class SettingsPresenterTest {
       NoopNetworkCacheManager,
       uploadLanguagePreferenceToBackendUseCase = NoopUploadLanguagePreferenceToBackendUseCase(),
       changeEmailSubscriptionPreferencesUseCase = NoopChangeEmailSubscriptionPreferencesUseCase(),
+      getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(),
     )
 
     settingsPresenter.test(
@@ -149,7 +156,7 @@ class SettingsPresenterTest {
         selectedTheme = Theme.LIGHT,
         showNotificationReminder = false,
         isSubscribedToEmails = false,
-        analyticsConsent = null,
+        analyticsConsent = AnalyticsConsent.NOT_DECIDED,
       ),
     ) {
       assertThat(awaitItem().selectedTheme).isEqualTo(Theme.LIGHT)

--- a/app/member-reminders/member-reminders-public/build.gradle.kts
+++ b/app/member-reminders/member-reminders-public/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation(projects.coreDemoMode)
   implementation(projects.dataContract)
   implementation(projects.dataPayingMember)
+  implementation(projects.dataSettingsDatastorePublic)
   implementation(projects.featureFlags)
 
   testImplementation(libs.apollo.annotations)
@@ -40,6 +41,7 @@ dependencies {
   testImplementation(projects.apolloTest)
   testImplementation(projects.coreCommonTest)
   testImplementation(projects.coreDatastoreTest)
+  testImplementation(projects.dataSettingsDatastoreTest)
   testImplementation(projects.featureFlagsTest)
   testImplementation(projects.loggingTest)
   testImplementation(projects.memberRemindersTest)

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCase.kt
@@ -6,6 +6,8 @@ import arrow.core.merge
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.data.coinsured.CoInsuredFlowType
+import com.hedvig.android.data.settings.datastore.AnalyticsConsent
+import com.hedvig.android.data.settings.datastore.GetAnalyticsConsentUseCase
 import com.hedvig.android.memberreminders.MemberReminder.ContactInfoUpdateNeeded
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -31,6 +33,7 @@ internal class GetMemberRemindersUseCaseImpl(
   private val getNeedsCoInsuredInfoRemindersUseCase: GetNeedsCoInsuredInfoRemindersUseCase,
   private val getContactInfoUpdateIsNeededUseCase: GetContactInfoUpdateIsNeededUseCase,
   private val getMissingChipIdReminderUseCase: GetMissingChipIdReminderUseCase,
+  private val getAnalyticsConsentUseCase: GetAnalyticsConsentUseCase,
 ) : GetMemberRemindersUseCase {
   override fun invoke(): Flow<MemberReminders> {
     return combine(
@@ -66,6 +69,9 @@ internal class GetMemberRemindersUseCaseImpl(
       getNeedsCoInsuredInfoRemindersUseCase.invoke(),
       getContactInfoUpdateIsNeededUseCase.invoke(),
       getMissingChipIdReminderUseCase.invoke(),
+      getAnalyticsConsentUseCase.invoke().map { consent ->
+        if (consent == AnalyticsConsent.NOT_DECIDED) MemberReminder.DecideAnalyticsConsent() else null
+      },
     ) { values ->
       val enableNotifications = values[0] as MemberReminder.EnableNotifications?
       val connectPayment = values[1] as MemberReminder.PaymentReminder?
@@ -74,6 +80,7 @@ internal class GetMemberRemindersUseCaseImpl(
         values[3] as? Either<CoInsuredInfoReminderError, NonEmptyList<MemberReminder.CoInsuredInfo>>
       val contactInfoReminder = values[4] as? Either<ErrorMessage, ContactInfoUpdateNeeded?>
       val missingChipIdReminder = values[5] as? Either<ErrorMessage, MemberReminder.MissingChipId?>
+      val decideAnalyticsConsent = values[6] as MemberReminder.DecideAnalyticsConsent?
 
       MemberReminders(
         connectPayment = connectPayment,
@@ -82,6 +89,7 @@ internal class GetMemberRemindersUseCaseImpl(
         coInsuredInfo = coInsuredInfoResult?.getOrNull(),
         updateContactInfo = contactInfoReminder?.getOrNull(),
         missingChipId = missingChipIdReminder?.getOrNull(),
+        decideAnalyticsConsent = decideAnalyticsConsent,
       )
     }
   }
@@ -94,6 +102,7 @@ data class MemberReminders(
   val coInsuredInfo: List<MemberReminder.CoInsuredInfo>? = null,
   val updateContactInfo: ContactInfoUpdateNeeded? = null,
   val missingChipId: MemberReminder.MissingChipId? = null,
+  val decideAnalyticsConsent: MemberReminder.DecideAnalyticsConsent? = null,
 ) {
   /**
    * In some cases a reminder may be present but may not be applicable in our current app state.
@@ -120,6 +129,9 @@ data class MemberReminders(
         addAll(it)
       }
       updateContactInfo?.let {
+        add(it)
+      }
+      decideAnalyticsConsent?.let {
         add(it)
       }
     }
@@ -166,6 +178,14 @@ sealed interface MemberReminder {
   }
 
   data class MissingChipId(
+    override val id: String = UUID.randomUUID().toString(),
+  ) : MemberReminder
+
+  /**
+   * The member has not answered the analytics-consent question yet. Offered only as a row in the
+   * home "To do" list, so it has no reminder card.
+   */
+  data class DecideAnalyticsConsent(
     override val id: String = UUID.randomUUID().toString(),
   ) : MemberReminder
 }

--- a/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCaseTest.kt
+++ b/app/member-reminders/member-reminders-public/src/test/kotlin/com/hedvig/android/memberreminders/GetMemberRemindersUseCaseTest.kt
@@ -15,7 +15,9 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isNullOrEmpty
 import com.hedvig.android.core.common.ErrorMessage
+import com.hedvig.android.core.datastore.FakeGetAnalyticsConsentUseCase
 import com.hedvig.android.data.coinsured.CoInsuredFlowType
+import com.hedvig.android.data.settings.datastore.AnalyticsConsent
 import com.hedvig.android.memberreminders.MemberReminder.CoInsuredInfo
 import com.hedvig.android.memberreminders.MemberReminder.UpcomingRenewal
 import com.hedvig.android.memberreminders.test.TestEnableNotificationsReminderSnoozeManager
@@ -35,6 +37,7 @@ class GetMemberRemindersUseCaseTest {
     val getNeedsCoInsuredInfoRemindersUseCase = TestGetNeedsCoInsuredInfoRemindersUseCase()
     val getContactInfoUpdateIsNeededUseCase = TestGetContactInfoUpdateIsNeededUseCase()
     val getMissingChipIdReminderUseCase = TestGetMissingChipIdReminderUseCase()
+    val getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(initialConsent = null)
     val getMemberRemindersUseCase = GetMemberRemindersUseCaseImpl(
       enableNotificationsReminderSnoozeManager = enableNotificationsReminderManager,
       getConnectPaymentReminderUseCase = getConnectPaymentReminderUseCase,
@@ -42,6 +45,7 @@ class GetMemberRemindersUseCaseTest {
       getNeedsCoInsuredInfoRemindersUseCase = getNeedsCoInsuredInfoRemindersUseCase,
       getContactInfoUpdateIsNeededUseCase = getContactInfoUpdateIsNeededUseCase,
       getMissingChipIdReminderUseCase = getMissingChipIdReminderUseCase,
+      getAnalyticsConsentUseCase = getAnalyticsConsentUseCase,
     )
 
     getMemberRemindersUseCase.invoke().test {
@@ -69,6 +73,7 @@ class GetMemberRemindersUseCaseTest {
     val getNeedsCoInsuredInfoRemindersUseCase = TestGetNeedsCoInsuredInfoRemindersUseCase()
     val getContactInfoUpdateIsNeededUseCase = TestGetContactInfoUpdateIsNeededUseCase()
     val getMissingChipIdReminderUseCase = TestGetMissingChipIdReminderUseCase()
+    val getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(initialConsent = null)
     val getMemberRemindersUseCase = GetMemberRemindersUseCaseImpl(
       enableNotificationsReminderSnoozeManager = enableNotificationsReminderManager,
       getConnectPaymentReminderUseCase = getConnectPaymentReminderUseCase,
@@ -76,6 +81,7 @@ class GetMemberRemindersUseCaseTest {
       getNeedsCoInsuredInfoRemindersUseCase = getNeedsCoInsuredInfoRemindersUseCase,
       getContactInfoUpdateIsNeededUseCase = getContactInfoUpdateIsNeededUseCase,
       getMissingChipIdReminderUseCase = getMissingChipIdReminderUseCase,
+      getAnalyticsConsentUseCase = getAnalyticsConsentUseCase,
     )
     val testId = "test"
 
@@ -101,6 +107,41 @@ class GetMemberRemindersUseCaseTest {
             )
         }
       }
+    }
+  }
+
+  @Test
+  fun `the analytics consent reminder shows only while the consent is undecided`() = runTest {
+    val enableNotificationsReminderManager = TestEnableNotificationsReminderSnoozeManager()
+    val getConnectPaymentReminderUseCase = TestGetConnectPaymentReminderUseCase()
+    val getUpcomingRenewalRemindersUseCase = TestGetUpcomingRenewalRemindersUseCase()
+    val getNeedsCoInsuredInfoRemindersUseCase = TestGetNeedsCoInsuredInfoRemindersUseCase()
+    val getContactInfoUpdateIsNeededUseCase = TestGetContactInfoUpdateIsNeededUseCase()
+    val getMissingChipIdReminderUseCase = TestGetMissingChipIdReminderUseCase()
+    val getAnalyticsConsentUseCase = FakeGetAnalyticsConsentUseCase(initialConsent = AnalyticsConsent.NOT_DECIDED)
+    val getMemberRemindersUseCase = GetMemberRemindersUseCaseImpl(
+      enableNotificationsReminderSnoozeManager = enableNotificationsReminderManager,
+      getConnectPaymentReminderUseCase = getConnectPaymentReminderUseCase,
+      getUpcomingRenewalRemindersUseCase = getUpcomingRenewalRemindersUseCase,
+      getNeedsCoInsuredInfoRemindersUseCase = getNeedsCoInsuredInfoRemindersUseCase,
+      getContactInfoUpdateIsNeededUseCase = getContactInfoUpdateIsNeededUseCase,
+      getMissingChipIdReminderUseCase = getMissingChipIdReminderUseCase,
+      getAnalyticsConsentUseCase = getAnalyticsConsentUseCase,
+    )
+
+    getMemberRemindersUseCase.invoke().test {
+      enableNotificationsReminderManager.showNotification.add(false)
+      getConnectPaymentReminderUseCase.turbine.add(ConnectPaymentReminderError.DomainError.AlreadySetup.left())
+      getUpcomingRenewalRemindersUseCase.turbine.add(UpcomingRenewalReminderError.NoUpcomingRenewals.left())
+      getNeedsCoInsuredInfoRemindersUseCase.turbine.add(CoInsuredInfoReminderError.NoCoInsuredReminders.left())
+      assertThat(awaitItem().decideAnalyticsConsent).isNotNull()
+
+      getAnalyticsConsentUseCase.consent.value = AnalyticsConsent.GRANTED
+      assertThat(awaitItem().decideAnalyticsConsent).isNull()
+
+      // Null stands for the analytics consent kill switch being on, which must not bring it back.
+      getAnalyticsConsentUseCase.consent.value = null
+      assertThat(awaitItem().decideAnalyticsConsent).isNull()
     }
   }
 

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderCards.kt
@@ -38,6 +38,7 @@ import hedvig.resources.CONTRACT_COINSURED_MISSING_INFO_TEXT
 import hedvig.resources.CONTRACT_COOWNERS_MISSING_INFO_TEXT
 import hedvig.resources.CONTRACT_VIEW_CERTIFICATE_BUTTON
 import hedvig.resources.DASHBOARD_RENEWAL_PROMPTER_BODY
+import hedvig.resources.HOME_TODO_SELECT_USAGE_DATA_TITLE
 import hedvig.resources.MISSING_CONTACT_INFO_CARD_BUTTON
 import hedvig.resources.MISSING_CONTACT_INFO_CARD_TEXT
 import hedvig.resources.PAYOUT_ADD_PAYOUT_METHOD
@@ -96,6 +97,10 @@ fun getMemberReminderMessage(reminder: MemberReminder): String {
     is MemberReminder.MissingChipId -> {
       stringResource(Res.string.CHIP_ID_MISSING_MESSAGE)
     }
+
+    is MemberReminder.DecideAnalyticsConsent -> {
+      stringResource(Res.string.HOME_TODO_SELECT_USAGE_DATA_TITLE)
+    }
   }
 }
 
@@ -138,16 +143,17 @@ fun MemberReminderCards(
   modifier: Modifier = Modifier,
 ) {
   Column(modifier) {
-    if (memberReminders.isEmpty()) return@Column
+    val cardReminders = memberReminders.cardReminders()
+    if (cardReminders.isEmpty()) return@Column
     // Every card is given the line count of the longest message, so that swiping between them
     // doesn't change the height of the carousel.
     BoxWithConstraints(Modifier.fillMaxWidth()) {
       val minLineCount = rememberMaxLineCountForReminders(
-        memberReminders = memberReminders,
+        memberReminders = cardReminders,
         maxWidthPx = constraints.maxWidth,
       )
       CardCarousel(
-        items = memberReminders,
+        items = cardReminders,
         contentPadding = contentPadding,
         key = { reminder -> reminder.id },
         indicatorColor = HedvigTheme.colorScheme.fillPrimary,
@@ -169,6 +175,15 @@ fun MemberReminderCards(
       }
     }
   }
+}
+
+/**
+ * The reminders [MemberReminderCards] actually renders. A reminder offered only elsewhere would
+ * otherwise take up an empty page in the carousel, so callers deciding whether to surround the
+ * carousel with anything should ask this first.
+ */
+fun List<MemberReminder>.cardReminders(): List<MemberReminder> {
+  return filter { it !is MemberReminder.DecideAnalyticsConsent }
 }
 
 @Composable
@@ -267,6 +282,9 @@ private fun MemberReminderCard(
         modifier = modifier,
       )
     }
+
+    // Filtered out by [cardReminders] before reaching here; the home "To do" list is where it is offered.
+    is MemberReminder.DecideAnalyticsConsent -> {}
   }
 }
 

--- a/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderToDoList.kt
+++ b/app/member-reminders/member-reminders-ui/src/main/kotlin/com/hedvig/android/memberreminders/ui/MemberReminderToDoList.kt
@@ -36,6 +36,7 @@ import com.hedvig.android.design.system.hedvig.hedvigDropShadow
 import com.hedvig.android.design.system.hedvig.horizontalDivider
 import com.hedvig.android.design.system.hedvig.icon.Card
 import com.hedvig.android.design.system.hedvig.icon.ChevronRight
+import com.hedvig.android.design.system.hedvig.icon.EQ
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.ID
 import com.hedvig.android.design.system.hedvig.icon.InfoOutline
@@ -49,6 +50,7 @@ import hedvig.resources.HOME_TODO_MISSING_PAYMENT_METHOD_TITLE
 import hedvig.resources.HOME_TODO_MISSING_PAYOUT_METHOD_TITLE
 import hedvig.resources.HOME_TODO_PAYMENT_OVERDUE_TITLE
 import hedvig.resources.HOME_TODO_REQUIRES_ACTION_SUBTITLE
+import hedvig.resources.HOME_TODO_SELECT_USAGE_DATA_TITLE
 import hedvig.resources.HOME_TODO_UPDATE_CONTACT_DETAILS_TITLE
 import hedvig.resources.Res
 import hedvig.resources.open_chat
@@ -73,6 +75,7 @@ fun MemberReminderToDoList(
   onNavigateToNewConversation: () -> Unit,
   navigateToContactInfo: () -> Unit,
   navigateToChipId: () -> Unit,
+  navigateToUsageData: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   var showMissedPaymentsDialog by rememberSaveable { mutableStateOf(false) }
@@ -94,6 +97,7 @@ fun MemberReminderToDoList(
       onShowMissedPaymentsDialog = { showMissedPaymentsDialog = true },
       navigateToContactInfo = navigateToContactInfo,
       navigateToChipId = navigateToChipId,
+      navigateToUsageData = navigateToUsageData,
     )
   }
   if (rows.isEmpty()) return
@@ -144,6 +148,7 @@ private fun MemberReminder.homeToDoOrder(): Int? = when (this) {
   is MemberReminder.MissingChipId -> 3
   is MemberReminder.CoInsuredInfo -> 4
   is MemberReminder.ContactInfoUpdateNeeded -> 5
+  is MemberReminder.DecideAnalyticsConsent -> 6
   is MemberReminder.UpcomingRenewal -> null
   is MemberReminder.EnableNotifications -> null
 }
@@ -179,6 +184,7 @@ private fun MemberReminder.toToDoRowOrNull(
   onShowMissedPaymentsDialog: () -> Unit,
   navigateToContactInfo: () -> Unit,
   navigateToChipId: () -> Unit,
+  navigateToUsageData: () -> Unit,
 ): ToDoRowData? = when (this) {
   is MemberReminder.PaymentReminder.TerminationDueToMissedPayments -> ToDoRowData(
     icon = HedvigIcons.WarningOutline,
@@ -223,6 +229,13 @@ private fun MemberReminder.toToDoRowOrNull(
     iconTint = ToDoRowIconTint.Primary,
     title = Res.string.HOME_TODO_UPDATE_CONTACT_DETAILS_TITLE,
     onClick = navigateToContactInfo,
+  )
+
+  is MemberReminder.DecideAnalyticsConsent -> ToDoRowData(
+    icon = HedvigIcons.EQ,
+    iconTint = ToDoRowIconTint.Primary,
+    title = Res.string.HOME_TODO_SELECT_USAGE_DATA_TITLE,
+    onClick = navigateToUsageData,
   )
 
   is MemberReminder.UpcomingRenewal -> null
@@ -324,6 +337,7 @@ private fun PreviewMemberReminderToDoList() {
           MemberReminder.CoInsuredInfo("contractId", CoInsuredFlowType.CoInsured),
           MemberReminder.CoInsuredInfo("contractId", CoInsuredFlowType.CoOwners),
           MemberReminder.ContactInfoUpdateNeeded,
+          MemberReminder.DecideAnalyticsConsent(),
         ),
         navigateToConnectPayment = {},
         navigateToConnectPayout = {},
@@ -331,6 +345,7 @@ private fun PreviewMemberReminderToDoList() {
         onNavigateToNewConversation = {},
         navigateToContactInfo = {},
         navigateToChipId = {},
+        navigateToUsageData = {},
         modifier = Modifier.padding(16.dp),
       )
     }


### PR DESCRIPTION
We need a new todo at the Home Screen if analytics consent is not set. [slack](https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1787730467958479) [figma](https://www.figma.com/design/SogcacjzOxkCC46XcZP8lQ/App-P2-2026?node-id=612-1302&m=dev)
Also, the analytics consent entry point in Settings was not guarded by the new feature flag.

- added a new GetAnalyticsConsentUseCase, use it in 3 places: Onboarding, Home, Settings
- added a new MemberReminder.DecideAnalyticsConsent