### PR TITLE
Give every onboarding button the same haptic tick

### DIFF
--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingContractCard.kt
@@ -100,7 +100,7 @@ internal fun OnboardingContractCard(
         } else {
           HedvigButton(
             text = stringResource(Res.string.ONBOARDING_ADD_BUTTON),
-            onClick = onAddClick,
+            onClick = withOnboardingHaptic(onAddClick),
             enabled = true,
             buttonStyle = ButtonDefaults.ButtonStyle.Primary,
             buttonSize = ButtonDefaults.ButtonSize.Small,

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingHaptics.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingHaptics.kt
@@ -1,0 +1,24 @@
+package com.hedvig.android.feature.onboarding.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+
+/**
+ * [onClick] with the tick every tappable thing in onboarding gives.
+ *
+ * Wrapping the click rather than exposing the feedback on its own means a control cannot be wired up
+ * with the click but without the tick: the flow is meant to feel the same throughout, and the buttons
+ * that do not go through [OnboardingStepButtons] have no other reason to remember it.
+ *
+ * [HapticFeedbackType.LongPress] rather than a lighter type because it is the sharper tick, and the
+ * one the flow has used since haptics were added to it.
+ */
+@Composable
+internal fun withOnboardingHaptic(onClick: () -> Unit): () -> Unit {
+  val hapticFeedback = LocalHapticFeedback.current
+  return {
+    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+    onClick()
+  }
+}

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/OnboardingStepScaffold.kt
@@ -34,8 +34,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -268,14 +266,10 @@ internal fun ColumnScope.OnboardingStepButtons(
     )
   }
   Spacer(Modifier.height(16.dp))
-  val hapticFeedback = LocalHapticFeedback.current
   val primaryButton = @Composable {
     HedvigButton(
       text = primaryText,
-      onClick = {
-        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-        onPrimaryClick()
-      },
+      onClick = withOnboardingHaptic(onPrimaryClick),
       enabled = primaryEnabled,
       modifier = Modifier
         .fillMaxWidth()
@@ -287,10 +281,7 @@ internal fun ColumnScope.OnboardingStepButtons(
     @Composable {
       HedvigButton(
         text = secondaryText,
-        onClick = {
-          hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-          onSecondaryClick()
-        },
+        onClick = withOnboardingHaptic(onSecondaryClick),
         enabled = true,
         buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
         modifier = Modifier

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/bundle/OnboardingBundleDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/bundle/OnboardingBundleDestination.kt
@@ -52,6 +52,7 @@ import com.hedvig.android.feature.onboarding.ui.OnboardingStepButtons
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepHeader
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepScaffold
 import com.hedvig.android.feature.onboarding.ui.progressFor
+import com.hedvig.android.feature.onboarding.ui.withOnboardingHaptic
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
@@ -251,7 +252,7 @@ private fun OnboardingCrossSellRow(
     Spacer(Modifier.width(16.dp))
     HedvigButton(
       text = stringResource(Res.string.ONBOARDING_SEE_PRICE_BUTTON),
-      onClick = { openUrl(crossSell.storeUrl) },
+      onClick = withOnboardingHaptic { openUrl(crossSell.storeUrl) },
       enabled = true,
       buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
       buttonSize = ButtonDefaults.ButtonSize.Small,

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/consent/OnboardingConsentDestination.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/consent/OnboardingConsentDestination.kt
@@ -51,6 +51,7 @@ import com.hedvig.android.feature.onboarding.ui.OnboardingProgressBarAnimation
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepHeader
 import com.hedvig.android.feature.onboarding.ui.OnboardingStepScaffold
 import com.hedvig.android.feature.onboarding.ui.progressFor
+import com.hedvig.android.feature.onboarding.ui.withOnboardingHaptic
 import com.hedvig.android.molecule.public.MoleculePresenter
 import com.hedvig.android.molecule.public.MoleculePresenterScope
 import com.hedvig.android.molecule.public.MoleculeViewModel
@@ -304,7 +305,7 @@ private fun OnboardingConsentScreen(
         Spacer(Modifier.height(16.dp))
         HedvigButton(
           text = stringResource(Res.string.ONBOARDING_ANALYTICS_ALLOW_BUTTON),
-          onClick = onAllow,
+          onClick = withOnboardingHaptic(onAllow),
           enabled = uiState.buttonsEnabled,
           buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
           modifier = Modifier
@@ -315,7 +316,7 @@ private fun OnboardingConsentScreen(
         Spacer(Modifier.height(8.dp))
         HedvigButton(
           text = stringResource(Res.string.ONBOARDING_ANALYTICS_DENY_BUTTON),
-          onClick = onDeny,
+          onClick = withOnboardingHaptic(onDeny),
           enabled = uiState.buttonsEnabled,
           buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
           modifier = Modifier

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
@@ -22,9 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.style.LineHeightStyle
@@ -38,6 +36,7 @@ import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.LocalTextStyle
 import com.hedvig.android.design.system.hedvig.Surface
 import com.hedvig.android.design.system.hedvig.tokens.MotionTokens
+import com.hedvig.android.feature.onboarding.ui.withOnboardingHaptic
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 
@@ -117,7 +116,7 @@ private fun KeypadKey(label: String, highlighted: Boolean, onKeypadClick: (Strin
     animationSpec = tween(MotionTokens.DurationLong1.toInt(), easing = MotionTokens.EasingEmphasizedCubicBezier),
     label = "keypad scale",
   )
-  val hapticFeedback = LocalHapticFeedback.current
+  val onKeyClick = withOnboardingHaptic { onKeypadClick(label) }
   Box(
     modifier = Modifier
       .size(KeySize)
@@ -126,10 +125,7 @@ private fun KeypadKey(label: String, highlighted: Boolean, onKeypadClick: (Strin
         scaleY = scale
       }
       .clip(HedvigTheme.shapes.cornerLarge)
-      .clickable(clickEnabled) {
-        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-        onKeypadClick(label)
-      }
+      .clickable(clickEnabled, onClick = onKeyClick)
       .background(containerColor, HedvigTheme.shapes.cornerLarge),
     contentAlignment = Alignment.Center,
   ) {

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/ui/phone/OnboardingPhoneKeypad.kt
@@ -116,7 +116,6 @@ private fun KeypadKey(label: String, highlighted: Boolean, onKeypadClick: (Strin
     animationSpec = tween(MotionTokens.DurationLong1.toInt(), easing = MotionTokens.EasingEmphasizedCubicBezier),
     label = "keypad scale",
   )
-  val onKeyClick = withOnboardingHaptic { onKeypadClick(label) }
   Box(
     modifier = Modifier
       .size(KeySize)
@@ -125,7 +124,7 @@ private fun KeypadKey(label: String, highlighted: Boolean, onKeypadClick: (Strin
         scaleY = scale
       }
       .clip(HedvigTheme.shapes.cornerLarge)
-      .clickable(clickEnabled, onClick = onKeyClick)
+      .clickable(clickEnabled, onClick = withOnboardingHaptic { onKeypadClick(label) })
       .background(containerColor, HedvigTheme.shapes.cornerLarge),
     contentAlignment = Alignment.Center,
   ) {


### PR DESCRIPTION
## Problem

The analytics consent screen's buttons give no haptic feedback, while Continue on every other onboarding step does.

The tick was written inline inside `OnboardingStepButtons`, so a step got it only by rendering its buttons through that shared component. The consent screen does not: Allow and Don't allow are two equal-weight buttons rather than the primary-and-secondary pill pair, so it hand-rolls its own `HedvigButton`s and never picked the tick up.

Two more were missing it for the same reason, so this was wider than the reported screen:

- The contract card's **Add** button, on the co-insured and pet-ID steps.
- **See price** on the bundle step.

## Change

Pasting the two haptic lines at each of those would have left five copies of something nothing ties together, which is how the consent screen came to be missing it in the first place. So the tick moves behind `withOnboardingHaptic`, which takes a click and returns it wrapped:

```kotlin
onClick = withOnboardingHaptic(onAllow)
```

Every button in the flow now goes through it, the numpad keys included. A control can no longer be wired up with the click but without the tick, and `LocalHapticFeedback` appears in exactly one file. Net fewer lines than before.

## Left alone deliberately

- **The top app bar's back and close icons.** Android does not usually buzz on nav chrome.
- **The error section's retry button.** It belongs to the design system, so changing it would buzz every screen in the app rather than just onboarding.
- **The theme step's three options.** They are `selectable` radio rows rather than buttons. Whether a selection should buzz is a feel decision rather than a bug, so it is not made here. One line per row if we want it.

## Verification

`:feature-onboarding:` compile, test, ktlintCheck and lint all pass.

Driven on a device to confirm the buttons still do their job: tapping "Don't allow" still advances to the phone step. The tick itself cannot be seen in a screenshot, so it needs a hand to confirm; tap through the flow and compare the consent buttons against Continue on any other step.
