### PR TITLE
pass isPaymentProtection to start tier flow (to show different loadin…

### DIFF
--- a/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
+++ b/app/app/src/main/kotlin/com/hedvig/android/app/navigation/HedvigEntryProvider.kt
@@ -421,8 +421,8 @@ private fun EntryProviderScope<HedvigNavKey>.addInsuranceEntries(
     startEditCoOwners = { contractId: String ->
       backstack.add(EditCoInsuredTriageKey(contractId, CoInsuredFlowType.CoOwners))
     },
-    onNavigateToStartChangeTier = { contractId: String ->
-      backstack.add(StartTierFlowKey(insuranceId = contractId))
+    onNavigateToStartChangeTier = { contractId: String, isPaymentProtection: Boolean ->
+      backstack.add(StartTierFlowKey(insuranceId = contractId, isPaymentProtection = isPaymentProtection))
     },
     startEditCoInsuredAddMissingInfo = { contractId: String ->
       backstack.add(CoInsuredAddInfoKey(contractId, CoInsuredFlowType.CoInsured))

--- a/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values-sv-rSE/strings.xml
@@ -153,6 +153,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Byggår</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">Du + %1$d</string>
   <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Det nya beloppet börjar gälla när din kvalificeringstid är slut. Fram till dess gäller ditt nuvarande belopp.</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PROCESSING">Hämtar försäkringsbelopp...</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Ändra utbetalningskonto</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Ändra skyddsnivå</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Chatta med en specialist</string>

--- a/app/core/core-resources/src/androidMain/res/values/strings.xml
+++ b/app/core/core-resources/src/androidMain/res/values/strings.xml
@@ -153,6 +153,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Year of construction</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">You + %1$d</string>
   <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Your new amount takes effect once your qualification period ends. Until then, your current amount applies.</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PROCESSING">Fetching insurance amount...</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Change payout account</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Change coverage level</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Talk to a human</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values-sv-rSE/strings.xml
@@ -152,6 +152,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Byggår</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">Du + %1$d</string>
   <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Det nya beloppet börjar gälla när din kvalificeringstid är slut. Fram till dess gäller ditt nuvarande belopp.</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PROCESSING">Hämtar försäkringsbelopp...</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Ändra utbetalningskonto</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Ändra skyddsnivå</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Chatta med en specialist</string>

--- a/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
+++ b/app/core/core-resources/src/commonMain/composeResources/values/strings.xml
@@ -152,6 +152,7 @@
   <string name="CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL">Year of construction</string>
   <string name="CHANGE_ADDRESS_YOU_PLUS">You + %1$d</string>
   <string name="CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO">Your new amount takes effect once your qualification period ends. Until then, your current amount applies.</string>
+  <string name="CHANGE_INSURANCE_AMOUNT_PROCESSING">Fetching insurance amount...</string>
   <string name="CHANGE_PAYOUT_METHOD_BUTTON_LABEL">Change payout account</string>
   <string name="CHANGE_TIER_BUTTON_TITLE">Change coverage level</string>
   <string name="CHATBOT_TALK_TO_HUMAN_BUTTON_TITLE">Talk to a human</string>

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/navigation/ChooseTierEntries.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/navigation/ChooseTierEntries.kt
@@ -27,9 +27,10 @@ import dev.zacsweers.metrox.viewmodel.metroViewModel
 fun EntryProviderScope<HedvigNavKey>.changeTierEntries(backstack: Backstack, onNavigateToNewConversation: () -> Unit) {
   entry<StartTierFlowKey> { key ->
     val insuranceId = key.insuranceId
+    val isPaymentProtection = key.isPaymentProtection
     val viewModel: StartTierFlowViewModel =
       assistedMetroViewModel<StartTierFlowViewModel, StartTierFlowViewModelFactory> {
-        create(insuranceId)
+        create(insuranceId, isPaymentProtection)
       }
     StartChangeTierFlowDestination(
       viewModel = viewModel,

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/navigation/ChooseTierNavDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/navigation/ChooseTierNavDestination.kt
@@ -15,6 +15,11 @@ data class StartTierFlowKey(
   /** Must match the name of the param inside [com.hedvig.android.navigation.core.HedvigDeepLinkContainer.changeTierWithContractId] */
   @SerialName("contractId")
   val insuranceId: String,
+  /**
+   * Known upfront by the entry points which already hold the contract, so that the loading state can use the
+   * insurance amount wording before the intent has been fetched. False when the caller only knows the contract id.
+   */
+  val isPaymentProtection: Boolean = false,
 ) : HedvigNavKey
 
 @Serializable

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/chooseinsurance/ChooseInsuranceToChangeTierDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/chooseinsurance/ChooseInsuranceToChangeTierDestination.kt
@@ -42,6 +42,7 @@ import com.hedvig.android.design.system.hedvig.icon.Close
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.feature.change.tier.data.CustomisableInsurance
 import com.hedvig.android.feature.change.tier.ui.stepstart.DeflectScreen
+import hedvig.resources.CHANGE_INSURANCE_AMOUNT_PROCESSING
 import hedvig.resources.Res
 import hedvig.resources.TERMINATION_NO_TIER_QUOTES_SUBTITLE
 import hedvig.resources.TIER_FLOW_PROCESSING
@@ -114,9 +115,13 @@ private fun ChooseInsuranceScreen(
       }
     }
 
-    ChooseInsuranceUiState.Loading -> {
+    is ChooseInsuranceUiState.Loading -> {
       HedvigFullScreenCenterAlignedLinearProgress(
-        title = stringResource(Res.string.TIER_FLOW_PROCESSING),
+        title = if (uiState.isPaymentProtection) {
+          stringResource(Res.string.CHANGE_INSURANCE_AMOUNT_PROCESSING)
+        } else {
+          stringResource(Res.string.TIER_FLOW_PROCESSING)
+        },
       )
     }
 
@@ -283,7 +288,8 @@ private class ChooseInsuranceUiStateProvider :
         changeTierIntentFailedToLoad = true,
       ),
       ChooseInsuranceUiState.Failure,
-      ChooseInsuranceUiState.Loading,
+      ChooseInsuranceUiState.Loading(isPaymentProtection = false),
+      ChooseInsuranceUiState.Loading(isPaymentProtection = true),
       ChooseInsuranceUiState.NotAllowed,
       ChooseInsuranceUiState.Deflect(
         "How to change back to your previous coverage",

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/chooseinsurance/ChooseInsuranceViewModel.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/chooseinsurance/ChooseInsuranceViewModel.kt
@@ -11,6 +11,7 @@ import com.hedvig.android.core.common.di.ActivityRetainedScope
 import com.hedvig.android.core.common.di.HedvigViewModel
 import com.hedvig.android.data.changetier.data.ChangeTierCreateSource.SELF_SERVICE
 import com.hedvig.android.data.changetier.data.ChangeTierRepository
+import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.feature.change.tier.data.CustomisableInsurance
 import com.hedvig.android.feature.change.tier.data.GetCustomizableInsurancesUseCase
 import com.hedvig.android.feature.change.tier.navigation.ChooseTierKey
@@ -35,7 +36,7 @@ internal class ChooseInsuranceViewModel(
   tierRepository: ChangeTierRepository,
   backstack: Backstack,
 ) : MoleculeViewModel<ChooseInsuranceToCustomizeEvent, ChooseInsuranceUiState>(
-    initialState = Loading,
+    initialState = Loading(isPaymentProtection = false),
     presenter = ChooseInsurancePresenter(
       getCustomizableInsurancesUseCase = getCustomizableInsurancesUseCase,
       tierRepository = tierRepository,
@@ -88,7 +89,7 @@ internal class ChooseInsurancePresenter(
 
     LaunchedEffect(insuranceToFetchIntentFor) {
       val customisableInsurance = insuranceToFetchIntentFor ?: return@LaunchedEffect
-      currentState = Loading
+      currentState = Loading(customisableInsurance.contractGroup == ContractGroup.PAYMENT_PROTECTION)
       tierRepository
         .startChangeTierIntentAndGetQuotesId(customisableInsurance.id, SELF_SERVICE)
         .fold(
@@ -128,7 +129,7 @@ internal class ChooseInsurancePresenter(
 
     LaunchedEffect(loadIteration) {
       if (lastState !is ChooseInsuranceUiState.Success) {
-        currentState = Loading
+        currentState = Loading(isPaymentProtection = false)
       }
       getCustomizableInsurancesUseCase.invoke().collect { contractsResult ->
         contractsResult.fold(
@@ -159,7 +160,9 @@ internal class ChooseInsurancePresenter(
 }
 
 internal sealed interface ChooseInsuranceUiState {
-  data object Loading : ChooseInsuranceUiState
+  // Payment protection reuses the tier flow only to pick an insured amount, so the loading state announces that it
+  // fetches an insurance amount rather than coverage levels. Only known once an insurance has been picked.
+  data class Loading(val isPaymentProtection: Boolean) : ChooseInsuranceUiState
 
   data class Success(
     val insuranceList: List<CustomisableInsurance>,

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepstart/StartTierFlowDestination.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepstart/StartTierFlowDestination.kt
@@ -37,6 +37,7 @@ import com.hedvig.android.feature.change.tier.ui.stepstart.FailureReason.GENERAL
 import com.hedvig.android.feature.change.tier.ui.stepstart.FailureReason.QUOTES_ARE_EMPTY
 import com.hedvig.android.feature.change.tier.ui.stepstart.StartTierChangeState.Failure
 import com.hedvig.android.feature.change.tier.ui.stepstart.StartTierChangeState.Loading
+import hedvig.resources.CHANGE_INSURANCE_AMOUNT_PROCESSING
 import hedvig.resources.DASHBOARD_OPEN_CHAT
 import hedvig.resources.Res
 import hedvig.resources.TERMINATION_FLOW_I_UNDERSTAND_TEXT
@@ -81,9 +82,13 @@ private fun StartChangeTierFlowScreen(
       )
     }
 
-    Loading -> {
+    is Loading -> {
       HedvigFullScreenCenterAlignedLinearProgress(
-        title = stringResource(Res.string.TIER_FLOW_PROCESSING),
+        title = if (uiState.isPaymentProtection) {
+          stringResource(Res.string.CHANGE_INSURANCE_AMOUNT_PROCESSING)
+        } else {
+          stringResource(Res.string.TIER_FLOW_PROCESSING)
+        },
       )
     }
 
@@ -213,7 +218,8 @@ private fun StartTierFlowScreenPreview(
 internal class StartTierChangeStateProvider :
   CollectionPreviewParameterProvider<StartTierChangeState>(
     listOf(
-      Loading,
+      Loading(isPaymentProtection = false),
+      Loading(isPaymentProtection = true),
       Failure(GENERAL),
       Failure(QUOTES_ARE_EMPTY),
       StartTierChangeState.Deflect(

--- a/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepstart/StartTierFlowViewModel.kt
+++ b/app/feature/feature-choose-tier/src/main/kotlin/com/hedvig/android/feature/change/tier/ui/stepstart/StartTierFlowViewModel.kt
@@ -34,12 +34,14 @@ import dev.zacsweers.metro.AssistedInject
 @HedvigViewModel(ActivityRetainedScope::class)
 internal class StartTierFlowViewModel(
   @Assisted insuranceID: String,
+  @Assisted isPaymentProtection: Boolean,
   tierRepository: ChangeTierRepository,
   backstack: Backstack,
 ) : MoleculeViewModel<StartTierChangeEvent, StartTierChangeState>(
-    initialState = Loading,
+    initialState = Loading(isPaymentProtection),
     presenter = StartTierChangePresenter(
       insuranceID = insuranceID,
+      isPaymentProtection = isPaymentProtection,
       tierRepository = tierRepository,
       backstack = backstack,
     ),
@@ -47,6 +49,7 @@ internal class StartTierFlowViewModel(
 
 internal class StartTierChangePresenter(
   private val insuranceID: String,
+  private val isPaymentProtection: Boolean,
   private val tierRepository: ChangeTierRepository,
   private val backstack: Backstack,
 ) : MoleculePresenter<StartTierChangeEvent, StartTierChangeState> {
@@ -57,7 +60,7 @@ internal class StartTierChangePresenter(
     var currentState by remember { mutableStateOf(lastState) }
     var loadIteration by remember { mutableIntStateOf(0) }
     LaunchedEffect(loadIteration) {
-      currentState = Loading
+      currentState = Loading(isPaymentProtection)
       tierRepository.startChangeTierIntentAndGetQuotesId(insuranceID, ChangeTierCreateSource.SELF_SERVICE).fold(
         ifLeft = { left: ErrorMessage ->
           logcat(WARN) { "Start TierFlow failed with: $left" }
@@ -99,7 +102,9 @@ internal class StartTierChangePresenter(
 }
 
 internal sealed interface StartTierChangeState {
-  data object Loading : StartTierChangeState
+  // Payment protection reuses the tier flow only to pick an insured amount, so the loading state announces that it
+  // fetches an insurance amount rather than coverage levels.
+  data class Loading(val isPaymentProtection: Boolean) : StartTierChangeState
 
   data class Failure(val reason: FailureReason) : StartTierChangeState
 

--- a/app/feature/feature-choose-tier/src/test/kotlin/ui/chooseinsurance/ChooseInsurancePresenterTest.kt
+++ b/app/feature/feature-choose-tier/src/test/kotlin/ui/chooseinsurance/ChooseInsurancePresenterTest.kt
@@ -18,6 +18,7 @@ import com.hedvig.android.data.changetier.data.ChangeTierDeductibleIntent
 import com.hedvig.android.data.changetier.data.DeflectOutput
 import com.hedvig.android.data.changetier.data.IntentOutput
 import com.hedvig.android.data.contract.ContractGroup.HOMEOWNER
+import com.hedvig.android.data.contract.ContractGroup.PAYMENT_PROTECTION
 import com.hedvig.android.data.contract.ContractGroup.RENTAL
 import com.hedvig.android.feature.change.tier.data.CustomisableInsurance
 import com.hedvig.android.feature.change.tier.data.GetCustomizableInsurancesUseCase
@@ -48,7 +49,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       skipItems(1)
       useCase.turbine.add(flowOf(ErrorMessage().left()))
       val state = awaitItem()
@@ -65,7 +66,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       skipItems(1)
       useCase.turbine.add(flowOf(null.right()))
       val state = awaitItem()
@@ -85,7 +86,7 @@ class ChooseInsurancePresenterTest {
         getCustomizableInsurancesUseCase = useCase,
         backstack = backstack,
       )
-      presenter.test(ChooseInsuranceUiState.Loading) {
+      presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
         assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
         useCase.turbine.add(
           flowOf(
@@ -124,7 +125,7 @@ class ChooseInsurancePresenterTest {
         getCustomizableInsurancesUseCase = useCase,
         backstack = TestBackstack(),
       )
-      presenter.test(ChooseInsuranceUiState.Loading) {
+      presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
         assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
         useCase.turbine.add(
           flowOf(
@@ -161,7 +162,7 @@ class ChooseInsurancePresenterTest {
         getCustomizableInsurancesUseCase = useCase,
         backstack = TestBackstack(),
       )
-      presenter.test(ChooseInsuranceUiState.Loading) {
+      presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
         assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
         useCase.turbine.add(
           flowOf(
@@ -189,7 +190,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
       useCase.turbine.add(flowOf(listOfInsurances.right()))
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Success::class)
@@ -207,7 +208,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
       useCase.turbine.add(flowOf(listOfInsurances.right()))
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Success::class)
@@ -225,7 +226,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
       useCase.turbine.add(flowOf(listOfInsurances.right()))
       skipItems(1)
@@ -248,7 +249,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = backstack,
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
       useCase.turbine.add(flowOf(listOfInsurances.right()))
       sendEvent(ChooseInsuranceToCustomizeEvent.SelectInsurance(listOfInsurances[0].id))
@@ -270,6 +271,28 @@ class ChooseInsurancePresenterTest {
   }
 
   @Test
+  fun `when the chosen insurance is payment protection the loading state carries the insurance amount wording`() =
+    runTest {
+      val tierRepo = FakeChangeTierRepository()
+      val useCase = FakeGetCustomizableInsurancesUseCase()
+      val presenter = ChooseInsurancePresenter(
+        tierRepository = tierRepo,
+        getCustomizableInsurancesUseCase = useCase,
+        backstack = TestBackstack(),
+      )
+      presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
+        skipItems(1)
+        useCase.turbine.add(flowOf(listOfInsurances.right()))
+        skipItems(1)
+        sendEvent(ChooseInsuranceToCustomizeEvent.SubmitSelectedInsuranceToCustomize(paymentProtectionInsurance))
+        assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
+          .prop(ChooseInsuranceUiState.Loading::isPaymentProtection)
+          .isEqualTo(true)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  @Test
   fun `if receive only one customisable insurance and deflectOutput is returned show deflect screen`() = runTest {
     val tierRepo = FakeChangeTierRepository()
     val useCase = FakeGetCustomizableInsurancesUseCase()
@@ -278,7 +301,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
       useCase.turbine.add(
         flowOf(
@@ -317,7 +340,7 @@ class ChooseInsurancePresenterTest {
       getCustomizableInsurancesUseCase = useCase,
       backstack = TestBackstack(),
     )
-    presenter.test(ChooseInsuranceUiState.Loading) {
+    presenter.test(ChooseInsuranceUiState.Loading(isPaymentProtection = false)) {
       assertThat(awaitItem()).isInstanceOf(ChooseInsuranceUiState.Loading::class)
       useCase.turbine.add(flowOf(listOfInsurances.right()))
       sendEvent(ChooseInsuranceToCustomizeEvent.SelectInsurance(listOfInsurances[0].id))
@@ -347,6 +370,13 @@ private class FakeGetCustomizableInsurancesUseCase() : GetCustomizableInsurances
     return turbine.awaitItem()
   }
 }
+
+private val paymentProtectionInsurance = CustomisableInsurance(
+  "ppiId",
+  "Payment protection",
+  "Payment protection",
+  PAYMENT_PROTECTION,
+)
 
 private val listOfInsurances = nonEmptyListOf(
   CustomisableInsurance(

--- a/app/feature/feature-choose-tier/src/test/kotlin/ui/stepstart/StartTierChangePresenterTest.kt
+++ b/app/feature/feature-choose-tier/src/test/kotlin/ui/stepstart/StartTierChangePresenterTest.kt
@@ -32,14 +32,33 @@ class StartTierChangePresenterTest {
   private val insuranceId = "testId"
 
   @Test
+  fun `when the contract is payment protection the loading state carries the insurance amount wording`() = runTest {
+    val tierRepo = FakeChangeTierRepository()
+    val presenter = StartTierChangePresenter(
+      tierRepository = tierRepo,
+      insuranceID = insuranceId,
+      isPaymentProtection = true,
+      backstack = TestBackstack(),
+    )
+    presenter.test(StartTierChangeState.Loading(isPaymentProtection = false)) {
+      skipItems(1)
+      assertThat(awaitItem()).isInstanceOf(StartTierChangeState.Loading::class)
+        .prop(StartTierChangeState.Loading::isPaymentProtection)
+        .isEqualTo(true)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
   fun `if the quote list comes empty show empty quotes screen`() = runTest {
     val tierRepo = FakeChangeTierRepository()
     val presenter = StartTierChangePresenter(
       tierRepository = tierRepo,
       insuranceID = insuranceId,
+      isPaymentProtection = false,
       backstack = TestBackstack(),
     )
-    presenter.test(StartTierChangeState.Loading) {
+    presenter.test(StartTierChangeState.Loading(isPaymentProtection = false)) {
       tierRepo.changeTierIntentTurbine.add(
         ChangeTierDeductibleIntent(
           IntentOutput(
@@ -63,9 +82,10 @@ class StartTierChangePresenterTest {
     val presenter = StartTierChangePresenter(
       tierRepository = tierRepo,
       insuranceID = insuranceId,
+      isPaymentProtection = false,
       backstack = TestBackstack(),
     )
-    presenter.test(StartTierChangeState.Loading) {
+    presenter.test(StartTierChangeState.Loading(isPaymentProtection = false)) {
       tierRepo.changeTierIntentTurbine.add(com.hedvig.android.core.common.ErrorMessage().left())
       skipItems(1)
       val state = awaitItem()
@@ -83,9 +103,10 @@ class StartTierChangePresenterTest {
     val presenter = StartTierChangePresenter(
       tierRepository = tierRepo,
       insuranceID = insuranceId,
+      isPaymentProtection = false,
       backstack = backstack,
     )
-    presenter.test(StartTierChangeState.Loading) {
+    presenter.test(StartTierChangeState.Loading(isPaymentProtection = false)) {
       tierRepo.changeTierIntentTurbine.add(
         ChangeTierDeductibleIntent(
           IntentOutput(
@@ -107,9 +128,10 @@ class StartTierChangePresenterTest {
     val presenter = StartTierChangePresenter(
       tierRepository = tierRepo,
       insuranceID = insuranceId,
+      isPaymentProtection = false,
       backstack = TestBackstack(),
     )
-    presenter.test(StartTierChangeState.Loading) {
+    presenter.test(StartTierChangeState.Loading(isPaymentProtection = false)) {
       tierRepo.changeTierIntentTurbine.add(
         ChangeTierDeductibleIntent(
           intentOutput = null,
@@ -133,9 +155,10 @@ class StartTierChangePresenterTest {
     val presenter = StartTierChangePresenter(
       tierRepository = tierRepo,
       insuranceID = insuranceId,
+      isPaymentProtection = false,
       backstack = TestBackstack(),
     )
-    presenter.test(StartTierChangeState.Loading) {
+    presenter.test(StartTierChangeState.Loading(isPaymentProtection = false)) {
       tierRepo.changeTierIntentTurbine.add(
         ChangeTierDeductibleIntent(
           intentOutput = IntentOutput(

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -102,7 +102,7 @@ internal fun ContractDetailDestination(
   onEditCoOwnersClick: (String) -> Unit,
   onMissingCoInsuredInfoClick: (String) -> Unit,
   onMissingCoOwnersInfoClick: (String) -> Unit,
-  onChangeTierClick: (String) -> Unit,
+  onChangeTierClick: (contractId: String, isPaymentProtection: Boolean) -> Unit,
   onChangeAddressClick: () -> Unit,
   onCancelInsuranceClick: (cancelInsuranceData: CancelInsuranceData) -> Unit,
   onNavigateToNewConversation: () -> Unit,
@@ -148,7 +148,7 @@ private fun ContractDetailScreen(
   onEditCoOwnersClick: (String) -> Unit,
   onMissingCoInsuredInfoClick: (String) -> Unit,
   onMissingCoOwnersInfoClick: (String) -> Unit,
-  onChangeTierClick: (String) -> Unit,
+  onChangeTierClick: (contractId: String, isPaymentProtection: Boolean) -> Unit,
   onChangeAddressClick: () -> Unit,
   onCancelInsuranceClick: (cancelInsuranceData: CancelInsuranceData) -> Unit,
   navigateUp: () -> Unit,
@@ -316,6 +316,7 @@ private fun ContractDetailScreen(
                     } else {
                       null
                     }
+                    val isPaymentProtection = contract.productVariant.contractGroup == PAYMENT_PROTECTION
                     YourInfoTab(
                       contractId = contract.id,
                       coverageItems = contract.displayItems,
@@ -326,10 +327,10 @@ private fun ContractDetailScreen(
                       allowEditCoInsured = contract.supportsEditCoInsured,
                       allowEditCoOwners = contract.supportsEditCoOwners,
                       allowChangeTier = contract.supportsTierChange,
-                      isPaymentProtection = contract.productVariant.contractGroup == PAYMENT_PROTECTION,
+                      isPaymentProtection = isPaymentProtection,
                       allowRemovingAddon = contract.supportsRemovingAddon,
                       onChangeTierClick = {
-                        onChangeTierClick(contract.id)
+                        onChangeTierClick(contract.id, isPaymentProtection)
                       },
                       isDecommissioned = contract.productVariant.contractType == ContractType.SE_CAR_DECOMMISSIONED,
                       upcomingChangesInsuranceAgreement = contract.upcomingInsuranceAgreement,
@@ -532,7 +533,7 @@ private fun PreviewContractDetailScreen() {
         onMissingCoInsuredInfoClick = {},
         onMissingCoOwnersInfoClick = {},
         openUrl = {},
-        onChangeTierClick = {},
+        onChangeTierClick = { _, _ -> },
         navigateToAddAddon = {},
         navigateToRemoveAddon = { _, _ -> },
         navigateToUpgradeAddon = { _, _ -> },
@@ -562,7 +563,7 @@ private fun PreviewContractDetailScreenFailure() {
         onMissingCoInsuredInfoClick = {},
         onMissingCoOwnersInfoClick = {},
         openUrl = {},
-        onChangeTierClick = {},
+        onChangeTierClick = { _, _ -> },
         navigateToAddAddon = {},
         navigateToRemoveAddon = { _, _ -> },
         navigateToUpgradeAddon = { _, _ -> },

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/navigation/InsuranceEntries.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/navigation/InsuranceEntries.kt
@@ -29,7 +29,7 @@ fun EntryProviderScope<HedvigNavKey>.insuranceEntries(
   openUrl: (String) -> Unit,
   openCrossSellUrl: (String) -> Unit,
   startMovingFlow: () -> Unit,
-  onNavigateToStartChangeTier: (contractId: String) -> Unit,
+  onNavigateToStartChangeTier: (contractId: String, isPaymentProtection: Boolean) -> Unit,
   startTerminationFlow: (cancelInsuranceData: CancelInsuranceData) -> Unit,
   startEditCoInsured: (contractId: String) -> Unit,
   startEditCoOwners: (contractId: String) -> Unit,
@@ -85,8 +85,8 @@ fun EntryProviderScope<HedvigNavKey>.insuranceEntries(
       navigateUp = backstack::navigateUp,
       navigateBack = backstack::popBackstack,
       imageLoader = imageLoader,
-      onChangeTierClick = dropUnlessResumed { contractId: String ->
-        onNavigateToStartChangeTier(contractId)
+      onChangeTierClick = dropUnlessResumed { contractId: String, isPaymentProtection: Boolean ->
+        onNavigateToStartChangeTier(contractId, isPaymentProtection)
       },
       navigateToRemoveAddon = onNavigateToRemoveAddon,
       navigateToUpgradeAddon = navigateToUpgradeAddon,


### PR DESCRIPTION
Pass `isPaymentProtection` to start tier flow (to show different loading phrase: "Fetching insurance amount..."). 
"Fetching coverage levels" still default for deep link.

[slack](https://hedviginsurance.slack.com/archives/C05TQ9TFQ6M/p1788254430684379)