### PR TITLE
Fix two lint configuration traps

### DIFF
--- a/build-logic/convention/src/main/kotlin/HedvigLintConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HedvigLintConventionPlugin.kt
@@ -57,7 +57,10 @@ class HedvigLintConventionPlugin : Plugin<Project> {
 }
 
 private fun Lint.configure(lintXmlFile: File, lintBaselineFile: File) {
-  baseline = lintBaselineFile
+  // Lint aborts the build whenever it has to create a baseline, even when it found nothing to put in
+  // one, and the baseline it leaves behind then suppresses real errors on the next run. A module opts
+  // in by committing the file: create it empty, then fill it with `updateLintBaseline`.
+  baseline = lintBaselineFile.takeIf(File::exists)
   lintConfig = lintXmlFile
   xmlReport = true
 }

--- a/hedvig-lint/lint.xml
+++ b/hedvig-lint/lint.xml
@@ -8,6 +8,12 @@
        config entry for a check absent from a given module isn't flagged. -->
   <issue id="UnknownIssueId" severity="ignore" />
 
+  <!-- Renovate (renovate.json) owns dependency freshness, so lint's version-staleness notices are
+       duplicate signal. They also resolve against the shared root gradle/libs.versions.toml rather
+       than the module being linted, so they report identically no matter which module runs lint. -->
+  <issue id="GradleDependency" severity="ignore" />
+  <issue id="NewerVersionAvailable" severity="ignore" />
+
   <issue id="ButtonCase" severity="ignore" />
   <issue id="TypographyDashes" severity="ignore" />
   <issue id="TypographyEllipsis" severity="ignore" />


### PR DESCRIPTION
Stop creating an empty baseline file when there is no need for one. New modules should now just build by default if they have no lint errors

🤖 AI description:

Two lint configuration fixes. Both surfaced while adding a new module, neither is specific to it. #3132 above is the follow-through: it deletes the 104 baselines this requirement produced.

**Only set the baseline when the module has one.** The convention plugin pointed `baseline` at `lint-baseline-<module>.xml` unconditionally, and lint aborts the build whenever it has to create that file, even when it found nothing to put in it. Adding any new module therefore failed `./gradlew lint` with a message naming neither the module nor the cause.

In practice this has been harmless, which is why 104 of the 105 checked-in baselines are empty: modules here produce no findings, so the generated file was empty and committing it suppressed nothing. The cost is the ritual and the failure itself, which nobody adding a module should have to learn.

It is not harmless when a module does have findings. The baseline lint writes records whatever it found, and the abort message tells you to re-run, so the second run passes. Demonstrated with 18 error-severity findings: run one aborts after writing all 18 into the baseline, and run two reports `no new issues (and 18 errors filtered by baseline)` with the build succeeding, nothing fixed.

Setting `baseline` only when the file exists removes both. Modules that carry a baseline behave exactly as before, and none are deleted in this PR.

**Ignore version catalog staleness.** `GradleDependency` and `NewerVersionAvailable` resolve against the shared root `gradle/libs.versions.toml` rather than the module being linted, so they report identically wherever lint runs and only a root-level module ever surfaces them. `renovate.json` already owns dependency freshness, so they are duplicate signal nobody acts on, and 77 of them appeared against a module that declares none of those dependencies. Both are now ignored in the shared `lint.xml`.

`./gradlew lint` passes across the repo.


