### PR TITLE
Widen mini button horizontal padding to 10.dp

### DIFF
--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/tokens/ButtonTokens.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/tokens/ButtonTokens.kt
@@ -134,7 +134,7 @@ internal object SmallSizeButtonTokens {
 }
 
 internal object MiniSizeButtonTokens {
-  val HorizontalPadding = 8.dp
+  val HorizontalPadding = 10.dp
   val TopPadding = 3.dp
   val BottomPadding = 3.dp
   val LabelTextFont = TypographyKeyTokens.Label


### PR DESCRIPTION
Direct change of the .dp for that one component according to new design

🤖 AI description:

📄 [**The button seam**](https://claude.ai/code/artifact/0b474493-2b02-468d-a680-64fe4ec2490e) — visual walkthrough of this stack.

`MiniSizeButtonTokens.HorizontalPadding` 8 → 10 dp, per Nils in [#design](https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1788770722028079?thread_ts=1788357331.667509&cid=C03U9C6Q7TP): now that #3126 made every button a pill, 8 dp left the label sitting too tight against the curve. Matches the updated UI Kit mini variant ([Figma](https://www.figma.com/design/5kmmDdh6StpXzbEfr7WevV/Hedvig-UI-Kit?node-id=26282-899), `px-10 py-3`, corner full).

The only consumer of `ButtonSize.Mini` in the app is `DemoModeLabel` (the "Exit demo mode" pill), plus the `design-showcase` micro-app. Both gain 4 dp of width. Height is unchanged at 24 dp.
