### PR TITLE
fix(tracking): only report a Firebase screen_view while resumed

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/ui/HedvigApp.kt
@@ -316,6 +316,11 @@ private fun ReportCurrentDestinationEffect(
  * name via [screenName] and the parameters from [ScreenParameterExtractor]. Parameters ride along the single
  * `screen_view` event keyed by screen name, acting as breakdown dimensions rather than fragmenting a screen into
  * separate entries.
+ *
+ * Only reports while the Activity is resumed, so a back stack change the member never saw is not counted as a
+ * screen they visited. A forced logout on an expired token, for instance, swaps the root while the app sits in the
+ * background. Returning to the app re-reports the current screen, matching how Firebase's own automatic screen
+ * tracking behaves.
  */
 @Composable
 private fun TrackScreenViewEffect(
@@ -323,16 +328,19 @@ private fun TrackScreenViewEffect(
   eventTrackingClient: EventTrackingClient,
   screenParameterExtractor: ScreenParameterExtractor,
 ) {
-  LaunchedEffect(backstackController, eventTrackingClient, screenParameterExtractor) {
-    snapshotFlow { backstackController.currentDestination }
-      .filterNotNull()
-      .collect { destination ->
-        eventTrackingClient.trackScreen(
-          name = destination.screenName(),
-          screenClass = destination::class.qualifiedName ?: destination::class.simpleName,
-          parameters = screenParameterExtractor.parametersFor(destination),
-        )
-      }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  LaunchedEffect(backstackController, eventTrackingClient, screenParameterExtractor, lifecycleOwner) {
+    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+      snapshotFlow { backstackController.currentDestination }
+        .filterNotNull()
+        .collect { destination ->
+          eventTrackingClient.trackScreen(
+            name = destination.screenName(),
+            screenClass = destination::class.qualifiedName ?: destination::class.simpleName,
+            parameters = screenParameterExtractor.parametersFor(destination),
+          )
+        }
+    }
   }
 }
 


### PR DESCRIPTION
Stacked on #3104. Base is that branch, so the diff here is one effect.

`TrackScreenViewEffect` fires on every destination change regardless of lifecycle, so a back stack change the member never saw gets reported as a screen they visited.

Real case: `SessionReconciler.logoutOnInvalidCredentials` collects `authStatus` with no lifecycle gate. A token going invalid while the app is backgrounded swaps the root and we log a `screen_view` for the login screen.

Datadog already gets this right. `Navigation3TrackingEffect` gates on RESUMED, and so does `ActivityViewTrackingStrategy`. The two systems disagreed in exactly this case and Firebase was the wrong one.

⚠️ **This raises `screen_view` volume.** `repeatOnLifecycle` restarts the collection on resume, so returning to the app re-reports the current screen. I think that's correct rather than a side effect, since Firebase's own automatic screen tracking behaves the same way, but it is a visible change to event counts.

## a11y
- [x] if these are UI changes - check for their accessibility

No UI changes.
