### PR TITLE
Make the member ID selectable so it can be copied

### DIFF
--- a/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/InformationDestination.kt
+++ b/app/feature/feature-profile/src/main/kotlin/com/hedvig/android/feature/profile/aboutapp/InformationDestination.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -195,11 +196,13 @@ private fun ColumnScope.InformationContent(
         HedvigText(stringResource(Res.string.PROFILE_ABOUT_APP_MEMBER_ID))
       },
       endSlot = {
-        HedvigText(
-          memberId,
-          color = HedvigTheme.colorScheme.textSecondary,
-          textAlign = TextAlign.End,
-        )
+        SelectionContainer {
+          HedvigText(
+            memberId,
+            color = HedvigTheme.colorScheme.textSecondary,
+            textAlign = TextAlign.End,
+          )
+        }
       },
     )
   }


### PR DESCRIPTION
It's something I always wanted to do, to be able to copy-paste the member-id if there is such a need. It's just a little convenience thing, as a "why not do this?" kind of thing

🤖 AI description:

The member ID row on Profile > Information now wraps its value in a `SelectionContainer`, so a long press selects the text and brings up the system copy action. Same pattern already used in `ChatLoadedScreen` and `PartnerDeflectDestination`.

Only the value is selectable, not the label, so a long press copies just the ID.

Verified with `:feature-profile:compileReleaseKotlin` and `:feature-profile:ktlintCheck`. Not run on a device yet.
