### PR TITLE
Qualify imports that hid their receiver

### DIFF
--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/ClickableList.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/ClickableList.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import com.hedvig.android.design.system.hedvig.ClickableListDefaults.iconSize
 import com.hedvig.android.design.system.hedvig.icon.ChevronRight
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.tokens.ColorSchemeKeyTokens
@@ -96,7 +95,7 @@ private fun ClickableListItem(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
           ) {
-            Icon(HedvigIcons.ChevronRight, "", Modifier.size(iconSize))
+            Icon(HedvigIcons.ChevronRight, "", Modifier.size(ClickableListDefaults.iconSize))
           }
         },
         spaceBetween = 4.dp,

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Dialog.kt
@@ -40,7 +40,6 @@ import com.hedvig.android.design.system.hedvig.DialogDefaults.ButtonSize.SMALL
 import com.hedvig.android.design.system.hedvig.DialogDefaults.DialogStyle
 import com.hedvig.android.design.system.hedvig.DialogDefaults.DialogStyle.Buttons
 import com.hedvig.android.design.system.hedvig.DialogDefaults.DialogStyle.NoButtons
-import com.hedvig.android.design.system.hedvig.DialogDefaults.defaultButtonSize
 import com.hedvig.android.design.system.hedvig.EmptyStateDefaults.EmptyStateButtonStyle
 import com.hedvig.android.design.system.hedvig.EmptyStateDefaults.EmptyStateIconStyle.ERROR
 import com.hedvig.android.design.system.hedvig.tokens.DialogTokens
@@ -86,7 +85,7 @@ fun HedvigAlertDialog(
   modifier: Modifier = Modifier,
   confirmButtonLabel: String = stringResource(Res.string.GENERAL_YES),
   dismissButtonLabel: String = stringResource(Res.string.GENERAL_NO),
-  buttonSize: DialogDefaults.ButtonSize = defaultButtonSize,
+  buttonSize: DialogDefaults.ButtonSize = DialogDefaults.defaultButtonSize,
 ) {
   HedvigAlertDialog(
     title = AnnotatedString(title),
@@ -109,7 +108,7 @@ fun HedvigAlertDialog(
   modifier: Modifier = Modifier,
   confirmButtonLabel: String = stringResource(Res.string.GENERAL_YES),
   dismissButtonLabel: String = stringResource(Res.string.GENERAL_NO),
-  buttonSize: DialogDefaults.ButtonSize = defaultButtonSize,
+  buttonSize: DialogDefaults.ButtonSize = DialogDefaults.defaultButtonSize,
 ) {
   HedvigDialog(
     style = Buttons(

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/HedvigBigCard.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/HedvigBigCard.kt
@@ -15,9 +15,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.hedvig.android.compose.ui.LayoutWithoutPlacement
-import com.hedvig.android.design.system.hedvig.BigCardDefaults.inputTextStyle
-import com.hedvig.android.design.system.hedvig.BigCardDefaults.labelTextStyle
-import com.hedvig.android.design.system.hedvig.BigCardDefaults.padding
 import com.hedvig.android.design.system.hedvig.tokens.ColorSchemeKeyTokens
 import com.hedvig.android.design.system.hedvig.tokens.TypographyKeyTokens
 
@@ -57,7 +54,7 @@ fun HedvigBigCard(
   inputText: String?,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
-  textStyle: TextStyle = inputTextStyle,
+  textStyle: TextStyle = BigCardDefaults.inputTextStyle,
 ) {
   Surface(
     shape = HedvigTheme.shapes.cornerLarge,
@@ -72,14 +69,14 @@ fun HedvigBigCard(
     LayoutWithoutPlacement(
       sizeAdjustingContent = {
         // Always take up the space that the two texts would take
-        Column(Modifier.padding(padding)) {
-          HedvigText(text = labelText, style = labelTextStyle)
+        Column(Modifier.padding(BigCardDefaults.padding)) {
+          HedvigText(text = labelText, style = BigCardDefaults.labelTextStyle)
           HedvigText(text = "H", style = textStyle)
         }
       },
     ) {
       if (inputText == null) {
-        Box(Modifier.padding(padding)) {
+        Box(Modifier.padding(BigCardDefaults.padding)) {
           HedvigText(
             text = labelText,
             style = textStyle,
@@ -88,10 +85,10 @@ fun HedvigBigCard(
           )
         }
       } else {
-        Column(Modifier.padding(padding)) {
+        Column(Modifier.padding(BigCardDefaults.padding)) {
           HedvigText(
             text = labelText,
-            style = labelTextStyle,
+            style = BigCardDefaults.labelTextStyle,
             color = bigCardColors.labelTextColor(enabled),
           )
           HedvigText(

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Notification.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Notification.kt
@@ -43,10 +43,6 @@ import com.hedvig.android.design.system.hedvig.NotificationDefaults.Notification
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority.Info
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority.InfoInline
 import com.hedvig.android.design.system.hedvig.NotificationDefaults.NotificationPriority.NeutralToast
-import com.hedvig.android.design.system.hedvig.NotificationDefaults.defaultStyle
-import com.hedvig.android.design.system.hedvig.NotificationDefaults.paddingNoIcon
-import com.hedvig.android.design.system.hedvig.NotificationDefaults.paddingWithIcon
-import com.hedvig.android.design.system.hedvig.NotificationDefaults.textStyle
 import com.hedvig.android.design.system.hedvig.icon.Campaign
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.InfoFilled
@@ -82,7 +78,7 @@ fun HedvigNotificationCard(
   priority: NotificationPriority,
   modifier: Modifier = Modifier,
   withIcon: Boolean = NotificationDefaults.withIconDefault,
-  style: InfoCardStyle = defaultStyle,
+  style: InfoCardStyle = NotificationDefaults.defaultStyle,
   buttonLoading: Boolean = false,
   minLines: Int = 1,
 ) {
@@ -104,10 +100,10 @@ fun HedvigNotificationCard(
   priority: NotificationPriority,
   modifier: Modifier = Modifier,
   withIcon: Boolean = NotificationDefaults.withIconDefault,
-  style: InfoCardStyle = defaultStyle,
+  style: InfoCardStyle = NotificationDefaults.defaultStyle,
   buttonLoading: Boolean = false,
 ) {
-  val padding = if (withIcon) paddingWithIcon else paddingNoIcon
+  val padding = if (withIcon) NotificationDefaults.paddingWithIcon else NotificationDefaults.paddingNoIcon
   val description = when (priority) {
     Attention, NotificationPriority.AttentionRound, Error, Info -> stringResource(Res.string.TALKBACK_NOTIFICATION_CARD)
     Campaign, InfoInline, NeutralToast, FancyInfo -> ""
@@ -125,7 +121,7 @@ fun HedvigNotificationCard(
     border = if (priority !is FancyInfo) priority.colors.borderColor else null,
   ) {
     val buttonDarkTheme = if (priority is InfoInline) isSystemInDarkTheme() else false
-    ProvideTextStyle(textStyle) {
+    ProvideTextStyle(NotificationDefaults.textStyle) {
       Row(Modifier.padding(padding)) {
         if (withIcon) {
           LayoutWithoutPlacement(
@@ -156,7 +152,7 @@ fun HedvigNotificationCard(
                     buttonSize = Small,
                     modifier = Modifier.weight(1f),
                   ) {
-                    HedvigText(style.leftButtonText, style = textStyle)
+                    HedvigText(style.leftButtonText, style = NotificationDefaults.textStyle)
                   }
                   Spacer(Modifier.width(4.dp))
                   HedvigButton(
@@ -166,7 +162,7 @@ fun HedvigNotificationCard(
                     buttonSize = Small,
                     modifier = Modifier.weight(1f),
                   ) {
-                    HedvigText(style.rightButtonText, style = textStyle)
+                    HedvigText(style.rightButtonText, style = NotificationDefaults.textStyle)
                   }
                 }
               }
@@ -184,11 +180,11 @@ fun HedvigNotificationCard(
                 ) {
                   LayoutWithoutPlacement(
                     sizeAdjustingContent = {
-                      HedvigText(style.buttonText, style = textStyle)
+                      HedvigText(style.buttonText, style = NotificationDefaults.textStyle)
                     },
                   ) {
                     if (!buttonLoading) {
-                      HedvigText(style.buttonText, style = textStyle)
+                      HedvigText(style.buttonText, style = NotificationDefaults.textStyle)
                     } else {
                       Box(
                         modifier = Modifier.fillMaxSize(),

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Tooltip.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Tooltip.kt
@@ -49,10 +49,6 @@ import com.hedvig.android.design.system.hedvig.TooltipDefaults.TooltipStyle.Camp
 import com.hedvig.android.design.system.hedvig.TooltipDefaults.TooltipStyle.Campaign.Brightness.BLEAK
 import com.hedvig.android.design.system.hedvig.TooltipDefaults.TooltipStyle.Campaign.Brightness.BRIGHT
 import com.hedvig.android.design.system.hedvig.TooltipDefaults.TooltipStyle.Inbox
-import com.hedvig.android.design.system.hedvig.TooltipDefaults.arrowHeightDp
-import com.hedvig.android.design.system.hedvig.TooltipDefaults.arrowSpaceFromEdgeWhenOffCenteredDp
-import com.hedvig.android.design.system.hedvig.TooltipDefaults.arrowWidthDp
-import com.hedvig.android.design.system.hedvig.TooltipDefaults.defaultStyle
 import com.hedvig.android.design.system.hedvig.tokens.TooltipTokens
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -63,7 +59,7 @@ fun HedvigTooltip(
   showTooltip: Boolean,
   tooltipShown: () -> Unit,
   modifier: Modifier = Modifier,
-  tooltipStyle: TooltipStyle = defaultStyle,
+  tooltipStyle: TooltipStyle = TooltipDefaults.defaultStyle,
   beakDirection: BeakDirection = BottomCenter,
   maxWidth: Dp = TooltipDefaults.defaultMaxWidth,
 ) {
@@ -150,9 +146,11 @@ private fun InnerChatTooltip(
 private fun Shape.withBeak(beakDirection: BeakDirection): Shape {
   return object : Shape {
     override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
-      val arrowSpaceFromEdgeWhenOffCentered: Float = with(density) { arrowSpaceFromEdgeWhenOffCenteredDp.toPx() }
-      val arrowWidth = with(density) { arrowWidthDp.toPx() }
-      val arrowHeight = with(density) { arrowHeightDp.toPx() }
+      val arrowSpaceFromEdgeWhenOffCentered: Float = with(density) {
+        TooltipDefaults.arrowSpaceFromEdgeWhenOffCenteredDp.toPx()
+      }
+      val arrowWidth = with(density) { TooltipDefaults.arrowWidthDp.toPx() }
+      val arrowHeight = with(density) { TooltipDefaults.arrowHeightDp.toPx() }
       val squircleSize: Size = when (beakDirection) {
         BottomCenter, BottomStart, BottomEnd, TopCenter, TopStart, TopEnd -> {
           size.copy(height = size.height - arrowHeight)

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/TopAppBar.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/TopAppBar.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
-import com.hedvig.android.design.system.hedvig.TopAppBarDefaults.windowInsets
 import com.hedvig.android.design.system.hedvig.icon.ArrowLeft
 import com.hedvig.android.design.system.hedvig.icon.Close
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
@@ -183,7 +182,7 @@ fun TopAppBarLayoutForActions(
     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
     verticalAlignment = Alignment.CenterVertically,
     modifier = modifier
-      .windowInsetsPadding(windowInsets)
+      .windowInsetsPadding(TopAppBarDefaults.windowInsets)
       .height(TopAppBarTokens.ContainerHeight)
       .fillMaxWidth()
       .padding(contentPadding),

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/freetext/FreeTextOverlay.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/freetext/FreeTextOverlay.kt
@@ -56,7 +56,6 @@ import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HorizontalDivider
 import com.hedvig.android.design.system.hedvig.Surface
-import com.hedvig.android.design.system.hedvig.freetext.FreeTextDefaults.counterPadding
 import com.hedvig.android.design.system.hedvig.fromToken
 import com.hedvig.android.design.system.hedvig.internal.Decoration
 import com.hedvig.android.design.system.hedvig.tokens.ColorSchemeKeyTokens.BackgroundBlack
@@ -241,7 +240,7 @@ private fun FreeTextOverlayContent(
             color = freeTextColors.labelColor,
             modifier = Modifier
               .fillMaxWidth()
-              .padding(counterPadding)
+              .padding(FreeTextDefaults.counterPadding)
               .wrapContentWidth(Alignment.End)
               .semantics {
                 contentDescription = characterLimitDescription

--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/freetext/FreeTextTriggerDisplay.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/freetext/FreeTextTriggerDisplay.kt
@@ -33,10 +33,6 @@ import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.
 import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.Height.Unlimited
 import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.Style
 import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.Style.Labeled
-import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.contentPadding
-import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.defaultHeight
-import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.defaultStyle
-import com.hedvig.android.design.system.hedvig.freetext.FreeTextDisplayDefaults.supportingTextPadding
 import com.hedvig.android.design.system.hedvig.fromToken
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
 import com.hedvig.android.design.system.hedvig.icon.WarningFilled
@@ -64,8 +60,8 @@ fun FreeTextDisplay(
   freeTextPlaceholder: String,
   modifier: Modifier = Modifier,
   maxLength: Int = FreeTextDisplayDefaults.maxLength,
-  height: Height = defaultHeight,
-  style: Style = defaultStyle,
+  height: Height = FreeTextDisplayDefaults.defaultHeight,
+  style: Style = FreeTextDisplayDefaults.defaultStyle,
   hasError: Boolean = false,
   supportingText: String? = null,
   showCount: Boolean = true,
@@ -87,7 +83,7 @@ fun FreeTextDisplay(
       color = freeTextColors.displayContainerColor,
     ) {
       Column(
-        Modifier.padding(contentPadding),
+        Modifier.padding(FreeTextDisplayDefaults.contentPadding),
       ) {
         if (style is Labeled && freeTextValue != null) {
           Row(Modifier.fillMaxWidth()) {
@@ -147,7 +143,7 @@ fun FreeTextDisplay(
           text = supportingText,
           color = displayColors.supportingTextColor,
           style = FreeTextDisplayDefaults.countLabelStyle.value,
-          modifier = Modifier.padding(supportingTextPadding),
+          modifier = Modifier.padding(FreeTextDisplayDefaults.supportingTextPadding),
         )
       }
     }

--- a/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/SubmittedAndClosedColumns.kt
+++ b/app/feature/feature-claim-details/src/main/kotlin/com/hedvig/android/feature/claim/details/ui/SubmittedAndClosedColumns.kt
@@ -21,7 +21,6 @@ import hedvig.resources.claim_status_detail_closed
 import hedvig.resources.claim_status_detail_submitted
 import java.util.Locale
 import kotlin.time.Clock
-import kotlin.time.Clock.System
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
@@ -77,7 +76,7 @@ private fun SubmittedAndClosedColumn(topText: String, bottomText: String, modifi
 }
 
 @Composable
-private fun currentTimeAsState(updateInterval: Duration = 1.seconds, clock: Clock = System): State<Instant> {
+private fun currentTimeAsState(updateInterval: Duration = 1.seconds, clock: Clock = Clock.System): State<Instant> {
   return produceState(initialValue = clock.now()) {
     while (isActive) {
       delay(updateInterval)
@@ -123,8 +122,8 @@ private fun PreviewSubmittedAndClosedInformation() {
   HedvigTheme {
     Surface(color = HedvigTheme.colorScheme.backgroundPrimary) {
       SubmittedAndClosedColumns(
-        submittedAt = System.now().minus(10.days),
-        closedAt = System.now().minus(30.seconds),
+        submittedAt = Clock.System.now().minus(10.days),
+        closedAt = Clock.System.now().minus(30.seconds),
         locale = Locale.ENGLISH,
       )
     }

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -231,8 +231,7 @@ import hedvig.resources.RESUME_CLAIM_DELETE_BUTTON
 import hedvig.resources.RESUME_CLAIM_DELETE_TITLE
 import hedvig.resources.RESUME_CLAIM_EXPIRED_BODY
 import hedvig.resources.RESUME_CLAIM_EXPIRED_TITLE
-import hedvig.resources.Res.drawable
-import hedvig.resources.Res.string
+import hedvig.resources.Res
 import hedvig.resources.TOAST_NEW_OFFER
 import hedvig.resources.blur_background
 import hedvig.resources.general_cancel_button
@@ -242,7 +241,7 @@ import hedvig.resources.home_tab_get_help
 import hedvig.resources.home_tab_welcome_title_without_name
 import hedvig.resources.ongoing_shop_session_dismiss_offer
 import kotlin.math.roundToInt
-import kotlin.time.Clock.System
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -393,8 +392,8 @@ private fun HomeScreen(
     // The draft is expired, so acknowledging the notice (Close button, scrim, or back) removes it.
     // Matches the Ready-for-dev design: single Close, closing removes the draft claim card.
     ErrorDialog(
-      title = stringResource(string.RESUME_CLAIM_EXPIRED_TITLE),
-      message = stringResource(string.RESUME_CLAIM_EXPIRED_BODY),
+      title = stringResource(Res.string.RESUME_CLAIM_EXPIRED_TITLE),
+      message = stringResource(Res.string.RESUME_CLAIM_EXPIRED_BODY),
       onDismiss = {
         showDraftExpiredDialog = false
         draftClaim?.let { deleteDraftClaim(it.id) }
@@ -404,10 +403,10 @@ private fun HomeScreen(
   val draftIdToDelete = draftIdPendingDeleteConfirmation
   if (draftIdToDelete != null) {
     HedvigAlertDialog(
-      title = stringResource(string.RESUME_CLAIM_DELETE_TITLE),
-      text = stringResource(string.RESUME_CLAIM_DELETE_BODY),
-      confirmButtonLabel = stringResource(string.RESUME_CLAIM_DELETE_BUTTON),
-      dismissButtonLabel = stringResource(string.general_cancel_button),
+      title = stringResource(Res.string.RESUME_CLAIM_DELETE_TITLE),
+      text = stringResource(Res.string.RESUME_CLAIM_DELETE_BODY),
+      confirmButtonLabel = stringResource(Res.string.RESUME_CLAIM_DELETE_BUTTON),
+      dismissButtonLabel = stringResource(Res.string.general_cancel_button),
       onDismissRequest = { draftIdPendingDeleteConfirmation = null },
       onConfirmClick = {
         draftIdPendingDeleteConfirmation = null
@@ -462,7 +461,7 @@ private fun HomeScreen(
             },
             onContinueDraftClaim = {
               if (draftClaim != null) {
-                if (draftClaim.isExpired(System.now())) {
+                if (draftClaim.isExpired(Clock.System.now())) {
                   showDraftExpiredDialog = true
                 } else {
                   navigateToClaimChat(true)
@@ -563,7 +562,7 @@ private fun HomeScreenTopBar(
       }
       if (shouldShowNewMessageTooltip) {
         HedvigTooltip(
-          message = stringResource(string.CHAT_NEW_MESSAGE),
+          message = stringResource(Res.string.CHAT_NEW_MESSAGE),
           showTooltip = shouldShowNewMessageTooltip,
           tooltipStyle = Inbox,
           beakDirection = TopEnd,
@@ -592,7 +591,7 @@ private fun ColumnScope.CrossSellsTooltip(uiState: Success, setEpochDayWhenLastT
     var shouldSetEpochDayWhenLastToolTipShown by remember { mutableStateOf(false) }
     LaunchedEffect(shouldSetEpochDayWhenLastToolTipShown) {
       if (shouldSetEpochDayWhenLastToolTipShown) {
-        val today = System.now().toLocalDateTime(
+        val today = Clock.System.now().toLocalDateTime(
           TimeZone.currentSystemDefault(),
         ).date.toEpochDays()
         delay(5000.milliseconds)
@@ -601,7 +600,7 @@ private fun ColumnScope.CrossSellsTooltip(uiState: Success, setEpochDayWhenLastT
     }
     if (shouldShowCrossSellsTooltip) {
       HedvigTooltip(
-        message = stringResource(string.TOAST_NEW_OFFER),
+        message = stringResource(Res.string.TOAST_NEW_OFFER),
         showTooltip = true,
         tooltipStyle = Campaign(
           subMessage = null,
@@ -688,7 +687,7 @@ private fun HomeScreenSuccess(
     // to "hide" it (the content cards already do; so do the pinned pills).
     if (HedvigTheme.colorScheme.isLight) {
       Image(
-        painter = painterResource(drawable.blur_background),
+        painter = painterResource(Res.drawable.blur_background),
         contentDescription = null,
         contentScale = ContentScale.Crop,
         modifier = Modifier.matchParentSize(),
@@ -1217,7 +1216,7 @@ private fun MemberRemindersSection(
           .padding(horizontalInsets),
       ) {
         HedvigText(
-          text = stringResource(string.HOME_TODO_SECTION_TITLE),
+          text = stringResource(Res.string.HOME_TODO_SECTION_TITLE),
           style = HedvigTheme.typography.headlineSmall,
           modifier = Modifier.semantics { heading() },
         )
@@ -1255,7 +1254,7 @@ private fun QuotesSection(
   val contentPadding = PaddingValues(horizontal = 16.dp) + horizontalInsets
   Column(Modifier.fillMaxWidth()) {
     HedvigText(
-      text = stringResource(string.HOME_QUOTES_SECTION_TITLE),
+      text = stringResource(Res.string.HOME_QUOTES_SECTION_TITLE),
       style = HedvigTheme.typography.headlineSmall,
       modifier = Modifier
         .padding(contentPadding)
@@ -1312,7 +1311,7 @@ private fun QuoteCard(
             HedvigText(text = session.title, style = HedvigTheme.typography.bodySmall)
             val secondary = session.monthlyNet?.let {
               stringResource(
-                string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,
+                Res.string.OFFER_COST_AND_PREMIUM_PERIOD_ABBREVIATION,
                 it,
               )
             } ?: session.subtitle
@@ -1334,13 +1333,13 @@ private fun QuoteCard(
           ) {
             Icon(
               imageVector = HedvigIcons.Close,
-              contentDescription = stringResource(string.ongoing_shop_session_dismiss_offer),
+              contentDescription = stringResource(Res.string.ongoing_shop_session_dismiss_offer),
             )
           }
         }
         Spacer(Modifier.height(12.dp))
         HedvigButton(
-          text = stringResource(string.general_continue_button),
+          text = stringResource(Res.string.general_continue_button),
           onClick = { onResumeClick(session.resumeUrl) },
           buttonStyle = Secondary,
           buttonSize = ButtonSize.Medium,
@@ -1367,7 +1366,7 @@ private fun QuickActionTilesSection(
       .padding(horizontalInsets),
   ) {
     HedvigText(
-      text = stringResource(string.HC_QUICK_ACTIONS_TITLE),
+      text = stringResource(Res.string.HC_QUICK_ACTIONS_TITLE),
       style = HedvigTheme.typography.headlineSmall,
       modifier = Modifier.semantics { heading() },
     )
@@ -1501,21 +1500,21 @@ private fun MainActionCarouselSection(
       .padding(horizontalInsets),
   ) {
     HedvigButton(
-      text = stringResource(string.home_tab_claim_button_text),
+      text = stringResource(Res.string.home_tab_claim_button_text),
       onClick = onMakeClaim,
       enabled = true,
       buttonStyle = RoundedPrimary,
     )
     if (isHelpCenterEnabled) {
       HedvigButton(
-        text = stringResource(string.home_tab_get_help),
+        text = stringResource(Res.string.home_tab_get_help),
         onClick = onHelpAndSupport,
         enabled = true,
         buttonStyle = RoundedLiquidGlass,
       )
     }
     HedvigButton(
-      text = stringResource(string.DASHBOARD_OPEN_CHAT),
+      text = stringResource(Res.string.DASHBOARD_OPEN_CHAT),
       onClick = onContactUs,
       enabled = true,
       buttonStyle = RoundedLiquidGlass,
@@ -1538,7 +1537,7 @@ private fun AddonsSection(
       .padding(horizontalInsets),
   ) {
     HedvigText(
-      text = stringResource(string.INSURANCE_ADDONS_SUBHEADING),
+      text = stringResource(Res.string.INSURANCE_ADDONS_SUBHEADING),
       style = HedvigTheme.typography.headlineSmall,
       modifier = Modifier.semantics { heading() },
     )
@@ -1548,7 +1547,7 @@ private fun AddonsSection(
         subtitle = addon.description,
         pillowImage = null,
         pillow = { AddonPillow(addon.flowType) },
-        buttonText = stringResource(string.HOME_ADDONS_READ_MORE_BUTTON),
+        buttonText = stringResource(Res.string.HOME_ADDONS_READ_MORE_BUTTON),
         onButtonClick = { navigateToAddonPurchaseFlow(addon.eligibleInsurancesIds) },
         imageLoader = imageLoader,
         modifier = Modifier.fillMaxWidth(),
@@ -1565,7 +1564,7 @@ private fun DiscoverInsurancesSection(
   imageLoader: ImageLoader,
 ) {
   CrossSellsSection(
-    title = stringResource(string.HOME_DISCOVER_SECTION_TITLE),
+    title = stringResource(Res.string.HOME_DISCOVER_SECTION_TITLE),
     crossSells = crossSells,
     onCrossSellClick = onCrossSellClick,
     modifier = Modifier.padding(horizontal = 16.dp),
@@ -1586,7 +1585,7 @@ private fun WelcomeMessage(firstName: String, modifier: Modifier = Modifier) {
   )
   if (firstName.isBlank()) {
     HedvigText(
-      text = stringResource(string.home_tab_welcome_title_without_name),
+      text = stringResource(Res.string.home_tab_welcome_title_without_name),
       style = titleStyle,
       modifier = modifier.fillMaxWidth(),
     )
@@ -1597,12 +1596,12 @@ private fun WelcomeMessage(firstName: String, modifier: Modifier = Modifier) {
     modifier = modifier.fillMaxWidth(),
   ) {
     HedvigText(
-      text = stringResource(string.HOME_GREETING_TITLE, firstName),
+      text = stringResource(Res.string.HOME_GREETING_TITLE, firstName),
       style = titleStyle,
       modifier = Modifier.fillMaxWidth(),
     )
     HedvigText(
-      text = stringResource(string.HOME_GREETING_SUBTITLE),
+      text = stringResource(Res.string.HOME_GREETING_SUBTITLE),
       color = HedvigTheme.colorScheme.textSecondary,
       style = titleStyle,
       modifier = Modifier.fillMaxWidth(),
@@ -1894,19 +1893,19 @@ private fun PreviewHomeScreenAllHomeTextTypes(
 
 private val previewQuickActions: List<QuickAction> = listOf(
   MultiSelectExpandedLink(
-    titleRes = string.HC_QUICK_ACTIONS_EDIT_INSURANCE_TITLE,
-    hintTextRes = string.HC_QUICK_ACTIONS_EDIT_INSURANCE_SUBTITLE,
+    titleRes = Res.string.HC_QUICK_ACTIONS_EDIT_INSURANCE_TITLE,
+    hintTextRes = Res.string.HC_QUICK_ACTIONS_EDIT_INSURANCE_SUBTITLE,
     links = listOf(
       StandaloneQuickLink(
-        titleRes = string.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_TITLE,
-        hintTextRes = string.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_SUBTITLE,
+        titleRes = Res.string.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_TITLE,
+        hintTextRes = Res.string.HC_QUICK_ACTIONS_UPGRADE_COVERAGE_SUBTITLE,
         quickLinkDestination = QuickLinkChangeTier,
       ),
     ),
   ),
   StandaloneQuickLink(
-    titleRes = string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_TITLE,
-    hintTextRes = string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_SUBTITLE,
+    titleRes = Res.string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_TITLE,
+    hintTextRes = Res.string.HC_QUICK_ACTIONS_CHANGE_ADDRESS_SUBTITLE,
     quickLinkDestination = QuickLinkChangeAddress,
   ),
 )

--- a/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/payments/PaymentsDestination.kt
+++ b/app/feature/feature-payments/src/main/kotlin/com/hedvig/android/feature/payments/ui/payments/PaymentsDestination.kt
@@ -117,7 +117,7 @@ import hedvig.resources.Res
 import hedvig.resources.TAB_PAYMENTS_TITLE
 import hedvig.resources.info_card_missing_payment_body
 import hedvig.resources.info_card_missing_payment_missing_payments_body
-import kotlin.time.Clock.System
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -822,7 +822,7 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "rdg",
         ),
         upcomingPaymentInfo = NoInfo,
@@ -837,7 +837,7 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "rdg",
         ),
         upcomingPaymentInfo = NoInfo,
@@ -854,7 +854,7 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "iky",
         ),
         upcomingPaymentInfo = InProgress,
@@ -869,12 +869,12 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(400.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "pwe",
         ),
         upcomingPaymentInfo = PaymentFailed(
-          System.now().toLocalDateTime(TimeZone.UTC).date,
-          System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
           isManualChargeAllowed = ManualChargeToPrompt(
             UiMoney(200.0, UiCurrencyCode.SEK),
           ),
@@ -890,7 +890,7 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "fkjse",
         ),
         upcomingPaymentInfo = NoInfo,
@@ -905,12 +905,12 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "qrdfgeth",
         ),
         upcomingPaymentInfo = PaymentFailed(
-          System.now().toLocalDateTime(TimeZone.UTC).date,
-          System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
           isManualChargeAllowed = null,
         ),
         ongoingCharges = emptyList(),
@@ -926,7 +926,7 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "qrdfgeth2",
         ),
         upcomingPaymentInfo = NoInfo,
@@ -943,17 +943,17 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "w345423t6",
         ),
         upcomingPaymentInfo = PaymentFailed(
-          System.now().toLocalDateTime(TimeZone.UTC).date,
-          System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
           isManualChargeAllowed = null,
         ),
         ongoingCharges = emptyList(),
         connectedPaymentInfo = ConnectedPaymentInfo.NeedsPayinSetup(
-          dueDateToConnect = System.now().plus(30.days).toLocalDateTime(TimeZone.UTC).date,
+          dueDateToConnect = Clock.System.now().plus(30.days).toLocalDateTime(TimeZone.UTC).date,
         ),
         showPayoutButton = false,
         memberType = MemberType.STANDARD_MEMBER,
@@ -964,17 +964,17 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "42345",
         ),
         upcomingPaymentInfo = PaymentFailed(
-          System.now().toLocalDateTime(TimeZone.UTC).date,
-          System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().minus(30.days).toLocalDateTime(TimeZone.UTC).date,
           isManualChargeAllowed = null,
         ),
         ongoingCharges = emptyList(),
         connectedPaymentInfo = ConnectedPaymentInfo.NeedsPayinSetup(
-          System.now().plus(30.days).toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().plus(30.days).toLocalDateTime(TimeZone.UTC).date,
         ),
         showPayoutButton = false,
         memberType = MemberType.STANDARD_MEMBER,
@@ -1029,7 +1029,7 @@ private class PaymentsStatePreviewProvider : CollectionPreviewParameterProvider<
         isRetrying = false,
         upcomingPayment = UpcomingPayment.Content(
           UiMoney(100.0, SEK),
-          System.now().toLocalDateTime(TimeZone.UTC).date,
+          Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
           "w345423t6",
         ),
         upcomingPaymentInfo = UpcomingPaymentInfo.NoInfo,

--- a/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
+++ b/app/ui/cross-sells/src/main/kotlin/com/hedvig/android/crosssells/CrossSells.kt
@@ -86,8 +86,6 @@ import hedvig.resources.CROSS_SELL_BANNER_TEXT
 import hedvig.resources.CROSS_SELL_SUBTITLE
 import hedvig.resources.CROSS_SELL_TITLE
 import hedvig.resources.Res
-import hedvig.resources.Res.plurals
-import hedvig.resources.Res.string
 import hedvig.resources.TALKBACK_OPEN_EXTERNAL_LINK
 import hedvig.resources.cross_sell_get_price
 import hedvig.resources.general_close_button
@@ -146,7 +144,7 @@ fun CrossSellFloatingBottomSheet(
     dragHandle = {
       CrossSellDragHandle(
         text = state.data?.recommendedCrossSell?.bannerText
-          ?: state.data?.recommendedAddon?.let { it.bannerText ?: stringResource(string.CROSS_SELL_BANNER_TEXT) },
+          ?: state.data?.recommendedAddon?.let { it.bannerText ?: stringResource(Res.string.CROSS_SELL_BANNER_TEXT) },
         modifier = Modifier
           .padding(horizontal = 16.dp)
           .clip(HedvigTheme.shapes.cornerXLargeTop),
@@ -185,7 +183,7 @@ fun CrossSellBottomSheet(
           contentPadding = PaddingValues(horizontal = 16.dp),
           text = state.data?.recommendedCrossSell?.bannerText
             ?: state.data?.recommendedAddon?.bannerText
-            ?: stringResource(string.CROSS_SELL_BANNER_TEXT),
+            ?: stringResource(Res.string.CROSS_SELL_BANNER_TEXT),
         )
       }
     } else {
@@ -246,7 +244,7 @@ private fun CrossSellsSheetContent(
       if (otherCrossSells.isNotEmpty()) {
         Column {
           Spacer(Modifier.height(24.dp))
-          HedvigText(stringResource(string.CROSS_SELL_SUBTITLE), Modifier.semantics { heading() })
+          HedvigText(stringResource(Res.string.CROSS_SELL_SUBTITLE), Modifier.semantics { heading() })
           Spacer(Modifier.height(24.dp))
           CrossSellsSection(
             crossSells = otherCrossSells,
@@ -259,7 +257,7 @@ private fun CrossSellsSheetContent(
       }
     }
     HedvigButton(
-      text = stringResource(string.general_close_button),
+      text = stringResource(Res.string.general_close_button),
       onClick = dismissSheet,
       enabled = true,
       buttonStyle = ButtonStyle.Ghost,
@@ -317,7 +315,7 @@ private fun CrossSellsFloatingSheetContent(
         if (otherCrossSells.isNotEmpty()) {
           Column {
             Spacer(Modifier.height(24.dp))
-            HedvigText(stringResource(string.CROSS_SELL_SUBTITLE), Modifier.semantics { heading() })
+            HedvigText(stringResource(Res.string.CROSS_SELL_SUBTITLE), Modifier.semantics { heading() })
             Spacer(Modifier.height(24.dp))
             CrossSellsSection(
               crossSells = otherCrossSells,
@@ -335,7 +333,7 @@ private fun CrossSellsFloatingSheetContent(
       shape = HedvigTheme.shapes.cornerLarge,
     ) {
       HedvigButton(
-        text = stringResource(string.general_close_button),
+        text = stringResource(Res.string.general_close_button),
         onClick = dismissSheet,
         enabled = true,
         buttonStyle = ButtonStyle.Secondary,
@@ -397,7 +395,7 @@ private fun AddonRecommendationSection(
       }
     }
     Spacer(Modifier.height(24.dp))
-    val headingDescription = stringResource(string.CROSS_SELL_TITLE) +
+    val headingDescription = stringResource(Res.string.CROSS_SELL_TITLE) +
       ": ${recommendedAddon.title}"
     HedvigText(
       text = recommendedAddon.title,
@@ -465,7 +463,7 @@ private fun RecommendationSection(
   ) {
     StackedPillows(recommendedCrossSell, imageLoader)
     Spacer(Modifier.height(24.dp))
-    val headingDescription = stringResource(string.CROSS_SELL_TITLE) +
+    val headingDescription = stringResource(Res.string.CROSS_SELL_TITLE) +
       ": ${recommendedCrossSell.crossSell.title}"
     HedvigText(
       text = recommendedCrossSell.crossSell.title,
@@ -491,7 +489,7 @@ private fun RecommendationSection(
         stepProgressItems.joinToString(separator = "; ") { item -> "${item.title} - ${item.subtitle}" }
       val description = "$dataDescription; " +
         pluralStringResource(
-          plurals.A11Y_NUMBER_OF_ELIGIBLE_INSURANCES,
+          Res.plurals.A11Y_NUMBER_OF_ELIGIBLE_INSURANCES,
           recommendedCrossSell.bundleProgress.numberOfEligibleContracts,
           recommendedCrossSell.bundleProgress.numberOfEligibleContracts,
         )
@@ -510,7 +508,7 @@ private fun RecommendationSection(
         onCrossSellClick(recommendedCrossSell.crossSell.storeUrl)
         dismissSheet()
       },
-      onClickLabel = stringResource(string.TALKBACK_OPEN_EXTERNAL_LINK),
+      onClickLabel = stringResource(Res.string.TALKBACK_OPEN_EXTERNAL_LINK),
       enabled = true,
       modifier = Modifier
         .fillMaxWidth()
@@ -593,16 +591,16 @@ private fun StackedPillows(recommendedCrossSell: RecommendedCrossSell, imageLoad
 
 @Composable
 private fun getHedvigStepProgressData(bundleProgress: BundleProgress): List<StepProgressItem> {
-  val firstStepTitle = stringResource(string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_TITLE_ONE_INSURANCE)
-  val firstStepSubtitle = stringResource(string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_SUBTITLE_NO_DISCOUNT)
+  val firstStepTitle = stringResource(Res.string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_TITLE_ONE_INSURANCE)
+  val firstStepSubtitle = stringResource(Res.string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_SUBTITLE_NO_DISCOUNT)
   val stepOne = StepProgressItem(firstStepTitle, firstStepSubtitle)
-  val secondStepTitle = stringResource(string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_TITLE_TWO_INSURANCES)
+  val secondStepTitle = stringResource(Res.string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_TITLE_TWO_INSURANCES)
   val secondStepSubtitle = stringResource(
-    string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_SUBTITLE_CURRENT_APPLIED_DISCOUNT,
+    Res.string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_SUBTITLE_CURRENT_APPLIED_DISCOUNT,
     "${bundleProgress.discountPercent}%",
   )
   val stepTwo = StepProgressItem(secondStepTitle, secondStepSubtitle)
-  val thirdStepTitle = stringResource(string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_TITLE_THREE_OR_MORE)
+  val thirdStepTitle = stringResource(Res.string.BUNDLE_DISCOUNT_PROGRESS_SEGMENT_TITLE_THREE_OR_MORE)
   val stepThree = StepProgressItem(thirdStepTitle, secondStepSubtitle)
   return listOf(stepOne, stepTwo, stepThree)
 }
@@ -676,7 +674,7 @@ fun CrossSellItemPlaceholder(imageLoader: ImageLoader, modifier: Modifier = Modi
 private fun CrossSellsSubHeaderWithDivider(title: String? = null) {
   Column {
     NotificationSubheading(
-      text = title ?: stringResource(string.insurance_tab_cross_sells_title),
+      text = title ?: stringResource(Res.string.insurance_tab_cross_sells_title),
       modifier = Modifier.semantics { heading() },
     )
     Spacer(Modifier.height(16.dp))
@@ -731,7 +729,7 @@ private fun CrossSellItem(
       onSheetDismissed()
     },
     imageLoader = imageLoader,
-    onButtonClickLabel = stringResource(string.TALKBACK_OPEN_EXTERNAL_LINK),
+    onButtonClickLabel = stringResource(Res.string.TALKBACK_OPEN_EXTERNAL_LINK),
     isLoading = isLoading,
     modifier = modifier,
     buttonSize = buttonSize,
@@ -894,12 +892,12 @@ private fun CrossSellItemWithDiscounts(
     }
     Spacer(Modifier.width(16.dp))
     HedvigButton(
-      text = buttonText ?: stringResource(string.cross_sell_get_price),
+      text = buttonText ?: stringResource(Res.string.cross_sell_get_price),
       onClick = {
         onCrossSellClick(storeUrl)
         onSheetDismissed()
       },
-      onClickLabel = stringResource(string.TALKBACK_OPEN_EXTERNAL_LINK),
+      onClickLabel = stringResource(Res.string.TALKBACK_OPEN_EXTERNAL_LINK),
       buttonSize = buttonSize,
       buttonStyle = ButtonStyle.PrimaryAlt,
       modifier = Modifier.hedvigPlaceholder(
@@ -926,7 +924,7 @@ private fun NotificationSubheading(text: String, modifier: Modifier = Modifier) 
 private fun CrossSellDragHandle(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues? = null,
-  text: String? = stringResource(string.CROSS_SELL_BANNER_TEXT),
+  text: String? = stringResource(Res.string.CROSS_SELL_BANNER_TEXT),
 ) {
   val direction = LocalLayoutDirection.current
   Box(


### PR DESCRIPTION
Fix all the wrongly imported places in the app manually, where we did `string.foo` rather than `Res.string.foo` as we've discussed in the past


🤖 AI description:

Fixes every existing violation of the import rule: 26 imports across 12 files. The rule itself and the ktlint check that enforces it are in the PR above, so this one is only hand-written source changes and can be read on its own.

**The rule being applied.** Import the type, never the namespace. An import may shorten a qualified reference only when the short name still says what it is to someone reading that line cold. `HomeUiState.Success` passes. `Res.string` and `Clock.System` do not: `string.FOO` names nothing, and `System.now()` reads as `java.lang.System`.

**One was a latent bug rather than style.** In `TopAppBar.kt` the identifier `windowInsets` meant two different things depending on where you read it. Three functions declare a `windowInsets: WindowInsets = TopAppBarDefaults.windowInsets` parameter and use it, so there the name is the parameter. `TopAppBarLayoutForActions` has no such parameter, so its bare `windowInsets` silently resolved to the file-level `import ...TopAppBarDefaults.windowInsets` instead, and only the compiler surfaced it once that import was gone.

No tooling catches this: the import is legitimately used at that one site, so `no-unused-imports` is right to stay quiet. It is exactly the readability failure the rule is about, since the same short name resolves to different things in one file.

For the 19 design system `Defaults` members the owning object lives in the same file, so they are now qualified as `TooltipDefaults.defaultStyle`, matching what `TopAppBar.kt` already did. References from inside an owning object's own body are untouched, since they resolve without an import.

`ktlintCheck` and `./gradlew lint` both pass, and the touched modules compile.

Worth knowing for anyone repeating this kind of qualification: it has to cover lowercase resource names too, since `string.general_close_button` stops resolving once the `Res.string` import goes. ktlint cannot catch that, because it never compiles. Only a build does.


