### PR TITLE
Delete the lint baselines that suppress nothing

### DIFF
--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-auth-listeners.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-auth-listeners.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-network-cache-manager.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-network-cache-manager.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-octopus-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-operation-error.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-operation-error.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-apollo-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-apollo-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-app.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-app.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-audio-player-data.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-audio-player-data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-core-api.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-core-api.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-core-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-core-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-core-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-core-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-event-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-event-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-auth-event-fake.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-auth-event-fake.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-authlib.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-authlib.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-claim-status.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-claim-status.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-pager-indicator.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-pager-indicator.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-ui.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-compose-webview.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-compose-webview.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-app-review.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-app-review.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-common-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-common-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-datastore-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-datastore-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-demo-mode.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-demo-mode.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-icons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-icons.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-locale.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-locale.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-markdown.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-markdown.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-rive.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-rive.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-core-ui-data.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-core-ui-data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-cross-sells.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-cross-sells.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-addons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-addons.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-changetier.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-changetier.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-chat.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-chat.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-claim-intent.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-claim-intent.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-coinsured.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-coinsured.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-conversations.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-conversations.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-claim-closed.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-claim-closed.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-flow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-cross-sell-after-flow.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-display-items.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-display-items.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-paying-member.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-paying-member.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-android.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-product-variant-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-settings-datastore-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-data-termination.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-data-termination.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-database-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-database-android.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-database-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-database-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-datadog-android.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-datadog-android.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-datadog-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-datadog-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-datadog-demo-tracking.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-datadog-demo-tracking.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-showcase-desktop.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-showcase-desktop.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-showcase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-showcase.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-design-system-api.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-design-system-api.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-addon-purchase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-addon-purchase.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-chat.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-chat.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-chip-id.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-chip-id.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-choose-tier.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-choose-tier.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-claim-details.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-claim-details.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-connect-payment-trustly.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-connect-payment-trustly.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-cross-sell-sheet.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-cross-sell-sheet.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-delete-account.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-delete-account.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-edit-coinsured.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-edit-coinsured.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-flags-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-flags-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-forever.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-forever.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-home.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-home.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-image-viewer.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-image-viewer.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-impersonation.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-impersonation.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-insurance-certificate.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-insurance-certificate.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-insurances.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-insurances.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-login.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-login.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-movingflow.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-movingflow.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-onboarding.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-onboarding.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-payments.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-payments.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-payout-account.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-payout-account.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-profile.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-profile.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-remove-addons.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-remove-addons.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-terminate-insurance.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-terminate-insurance.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-feature-travel-certificate.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-feature-travel-certificate.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-file-upload-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-file-upload-ui.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-forever-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-forever-ui.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-initializable.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-initializable.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-data.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-migration.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-migration.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-language-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-language-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-logging-device-model.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-logging-device-model.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-logging-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-logging-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-member-reminders-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-member-reminders-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-member-reminders-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-member-reminders-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-member-reminders-ui.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-member-reminders-ui.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-molecule-test.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-molecule-test.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-activity.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-activity.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-common.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-common.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-navigation-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-navigation-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-badge-data-public.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-badge-data-public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-firebase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-firebase.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-notification-permission.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-notification-permission.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-test-clock.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-test-clock.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-theme.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-theme.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tier-comparison.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tier-comparison.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tracking-core.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tracking-core.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tracking-datadog.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tracking-datadog.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-tracking-firebase.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-tracking-firebase.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-ui-emergency.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-ui-emergency.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>

--- a/hedvig-lint/lint-baseline/lint-baseline-ui-phone-number.xml
+++ b/hedvig-lint/lint-baseline/lint-baseline-ui-phone-number.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
-
-</issues>


### PR DESCRIPTION
Delete all the empty baseline files which were noise without giving us any benefit

🤖 AI description:

The systematic half of #3121. That PR stopped lint requiring a baseline per module; this deletes the ones that requirement produced.

**What goes.** 104 of the 105 checked-in baselines contain no entries at all, and all 104 are byte-identical at 188 bytes. They existed only because lint aborts whenever it has to create a missing baseline, so every module the convention plugin touched needed the file whether it suppressed anything or not.

With #3121 in place a baseline now means what it says: this module suppresses findings. These 104 said nothing.

**What stays.** `lint-baseline-core-resources.xml`, whose 39 entries are the only ones carrying information. It is also the record of what would surface if AGP ever gives KMP modules a runnable lint task, which is why it is worth keeping even though nothing enforces it today (it was generated by lint 8.8.0-alpha09 and cannot be regenerated, since that module has no lint task).

**Verified a no-op.** An empty baseline suppresses nothing, so removing it cannot change a result. Confirmed by running the full `./gradlew lint` with all 104 gone: BUILD SUCCESSFUL, no baseline recreated, no untracked files left behind.

**Adding a baseline from here.** Create the file empty, then fill it with `updateLintBaseline`. The task is a no-op when no file exists, and the convention plugin's comment says so at the point where `baseline` is set.
