### PR TITLE
Fix: showPolicyHolderRow and coOwners

### DIFF
--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/ContractDetailDestination.kt
@@ -44,6 +44,7 @@ import com.hedvig.android.compose.ui.plus
 import com.hedvig.android.core.uidata.UiCurrencyCode
 import com.hedvig.android.core.uidata.UiMoney
 import com.hedvig.android.data.contract.ChipIdState
+import com.hedvig.android.data.contract.ContractGroup
 import com.hedvig.android.data.contract.ContractGroup.PAYMENT_PROTECTION
 import com.hedvig.android.data.contract.ContractGroup.RENTAL
 import com.hedvig.android.data.contract.ContractId
@@ -378,6 +379,7 @@ private fun ContractDetailScreen(
                       onFillChipId = {
                         navigateToChipIdScreen(contract.id)
                       },
+                      showPolicyHolderRow = contract.shouldShowInsuredPeople(),
                     )
                   }
 
@@ -443,6 +445,12 @@ private fun PagerSelector(pagerState: PagerState, modifier: Modifier = Modifier)
     tabSize = Small,
     tabStyle = Filled,
   )
+}
+
+private fun InsuranceContract.shouldShowInsuredPeople(): Boolean {
+  val allowsCoInsured = supportsEditCoInsured || supportsEditCoOwners
+  val isException = productVariant.contractGroup == PAYMENT_PROTECTION
+  return allowsCoInsured || isException
 }
 
 @HedvigPreview

--- a/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
+++ b/app/feature/feature-insurances/src/main/kotlin/com/hedvig/android/feature/insurances/insurancedetail/yourinfo/YourInfoTab.kt
@@ -51,7 +51,6 @@ import com.hedvig.android.design.system.hedvig.HedvigShortMultiScreenPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.HighlightLabel
-import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighLightSize.Small
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor.Amber
 import com.hedvig.android.design.system.hedvig.HighlightLabelDefaults.HighlightColor.Red
@@ -100,7 +99,6 @@ import hedvig.resources.CONTRACT_ADD_COINSURED_ACTIVE_UNTIL
 import hedvig.resources.CONTRACT_COINSURED
 import hedvig.resources.CONTRACT_COINSURED_ADD_PERSONAL_INFO
 import hedvig.resources.CONTRACT_COINSURED_MISSING_ADD_INFO
-import hedvig.resources.CONTRACT_COOWNER
 import hedvig.resources.CONTRACT_COOWNERS_ADD_PERSONAL_INFO
 import hedvig.resources.CONTRACT_EDIT_INFO_LABEL
 import hedvig.resources.CONTRACT_NO_INFORMATION
@@ -164,6 +162,7 @@ internal fun YourInfoTab(
   navigateToRemoveAddon: (ContractId?, AddonVariant?) -> Unit,
   navigateToUpgradeAddon: (ContractId?, AddonVariant?) -> Unit,
   navigateToAddAddon: (AvailableAddon) -> Unit,
+  showPolicyHolderRow: Boolean,
   modifier: Modifier = Modifier,
 ) {
   val dateTimeFormatter = rememberHedvigDateTimeFormatter()
@@ -313,29 +312,22 @@ internal fun YourInfoTab(
             modifier = Modifier.padding(horizontal = 16.dp),
           )
         }
-
+        if (showPolicyHolderRow) {
+          val insuredPeopleExceptHolder = coInsured.takeIf { it.isNotEmpty() } ?: coOwners
           HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
           Spacer(Modifier.height(16.dp))
           ContractOwnerSection(
-            coInsuredList = coInsured,
+            coInsuredList = insuredPeopleExceptHolder,
             modifier = Modifier.padding(horizontal = 16.dp),
             contractHolderDisplayName = contractHolderDisplayName,
             contractHolderSSN = contractHolderSSN,
           )
-
-        if (allowEditCoInsured && coInsured.isNotEmpty()) {
-          CoInsuredSection(
-            coInsuredList = coInsured,
-            isCoOwner = false,
-            modifier = Modifier.padding(horizontal = 16.dp),
-          )
-        }
-        if (allowEditCoOwners && coOwners.isNotEmpty()) {
-          CoInsuredSection(
-            coInsuredList = coOwners,
-            isCoOwner = true,
-            modifier = Modifier.padding(horizontal = 16.dp),
-          )
+          if (insuredPeopleExceptHolder.isNotEmpty()) {
+            CoInsuredSection(
+              coInsuredList = insuredPeopleExceptHolder,
+              modifier = Modifier.padding(horizontal = 16.dp),
+            )
+          }
         }
       }
     }
@@ -834,11 +826,7 @@ internal fun ContractOwnerSection(
 }
 
 @Composable
-internal fun CoInsuredSection(
-  coInsuredList: List<CoInsured>,
-  isCoOwner: Boolean,
-  modifier: Modifier,
-) {
+internal fun CoInsuredSection(coInsuredList: List<CoInsured>, modifier: Modifier) {
   val dateTimeFormatter = rememberHedvigDateTimeFormatter()
   val birthDateTimeFormatter = rememberHedvigBirthDateDateTimeFormatter()
   Column(modifier = modifier) {
@@ -853,11 +841,7 @@ internal fun CoInsuredSection(
             Column {
               HedvigText(
                 text = coInsured.getDisplayName().ifBlank {
-                  if (isCoOwner) {
-                    stringResource(Res.string.CONTRACT_COOWNER)
-                  } else {
-                    stringResource(Res.string.CONTRACT_COINSURED)
-                  }
+                  stringResource(Res.string.CONTRACT_COINSURED)
                 },
               )
 
@@ -929,27 +913,30 @@ private fun PreviewYourInfoTab(
           DisplayItem("Type", Text("Homeowner")),
           DisplayItem("Size", Text("56 m2")),
         ),
-        coInsured = if (onlyInsuranceHolder) emptyList() else
+        coInsured = if (onlyInsuranceHolder) {
+          emptyList()
+        } else {
           listOf(
-          CoInsured(
-            ssn = "199101131000",
-            birthDate = null,
-            firstName = "Hu",
-            lastName = "Li",
-            activatesOn = LocalDate.fromEpochDays(300),
-            terminatesOn = null,
-            hasMissingInfo = false,
-          ),
-          CoInsured(
-            ssn = "1234020312",
-            birthDate = null,
-            firstName = "Testersson",
-            lastName = "Tester",
-            activatesOn = null,
-            terminatesOn = null,
-            hasMissingInfo = false,
-          ),
-        ),
+            CoInsured(
+              ssn = "199101131000",
+              birthDate = null,
+              firstName = "Hu",
+              lastName = "Li",
+              activatesOn = LocalDate.fromEpochDays(300),
+              terminatesOn = null,
+              hasMissingInfo = false,
+            ),
+            CoInsured(
+              ssn = "1234020312",
+              birthDate = null,
+              firstName = "Testersson",
+              lastName = "Tester",
+              activatesOn = null,
+              terminatesOn = null,
+              hasMissingInfo = false,
+            ),
+          )
+        },
         coOwners = listOf(),
         allowChangeAddress = true,
         allowTerminatingInsurance = true,
@@ -1066,6 +1053,7 @@ private fun PreviewYourInfoTab(
         navigateToAddAddon = {},
         chipIdState = ChipIdState.Missing,
         onFillChipId = {},
+        showPolicyHolderRow = false,
       )
     }
   }


### PR DESCRIPTION
policyHolder and Insured people rows should only be shown for PPI and the contracts allowing edit coInsured/coOwners