### PR TITLE
Lift the liquid glass buttons off the ButtonSize axis

### DIFF
--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Button.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/Button.kt
@@ -90,31 +90,71 @@ fun HedvigButton(
     onClickLabel = onClickLabel,
     isLoading = isLoading,
   ) {
-    val buttonColors = buttonStyle.style.buttonColors
-    val loadingTransition = updateTransition(isLoading, label = "loading transition")
-    loadingTransition.AnimatedContent(
-      transitionSpec = {
-        fadeIn(tween(durationMillis = 220, delayMillis = 90)) togetherWith fadeOut(tween(90))
-      },
-      contentAlignment = Alignment.Center,
-    ) { loading ->
-      if (loading) {
-        LayoutWithoutPlacement(
-          sizeAdjustingContent = { HedvigText(text = text, modifier = Modifier.withoutPlacement()) },
-        ) {
-          val desc = stringResource(Res.string.TALKBACK_LOADING_STATE_BUTTON)
-          ThreeDotsLoading(
-            stableColor = buttonColors.activeLoadingIndicatorColor,
-            temporaryColor = buttonColors.inactiveLoadingIndicatorColor,
-            modifier = Modifier.wrapContentSize(Alignment.Center)
-              .semantics {
-                contentDescription = desc
-              },
-          )
-        }
-      } else {
-        HedvigText(text = text, textAlign = TextAlign.Center)
+    ButtonLabel(text = text, isLoading = isLoading, buttonColors = buttonStyle.style.buttonColors)
+  }
+}
+
+/**
+ * A pill of the iOS liquid glass material, lifted off the content behind it by a drop shadow.
+ * Unlike [HedvigButton] it takes no [ButtonSize]: Figma draws these at exactly one size, so there
+ * is nothing to choose. See [ButtonDefaults.LiquidGlassButtonStyle].
+ *
+ * @param isLoading Behaves as it does on [HedvigButton].
+ */
+@Composable
+fun HedvigLiquidGlassButton(
+  text: String,
+  onClick: () -> Unit,
+  enabled: Boolean,
+  modifier: Modifier = Modifier,
+  glassStyle: ButtonDefaults.LiquidGlassButtonStyle = ButtonDefaults.LiquidGlassButtonStyle.Tinted,
+  interactionSource: MutableInteractionSource? = null,
+  border: Color? = null,
+  onClickLabel: String? = null,
+  isLoading: Boolean = false,
+) {
+  val style = glassStyle.style
+  ButtonImpl(
+    onClick = onClick,
+    enabled = enabled,
+    modifier = modifier,
+    style = style,
+    size = Size.LiquidGlass,
+    interactionSource = interactionSource,
+    border = border,
+    onClickLabel = onClickLabel,
+    isLoading = isLoading,
+  ) {
+    ButtonLabel(text = text, isLoading = isLoading, buttonColors = style.buttonColors)
+  }
+}
+
+/** The label slot shared by [HedvigButton] and [HedvigLiquidGlassButton], including the loading swap. */
+@Composable
+private fun ButtonLabel(text: String, isLoading: Boolean, buttonColors: ButtonColors) {
+  val loadingTransition = updateTransition(isLoading, label = "loading transition")
+  loadingTransition.AnimatedContent(
+    transitionSpec = {
+      fadeIn(tween(durationMillis = 220, delayMillis = 90)) togetherWith fadeOut(tween(90))
+    },
+    contentAlignment = Alignment.Center,
+  ) { loading ->
+    if (loading) {
+      LayoutWithoutPlacement(
+        sizeAdjustingContent = { HedvigText(text = text, modifier = Modifier.withoutPlacement()) },
+      ) {
+        val desc = stringResource(Res.string.TALKBACK_LOADING_STATE_BUTTON)
+        ThreeDotsLoading(
+          stableColor = buttonColors.activeLoadingIndicatorColor,
+          temporaryColor = buttonColors.inactiveLoadingIndicatorColor,
+          modifier = Modifier.wrapContentSize(Alignment.Center)
+            .semantics {
+              contentDescription = desc
+            },
+        )
       }
+    } else {
+      HedvigText(text = text, textAlign = TextAlign.Center)
     }
   }
 }
@@ -132,10 +172,40 @@ fun HedvigButton(
   isLoading: Boolean = false,
   content: @Composable RowScope.() -> Unit,
 ) {
+  ButtonImpl(
+    onClick = onClick,
+    enabled = enabled,
+    modifier = modifier,
+    style = buttonStyle.style,
+    size = buttonSize.size,
+    interactionSource = interactionSource,
+    border = border,
+    onClickLabel = onClickLabel,
+    isLoading = isLoading,
+    content = content,
+  )
+}
+
+/**
+ * The one rendering path behind [HedvigButton] and [HedvigLiquidGlassButton]. [style] and [size] arrive
+ * already resolved, which is what keeps the two axes independent: a caller's [ButtonStyle] cannot
+ * reach in and change the metrics its [ButtonSize] asked for.
+ */
+@Composable
+private fun ButtonImpl(
+  onClick: () -> Unit,
+  enabled: Boolean,
+  modifier: Modifier,
+  style: Style,
+  size: Size,
+  interactionSource: MutableInteractionSource?,
+  border: Color?,
+  onClickLabel: String?,
+  isLoading: Boolean,
+  content: @Composable RowScope.() -> Unit,
+) {
   @Suppress("NAME_SHADOWING")
   val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-  val style = buttonStyle.style
-  val size = buttonSize.sizeIn(style)
   val buttonColors = style.buttonColors
   val containerColor = buttonColors.containerColor(enabled)
   val contentColor = buttonColors.contentColor(enabled)
@@ -284,14 +354,11 @@ private fun PreviewRoundedButtons() {
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier.padding(16.dp),
       ) {
-        for (buttonStyle in listOf(
-          ButtonDefaults.ButtonStyle.RoundedPrimary,
-          ButtonDefaults.ButtonStyle.RoundedLiquidGlass,
-        )) {
+        for (glassStyle in ButtonDefaults.LiquidGlassButtonStyle.entries) {
           Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            HedvigButton("Make a claim", {}, enabled = true, buttonStyle = buttonStyle)
-            HedvigButton("Disabled", {}, enabled = false, buttonStyle = buttonStyle)
-            HedvigButton("Loading", {}, enabled = true, buttonStyle = buttonStyle, isLoading = true)
+            HedvigLiquidGlassButton("Make a claim", {}, enabled = true, glassStyle = glassStyle)
+            HedvigLiquidGlassButton("Disabled", {}, enabled = false, glassStyle = glassStyle)
+            HedvigLiquidGlassButton("Loading", {}, enabled = true, glassStyle = glassStyle, isLoading = true)
           }
         }
       }
@@ -310,12 +377,22 @@ object ButtonDefaults {
     SecondaryAlt,
     Ghost,
     Red,
+  }
 
-    /** A filled pill with the sheen and drop shadow of the iOS glass material. */
-    RoundedPrimary,
+  /**
+   * The two variants of [HedvigLiquidGlassButton]. Figma models them as one component with a
+   * boolean Tinted variant, so they are a pair here rather than two entries in [ButtonStyle]: both
+   * carry the same drop shadow and the same fixed padding, and neither takes a [ButtonSize].
+   */
+  enum class LiquidGlassButtonStyle {
+    /**
+     * An opaque pill, Figma's `Tinted = True`. Renders in the same colors as [ButtonStyle.Primary]
+     * at every state; the drop shadow is the only thing that distinguishes the two.
+     */
+    Tinted,
 
-    /** A translucent pill of the iOS glass material, letting the backdrop show through. */
-    RoundedLiquidGlass,
+    /** A translucent pill, Figma's `Tinted = False`, letting the backdrop show through. */
+    Regular,
   }
 
   enum class ButtonSize {
@@ -334,8 +411,12 @@ private val ButtonDefaults.ButtonStyle.style: Style
     ButtonDefaults.ButtonStyle.SecondaryAlt -> Style.SecondaryAlt
     ButtonDefaults.ButtonStyle.Ghost -> Style.Ghost
     ButtonDefaults.ButtonStyle.Red -> Style.Red
-    ButtonDefaults.ButtonStyle.RoundedPrimary -> Style.LiquidGlassTinted
-    ButtonDefaults.ButtonStyle.RoundedLiquidGlass -> Style.LiquidGlassRegular
+  }
+
+private val ButtonDefaults.LiquidGlassButtonStyle.style: Style
+  get() = when (this) {
+    ButtonDefaults.LiquidGlassButtonStyle.Tinted -> Style.LiquidGlassTinted
+    ButtonDefaults.LiquidGlassButtonStyle.Regular -> Style.LiquidGlassRegular
   }
 
 private val ButtonSize.size: Size
@@ -345,20 +426,6 @@ private val ButtonSize.size: Size
     ButtonSize.Small -> Size.Small
     ButtonSize.Mini -> Size.Mini
   }
-
-/**
- * The metrics this size takes on within [style]. The glass styles get their own tighter padding at
- * [ButtonSize.Large]; at every smaller size they fall back to the standard button metrics. Corner
- * radius is not part of this: every button is a pill, see [ButtonTokens.ContainerShape].
- */
-// TODO: that fallback is a silent one, and Figma draws the liquid glass buttons at one fixed size
-//  rather than across the size scale. Lift them off the size axis so the combination stops being
-//  expressible.
-@Composable
-private fun ButtonSize.sizeIn(style: Style): Size = when {
-  style.glassMaterial != null && this == ButtonSize.Large -> Size.LiquidGlass
-  else -> size
-}
 
 @Immutable
 private data class ButtonColors(

--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -110,9 +110,8 @@ import com.hedvig.android.data.coinsured.CoInsuredFlowType
 import com.hedvig.android.data.contract.CrossSell
 import com.hedvig.android.data.contract.ImageAsset
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonSize
-import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.RoundedLiquidGlass
-import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.RoundedPrimary
 import com.hedvig.android.design.system.hedvig.ButtonDefaults.ButtonStyle.Secondary
+import com.hedvig.android.design.system.hedvig.ButtonDefaults.LiquidGlassButtonStyle
 import com.hedvig.android.design.system.hedvig.DraftClaimDialog
 import com.hedvig.android.design.system.hedvig.ErrorDialog
 import com.hedvig.android.design.system.hedvig.HedvigAlertDialog
@@ -121,6 +120,7 @@ import com.hedvig.android.design.system.hedvig.HedvigButton
 import com.hedvig.android.design.system.hedvig.HedvigCard
 import com.hedvig.android.design.system.hedvig.HedvigErrorSection
 import com.hedvig.android.design.system.hedvig.HedvigFullScreenCenterAlignedProgressDebounced
+import com.hedvig.android.design.system.hedvig.HedvigLiquidGlassButton
 import com.hedvig.android.design.system.hedvig.HedvigPreview
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
@@ -1499,25 +1499,25 @@ private fun MainActionCarouselSection(
       .padding(horizontal = 16.dp)
       .padding(horizontalInsets),
   ) {
-    HedvigButton(
+    HedvigLiquidGlassButton(
       text = stringResource(Res.string.home_tab_claim_button_text),
       onClick = onMakeClaim,
       enabled = true,
-      buttonStyle = RoundedPrimary,
+      glassStyle = LiquidGlassButtonStyle.Tinted,
     )
     if (isHelpCenterEnabled) {
-      HedvigButton(
+      HedvigLiquidGlassButton(
         text = stringResource(Res.string.home_tab_get_help),
         onClick = onHelpAndSupport,
         enabled = true,
-        buttonStyle = RoundedLiquidGlass,
+        glassStyle = LiquidGlassButtonStyle.Regular,
       )
     }
-    HedvigButton(
+    HedvigLiquidGlassButton(
       text = stringResource(Res.string.DASHBOARD_OPEN_CHAT),
       onClick = onContactUs,
       enabled = true,
-      buttonStyle = RoundedLiquidGlass,
+      glassStyle = LiquidGlassButtonStyle.Regular,
     )
   }
 }

--- a/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/button/ShowcaseButton.kt
+++ b/micro-apps/design-showcase/src/main/kotlin/com/hedvig/android/sample/design/showcase/button/ShowcaseButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.hedvig.android.compose.ui.LayoutWithoutPlacement
 import com.hedvig.android.design.system.hedvig.ButtonDefaults
 import com.hedvig.android.design.system.hedvig.HedvigButton
+import com.hedvig.android.design.system.hedvig.HedvigLiquidGlassButton
 import com.hedvig.android.design.system.hedvig.HedvigText
 import com.hedvig.android.design.system.hedvig.HedvigTheme
 import com.hedvig.android.design.system.hedvig.Surface
@@ -43,6 +44,45 @@ internal fun ShowcaseButton() {
             }
           }
           ButtonSizesRow(size, index == 0)
+        }
+      }
+      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(modifier = Modifier.align(Alignment.CenterVertically)) {
+          LayoutWithoutPlacement(
+            sizeAdjustingContent = {
+              HedvigText(
+                text = ButtonDefaults.ButtonSize.entries.map { it.name }.maxBy { it.length },
+                style = HedvigTheme.typography.bodyMedium,
+              )
+            },
+          ) {
+            HedvigText(text = "Glass", style = HedvigTheme.typography.bodyMedium)
+          }
+        }
+        LiquidGlassButtonsRow()
+      }
+    }
+  }
+}
+
+/**
+ * Liquid glass buttons take no [ButtonDefaults.ButtonSize], so they get a row of their own rather
+ * than a column inside each size.
+ */
+@Composable
+private fun LiquidGlassButtonsRow() {
+  Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
+    for (type in ShowcaseButtonType.entries) {
+      Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        for (glassStyle in ButtonDefaults.LiquidGlassButtonStyle.entries) {
+          HedvigLiquidGlassButton(
+            text = "Button label",
+            onClick = {},
+            enabled = type != ShowcaseButtonType.Disabled,
+            glassStyle = glassStyle,
+            isLoading = type == ShowcaseButtonType.Loading,
+            interactionSource = showcaseInteractionSource(type),
+          )
         }
       }
     }
@@ -90,25 +130,31 @@ private fun ShowcaseButton(
     buttonStyle = buttonStyle,
     buttonSize = buttonSize,
     isLoading = showcaseButtonType == ShowcaseButtonType.Loading,
-    interactionSource = if (showcaseButtonType == ShowcaseButtonType.Hover) {
-      remember {
-        object : MutableInteractionSource {
-          override val interactions: Flow<Interaction>
-            get() = flowOf(HoverInteraction.Enter())
-
-          override suspend fun emit(interaction: Interaction) {
-          }
-
-          override fun tryEmit(interaction: Interaction): Boolean {
-            return false
-          }
-        }
-      }
-    } else {
-      null
-    },
+    interactionSource = showcaseInteractionSource(showcaseButtonType),
     modifier = modifier,
   )
+}
+
+/** A source that reports a permanent hover, so the hover column renders in its hovered colors. */
+@Composable
+private fun showcaseInteractionSource(type: ShowcaseButtonType): MutableInteractionSource? {
+  return if (type == ShowcaseButtonType.Hover) {
+    remember {
+      object : MutableInteractionSource {
+        override val interactions: Flow<Interaction>
+          get() = flowOf(HoverInteraction.Enter())
+
+        override suspend fun emit(interaction: Interaction) {
+        }
+
+        override fun tryEmit(interaction: Interaction): Boolean {
+          return false
+        }
+      }
+    }
+  } else {
+    null
+  }
 }
 
 private enum class ShowcaseButtonType {


### PR DESCRIPTION
Extract the glass button outside of the entire rest of the button system because it does not respect the multiple-size scenario anyway and we had to do if-checks for the glass scenario to adjust the size of the button due to this fact. We had code like
```
@Composable
private fun ButtonSize.sizeIn(style: Style): Size = when {
  style.glassMaterial != null && this == ButtonSize.Large -> Size.Glass
  else -> size
}
```
which felt wrong so I figured might as well take that special case out since we only have one size in the app for now. If we get more such buttons we can consider bringing it back into the same size system

🤖 AI description:

📄 [**The button seam**](https://claude.ai/code/artifact/0b474493-2b02-468d-a680-64fe4ec2490e) — visual walkthrough of the final API, the size scale, and the Figma mapping.

`sizeIn(style)` let a `ButtonStyle` reach across and change the metrics a `ButtonSize` asked for, gated on `this == ButtonSize.Large`. So `RoundedPrimary` at `Medium` silently rendered with standard Medium padding: no error, no warning. Nothing hit it today (all three call sites are `Large`), but `design-showcase` was rendering the bogus combinations.

- `RoundedPrimary`/`RoundedLiquidGlass` leave `ButtonStyle` for `LiquidGlassButtonStyle { Tinted, Regular }`.
- New `HedvigLiquidGlassButton`, which takes no `ButtonSize`.
- Both funnel into a private `ButtonImpl` receiving `Style` and `Size` already resolved, so the axes can't cross. `sizeIn()` is deleted.
- Showcase gets a dedicated Glass row instead of a cell per size.

**The misuse is now a compile error**, not a silent fallback. Three probes against the new API:

```
Argument type mismatch: actual type is 'ButtonDefaults.LiquidGlassButtonStyle',
  but 'ButtonDefaults.ButtonStyle' was expected.
No parameter with name 'buttonSize' found.
Unresolved reference 'RoundedPrimary'.
```

The two enums are disjoint, `HedvigLiquidGlassButton` has no size parameter, and `Size` is a private sealed interface so `Size.LiquidGlass` isn't nameable outside `Button.kt`. (`Modifier.liquidGlass` stays public for `ToolbarIcons`, so a glass material can still be hand-applied to any button — but that's explicit, and nothing gets silently substituted.)

**Naming**, following @panasetskaya's review comment. She was right that `Primary` isn't glass: it resolves to the same nine color tokens as `ButtonStyle.Primary` at every state. But the Figma file settles what these actually are. [Make a claim](https://www.figma.com/design/SogcacjzOxkCC46XcZP8lQ/App-P2-2026?node-id=429-8162) and [Help & support](https://www.figma.com/design/SogcacjzOxkCC46XcZP8lQ/App-P2-2026?node-id=429-8163) are two instances of one component with a boolean `Tinted` variant, and **both** BG children carry the same drop shadow, `0px 8px 40px rgba(0,0,0,0.12)`, which is exactly our `glassDropShadow`. So they are a pair, design calls the pair liquid glass, and the code now says the same.

Metrics check out against Figma: fill `#121212`, 20dp horizontal padding, 48dp height (12 + 24 + 12), full corner radius.

Verified on a Pixel 6 Pro: home action row renders all three buttons correctly, and the showcase shows the six remaining styles per size plus the Glass row.
