### PR TITLE
Cover the provider that threads the auth engine, and fix a leaked dependency

### DIFF
--- a/app/auth/auth-core-public/build.gradle.kts
+++ b/app/auth/auth-core-public/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   testImplementation(libs.assertK)
   testImplementation(libs.coroutines.test)
   testImplementation(libs.junit)
+  testImplementation(libs.ktor.client.mock)
   testImplementation(libs.turbine)
   testImplementation(projects.authCoreTest)
   testImplementation(projects.coreDatastoreTest)

--- a/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/di/AuthMetroProvidersTest.kt
+++ b/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/di/AuthMetroProvidersTest.kt
@@ -39,6 +39,16 @@ class AuthMetroProvidersTest {
 
     assertThat(engine.requestHistory.single().url.host).isEqualTo("auth.prod.hedvigit.com")
   }
+
+  @Test
+  fun `a non-production build reaches the staging auth host`() = runTest {
+    val engine = MockEngine { respond(content = "", status = HttpStatusCode.InternalServerError) }
+
+    val repository = providers.provideAuthRepository(buildConstants(isProduction = false), engine)
+    repository.startLoginAttempt(LoginMethod.SE_BANKID, OtpMarket.SE)
+
+    assertThat(engine.requestHistory.single().url.host).isEqualTo("auth.dev.hedvigit.com")
+  }
 }
 
 private fun buildConstants(isProduction: Boolean) = object : HedvigBuildConstants {

--- a/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/di/AuthMetroProvidersTest.kt
+++ b/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/di/AuthMetroProvidersTest.kt
@@ -9,6 +9,7 @@ import com.hedvig.android.core.buildconstants.HedvigBuildConstants
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -40,6 +41,38 @@ class AuthMetroProvidersTest {
     assertThat(engine.requestHistory.single().url.host).isEqualTo("auth.prod.hedvigit.com")
   }
 
+  /**
+   * The auth host is decided twice, from two hand-maintained tables that nothing ties together.
+   * `AuthEnvironment` in :authlib picks the URL the client actually calls, and
+   * [HedvigBuildConstants.urlAuthService] is what :datadog-android hands to Datadog as the host to
+   * instrument. If those drift apart, login keeps working and Datadog quietly stops recording it,
+   * which is the silence #3140 existed to end.
+   *
+   * The rows below mirror `AndroidBuildConfig.appFlavor` and `AppConfigUrlHolder`, both private to
+   * their own modules, so this cannot catch an edit made on that side alone. It does catch the
+   * `AuthEnvironment` table, or the provider, drifting away from them.
+   */
+  @Test
+  fun `every build flavour calls the same auth host it tells Datadog to instrument`() = runTest {
+    val flavours = listOf(
+      Flavour("Production", isProduction = true, urlAuthService = "https://auth.prod.hedvigit.com"),
+      Flavour("Staging", isProduction = false, urlAuthService = "https://auth.dev.hedvigit.com"),
+      Flavour("Develop", isProduction = false, urlAuthService = "https://auth.dev.hedvigit.com"),
+    )
+
+    for (flavour in flavours) {
+      val engine = MockEngine { respond(content = "", status = HttpStatusCode.InternalServerError) }
+      val buildConstants = buildConstants(flavour.isProduction, flavour.urlAuthService)
+
+      providers
+        .provideAuthRepository(buildConstants, engine)
+        .startLoginAttempt(LoginMethod.SE_BANKID, OtpMarket.SE)
+
+      assertThat(engine.requestHistory.single().url.host, name = flavour.name)
+        .isEqualTo(Url(buildConstants.urlAuthService).host)
+    }
+  }
+
   @Test
   fun `a non-production build reaches the staging auth host`() = runTest {
     val engine = MockEngine { respond(content = "", status = HttpStatusCode.InternalServerError) }
@@ -51,12 +84,12 @@ class AuthMetroProvidersTest {
   }
 }
 
-private fun buildConstants(isProduction: Boolean) = object : HedvigBuildConstants {
+private fun buildConstants(isProduction: Boolean, urlAuthService: String = "") = object : HedvigBuildConstants {
   override val urlGraphqlOctopus: String = ""
   override val urlBaseWeb: String = ""
   override val urlOdyssey: String = ""
   override val urlHedvigGateway: String = ""
-  override val urlAuthService: String = ""
+  override val urlAuthService: String = urlAuthService
   override val urlBotService: String = ""
   override val urlClaimsService: String = ""
   override val deepLinkHosts: List<String> = listOf("")
@@ -70,3 +103,5 @@ private fun buildConstants(isProduction: Boolean) = object : HedvigBuildConstant
   override val model: String = ""
   override val userAgent: String = ""
 }
+
+private data class Flavour(val name: String, val isProduction: Boolean, val urlAuthService: String)

--- a/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/di/AuthMetroProvidersTest.kt
+++ b/app/auth/auth-core-public/src/test/kotlin/com/hedvig/android/auth/di/AuthMetroProvidersTest.kt
@@ -1,0 +1,62 @@
+package com.hedvig.android.auth.di
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import com.hedvig.android.authlib.LoginMethod
+import com.hedvig.android.authlib.OtpMarket
+import com.hedvig.android.core.buildconstants.HedvigBuildConstants
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AuthMetroProvidersTest {
+  private val providers = object : AuthMetroProviders {}
+
+  /**
+   * The repository is only instrumented because this provider threads the supplied engine through.
+   * Reverting it to the two-argument `NetworkAuthRepository` constructor still compiles, and no
+   * other test would notice, so this asserts the request actually leaves through the given engine.
+   */
+  @Test
+  fun `the provided repository sends its requests through the supplied engine`() = runTest {
+    val engine = MockEngine { respond(content = "", status = HttpStatusCode.InternalServerError) }
+
+    val repository = providers.provideAuthRepository(buildConstants(isProduction = false), engine)
+    repository.startLoginAttempt(LoginMethod.SE_BANKID, OtpMarket.SE)
+
+    assertThat(engine.requestHistory).hasSize(1)
+  }
+
+  @Test
+  fun `a production build reaches the production auth host`() = runTest {
+    val engine = MockEngine { respond(content = "", status = HttpStatusCode.InternalServerError) }
+
+    val repository = providers.provideAuthRepository(buildConstants(isProduction = true), engine)
+    repository.startLoginAttempt(LoginMethod.SE_BANKID, OtpMarket.SE)
+
+    assertThat(engine.requestHistory.single().url.host).isEqualTo("auth.prod.hedvigit.com")
+  }
+}
+
+private fun buildConstants(isProduction: Boolean) = object : HedvigBuildConstants {
+  override val urlGraphqlOctopus: String = ""
+  override val urlBaseWeb: String = ""
+  override val urlOdyssey: String = ""
+  override val urlHedvigGateway: String = ""
+  override val urlAuthService: String = ""
+  override val urlBotService: String = ""
+  override val urlClaimsService: String = ""
+  override val deepLinkHosts: List<String> = listOf("")
+  override val appVersionName: String = ""
+  override val appVersionCode: String = ""
+  override val appPackageId: String = ""
+  override val isDebug: Boolean = false
+  override val isProduction: Boolean = isProduction
+  override val buildApiVersion: Int = Int.MAX_VALUE
+  override val platformName: String = ""
+  override val model: String = ""
+  override val userAgent: String = ""
+}

--- a/app/datadog/datadog-android/build.gradle.kts
+++ b/app/datadog/datadog-android/build.gradle.kts
@@ -5,13 +5,13 @@ plugins {
 
 dependencies {
   api(libs.androidx.other.startup)
+  api(libs.ktor.client.core)
 
   implementation(libs.datadog.sdk.core)
   implementation(libs.datadog.sdk.logs)
   implementation(libs.datadog.sdk.okhttp)
   implementation(libs.datadog.sdk.rum)
   implementation(libs.datadog.sdk.trace.otel)
-  implementation(libs.ktor.client.core)
   implementation(libs.ktor.client.okhttp)
   implementation(libs.timber)
   implementation(projects.authCorePublic)


### PR DESCRIPTION
A test to help prevent accidentally re-introducing this problem of not using the right engine in the future

🤖 AI description:

Follow-up to #3140, which routed the login HTTP call through a Datadog-instrumented ktor engine so the login SLO measures actual login requests. That fix hangs on one line in `AuthMetroProviders.provideAuthRepository`, and the old engine-less `NetworkAuthRepository` constructor is still public because iOS uses it. Reverting the provider to it would compile and pass every existing test while silently dropping login instrumentation again.

`AuthMetroProvidersTest` closes that hole with a `MockEngine`. One test asserts the request leaves through the supplied engine, two assert that production and non-production builds hit their respective auth hosts, and a fourth pins something the first three do not: the auth host is decided twice, by `AuthEnvironment` in `:authlib` for the URL we call and by `HedvigBuildConstants.urlAuthService` for the host we hand Datadog to instrument, with nothing tying those two tables together. They agree today for all three flavours. If they ever drift, login keeps working and Datadog quietly stops recording it.

All mutation-checked: reverting the provider to the two-argument constructor fails the first test, collapsing the flavour branch so both map to production fails the staging test and only that one, and pointing `AuthEnvironment.STAGING` at a different host fails the flavour test.

The `:datadog-android` change moves `ktor-client-core` from `implementation` to `api`, because `AuthNetworkMetroProviders` publicly returns `HttpClientEngine` and was only resolving via a leak through `:auth-core-public`. About 100 other modules have the same class of issue; that is pre-existing, does not fail CI, and is out of scope here.
