### PR TITLE
Let the home quick action tiles scroll out to the section's edges

### DIFF
--- a/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
+++ b/app/feature/feature-home/src/main/kotlin/com/hedvig/android/feature/home/home/ui/HomeDestination.kt
@@ -1358,22 +1358,23 @@ private fun QuickActionTilesSection(
   onEditInsurance: (MultiSelectExpandedLink) -> Unit,
   horizontalInsets: PaddingValues,
 ) {
+  val contentPadding = PaddingValues(horizontal = 16.dp) + horizontalInsets
   Column(
     verticalArrangement = Arrangement.spacedBy(8.dp),
-    modifier = Modifier
-      .fillMaxWidth()
-      .padding(horizontal = 16.dp)
-      .padding(horizontalInsets),
+    modifier = Modifier.fillMaxWidth(),
   ) {
     HedvigText(
       text = stringResource(Res.string.HC_QUICK_ACTIONS_TITLE),
       style = HedvigTheme.typography.headlineSmall,
-      modifier = Modifier.semantics { heading() },
+      modifier = Modifier
+        .padding(contentPadding)
+        .semantics { heading() },
     )
     Row(
       horizontalArrangement = Arrangement.spacedBy(8.dp),
       modifier = Modifier
         .horizontalScroll(rememberScrollState())
+        .padding(contentPadding)
         .height(IntrinsicSize.Max),
     ) {
       quickActions.forEach { action ->
@@ -1390,7 +1391,6 @@ private fun QuickActionTilesSection(
             .fillMaxHeight(),
         )
       }
-      Spacer(Modifier.width(8.dp))
     }
   }
 }


### PR DESCRIPTION
Fix the horizontal scroll being cut-off by the horizontal padding

🤖 AI description:

The quick actions row applied the section's 16.dp padding to the outer `Column`, above `horizontalScroll`, so the scrolling viewport was 32.dp narrower than the sheet and clipped the tiles there instead of at its edges. Carrying the padding inside the scroll turns it into content padding, which is what every other scrollable section on Home already does: `MainActionCarouselSection` puts it after `.horizontalScroll()`, and the carousels hand it to `HorizontalPager(contentPadding = ...)`.

The trailing `Spacer(Modifier.width(8.dp))` goes with it, since the end padding is the real trailing room now.

Before, mid-scroll on a Pixel 6 Pro. The partial tiles stop 16.dp short of each edge, with a strip of bare sheet beyond them:

<img width="1440" height="600" alt="before-cut-off-16dp" src="https://github.com/user-attachments/assets/c97e56f1-5a48-4b17-9cfa-2f4003e6c8ae" />

After, same scroll position. The tiles run out to the edges:

<img width="1440" height="600" alt="after-scrolls-to-edge" src="https://github.com/user-attachments/assets/e4c36950-071a-4192-943b-92d8150d9947" />

At rest the first tile still lines up with the heading, and scrolled to the far end the last tile stops 16.dp from the right, so the row stays symmetric:

<img width="1440" height="600" alt="after-scrolled-to-end" src="https://github.com/user-attachments/assets/85578bcb-553e-4dc1-aeca-5f5a6b5e9b98" />

`:feature-home:ktlintCheck` passes.
