### PR TITLE
Fix the ktlint failures already present on develop

### DIFF
--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/redirection/TerminationRedirectionDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/redirection/TerminationRedirectionDestination.kt
@@ -156,7 +156,8 @@ private fun PreviewTerminationRedirectionDestinationWithImage() {
       TerminationRedirectionDestination(
         redirection = SurveyOptionRedirection(
           title = "Bring Hedvig to your new home",
-          description = "Move your insurance to your new home with Hedvig and get 15% off your home insurance the first year.",
+          description = "Move your insurance to your new home with Hedvig and get 15% off your home insurance " +
+            "the first year.",
           type = RedirectionType.UPDATE_ADDRESS,
           actionText = "See price for new home",
           image = RedirectionImage(url = "", overlayText = "15% off"),
@@ -179,7 +180,8 @@ private fun PreviewTerminationRedirectionDestinationWithoutImage() {
       TerminationRedirectionDestination(
         redirection = SurveyOptionRedirection(
           title = "Bring Hedvig to your new home",
-          description = "Move your insurance to your new home with Hedvig and get 15% off your home insurance the first year.",
+          description = "Move your insurance to your new home with Hedvig and get 15% off your home insurance " +
+            "the first year.",
           type = RedirectionType.UPDATE_ADDRESS,
           actionText = "See price for new home",
           image = null,


### PR DESCRIPTION
Fix some red warnings to make the rest of the stack cleaner


🤖 AI description:

`ktlintCheck` fails on develop with two `standard:max-line-length` errors, unrelated to any in-flight work. Left alone it makes any PR that touches ktlint config look like it broke CI, which is why this sits at the bottom of the stack: the PR above adds a new ktlint rule, and that rule is only trustworthy if the task it runs under is otherwise clean.

That rule is not auto-fixable, so this is a hand fix. The same 127 character description string appears in two previews in `TerminationRedirectionDestination.kt` and is now split across two literals.

Repo-wide `ktlintCheck` goes from 2 errors to 0, and stays at 0 from the top of the stack. The module still compiles.
