### PR TITLE
Migrate to the standalone Apollo normalized cache

### DIFF
--- a/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/normalizedcache/ApolloNormalizedCacheAuthEventListener.kt
+++ b/app/apollo/apollo-auth-listeners/src/main/kotlin/com/hedvig/android/apollo/auth/listeners/normalizedcache/ApolloNormalizedCacheAuthEventListener.kt
@@ -1,7 +1,7 @@
 package com.hedvig.android.apollo.auth.listeners.normalizedcache
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.apolloStore
+import com.apollographql.cache.normalized.apolloStore
 import com.hedvig.android.auth.event.AuthEventListener
 import com.hedvig.android.core.common.di.AppScope
 import dev.zacsweers.metro.ContributesIntoSet

--- a/app/apollo/apollo-core/src/commonMain/kotlin/com/hedvig/android/apollo/ApolloCallExt.kt
+++ b/app/apollo/apollo-core/src/commonMain/kotlin/com/hedvig/android/apollo/ApolloCallExt.kt
@@ -13,8 +13,8 @@ import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.cache.normalized.watch
 import com.apollographql.apollo.exception.CacheMissException
+import com.apollographql.cache.normalized.watch
 import com.hedvig.android.apollo.ApolloOperationError.CacheMiss
 import com.hedvig.android.apollo.ApolloOperationError.OperationError
 import com.hedvig.android.apollo.ApolloOperationError.OperationException

--- a/app/apollo/apollo-network-cache-manager/src/commonMain/kotlin/com/hedvig/android/apollo/NetworkCacheManager.kt
+++ b/app/apollo/apollo-network-cache-manager/src/commonMain/kotlin/com/hedvig/android/apollo/NetworkCacheManager.kt
@@ -1,7 +1,7 @@
 package com.hedvig.android.apollo
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.apolloStore
+import com.apollographql.cache.normalized.apolloStore
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.LogPriority
 import com.hedvig.android.logger.logcat
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 
 interface NetworkCacheManager {
-  fun clearCache()
+  suspend fun clearCache()
 }
 
 @ContributesBinding(AppScope::class)
@@ -19,7 +19,7 @@ interface NetworkCacheManager {
 internal class ApolloNetworkCacheManager(
   private val apolloClient: ApolloClient,
 ) : NetworkCacheManager {
-  override fun clearCache() {
+  override suspend fun clearCache() {
     val didClearAllRecords = apolloClient.apolloStore.clearAll()
     if (didClearAllRecords) {
       logcat { "Did clear entire apolloStore cache" }

--- a/app/apollo/apollo-octopus-public/build.gradle.kts
+++ b/app/apollo/apollo-octopus-public/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
       api(libs.apollo.adapters.core)
       api(libs.apollo.adapters.datetime)
       api(libs.apollo.api)
+      api(libs.apollo.normalizedCache)
       api(libs.kotlinx.datetime)
       implementation(projects.coreBuildConstants)
       implementation(projects.coreCommonPublic)

--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/extra.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/extra.graphqls
@@ -1,6 +1,6 @@
 extend schema
 @link(
-    url: "https://specs.apollo.dev/kotlin_labs/v0.3",
+    url: "https://specs.apollo.dev/cache/v0.4",
     import: ["@typePolicy"]
 )
 

--- a/app/data/data-addons/src/main/kotlin/com/hedvig/android/data/addons/data/GetAddonBannerInfoUseCase.kt
+++ b/app/data/data-addons/src/main/kotlin/com/hedvig/android/data/addons/data/GetAddonBannerInfoUseCase.kt
@@ -6,8 +6,8 @@ import arrow.core.NonEmptyList
 import arrow.core.raise.either
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy.CacheAndNetwork
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy.CacheAndNetwork
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/data/data-claim-intent/src/commonMain/kotlin/com/hedvig/android/data/claimintent/GetResumableClaimIntentUseCase.kt
+++ b/app/data/data-claim-intent/src/commonMain/kotlin/com/hedvig/android/data/claimintent/GetResumableClaimIntentUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.data.claimintent
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/data/data-conversations/src/commonMain/kotlin/com/hedvig/android/data/conversations/HasAnyActiveConversationUseCase.kt
+++ b/app/data/data-conversations/src/commonMain/kotlin/com/hedvig/android/data/conversations/HasAnyActiveConversationUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.data.conversations
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.di.AppScope

--- a/app/data/data-termination/src/commonMain/kotlin/com/hedvig/android/data/termination/data/GetTerminatableContractsUseCase.kt
+++ b/app/data/data-termination/src/commonMain/kotlin/com/hedvig/android/data/termination/data/GetTerminatableContractsUseCase.kt
@@ -5,8 +5,8 @@ import arrow.core.NonEmptyList
 import arrow.core.raise.either
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/data/GetInsuranceForTravelAddonUseCase.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/data/GetInsuranceForTravelAddonUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/data/GetQuoteCostBreakdownUseCase.kt
+++ b/app/feature/feature-addon-purchase/src/main/kotlin/com/hedvig/android/feature/addon/purchase/data/GetQuoteCostBreakdownUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.addon.purchase.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/CbmChatRepository.kt
@@ -16,9 +16,9 @@ import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import arrow.fx.coroutines.parMap
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.doNotStore
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.doNotStore
+import com.apollographql.cache.normalized.fetchPolicy
 import com.benasher44.uuid.Uuid
 import com.eygraber.uri.toKmpUri
 import com.hedvig.android.apollo.ApolloOperationError

--- a/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/GetAllConversationsUseCase.kt
+++ b/app/feature/feature-chat/src/main/kotlin/com/hedvig/android/feature/chat/data/GetAllConversationsUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.chat.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy.CacheAndNetwork
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy.CacheAndNetwork
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-chip-id/src/main/kotlin/com/hedvig/android/feature/chip/id/data/GetContractsWithMissingChipIdUseCase.kt
+++ b/app/feature/feature-chip-id/src/main/kotlin/com/hedvig/android/feature/chip/id/data/GetContractsWithMissingChipIdUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.chip.id.data
 
 import arrow.core.Either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/FormFieldSearchUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/FormFieldSearchUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.feature.claim.chat.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/GetClaimIntentUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/GetClaimIntentUseCase.kt
@@ -5,8 +5,8 @@ import arrow.core.left
 import arrow.core.raise.either
 import arrow.core.right
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/ResumeClaimUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/ResumeClaimUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.feature.claim.chat.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.language.LanguageService

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/StartClaimIntentUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/feature/claim/chat/data/StartClaimIntentUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/data/GetClaimDetailUiStateUseCase.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/data/GetClaimDetailUiStateUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.core.uidata.UiFile

--- a/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
+++ b/app/feature/feature-cross-sell-sheet/src/main/kotlin/com/hedvig/android/feature/cross/sell/sheet/CrossSellSheetViewModel.kt
@@ -11,8 +11,8 @@ import arrow.core.left
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-delete-account/src/main/kotlin/com/hedvig/android/feature/deleteaccount/data/DeleteAccountStateUseCase.kt
+++ b/app/feature/feature-delete-account/src/main/kotlin/com/hedvig/android/feature/deleteaccount/data/DeleteAccountStateUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.deleteaccount.data
 
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.di.AppScope
 import dev.zacsweers.metro.Inject

--- a/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/data/GetPuppyGuideUseCase.kt
+++ b/app/feature/feature-help-center/src/commonMain/kotlin/com/hedvig/android/feature/help/center/data/GetPuppyGuideUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.help.center.data
 
 import arrow.core.Either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/data/GetHomeDataUseCase.kt
@@ -8,8 +8,8 @@ import arrow.core.raise.either
 import arrow.core.raise.nullable
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.uidata.UiCurrencyCode

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCase.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/data/GetInsuranceContractsUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/selectcontract/SelectContractDestination.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/selectcontract/SelectContractDestination.kt
@@ -200,6 +200,7 @@ val previewMovingIntent = MoveIntentV2CreateMutation.Data.MoveIntentCreate.MoveI
   extraBuildingTypesV2 = listOf(),
   currentHomeAddresses = listOf(
     MoveIntentV2CreateMutation.Data.MoveIntentCreate.MoveIntent.CurrentHomeAddress(
+      __typename = "",
       id = "id1",
       suggestedNumberCoInsured = 2,
       displaySubtitle = "Subtitle",
@@ -208,6 +209,7 @@ val previewMovingIntent = MoveIntentV2CreateMutation.Data.MoveIntentCreate.MoveI
       maxMovingDate = LocalDate(2024, 12, 31),
     ),
     MoveIntentV2CreateMutation.Data.MoveIntentCreate.MoveIntent.CurrentHomeAddress(
+      __typename = "",
       id = "id2",
       suggestedNumberCoInsured = 2,
       displaySubtitle = "Subtitle",

--- a/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/GetMoveIntentCostUseCase.kt
+++ b/app/feature/feature-movingflow/src/main/kotlin/com/hedvig/android/feature/movingflow/ui/summary/GetMoveIntentCostUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.movingflow.ui.summary
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingRepository.kt
+++ b/app/feature/feature-onboarding/src/main/kotlin/com/hedvig/android/feature/onboarding/data/OnboardingRepository.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetChargeDetailsUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetChargeDetailsUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.payments.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy.NetworkFirst
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy.NetworkFirst
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetDiscountsUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetDiscountsUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.payments.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetManualChargeInfoUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetManualChargeInfoUseCase.kt
@@ -5,8 +5,8 @@ import arrow.core.raise.context.bind
 import arrow.core.raise.context.either
 import arrow.core.raise.context.raise
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetMemberPaymentsDetailsUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetMemberPaymentsDetailsUseCase.kt
@@ -5,8 +5,8 @@ import arrow.core.raise.context.bind
 import arrow.core.raise.context.either
 import arrow.core.raise.context.raise
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetPaymentsHistoryUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/data/GetPaymentsHistoryUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.payments.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetForeverInformationUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetForeverInformationUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.payments.overview.data
 
 import arrow.core.Either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetShouldShowPayoutUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.right
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/overview/data/GetUpcomingPaymentUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.right
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/data/GetPayoutAccountUseCase.kt
+++ b/app/feature/feature-payout-account/src/main/kotlin/com/hedvig/android/feature/payoutaccount/data/GetPayoutAccountUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.payoutaccount.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/GetEurobonusDataUseCase.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/data/GetEurobonusDataUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.profile.data
 
 import arrow.core.Either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ApolloOperationError
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsPresenter.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/settings/SettingsPresenter.kt
@@ -49,8 +49,10 @@ internal class SettingsPresenter(
         is SettingsEvent.ChangeLanguage -> {
           selectedLanguage = event.language
           languageService.setLanguage(event.language)
-          cacheManager.clearCache()
-          launch { uploadLanguagePreferenceToBackendUseCase.invoke() }
+          launch {
+            cacheManager.clearCache()
+            uploadLanguagePreferenceToBackendUseCase.invoke()
+          }
         }
 
         is SettingsEvent.ChangeTheme -> {

--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/GetEurobonusStatusUseCase.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/tab/GetEurobonusStatusUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/NoopNetworkCacheManager.kt
+++ b/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/NoopNetworkCacheManager.kt
@@ -3,5 +3,5 @@ package com.hedvig.android.feature
 import com.hedvig.android.apollo.NetworkCacheManager
 
 val NoopNetworkCacheManager = object : NetworkCacheManager {
-  override fun clearCache() {}
+  override suspend fun clearCache() {}
 }

--- a/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/eurobonus/EurobonusPresenterTest.kt
+++ b/app/feature/feature-profile/src/test/kotlin/com/hedvig/android/feature/profile/eurobonus/EurobonusPresenterTest.kt
@@ -20,7 +20,12 @@ class EurobonusPresenterTest {
     "name",
     id = "id",
     partnerData = EurobonusDataQuery.Data.CurrentMember.PartnerData(
-      EurobonusDataQuery.Data.CurrentMember.PartnerData.Sas("BA1234556", true),
+      __typename = "",
+      sas = EurobonusDataQuery.Data.CurrentMember.PartnerData.Sas(
+        __typename = "",
+        eurobonusNumber = "BA1234556",
+        eligible = true,
+      ),
     ),
   )
 

--- a/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/data/GetAddonRemovalCostBreakdownUseCase.kt
+++ b/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/data/GetAddonRemovalCostBreakdownUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.feature.remove.addons.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/data/GetInsurancesWithRemovableAddonsUseCase.kt
+++ b/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/data/GetInsurancesWithRemovableAddonsUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.feature.remove.addons.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/data/StartAddonRemovalUseCase.kt
+++ b/app/feature/feature-remove-addons/src/commonMain/kotlin/com/hedvig/feature/remove/addons/data/StartAddonRemovalUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.feature.remove.addons.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
@@ -5,8 +5,8 @@ import arrow.core.left
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/data/GetCoInsuredForContractUseCase.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/data/GetCoInsuredForContractUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.feature.travelcertificate.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/data/GetEligibleContractsWithAddressUseCase.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/data/GetEligibleContractsWithAddressUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.travelcertificate.data
 
 import arrow.core.Either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/data/GetTravelCertificatesHistoryUseCase.kt
+++ b/app/feature/feature-travel-certificate/src/main/kotlin/com/hedvig/android/feature/travelcertificate/data/GetTravelCertificatesHistoryUseCase.kt
@@ -2,8 +2,8 @@ package com.hedvig.android.feature.travelcertificate.data
 
 import arrow.core.Either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetConnectPaymentReminderUseCase.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetContactInfoUpdateIsNeededUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.memberreminders
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMissingChipIdReminderUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetMissingChipIdReminderUseCase.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.memberreminders
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetNeedsCoInsuredInfoRemindersUseCase.kt
@@ -6,8 +6,8 @@ import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage

--- a/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetUpcomingRenewalRemindersUseCase.kt
+++ b/app/member-reminders/member-reminders-public/src/main/kotlin/com/hedvig/android/memberreminders/GetUpcomingRenewalRemindersUseCase.kt
@@ -6,8 +6,8 @@ import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import arrow.core.toNonEmptyListOrNull
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.apollo.safeFlow

--- a/app/network/network-clients/src/commonMain/kotlin/com/hedvig/android/network/clients/di/NetworkMetroProviders.kt
+++ b/app/network/network-clients/src/commonMain/kotlin/com/hedvig/android/network/clients/di/NetworkMetroProviders.kt
@@ -1,9 +1,8 @@
 package com.hedvig.android.network.clients.di
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.ktor.ktorClient
 import com.hedvig.android.core.buildconstants.HedvigBuildConstants
 import com.hedvig.android.core.common.di.AppScope
@@ -33,6 +32,7 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.plugin
 import io.ktor.client.request.header
 import io.ktor.client.request.headers
+import octopus.cache.Cache
 
 @ContributesTo(AppScope::class)
 interface NetworkMetroProviders {
@@ -65,12 +65,14 @@ interface NetworkMetroProviders {
     normalizedCacheFactory: NormalizedCacheFactory,
     httpClient: HttpClient,
     hedvigBuildConstants: HedvigBuildConstants,
-  ): ApolloClient = ApolloClient.Builder()
-    .normalizedCache(normalizedCacheFactory)
-    .ktorClient(httpClient)
-    .httpServerUrl(hedvigBuildConstants.urlGraphqlOctopus)
-    .run { extraApolloClientConfiguration.configure(this) }
-    .build()
+  ): ApolloClient = with(Cache) {
+    ApolloClient.Builder()
+      .cache(normalizedCacheFactory)
+      .ktorClient(httpClient)
+      .httpServerUrl(hedvigBuildConstants.urlGraphqlOctopus)
+      .run { extraApolloClientConfiguration.configure(this) }
+      .build()
+  }
 }
 
 private fun buildKtorClient(

--- a/app/notification-badge-data/notification-badge-data-public/src/main/kotlin/com/hedvig/android/notification/badge/data/crosssell/GetCrossSellRecommendationIdUseCase.kt
+++ b/app/notification-badge-data/notification-badge-data-public/src/main/kotlin/com/hedvig/android/notification/badge/data/crosssell/GetCrossSellRecommendationIdUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.android.notification.badge.data.crosssell
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.logger.logcat

--- a/app/notification-badge-data/notification-badge-data-public/src/main/kotlin/com/hedvig/android/notification/badge/data/payment/GetIfMissedPaymentUseCase.kt
+++ b/app/notification-badge-data/notification-badge-data-public/src/main/kotlin/com/hedvig/android/notification/badge/data/payment/GetIfMissedPaymentUseCase.kt
@@ -1,8 +1,8 @@
 package com.hedvig.android.notification.badge.data.payment
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.safeFlow
 import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryDemo.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryDemo.kt
@@ -20,23 +20,25 @@ internal class ForeverRepositoryDemo : ForeverRepository {
         __typename = "",
         id = "id",
         insuranceCost = FullReferralsQuery.Data.CurrentMember.InsuranceCost(
+          __typename = "",
           monthlyGross = FullReferralsQuery.Data.CurrentMember.InsuranceCost.MonthlyGross(
             __typename = "",
             amount = 60.0,
             currencyCode = CurrencyCode.SEK,
           ),
-          FullReferralsQuery.Data.CurrentMember.InsuranceCost.MonthlyNet(
+          monthlyNet = FullReferralsQuery.Data.CurrentMember.InsuranceCost.MonthlyNet(
             __typename = "",
             amount = 40.0,
             currencyCode = CurrencyCode.SEK,
           ),
-          FullReferralsQuery.Data.CurrentMember.InsuranceCost.MonthlyDiscount(
+          monthlyDiscount = FullReferralsQuery.Data.CurrentMember.InsuranceCost.MonthlyDiscount(
             __typename = "",
             amount = 20.0,
             currencyCode = CurrencyCode.SEK,
           ),
         ),
         referralInformation = FullReferralsQuery.Data.CurrentMember.ReferralInformation(
+          __typename = "",
           code = "DEMOCODE",
           monthlyDiscountPerReferral = FullReferralsQuery.Data.CurrentMember.ReferralInformation.MonthlyDiscountPerReferral(
             __typename = "",
@@ -46,6 +48,7 @@ internal class ForeverRepositoryDemo : ForeverRepository {
           referredBy = null,
           referrals = listOf(
             FullReferralsQuery.Data.CurrentMember.ReferralInformation.Referral(
+              __typename = "",
               name = "Adam",
               status = MemberReferralStatus.ACTIVE,
               activeDiscount = FullReferralsQuery.Data.CurrentMember.ReferralInformation.Referral.ActiveDiscount(
@@ -55,6 +58,7 @@ internal class ForeverRepositoryDemo : ForeverRepository {
               ),
             ),
             FullReferralsQuery.Data.CurrentMember.ReferralInformation.Referral(
+              __typename = "",
               name = "Claire",
               status = MemberReferralStatus.PENDING,
               activeDiscount = FullReferralsQuery.Data.CurrentMember.ReferralInformation.Referral.ActiveDiscount(

--- a/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryImpl.kt
+++ b/app/shared/forever-ui/src/main/kotlin/com/hedvig/android/shared/foreverui/ui/data/ForeverRepositoryImpl.kt
@@ -3,8 +3,8 @@ package com.hedvig.android.shared.foreverui.ui.data
 import arrow.core.Either
 import arrow.core.raise.either
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import com.hedvig.android.apollo.ErrorMessage
 import com.hedvig.android.apollo.safeExecute
 import com.hedvig.android.core.common.ErrorMessage

--- a/build-logic/convention/src/main/kotlin/com/hedvig/android/HedvigGradlePluginExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/hedvig/android/HedvigGradlePluginExtension.kt
@@ -113,12 +113,14 @@ abstract class HedvigGradlePluginExtension @Inject constructor(
 
 private abstract class ApolloSchemaHandler {
   fun configure(project: Project, apolloServiceAction: Action<Service>) {
+    val libs = project.the<LibrariesForLibs>()
     with(project) {
-      pluginManager.apply(the<LibrariesForLibs>().plugins.apollo.get().pluginId)
+      pluginManager.apply(libs.plugins.apollo.get().pluginId)
     }
     project.extensions.configure<ApolloExtension> {
       service("octopus") {
         apolloServiceAction.execute(this)
+        configureNormalizedCachePlugin(libs, packageName.get())
       }
     }
     // The introspection download task writes the schema to the file configured in the octopus
@@ -202,10 +204,22 @@ private abstract class ApolloHandler {
 
         @Suppress("OPT_IN_USAGE")
         dependsOn(project.dependencies.project(":apollo-octopus-public"), true)
+        configureNormalizedCachePlugin(libs, packageName)
         extraConfiguration.execute(this)
       }
     }
   }
+}
+
+/**
+ * The normalized cache ships its own Apollo compiler plugin, which does two things: it reads
+ * `@typePolicy` off the schema to generate the `<packageName>.cache.Cache` object, and it rewrites a
+ * service's operations to select the key fields the cache needs to normalize the response. The
+ * second half is per-service, so every module declaring an Apollo service configures the plugin.
+ */
+private fun Service.configureNormalizedCachePlugin(libs: LibrariesForLibs, packageName: String) {
+  plugin(libs.apollo.normalizedCachePlugin)
+  pluginArgument("com.apollographql.cache.packageName", packageName)
 }
 
 private abstract class ComposeHandler {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidGradlePlugin = "9.3.1"
 apollo = "5.0.1"
 apolloAdapters = "0.7.0"
 apolloEngineKtor = "1.0.0-alpha.0"
+apolloNormalizedCache = "1.0.7"
 cacheFix = "3.0.3"
 crashlytics = "3.0.7"
 datadogPlugin = "1.29.0"
@@ -141,7 +142,8 @@ apollo-adapters-datetime = { module = "com.apollographql.adapters:apollo-adapter
 apollo-annotations = { module = "com.apollographql.apollo:apollo-annotations", version.ref = "apollo" }
 apollo-api = { module = "com.apollographql.apollo:apollo-api", version.ref = "apollo" }
 apollo-engine-ktor = { module = "com.apollographql.ktor:apollo-engine-ktor", version.ref = "apolloEngineKtor" }
-apollo-normalizedCache = { module = "com.apollographql.apollo:apollo-normalized-cache", version.ref = "apollo" }
+apollo-normalizedCache = { module = "com.apollographql.cache:normalized-cache", version.ref = "apolloNormalizedCache" }
+apollo-normalizedCachePlugin = { module = "com.apollographql.cache:normalized-cache-apollo-compiler-plugin", version.ref = "apolloNormalizedCache" }
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
 apollo-testingSupport = { module = "com.apollographql.apollo:apollo-testing-support", version.ref = "apollo" }
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }


### PR DESCRIPTION
## Why

Apollo Kotlin 5.0 deprecated its built-in normalized cache (`com.apollographql.apollo.cache.normalized`) in favour of the extracted [`com.apollographql.cache:normalized-cache`](https://github.com/apollographql/apollo-kotlin-normalized-cache) library. Every `fetchPolicy`, `watch`, `doNotStore` and `apolloStore` call site in the app was hitting that deprecation, 51 files across 29 modules.

## What

The catalog alias `apollo-normalizedCache` is repointed at the new artifact (1.0.7), so the 31 module build files that depend on it are unchanged. `FetchPolicy`, `fetchPolicy`, `watch`, `doNotStore` and `apolloStore` all kept their names in the new package, so 48 of the 51 touched files are pure import swaps. `MemoryCacheFactory` moved into a `.memory` subpackage.

Three things needed real porting:

**The new library ships its own Apollo compiler plugin and requires it.** It reads `@typePolicy` off the schema to generate `<packageName>.cache.Cache`, and rewrites each service's operations to select the key fields the cache needs to normalize a response. The second half is per-service, so `build-logic` configures the plugin for every Apollo service rather than only the schema module. `@typePolicy` now comes from `specs.apollo.dev/cache/v0.4` instead of `kotlin_labs/v0.3`.

**There is no single-argument `normalizedCache` overload any more.** `NetworkMetroProviders` builds the `ApolloClient` through the generated `Cache.cache(factory)`, which passes the schema's type policies (`Member`, `Contract`, `Claim`, `Conversation`, `ChatMessage` and its subtypes, same set as before).

**`ApolloStore.clearAll()` is `suspend`,** so `NetworkCacheManager.clearCache()` is too. All eight call sites were already in suspend contexts except `SettingsPresenter`, whose `CollectEvents` lambda is not. There the clear moved into the `launch` that already followed it, which preserves the original ordering (clear completes before the language upload starts).

Because operations now select key fields, several generated response types gained a `__typename` parameter. `ForeverRepositoryDemo`, the `SelectContractDestination` previews and `EurobonusPresenterTest` construct those types by hand and were updated to match.

## No behaviour change expected

- `FetchPolicy.NetworkOnly` still writes to the cache; skipping the read is `noCache`, skipping the write is still `doNotStore`.
- Only the memory cache is in use, so the new SQLite blob format (which wipes an old-schema database on first open) does not apply.
- `defaultMaxAge` stays infinite and `keyScope` stays `TYPE`, matching the old defaults.

## Verification

- `./gradlew :app:compileDebugKotlin`
- `./gradlew test` — green, including the 28 re-run `feature-profile` tests
- `./gradlew jvmTest` — the KMP `commonTest` path that a plain `test` run skips
- `./gradlew ktlintCheck` — clean on everything touched here
- `./gradlew :umbrella:assembleHedvigSharedReleaseXCFramework` — several `commonMain` modules now pull the new library on Kotlin/Native, and the umbrella workflow's path filter would not have caught a break there

## Left alone

`YourInfoTab.kt` and `TerminationRedirectionDestination.kt` fail `ktlintCheck` on unmodified `develop` (indentation/wrapping and two long lines). Unrelated to this change, so not fixed here; worth a separate cleanup.
