### PR TITLE
Import the type, never the namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,47 @@ Configuration in `.editorconfig`:
 - **Entry functions:** `{feature}Entries`
 - **Use cases:** `{Action}{Domain}UseCase` (e.g., `GetHomeDataUseCase`)
 
+### Imports
+
+**Import the type, never the namespace.** An import may shorten a qualified reference only when the
+short name still says what it is to someone reading that line cold, without scrolling to the import
+list. Sealed subclasses, enum entries and other types pass that test. A member reached through a
+receiver that carries the meaning does not.
+
+Always allowed (this is the house style, ~1200 such imports exist):
+
+```kotlin
+import com.hedvig.android.feature.home.home.ui.HomeUiState.Success   // `is Success ->` reads fine
+import com.hedvig.android.design.system.hedvig.TooltipDefaults.BeakDirection.TopEnd
+import kotlin.time.Duration.Companion.seconds                        // enables the `5.seconds` idiom
+```
+
+Never allowed, because the receiver is the meaning:
+
+```kotlin
+import hedvig.resources.Res.string      // ❌ `stringResource(string.FOO)`  → use `Res.string.FOO`
+import hedvig.resources.Res.drawable    // ❌ `painterResource(drawable.x)` → use `Res.drawable.x`
+import kotlin.time.Clock.System         // ❌ `System.now()`               → use `Clock.System.now()`
+import ...hedvig.TooltipDefaults.defaultStyle  // ❌ `defaultStyle` alone names nothing
+```
+
+`Res` and `Clock` are the two that come up most: 193 files import `hedvig.resources.Res` plainly and
+that is the standard. `System.now()` additionally reads as `java.lang.System` to anyone skimming.
+
+**Separately: never make an import-only change to a line you are not otherwise editing.** Converting
+existing `HomeEvent.RefreshData` call sites to a bare `RefreshData` (or the reverse) is a whole-file
+rewrite disguised as a diff. It buries the real change under churn and makes review and `git blame`
+worse for no behavioural gain.
+
+**Why:** both halves of this rule protect the reader. The first protects whoever reads the line
+later, the second protects whoever reviews the PR now. PR #3100 was one screen refactor carrying 29
+gratuitous new imports and ~60 rewritten call sites, and the formatting noise overshadowed the
+actual work.
+
+**How to apply:** if you are touching a line for a real reason, use the correct form. If you are not
+touching it, leave its qualification exactly as it is. Import cleanups that are genuinely wanted go
+in their own commit.
+
 ### Comments
 
 Code comments and KDoc must describe the **current** code and stand on their own. A comment fails to earn its place in two ways: it tells the wrong kind of story, or it repeats what is already there. Before writing one, apply the test: *would this make sense to someone reading the file cold, with no knowledge of the PR, the conversation, or what was decided against?* If not, it does not belong in the source. Do not reference:

--- a/build-logic/convention/src/main/kotlin/HedvigGradlePlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HedvigGradlePlugin.kt
@@ -38,6 +38,14 @@ private fun Project.configureKtlint(libs: LibrariesForLibs) {
     reporters = arrayOf(ReporterType.checkstyle.name)
   }
 
+  // `ktlint` is kotlinter's configuration for additional rule sets, so this puts our rules on every
+  // module's ktlint run. hedvig-ktlint itself is skipped so that it does not depend on itself.
+  if (name != "hedvig-ktlint") {
+    dependencies {
+      add("ktlint", project(":hedvig-ktlint"))
+    }
+  }
+
   tasks.withType<org.jmailen.gradle.kotlinter.tasks.LintTask>().configureEach {
     exclude { it.file.path.contains("generated/") }
     reports.set(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ kmpNativeCoroutines = "1.0.5"
 kotlin = "2.4.10"
 kotlinpoet = "2.3.0"
 kotlinter = "5.6.0"
+# Must match the ktlint that kotlinter bundles, so the custom ruleset links against the same API
+ktlintCore = "1.8.0"
 ksp = "2.3.10"
 ktor = "3.5.1"
 license = "0.9.9"
@@ -270,6 +272,8 @@ kmpNativeCoroutines-gradlePlugin = { module = "com.rickclephas.kmp.nativecorouti
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinSerialization-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 kotlinter-gradlePlugin = { module = "org.jmailen.gradle:kotlinter-gradle", version.ref = "kotlinter" }
+ktlint-ruleEngineCore = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlintCore" }
+ktlint-cliRulesetCore = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlintCore" }
 ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 license-gradlePlugin = { module = "com.jaredsburrows.license:com.jaredsburrows.license.gradle.plugin", version.ref = "license" }
 metro-gradlePlugin = { module = "dev.zacsweers.metro:dev.zacsweers.metro.gradle.plugin", version.ref = "metro" }

--- a/hedvig-ktlint/build.gradle.kts
+++ b/hedvig-ktlint/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("hedvig.jvm.library")
+  id("hedvig.gradle.plugin")
+}
+
+dependencies {
+  compileOnly(libs.ktlint.ruleEngineCore)
+  compileOnly(libs.ktlint.cliRulesetCore)
+}

--- a/hedvig-ktlint/src/main/kotlin/com/hedvig/android/ktlint/HedvigRuleSetProvider.kt
+++ b/hedvig-ktlint/src/main/kotlin/com/hedvig/android/ktlint/HedvigRuleSetProvider.kt
@@ -1,0 +1,13 @@
+package com.hedvig.android.ktlint
+
+import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+
+internal const val CUSTOM_RULE_SET_ID = "hedvig"
+
+class HedvigRuleSetProvider : RuleSetProviderV3(RuleSetId(CUSTOM_RULE_SET_ID)) {
+  override fun getRuleProviders(): Set<RuleProvider> = setOf(
+    RuleProvider { NamespaceImportRule() },
+  )
+}

--- a/hedvig-ktlint/src/main/kotlin/com/hedvig/android/ktlint/NamespaceImportRule.kt
+++ b/hedvig-ktlint/src/main/kotlin/com/hedvig/android/ktlint/NamespaceImportRule.kt
@@ -1,0 +1,74 @@
+package com.hedvig.android.ktlint
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * Reports imports that shorten a qualified reference past the point where the short name still says
+ * what it is, such as `import hedvig.resources.Res.string` turning `Res.string.FOO` into `string.FOO`.
+ *
+ * This runs through kotlinter on every source set, `commonMain` and `iosMain` included, which is why
+ * the rule lives here rather than as an Android Lint check: AGP's KMP library plugin registers no
+ * task that runs Android Lint (https://issuetracker.google.com/issues/246751841), so a lint check
+ * cannot see a KMP module at all, and the design system is one.
+ *
+ * The cost of that reach is precision. ktlint has no type resolution, so an owner is recognized by
+ * the shape of the import path rather than by resolving it, and [CAPITALIZED_PACKAGES] carries the
+ * exceptions. Trading the heuristic for a resolved owner across the whole codebase needs an analyzer
+ * that both resolves types and runs on every source set: Android Lint, once the issue above is
+ * fixed, or detekt with type resolution.
+ */
+internal class NamespaceImportRule :
+  Rule(
+    ruleId = RuleId("$CUSTOM_RULE_SET_ID:namespace-import"),
+    about = About(
+      maintainer = "Hedvig",
+      repositoryUrl = "https://github.com/HedvigInsurance/android",
+      issueTrackerUrl = "https://github.com/HedvigInsurance/android/issues",
+    ),
+  ) {
+  override fun beforeVisitChildNodes(
+    node: ASTNode,
+    autoCorrect: Boolean,
+    emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+  ) {
+    if (node.elementType != ElementType.IMPORT_DIRECTIVE) return
+    val text = node.text
+    // An alias is a deliberate act of renaming, and gives the use site a name of its own.
+    if (text.contains(" as ")) return
+    val qualifiedName = text.removePrefix("import").trim()
+    if (qualifiedName.isEmpty() || qualifiedName.endsWith("*")) return
+
+    val importedName = qualifiedName.substringAfterLast('.')
+    val ownerPath = qualifiedName.substringBeforeLast('.', "")
+    val ownerName = ownerPath.substringAfterLast('.')
+    if (importedName.isEmpty() || ownerName.isEmpty()) return
+    if (!ownerName.first().isUpperCase()) return
+    // `Duration.Companion.seconds` and friends exist to enable the `5.seconds` receiver idiom.
+    if (ownerName == "Companion") return
+    if (CAPITALIZED_PACKAGES.any { qualifiedName.startsWith(it) }) return
+
+    val importsAMember = importedName.first().isLowerCase()
+    if (!importsAMember && qualifiedName !in DENIED_IMPORTS) return
+
+    emit(
+      node.startOffset,
+      "Import $ownerName and write $ownerName.$importedName at the use site. " +
+        "On its own, $importedName no longer says what it is.",
+      false,
+    )
+  }
+
+  private companion object {
+    /**
+     * Kotlin/Native interop packages are capitalized after the framework they bind, so their
+     * top-level declarations look identical to members of a class.
+     */
+    val CAPITALIZED_PACKAGES = listOf("platform.")
+
+    /** Imports that read as a type but still leave nothing meaningful at the use site. */
+    val DENIED_IMPORTS = setOf("kotlin.time.Clock.System")
+  }
+}

--- a/hedvig-ktlint/src/main/resources/META-INF/services/com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
+++ b/hedvig-ktlint/src/main/resources/META-INF/services/com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
@@ -1,0 +1,1 @@
+com.hedvig.android.ktlint.HedvigRuleSetProvider

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,3 +69,4 @@ include("design-showcase-desktop")
 project(":design-showcase-desktop").projectDir =
   rootProject.projectDir.resolve("micro-apps").resolve("design-showcase-desktop")
 include("hedvig-lint")
+include("hedvig-ktlint")


### PR DESCRIPTION
A structured way to catch these https://github.com/HedvigInsurance/android/pull/3130 problems, by enforcing the import rule through a ktlint rule.


🤖 AI description:

States the import rule in `CLAUDE.md` and enforces it with a ktlint rule. #3130 below has already fixed every existing violation, so the tree is clean when this lands.

**The rule.** Import the type, never the namespace. An import may shorten a qualified reference only when the short name still says what it is to someone reading that line cold. `HomeUiState.Success` and `Duration.Companion.seconds` pass. `Res.string` and `Clock.System` do not: `string.FOO` names nothing, and `System.now()` reads as `java.lang.System`. The rule also bans import-only changes to lines you are not otherwise editing.

**Why it needs writing down.** PR #3100 was one screen refactor in one file, and most of its +250/-139 was not the refactor: 29 new imports and around 60 rewritten call sites shortening `Res.string.FOO` into `string.FOO`. The real change was buried under the churn, and the shortened forms read worse than what they replaced.

**The check.** A ktlint custom ruleset in the new `hedvig-ktlint` module, `RuleSetProviderV3` against ktlint 1.8.0, the version kotlinter 5.6.0 bundles. Wired into every module through kotlinter's `ktlint` configuration, so it runs on every source set. Verified by planting a violation in `design-system-hedvig`: it reports in `commonMain` and `iosMain`, not only on Android and JVM modules.

**Why ktlint rather than Android Lint.** Android Lint would resolve the owner instead of inferring it from the shape of the import path, but it cannot see a KMP module at all, since AGP registers no lint task there ([246751841](https://issuetracker.google.com/issues/246751841)), and the design system is where 19 of the violations lived. The commit message records the four workarounds tried before giving up on it. #3123 added Lint as a second mechanism and was closed as not worth maintaining the same policy twice.

**The limitation is precision, not reach.** Without type resolution, `CAPITALIZED_PACKAGES` has to exclude Kotlin/Native interop packages by prefix, because `platform.Foundation.systemLocale` is shaped exactly like a member import. That costs nothing today: `platform.*` appears in 8 files, all `nativeMain`, and the repo has no other capitalized-package member imports. The rule's KDoc records what a permanent fix would need, an analyzer that both resolves types and runs on every source set.

Star imports are deliberately not handled here; ktlint's own `standard:no-wildcard-imports` already owns them.

`ktlintCheck` reports zero `namespace-import` hits across every module and source set, and `./gradlew lint` passes.

