### PR TITLE
feat(terminate): use server-provided actionText for suggestion buttons

### DIFF
--- a/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
+++ b/app/apollo/apollo-octopus-public/src/commonMain/graphql/com/hedvig/android/apollo/octopus/schema.graphqls
@@ -5442,6 +5442,7 @@ enum TerminationFlowSurveyOptionRedirectionType {
 type TerminationFlowSurveyOptionSuggestion {
   type: TerminationFlowSurveyOptionSuggestionType!
   description: String!
+  actionText: String
   url: String
 }
 enum TerminationFlowSurveyOptionSuggestionType {

--- a/app/feature/feature-terminate-insurance/src/main/graphql/QueryTerminationSurvey.graphql
+++ b/app/feature/feature-terminate-insurance/src/main/graphql/QueryTerminationSurvey.graphql
@@ -64,5 +64,6 @@ query TerminationSurvey($contractId: UUID!, $redirectionEnabled: Boolean!) {
 fragment TerminationSurveyOptionSuggestionFragment on TerminationFlowSurveyOptionSuggestion {
   type
   description
+  actionText
   url
 }

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminateInsuranceRepository.kt
@@ -263,6 +263,7 @@ private fun TerminationSurveyOptionSuggestionFragment.toSuggestion(): SurveyOpti
       }
     },
     description = description,
+    actionText = actionText,
     url = url,
   )
 }

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminationSurveyOption.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/data/TerminationSurveyOption.kt
@@ -18,6 +18,11 @@ internal data class TerminationSurveyOption(
 internal data class SurveyOptionSuggestion(
   val type: SuggestionType,
   val description: String,
+  /**
+   * The label for the suggestion's action button, when the backend has one to offer. Suggestions without their own
+   * label fall back to a label picked from the [type].
+   */
+  val actionText: String? = null,
   val url: String?,
 )
 

--- a/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
+++ b/app/feature/feature-terminate-insurance/src/main/kotlin/com/hedvig/android/feature/terminateinsurance/step/survey/TerminationSurveyDestination.kt
@@ -65,6 +65,7 @@ import hedvig.resources.TERMINATION_SURVEY_FEEDBACK_POPOVER_HINT
 import hedvig.resources.general_close_button
 import hedvig.resources.general_continue_button
 import hedvig.resources.something_went_wrong
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -291,22 +292,22 @@ private fun SelectedSurveyInfoBox(
           },
           style = when (suggestion.type) {
             SuggestionType.UPDATE_ADDRESS -> InfoCardStyle.Button(
-              buttonText = stringResource(Res.string.TERMINATION_OFFER_BUTTON_UPDATE_ADDRESS),
+              buttonText = suggestion.actionText.orFallback(Res.string.TERMINATION_OFFER_BUTTON_UPDATE_ADDRESS),
               onButtonClick = dropUnlessResumed { navigateToMovingFlow() },
             )
 
             SuggestionType.DOWNGRADE_PRICE -> InfoCardStyle.Button(
-              buttonText = stringResource(Res.string.CHANGE_TIER_BUTTON_TITLE),
+              buttonText = suggestion.actionText.orFallback(Res.string.CHANGE_TIER_BUTTON_TITLE),
               onButtonClick = tryToDowngradePrice,
             )
 
             SuggestionType.UPGRADE_COVERAGE -> InfoCardStyle.Button(
-              buttonText = stringResource(Res.string.CHANGE_TIER_BUTTON_TITLE),
+              buttonText = suggestion.actionText.orFallback(Res.string.CHANGE_TIER_BUTTON_TITLE),
               onButtonClick = tryToUpgradeCoverage,
             )
 
             SuggestionType.REDIRECT -> InfoCardStyle.Button(
-              buttonText = stringResource(Res.string.SUMMARY_SCREEN_LEARN_MORE_BUTTON),
+              buttonText = suggestion.actionText.orFallback(Res.string.SUMMARY_SCREEN_LEARN_MORE_BUTTON),
               onButtonClick = { suggestion.url?.let { openUrl(it) } },
             )
 
@@ -319,6 +320,16 @@ private fun SelectedSurveyInfoBox(
       Spacer(Modifier)
     }
   }
+}
+
+/**
+ * A suggestion carries its own action button label when the backend has one that fits better than anything we could
+ * pick from the suggestion type alone, like offering to change the insured amount instead of the tier. [fallback]
+ * covers the suggestions which come without one.
+ */
+@Composable
+private fun String?.orFallback(fallback: StringResource): String {
+  return this?.takeIf { it.isNotBlank() } ?: stringResource(fallback)
 }
 
 @Composable
@@ -481,7 +492,12 @@ private val previewReason2 = TerminationSurveyOption(
   id = "2",
   title = "I got a better offer elsewhere",
   subOptions = listOf(),
-  suggestion = null,
+  suggestion = SurveyOptionSuggestion(
+    type = SuggestionType.DOWNGRADE_PRICE,
+    description = "We can offer you a better price",
+    actionText = "Change amount",
+    url = null,
+  ),
   feedbackRequired = true,
   listIndex = 1,
 )


### PR DESCRIPTION
Propagates the new `actionText` field on `TerminationFlowSurveyOptionSuggestion` from [underwriter#1766](https://github.com/HedvigInsurance/underwriter/pull/1766). iOS does the same in [ugglan#2618](https://github.com/HedvigInsurance/ugglan/pull/2618).

🤖 AI description:

- Synced the octopus schema, `actionText` added to the query fragment, the field mapped onto `SurveyOptionSuggestion`.
- The four suggestion buttons now prefer the server label and fall back to the current per-type label, since the backend only fills `actionText` for the update-address, change-tier and change-amount suggestions and leaves `REDIRECT` without one. Blank strings take the fallback too.
- Gave a preview fixture an `actionText` so the new path shows up in previews.

Nothing was needed for the rest of underwriter#1766: the new option ids (`BETTER_PRICE_CHANGE_AMOUNT`, `MISSING_COVERAGE_OR_TERMS_CHANGE_AMOUNT`) and the `SURVEY_OTHER_REASON` retitling flow through on their own, since the app never hardcodes survey option ids and takes titles from the server.

Unlike iOS, the label preference lives in the composable rather than the model, because `Res.string` only resolves inside a composable and the `when (suggestion.type)` block picks the text, the click handler and the card style together. That also means it is not reachable from a presenter test, so no test was added.

`:feature-terminate-insurance:compileReleaseKotlin` and `:test` pass. `ktlintCheck` for the module fails on two pre-existing max-line-length violations in `TerminationRedirectionDestination.kt`, which this branch does not touch.

### Worth a look before this ships

The change-amount suggestions reuse the `UPGRADE_COVERAGE` / `DOWNGRADE_PRICE` types, which both route into the change-tier flow. The button will now read "Change amount" but still start change-tier, so it is worth checking that flow returns something sensible for a Payment Protection contract.
