### PR TITLE
chore: import CancellationException from kotlinx.coroutines

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/crosssell/GetMemberAuthorizationCodeUseCase.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/crosssell/GetMemberAuthorizationCodeUseCase.kt
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
-import io.ktor.utils.io.CancellationException
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 


### PR DESCRIPTION
`GetMemberAuthorizationCodeUseCase` imported `CancellationException` from `io.ktor.utils.io`, an accidental auto-import in a file that otherwise only touches ktor for the `HttpClient` call.

Ktor's `io.ktor.utils.io.CancellationException` is a typealias to the same underlying exception, so **behaviour is unchanged**. The problem is purely readability: the import implies the cancellation being caught and rethrown is ktor-specific, when it is the ordinary coroutine cancellation.

`kotlinx.coroutines.CancellationException` is what the rest of `:app` already uses (`SafeAndroidUriHandler`, same source set), and it was the most common convention in the codebase (4 usages, vs 2 for the stdlib `kotlin.coroutines.cancellation` variant in KMP file-upload code).

### Scope

This was the only occurrence in the codebase. I swept the working tree and every `origin/*` branch: the single hit is this one file, which is why it shows up on many in-flight branches. Fixing it on `develop` resolves it everywhere once they merge.

### Verification

`./gradlew :app:ktlintCheck :app:compileDebugKotlin` passes, with both tasks confirmed executed rather than up-to-date.