### PR TITLE
change showing policy holder row logic (always show even without coInsured)

### DIFF
--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
+import com.hedvig.android.compose.ui.preview.BooleanCollectionPreviewParameterProvider
 import com.hedvig.android.compose.ui.preview.DoubleBooleanCollectionPreviewParameterProvider
 import com.hedvig.android.core.common.daysUntil
 import com.hedvig.android.core.uidata.UiCurrencyCode
@@ -46,6 +47,7 @@ import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigDateTimeFormatterDefaults
 import com.hedvig.android.design.system.hedvig.HedvigNotificationCard
 import com.hedvig.android.design.system.hedvig.HedvigPreview
+import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HighlightLabel
@@ -311,22 +313,19 @@ internal fun YourInfoTab(
             modifier = Modifier.padding(horizontal = 16.dp),
           )
         }
-        if (allowEditCoInsured || allowEditCoOwners) {
+
           HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
           Spacer(Modifier.height(16.dp))
           ContractOwnerSection(
             coInsuredList = coInsured,
             modifier = Modifier.padding(horizontal = 16.dp),
+            contractHolderDisplayName = contractHolderDisplayName,
+            contractHolderSSN = contractHolderSSN,
           )
-          if (coInsured.isEmpty() && coOwners.isEmpty()) {
-            Spacer(Modifier.height(16.dp))
-          }
-        }
+
         if (allowEditCoInsured && coInsured.isNotEmpty()) {
           CoInsuredSection(
             coInsuredList = coInsured,
-            contractHolderDisplayName = contractHolderDisplayName,
-            contractHolderSSN = contractHolderSSN,
             isCoOwner = false,
             modifier = Modifier.padding(horizontal = 16.dp),
           )
@@ -334,8 +333,6 @@ internal fun YourInfoTab(
         if (allowEditCoOwners && coOwners.isNotEmpty()) {
           CoInsuredSection(
             coInsuredList = coOwners,
-            contractHolderDisplayName = contractHolderDisplayName,
-            contractHolderSSN = contractHolderSSN,
             isCoOwner = true,
             modifier = Modifier.padding(horizontal = 16.dp),
           )
@@ -763,7 +760,12 @@ internal fun PriceRow(
 }
 
 @Composable
-internal fun ContractOwnerSection(coInsuredList: List<CoInsured>, modifier: Modifier) {
+internal fun ContractOwnerSection(
+  coInsuredList: List<CoInsured>,
+  contractHolderDisplayName: String,
+  contractHolderSSN: String?,
+  modifier: Modifier,
+) {
   Column(modifier = modifier) {
     HorizontalItemsWithMaximumSpaceTaken(
       startSlot = {
@@ -794,20 +796,6 @@ internal fun ContractOwnerSection(coInsuredList: List<CoInsured>, modifier: Modi
       },
       spaceBetween = 8.dp,
     )
-  }
-}
-
-@Composable
-internal fun CoInsuredSection(
-  coInsuredList: List<CoInsured>,
-  contractHolderDisplayName: String,
-  contractHolderSSN: String?,
-  isCoOwner: Boolean,
-  modifier: Modifier,
-) {
-  val dateTimeFormatter = rememberHedvigDateTimeFormatter()
-  val birthDateTimeFormatter = rememberHedvigBirthDateDateTimeFormatter()
-  Column(modifier = modifier) {
     Spacer(Modifier.height(16.dp))
     HorizontalDivider()
     HorizontalItemsWithMaximumSpaceTaken(
@@ -842,6 +830,18 @@ internal fun CoInsuredSection(
       },
       spaceBetween = 8.dp,
     )
+  }
+}
+
+@Composable
+internal fun CoInsuredSection(
+  coInsuredList: List<CoInsured>,
+  isCoOwner: Boolean,
+  modifier: Modifier,
+) {
+  val dateTimeFormatter = rememberHedvigDateTimeFormatter()
+  val birthDateTimeFormatter = rememberHedvigBirthDateDateTimeFormatter()
+  Column(modifier = modifier) {
     for (coInsured in coInsuredList) {
       HorizontalDivider()
       HorizontalItemsWithMaximumSpaceTaken(
@@ -914,9 +914,11 @@ internal fun CoInsuredSection(
 }
 
 @Composable
-@HedvigPreview
+@HedvigShortMultiScreenPreview
 @Preview(name = "long", device = "spec:width=1080px,height=5000px,dpi=440")
-private fun PreviewYourInfoTab() {
+private fun PreviewYourInfoTab(
+  @PreviewParameter(BooleanCollectionPreviewParameterProvider::class) onlyInsuranceHolder: Boolean,
+) {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       YourInfoTab(
@@ -927,24 +929,25 @@ private fun PreviewYourInfoTab() {
           DisplayItem("Type", Text("Homeowner")),
           DisplayItem("Size", Text("56 m2")),
         ),
-        coInsured = listOf(
+        coInsured = if (onlyInsuranceHolder) emptyList() else
+          listOf(
           CoInsured(
-            ssn = "199101131093",
+            ssn = "199101131000",
             birthDate = null,
-            firstName = "Hugo",
-            lastName = "Linder",
+            firstName = "Hu",
+            lastName = "Li",
             activatesOn = LocalDate.fromEpochDays(300),
-            terminatesOn = LocalDate.fromEpochDays(400),
+            terminatesOn = null,
             hasMissingInfo = false,
           ),
           CoInsured(
-            ssn = null,
+            ssn = "1234020312",
             birthDate = null,
-            firstName = null,
-            lastName = null,
+            firstName = "Testersson",
+            lastName = "Tester",
             activatesOn = null,
             terminatesOn = null,
-            hasMissingInfo = true,
+            hasMissingInfo = false,
           ),
         ),
         coOwners = listOf(),
@@ -986,7 +989,7 @@ private fun PreviewYourInfoTab() {
               firstName = "Hugo",
               lastName = "Linder",
               activatesOn = LocalDate.fromEpochDays(300),
-              terminatesOn = LocalDate.fromEpochDays(300),
+              terminatesOn = null,
               hasMissingInfo = false,
             ),
             CoInsured(


### PR DESCRIPTION
[slack](https://hedviginsurance.slack.com/archives/C0B7FABE2KU/p1788272490735759?thread_ts=1788249991.321569&cid=C0B7FABE2KU)