### PR TITLE
Record post-release monitor work, the action-based precedent, and the auth SLOs that already exist

### DIFF
--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -345,11 +345,22 @@ Android cannot fix. Worth knowing before anyone treats it as the primary defence
 rebuilds backend auth availability inside RUM.
 
 `Auth: login (iOS)` does exist (`9028984bed7351dc92b7e58e5c7db82f`, 7d at 99%, monitor `93102231`)
-and reads 99.95%, state OK. That is not reassurance. It divides `ios.login.network.error`
-(`event_type: error`) by `ios.login.network.count` (`event_type: resource`), the same numerator and
-denominator mismatch that made the Android SLO report 534% of its budget. It looks healthy for the
-same reason the Android one looked healthy right up until it did not. Android got paged first
-because its view names broke, not because iOS is better instrumented.
+and reads 99.95%, state OK. **That is not reassurance.** Checked 2026-09-11, it is
+
+```
+(sum:ios.login.network.count - sum:ios.login.network.error) / sum:ios.login.network.count
+```
+
+which is the Android defect exactly. `ios.login.network.count` is `event_type: resource`,
+`ios.login.network.error` is `event_type: error`, so the numerator subtracts one kind of event from
+a count of a different kind and can go negative. That is what made the Android SLO report 534% of
+its budget. The two halves do not even agree on what screen they watch: the count filters
+`@view.name:BankIDLoginQRView`, the error filters `@view.name:(BankIDLoginQR OR BankIDLoginQRView)`,
+and the error metric carries no `@application.id` filter at all.
+
+It looks healthy for the same reason the Android one looked healthy right up until it did not.
+Android got paged first because its view names broke, not because iOS is better instrumented. This
+is worth raising with the iOS side; it is their metric to fix, and nothing in this repo can.
 
 Also worth knowing as a precedent: `Purchase: completed signs` is an SLO over
 `hedvig.events.signing.completed / hedvig.events.signing.started` with a **70%** target. So the org already has a funnel SLO built on

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -1,7 +1,8 @@
 # Datadog Android metric recovery
 
-**Status: four items open.** One is time-boxed: flip `notify_no_data` on monitor `93408872` a few
-days after the release that carries the auth instrumentation, see below. The `OR`-branch cleanup is
+**Status: four items open.** Two are time-boxed to the release carrying the auth instrumentation:
+flip `notify_no_data` on monitor `93408872` a few days after, and take the SLO window back to 7 days
+about a week after. See "After the release" below. The `OR`-branch cleanup is
 blocked on the pre-14.3.6 install base draining, which was still about 13% of prod view traffic on
 2026-09-10. The claim-submission-failure action is unstarted. The guard-rail monitor is also still
 just a suggestion.
@@ -238,28 +239,51 @@ roughly the same 1.4%. This metric is the denominator of the Claims flow (Androi
 reads marginally better. Two keys in the new scope, `StartClaimPledgeKey` and `UpdateAppKey`, have no
 old equivalent to measure, but neither issues network requests in normal use.
 
-## PENDING: flip `notify_no_data` on monitor 93408872
+## After the release: two changes to monitor 93408872
 
-**Do this a few days after the release carrying the auth instrumentation, once
-`android.login.network.count` shows steady prod traffic.**
+Both wait for the release that carries the auth instrumentation, because before it there is
+legitimately no prod data on `android.login.network.count`.
 
-```
-pup api -X PUT v1/monitor/93408872 --input <monitor json with options.notify_no_data = true>
-```
+### A few days after: flip `notify_no_data` to true
 
 Start with `no_data_timeframe` around 12 hours and tighten once the real overnight pattern is
-visible. Login runs at roughly 50 attempts a day, so about two an hour, and a tighter window will
-page on an ordinary quiet night.
+visible. Login runs at roughly 50 attempts a day, about two an hour, so a tighter window will page
+on an ordinary quiet night.
 
-**Why it matters.** The SLI counts `POST /member-login` resource events with a 5xx status. A request
-that never reaches the server produces a RUM error and no resource at all, so it lands in neither
-side of the ratio. If auth becomes unreachable, the denominator collapses toward zero and the SLI
-reads 100% or no-data. With `notify_no_data: false` nothing fires, so the worst outage produces the
-best number and silence. Treating the collapse itself as the alert is the cheapest cover for the one
-failure mode this SLI cannot otherwise see.
+**Why.** The SLI counts `POST /member-login` resource events with a 5xx status. A request that never
+reaches the server produces a RUM error and no resource at all, so it lands in neither side of the
+ratio. If auth becomes unreachable the denominator collapses toward zero and the SLI reads 100% or
+no-data. With `notify_no_data: false` nothing fires, so the worst outage produces the best number and
+silence. Treating the collapse itself as the alert is the cheapest cover for the one failure mode
+this SLI cannot otherwise see.
 
-**Why not now.** Before the release there is legitimately no prod data, so flipping it early means a
-monitor that fires continuously and gets muted, which is worse than leaving it off.
+### About a week after: take the SLO window back to 7 days
+
+Set the SLO `timeframe` and its `thresholds[].timeframe` back to `7d`, and the monitor query back to
+`error_budget("29588e73473d54f09814173755548b80").over("7d")`. All three have to move together or
+the monitor asks the SLO for a window it no longer defines.
+
+**Why.** `error_budget(...).over(30d)` is a trailing window, so once the budget is burned the monitor
+stays red until the burning events age out, up to a month. Seven days recovers four times faster.
+
+**Check the arithmetic against real traffic before doing it.** The window was widened to 30d to get a
+usable budget, and shortening it takes that back. At the expected volume:
+
+| Window and target | Budget |
+|---|---|
+| 7d at 99% | about 3.6 failures |
+| 30d at 99% | about 15.5 failures |
+| 7d at 97% | about 10.8 failures |
+
+Based on 1,547 login-screen impressions over 30 days, so roughly 361 attempts a week. A 7-day window
+at 99% means any week with four 5xx responses breaches. If that turns out to be normal variance
+rather than a real signal, the lever to reach for is the **target**, not the window: 7d at a lower
+target buys headroom and keeps fast recovery. Pick it from the first weeks of real data rather than
+assuming 99%, which was inherited and never chosen for this signal.
+
+Burn-rate alerting solves both the recovery time and the sensitivity properly, and is the textbook
+answer. It was deliberately not done, because it needs a new monitor and real traffic to size
+thresholds against. Revisit if the 7d window turns out to flap.
 
 ## Guard rail worth adding
 

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -1,11 +1,14 @@
 # Datadog Android metric recovery
 
 **Status: four items open.** Two are time-boxed to the release carrying the auth instrumentation:
-flip `notify_no_data` on monitor `93408872` a few days after, and take the SLO window back to 7 days
-about a week after. See "After the release" below. The `OR`-branch cleanup is
-blocked on the pre-14.3.6 install base draining, which was still about 13% of prod view traffic on
-2026-09-10. The claim-submission-failure action is unstarted. The guard-rail monitor is also still
-just a suggestion.
+cover the auth-unreachable failure mode on monitor `93408872` a few days after, and take the SLO
+window back to 7 days about a week after. See "After the release" below, and note that the
+`notify_no_data` flag originally written down for the first of those does not work on an SLO alert
+monitor, so that item needs a different mechanism. The `OR`-branch cleanup is blocked on the
+pre-14.3.6 install base draining. Measured 2026-09-11, versions at or below 14.3.2 were 12.0% of
+prod view events over 30 days but only **1.1% over 7 days and 0.8% over one day**, so the 30-day
+figure lags badly and the trigger is closer than it looks. The claim-submission-failure action is
+unstarted. The guard-rail monitor is also still just a suggestion.
 
 Last updated 2026-09-11.
 
@@ -21,7 +24,8 @@ Measured: app versions up to 14.3.2 emit 42 to 79 distinct `@view.name` values; 
 three or four, all activity-level. All 18 custom `android.*` RUM metrics filter on `@view.name` or
 `@view.url`, so all 18 broke. Control: `trace.android.request.hits` was flat across the same window
 (1.39M vs 1.41M), so usage never changed. The 13 `ios.*` metrics were unaffected, because iOS names
-views differently and its two newest metrics are action-based.
+views differently. Three of the 13 are action-based, which is a separate property worth knowing but
+not the reason they survived.
 
 Consumers all reference the metrics **by name**, so the "Apps (Android + iOS)" dashboard, monitor
 12054196, and the three Android SLOs need no edits of their own. The SLOs are metric-based
@@ -222,10 +226,16 @@ Action-based metrics do not break when navigation changes.
 
 To be precise about why no iOS metric broke here: the Nav2 to Nav3 migration was Android-only, so
 iOS view names never moved. Only 3 of the 13 `ios.*` metrics are actually action-based
-(`ios.addonPurchased`, `ios.addonUpgraded`, `ios.claims.end.count`). Those three are the only metrics
-in the whole org immune to a rename, and iOS emits them through `log.addUserAction(...)` in
-`DatadogLogger.swift` with the names held as a Swift enum in `ChangeAddonViewModel.swift`. So this is
-not a novel idea, it is catching up to a pattern already in production on the other platform.
+(`ios.addonPurchased`, `ios.addonUpgraded`, `ios.claims.end.count`), and only two of them are
+genuinely rename-proof. Those two take their names from a Swift enum in `ChangeAddonViewModel.swift`
+and go out through `log.addUserAction(...)`, whose sink is `DatadogLogger.swift`. The third is a
+cautionary tale: `ios.claims.end.count` filters
+`@action.name:ClaimIntentStepContentSummary`, which `ClaimIntentClientOctopus.swift` emits as
+`content.__typename`, a GraphQL type name owned by the backend schema. Rename that type and the
+metric dies silently, so an action name is only durable if the app owns the constant.
+
+So this is not a novel idea, it is catching up to a pattern already in production on the other
+platform, with one example of how to get it wrong.
 
 The counter-example is on iOS too. `ios.login.network.error` excludes user-facing translated strings,
 both the English and Swedish wording of the BankID cancellation and the "no existing Hedvig member"
@@ -252,23 +262,28 @@ roughly the same 1.4%. This metric is the denominator of the Claims flow (Androi
 reads marginally better. Two keys in the new scope, `StartClaimPledgeKey` and `UpdateAppKey`, have no
 old equivalent to measure, but neither issues network requests in normal use.
 
-## After the release: two changes to monitor 93408872
+## After the release: two follow-ups on the login SLO
 
 Both wait for the release that carries the auth instrumentation, because before it there is
-legitimately no prod data on `android.login.network.count`.
+legitimately no prod data on `android.login.network.count`. The second is a change to monitor
+`93408872`; the first, as it turns out, cannot be.
 
-### A few days after: flip `notify_no_data` to true
+### A few days after: cover the auth-unreachable failure mode
 
-Start with `no_data_timeframe` around 12 hours and tighten once the real overnight pattern is
-visible. Login runs at roughly 50 attempts a day, about two an hour, so a tighter window will page
-on an ordinary quiet night.
+**The obvious lever does not exist.** An earlier version of this document said to flip
+`notify_no_data` to `true` on monitor `93408872`. That monitor is `type: "slo alert"`, and
+`notify_no_data` is not honoured on SLO alert monitors: the field reads `false` and carries no
+`no_data_timeframe`. It is not a setting someone forgot to turn on. Across the org, all 32 SLO alert
+monitors have it `false`, and the only 2 monitors setting it `true` are ordinary metric monitors.
+So the gap below is real but needs a separate monitor to cover, not a flag. **That choice is open.**
 
-**Why.** The SLI counts `POST /member-login` resource events with a 5xx status. A request that never
+**Why it matters.** The SLI counts `POST /member-login` resource events with a 5xx status. A request that never
 reaches the server produces a RUM error and no resource at all, so it lands in neither side of the
 ratio. If auth becomes unreachable the denominator collapses toward zero and the SLI reads 100% or
-no-data. With `notify_no_data: false` nothing fires, so the worst outage produces the best number and
-silence. Treating the collapse itself as the alert is the cheapest cover for the one failure mode
-this SLI cannot otherwise see.
+no-data. Nothing fires, so the worst outage produces the best number and silence. Treating the
+collapse itself as the alert is the only cover for the one failure mode this SLI cannot otherwise
+see, and on an SLO alert monitor that means a second monitor watching
+`sum:android.login.network.count` for an absence.
 
 ### About a week after: take the SLO window back to 7 days
 
@@ -284,19 +299,30 @@ usable budget, and shortening it takes that back. At the expected volume:
 
 | Window and target | Budget |
 |---|---|
-| 7d at 99% | about 3.6 failures |
-| 30d at 99% | about 15.5 failures |
-| 7d at 97% | about 10.8 failures |
+| 7d at 99% | about 7 failures |
+| 30d at 99% | about 30 failures |
+| 7d at 97% | about 21 failures |
 
-Based on 1,547 login-screen impressions over 30 days, so roughly 361 attempts a week. A 7-day window
-at 99% means any week with four 5xx responses breaches. If that turns out to be normal variance
+Based on 3,014 Swedish-login view impressions over the 30 days to 2026-09-11, so roughly 703 attempts
+a week, around 100 a day. A 7-day window at 99% means any week with seven 5xx responses breaches.
+
+**Re-measure before acting on this.** An earlier reading of the same query returned 1,547, half the
+current figure, because login-view impressions were themselves suppressed by the Nav3 breakage and
+are still recovering as the fixed build rolls out. The input is moving, and moving upward, so treat
+these numbers as a floor. Retries also mean one member can produce more than one attempt. If that turns out to be normal variance
 rather than a real signal, the lever to reach for is the **target**, not the window: 7d at a lower
 target buys headroom and keeps fast recovery. Pick it from the first weeks of real data rather than
 assuming 99%, which was inherited and never chosen for this signal.
 
 Burn-rate alerting solves both the recovery time and the sensitivity properly, and is the textbook
-answer. It was deliberately not done, because it needs a new monitor and real traffic to size
-thresholds against. Revisit if the 7d window turns out to flap.
+answer. It was not done here only because it needs a new monitor, but the sizing does not have to be
+invented: the org already runs 9 burn-rate monitors, shaped like
+
+```
+burn_rate("<slo id>").over("7d").long_window("1h").short_window("5m") > 16.8
+```
+
+Revisit if the 7d window turns out to flap.
 
 ## What already measures auth, so nobody builds it a third time
 
@@ -313,11 +339,15 @@ adds is the network path between the member and the server, which is real, but i
 Android cannot fix. Worth knowing before anyone treats it as the primary defence for auth, or
 rebuilds backend auth availability inside RUM.
 
-There is no `Auth: login (iOS)` SLO. Android is the only platform alerting on login, which is why
-Android is the platform that got paged.
+`Auth: login (iOS)` does exist (`9028984bed7351dc92b7e58e5c7db82f`, 7d at 99%, monitor `93102231`)
+and reads 99.95%, state OK. That is not reassurance. It divides `ios.login.network.error`
+(`event_type: error`) by `ios.login.network.count` (`event_type: resource`), the same numerator and
+denominator mismatch that made the Android SLO report 534% of its budget. It looks healthy for the
+same reason the Android one looked healthy right up until it did not. Android got paged first
+because its view names broke, not because iOS is better instrumented.
 
 Also worth knowing as a precedent: `Purchase: completed signs` is an SLO over
-`hedvig.events.signing.completed` with a **70%** target. So the org already has a funnel SLO built on
+`hedvig.events.signing.completed / hedvig.events.signing.started` with a **70%** target. So the org already has a funnel SLO built on
 explicit events rather than HTTP outcomes, and already accepts a target chosen from reality instead
 of a round number.
 

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -5,8 +5,10 @@ take the SLO window back to 7 days about a week after. See "After the release" b
 auth-unreachable gap that used to be a fourth item is closed as accepted, also below.
 
 The `OR`-branch cleanup is blocked on the pre-14.3.6 install base draining. Measured 2026-09-11,
-versions at or below 14.3.2 were 12.0% of prod view events over 30 days but only **1.1% over 7 days
-and 0.8% over one day**, so the 30-day figure lags badly and the trigger is closer than it looks.
+versions at or below 14.3.2 were about 11.5% of prod view events over 30 days but only **1.1% over 7
+days and 0.7% over one day**, so the 30-day figure lags badly and the trigger is closer than it
+looks. Every number in this document is re-runnable; the commands are inline next to each one, and
+they should be re-run rather than trusted, because most of these are still moving.
 
 The claim-submission-failure action is unstarted, and the guard-rail monitor is still just a
 suggestion.
@@ -67,7 +69,18 @@ measures and they will confuse the next person.
 
 ### Trigger condition
 
-Remove them once traffic from app versions at or below 14.3.2 is negligible. Check with:
+Remove them once traffic from app versions at or below 14.3.2 is negligible.
+
+To get the share directly, over any window (this is where the header's 30d/7d/1d figures come from):
+
+```bash
+pup rum aggregate \
+  --query '@type:view @application.id:4d7b8355-396d-406e-b543-30a073050e8f @session.type:user' \
+  --compute count --group-by version --limit 200 --from 7d
+```
+
+Sum the buckets whose version is at or below 14.3.2 and divide by the total. Or check a single
+known-old view name, which returns nothing once the old builds are gone:
 
 ```
 pup rum aggregate \
@@ -275,14 +288,26 @@ Nothing fires. The worst outage produces the best number and silence.
 An earlier version of this document said to cover that by flipping `notify_no_data` to `true` on
 monitor `93408872`. **That does not work.** The monitor is `type: "slo alert"`, and `notify_no_data`
 is not honoured on SLO alert monitors: the field reads `false` and carries no `no_data_timeframe`.
+
+```bash
+pup api "/api/v1/monitor/93408872" | jq '.data | {type, notify_no_data: .options.notify_no_data}'
+```
+
 It is not a setting someone forgot to turn on. Across the org, all 32 SLO alert monitors have it
-`false`, and the only 2 monitors setting it `true` are ordinary metric monitors.
+`false`, and the only 2 monitors setting it `true` are ordinary metric monitors, both of the
+"no signs on the website" absence-alarm kind:
+
+```bash
+pup api "/api/v1/monitor?page_size=1000" \
+  | jq -r '.data[] | [.type, (.options.notify_no_data|tostring), .name] | @tsv' \
+  | sort | uniq -c -f1
+```
 
 Covering it properly would mean a second monitor watching `sum:android.login.network.count` for an
 absence. That is not being built, for two reasons. The gap has existed for as long as the SLO has,
-so nothing is getting worse. And an auth service that is actually unreachable is already caught
-server-side by `Auth: post auth` and `Auth: get member credentials`, which run on APM traces with
-the full population and no client sampling, so someone gets paged either way. What this SLO uniquely
+so nothing is getting worse. And a genuinely unreachable auth service is already caught server-side
+by the `Auth: post auth` and `Auth: get member credentials` SLOs, which run on APM traces with the
+full population and no client sampling, so someone gets paged either way. What this SLO uniquely
 sees is the network path between the member and the server, which is also the part Android cannot
 fix.
 
@@ -306,17 +331,29 @@ usable budget, and shortening it takes that back. At the expected volume:
 
 | Window and target | Budget |
 |---|---|
-| 7d at 99% | about 7 failures |
-| 30d at 99% | about 30 failures |
-| 7d at 97% | about 21 failures |
+| 7d at 99% | about 8 failures |
+| 30d at 99% | about 34 failures |
+| 7d at 97% | about 23 failures |
 
-Based on 3,014 Swedish-login view impressions over the 30 days to 2026-09-11, so roughly 703 attempts
-a week, around 100 a day. A 7-day window at 99% means any week with seven 5xx responses breaches.
+Based on Swedish-login view impressions over the 30 days to 2026-09-11, which read 3,361 and are
+climbing, so roughly 780 attempts a week, a bit over 100 a day. A 7-day window at 99% means any week
+with eight 5xx responses breaches. Re-read the input with:
 
-**Re-measure before acting on this.** An earlier reading of the same query returned 1,547, half the
-current figure, because login-view impressions were themselves suppressed by the Nav3 breakage and
-are still recovering as the fixed build rolls out. The input is moving, and moving upward, so treat
-these numbers as a floor. Retries also mean one member can produce more than one attempt. If that turns out to be normal variance
+```bash
+pup rum aggregate \
+  --query '@type:view @application.id:4d7b8355-396d-406e-b543-30a073050e8f @session.type:user
+           @view.name:(com.hedvig.android.feature.login.navigation.SwedishLoginKey OR
+                       com.hedvig.android.feature.login.navigation.LoginDestinations.SwedishLogin)' \
+  --compute count --from 30d
+```
+
+Both names are needed: the second is the pre-14.3.6 spelling, and dropping it undercounts.
+
+**Re-measure before acting on this.** An earlier reading of the same query returned 1,547, less than
+half the current figure, because login-view impressions were themselves suppressed by the Nav3
+breakage and are still recovering as the fixed build rolls out. The input is moving, and moving
+upward, so treat these numbers as a floor. Retries also mean one member can produce more than one
+attempt. If that turns out to be normal variance
 rather than a real signal, the lever to reach for is the **target**, not the window: 7d at a lower
 target buys headroom and keeps fast recovery. Pick it from the first weeks of real data rather than
 assuming 99%, which was inherited and never chosen for this signal.
@@ -330,44 +367,6 @@ burn_rate("<slo id>").over("7d").long_window("1h").short_window("5m") > 16.8
 ```
 
 Revisit if the 7d window turns out to flap.
-
-## What already measures auth, so nobody builds it a third time
-
-Checked 2026-09-11. Two server-side SLOs already cover auth availability, on APM traces rather than
-RUM, with the full population and no client sampling:
-
-| SLO | Built on | SLI at the time of checking |
-|---|---|---|
-| Auth: post auth | `trace.http.request.*`, `service:auth` | 99.958% |
-| Auth: get member credentials | `trace.http.request.*`, `service:auth` | 100% |
-
-`Auth: login (Android)` is a client-side view of a question those two already answer better. What it
-adds is the network path between the member and the server, which is real, but is also the part
-Android cannot fix. Worth knowing before anyone treats it as the primary defence for auth, or
-rebuilds backend auth availability inside RUM.
-
-`Auth: login (iOS)` does exist (`9028984bed7351dc92b7e58e5c7db82f`, 7d at 99%, monitor `93102231`)
-and reads 99.95%, state OK. **That is not reassurance.** Checked 2026-09-11, it is
-
-```
-(sum:ios.login.network.count - sum:ios.login.network.error) / sum:ios.login.network.count
-```
-
-which is the Android defect exactly. `ios.login.network.count` is `event_type: resource`,
-`ios.login.network.error` is `event_type: error`, so the numerator subtracts one kind of event from
-a count of a different kind and can go negative. That is what made the Android SLO report 534% of
-its budget. The two halves do not even agree on what screen they watch: the count filters
-`@view.name:BankIDLoginQRView`, the error filters `@view.name:(BankIDLoginQR OR BankIDLoginQRView)`,
-and the error metric carries no `@application.id` filter at all.
-
-It looks healthy for the same reason the Android one looked healthy right up until it did not.
-Android got paged first because its view names broke, not because iOS is better instrumented. This
-is worth raising with the iOS side; it is their metric to fix, and nothing in this repo can.
-
-Also worth knowing as a precedent: `Purchase: completed signs` is an SLO over
-`hedvig.events.signing.completed / hedvig.events.signing.started` with a **70%** target. So the org already has a funnel SLO built on
-explicit events rather than HTTP outcomes, and already accepts a target chosen from reality instead
-of a round number.
 
 ## Guard rail worth adding
 

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -2,12 +2,14 @@
 
 **Status: three items open.** One is time-boxed to the release carrying the auth instrumentation:
 take the SLO window back to 7 days about a week after. See "After the release" below. The
-auth-unreachable gap that used to be a fourth item is closed as accepted, also below. The
-`OR`-branch cleanup is blocked on the
-pre-14.3.6 install base draining. Measured 2026-09-11, versions at or below 14.3.2 were 12.0% of
-prod view events over 30 days but only **1.1% over 7 days and 0.8% over one day**, so the 30-day
-figure lags badly and the trigger is closer than it looks. The claim-submission-failure action is
-unstarted. The guard-rail monitor is also still just a suggestion.
+auth-unreachable gap that used to be a fourth item is closed as accepted, also below.
+
+The `OR`-branch cleanup is blocked on the pre-14.3.6 install base draining. Measured 2026-09-11,
+versions at or below 14.3.2 were 12.0% of prod view events over 30 days but only **1.1% over 7 days
+and 0.8% over one day**, so the 30-day figure lags badly and the trigger is closer than it looks.
+
+The claim-submission-failure action is unstarted, and the guard-rail monitor is still just a
+suggestion.
 
 Last updated 2026-09-11.
 

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -1,10 +1,12 @@
 # Datadog Android metric recovery
 
-**Status: three items open.** The `OR`-branch cleanup is blocked on the pre-14.3.6 install base
-draining, which was still about 13% of prod view traffic on 2026-09-10. The
-claim-submission-failure action is unstarted. The guard-rail monitor is also still just a suggestion.
+**Status: four items open.** One is time-boxed: flip `notify_no_data` on monitor `93408872` a few
+days after the release that carries the auth instrumentation, see below. The `OR`-branch cleanup is
+blocked on the pre-14.3.6 install base draining, which was still about 13% of prod view traffic on
+2026-09-10. The claim-submission-failure action is unstarted. The guard-rail monitor is also still
+just a suggestion.
 
-Last updated 2026-09-10.
+Last updated 2026-09-11.
 
 ## What broke
 
@@ -235,6 +237,29 @@ the denominator with a 0% error rate on the added traffic**, which dilutes the m
 roughly the same 1.4%. This metric is the denominator of the Claims flow (Android) SLO, so the SLO
 reads marginally better. Two keys in the new scope, `StartClaimPledgeKey` and `UpdateAppKey`, have no
 old equivalent to measure, but neither issues network requests in normal use.
+
+## PENDING: flip `notify_no_data` on monitor 93408872
+
+**Do this a few days after the release carrying the auth instrumentation, once
+`android.login.network.count` shows steady prod traffic.**
+
+```
+pup api -X PUT v1/monitor/93408872 --input <monitor json with options.notify_no_data = true>
+```
+
+Start with `no_data_timeframe` around 12 hours and tighten once the real overnight pattern is
+visible. Login runs at roughly 50 attempts a day, so about two an hour, and a tighter window will
+page on an ordinary quiet night.
+
+**Why it matters.** The SLI counts `POST /member-login` resource events with a 5xx status. A request
+that never reaches the server produces a RUM error and no resource at all, so it lands in neither
+side of the ratio. If auth becomes unreachable, the denominator collapses toward zero and the SLI
+reads 100% or no-data. With `notify_no_data: false` nothing fires, so the worst outage produces the
+best number and silence. Treating the collapse itself as the alert is the cheapest cover for the one
+failure mode this SLI cannot otherwise see.
+
+**Why not now.** Before the release there is legitimately no prod data, so flipping it early means a
+monitor that fires continuously and gets muted, which is worse than leaving it off.
 
 ## Guard rail worth adding
 

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -218,8 +218,21 @@ The durable form of a failure signal is an action, not a screen or a UI state:
 logAction(type = ActionType.CUSTOM, name = "CLAIM_SUBMISSION_FAILED")
 ```
 
-Action-based metrics do not break when navigation changes, which is why no iOS metric broke in this
-incident. Note that the two obvious instrumentation points are both wrong: `failedToStart` and
+Action-based metrics do not break when navigation changes.
+
+To be precise about why no iOS metric broke here: the Nav2 to Nav3 migration was Android-only, so
+iOS view names never moved. Only 3 of the 13 `ios.*` metrics are actually action-based
+(`ios.addonPurchased`, `ios.addonUpgraded`, `ios.claims.end.count`). Those three are the only metrics
+in the whole org immune to a rename, and iOS emits them through `log.addUserAction(...)` in
+`DatadogLogger.swift` with the names held as a Swift enum in `ChangeAddonViewModel.swift`. So this is
+not a novel idea, it is catching up to a pattern already in production on the other platform.
+
+The counter-example is on iOS too. `ios.login.network.error` excludes user-facing translated strings,
+both the English and Swedish wording of the BankID cancellation and the "no existing Hedvig member"
+message, plus the entire United States by geolocation. Lokalise is one project shared across Android,
+iOS and the backends, so a translator editing that copy silently changes what a reliability metric
+counts. That is a worse coupling than view names, and it is a good argument for moving the signal
+into code rather than tightening the filter. Note that the two obvious instrumentation points are both wrong: `failedToStart` and
 `errorSubmittingStep` are transient, retryable states that are set and cleared repeatedly, so
 instrumenting them counts error *displays*, not failed claims, and a member on a flaky connection
 produces several. Emit at a terminal boundary instead, for example when the member abandons the flow
@@ -284,6 +297,29 @@ assuming 99%, which was inherited and never chosen for this signal.
 Burn-rate alerting solves both the recovery time and the sensitivity properly, and is the textbook
 answer. It was deliberately not done, because it needs a new monitor and real traffic to size
 thresholds against. Revisit if the 7d window turns out to flap.
+
+## What already measures auth, so nobody builds it a third time
+
+Checked 2026-09-11. Two server-side SLOs already cover auth availability, on APM traces rather than
+RUM, with the full population and no client sampling:
+
+| SLO | Built on | SLI at the time of checking |
+|---|---|---|
+| Auth: post auth | `trace.http.request.*`, `service:auth` | 99.958% |
+| Auth: get member credentials | `trace.http.request.*`, `service:auth` | 100% |
+
+`Auth: login (Android)` is a client-side view of a question those two already answer better. What it
+adds is the network path between the member and the server, which is real, but is also the part
+Android cannot fix. Worth knowing before anyone treats it as the primary defence for auth, or
+rebuilds backend auth availability inside RUM.
+
+There is no `Auth: login (iOS)` SLO. Android is the only platform alerting on login, which is why
+Android is the platform that got paged.
+
+Also worth knowing as a precedent: `Purchase: completed signs` is an SLO over
+`hedvig.events.signing.completed` with a **70%** target. So the org already has a funnel SLO built on
+explicit events rather than HTTP outcomes, and already accepts a target chosen from reality instead
+of a round number.
 
 ## Guard rail worth adding
 

--- a/docs/plans/2026-08-27-datadog-android-metric-recovery.md
+++ b/docs/plans/2026-08-27-datadog-android-metric-recovery.md
@@ -1,10 +1,9 @@
 # Datadog Android metric recovery
 
-**Status: four items open.** Two are time-boxed to the release carrying the auth instrumentation:
-cover the auth-unreachable failure mode on monitor `93408872` a few days after, and take the SLO
-window back to 7 days about a week after. See "After the release" below, and note that the
-`notify_no_data` flag originally written down for the first of those does not work on an SLO alert
-monitor, so that item needs a different mechanism. The `OR`-branch cleanup is blocked on the
+**Status: three items open.** One is time-boxed to the release carrying the auth instrumentation:
+take the SLO window back to 7 days about a week after. See "After the release" below. The
+auth-unreachable gap that used to be a fourth item is closed as accepted, also below. The
+`OR`-branch cleanup is blocked on the
 pre-14.3.6 install base draining. Measured 2026-09-11, versions at or below 14.3.2 were 12.0% of
 prod view events over 30 days but only **1.1% over 7 days and 0.8% over one day**, so the 30-day
 figure lags badly and the trigger is closer than it looks. The claim-submission-failure action is
@@ -262,30 +261,36 @@ roughly the same 1.4%. This metric is the denominator of the Claims flow (Androi
 reads marginally better. Two keys in the new scope, `StartClaimPledgeKey` and `UpdateAppKey`, have no
 old equivalent to measure, but neither issues network requests in normal use.
 
-## After the release: two follow-ups on the login SLO
+## Accepted: this SLO cannot see an unreachable auth service
 
-Both wait for the release that carries the auth instrumentation, because before it there is
-legitimately no prod data on `android.login.network.count`. The second is a change to monitor
-`93408872`; the first, as it turns out, cannot be.
+**Decided 2026-09-11. No action. Do not reopen this without new information.**
 
-### A few days after: cover the auth-unreachable failure mode
+The SLI counts `POST /member-login` resource events with a 5xx status. A request that never reaches
+the server produces a RUM error and no resource at all, so it lands in neither side of the ratio. If
+auth becomes unreachable the denominator collapses toward zero and the SLI reads 100% or no-data.
+Nothing fires. The worst outage produces the best number and silence.
 
-**The obvious lever does not exist.** An earlier version of this document said to flip
-`notify_no_data` to `true` on monitor `93408872`. That monitor is `type: "slo alert"`, and
-`notify_no_data` is not honoured on SLO alert monitors: the field reads `false` and carries no
-`no_data_timeframe`. It is not a setting someone forgot to turn on. Across the org, all 32 SLO alert
-monitors have it `false`, and the only 2 monitors setting it `true` are ordinary metric monitors.
-So the gap below is real but needs a separate monitor to cover, not a flag. **That choice is open.**
+An earlier version of this document said to cover that by flipping `notify_no_data` to `true` on
+monitor `93408872`. **That does not work.** The monitor is `type: "slo alert"`, and `notify_no_data`
+is not honoured on SLO alert monitors: the field reads `false` and carries no `no_data_timeframe`.
+It is not a setting someone forgot to turn on. Across the org, all 32 SLO alert monitors have it
+`false`, and the only 2 monitors setting it `true` are ordinary metric monitors.
 
-**Why it matters.** The SLI counts `POST /member-login` resource events with a 5xx status. A request that never
-reaches the server produces a RUM error and no resource at all, so it lands in neither side of the
-ratio. If auth becomes unreachable the denominator collapses toward zero and the SLI reads 100% or
-no-data. Nothing fires, so the worst outage produces the best number and silence. Treating the
-collapse itself as the alert is the only cover for the one failure mode this SLI cannot otherwise
-see, and on an SLO alert monitor that means a second monitor watching
-`sum:android.login.network.count` for an absence.
+Covering it properly would mean a second monitor watching `sum:android.login.network.count` for an
+absence. That is not being built, for two reasons. The gap has existed for as long as the SLO has,
+so nothing is getting worse. And an auth service that is actually unreachable is already caught
+server-side by `Auth: post auth` and `Auth: get member credentials`, which run on APM traces with
+the full population and no client sampling, so someone gets paged either way. What this SLO uniquely
+sees is the network path between the member and the server, which is also the part Android cannot
+fix.
 
-### About a week after: take the SLO window back to 7 days
+The thing to remember is the reading rule: **a green `Auth: login (Android)` is not by itself
+evidence that login works.** Check that the denominator is non-zero before believing it.
+
+## After the release: take the SLO window back to 7 days
+
+This waits for the release that carries the auth instrumentation, because before it there is
+legitimately no prod data on `android.login.network.count`. About a week after it is the right time.
 
 Set the SLO `timeframe` and its `thresholds[].timeframe` back to `7d`, and the monitor query back to
 `error_budget("29588e73473d54f09814173755548b80").over("7d")`. All three have to move together or


### PR DESCRIPTION


🤖 AI description:

Doc only. Records the post-release follow-up, the action-based precedent on iOS, and the auth SLOs that already exist. Every claim in it was checked against live Datadog on 2026-09-11, and several earlier ones did not survive that check, so the diff is part new material and part correction.

**After the release: take the SLO window back to 7 days.** `error_budget(...).over("30d")` is a trailing window, so once the budget is burned the monitor stays red until the events age out, up to a month. Seven days recovers four times faster. The arithmetic is recorded with it: at ~703 login attempts a week, 7d at 99% is about 7 failures of budget against 30 at 30d, so if that turns out to be normal variance the lever is the target, not the window. The figure is flagged as a floor, since login-view impressions are themselves still recovering from the Nav3 breakage and the same query read half as much a few days earlier.

**Accepted, not fixed: this SLO cannot see an unreachable auth service.** A request that never reaches the server produces a RUM error and no resource, so it lands in neither side of the ratio and an auth outage reads 100% or no-data with nothing firing. The original plan was to flip `notify_no_data` on monitor `93408872`. That does not work: the monitor is `type: "slo alert"`, and the flag is not honoured there. Org-wide, all 32 SLO alert monitors have it false and the only 2 setting it true are ordinary metric monitors. Covering it properly needs a second absence monitor, which is deliberately not being built, because the gap is as old as the SLO and a genuinely unreachable auth service is already caught server-side on APM traces. What the doc records instead is the reading rule: a green `Auth: login (Android)` means nothing without a non-zero denominator.

**The iOS action-based precedent, with its counter-example.** The doc used to say no iOS metric broke because they are action-based. That is not the reason. The Nav3 migration was Android-only, and only 3 of 13 `ios.*` metrics are action-based. Of those three only two are genuinely rename-proof, because they take their names from a Swift enum the app owns. The third, `ios.claims.end.count`, filters on a GraphQL `__typename` owned by the backend schema, so it dies silently on a schema rename. The proposed `CLAIM_SUBMISSION_FAILED` action is therefore catching up to a working pattern, with one recorded example of how to get it wrong. `ios.login.network.error` filtering on Lokalise-managed translated strings is recorded as the worse coupling it is.

**What already measures auth.** Two server-side SLOs cover auth availability on APM traces with the full population and no client sampling. `Auth: login (iOS)` also exists, contrary to an earlier claim in this doc that it did not, and it reads 99.95% OK while dividing an error-type metric by a resource-type metric, the same mismatch that made the Android SLO report 534% of its budget. It looks healthy for the same reason the Android one did right up until it did not. Also notes `Purchase: completed signs` (`completed / started`, 70% target) as existing precedent for a funnel SLO on explicit events.

Other corrections: the install-base trigger for the `OR`-branch cleanup is split into 30d/7d/1d, because the 12% figure the doc leaned on is a 30-day average and the 7-day number is 1.1%, so the trigger is much closer than it read; and the burn-rate note now points at the 9 burn-rate monitors the org already runs rather than claiming the thresholds have to be sized from scratch.
