### PR TITLE
Add a scripted demo-mode claim flow

### DIFF
--- a/app/feature/feature-claim-chat/build.gradle.kts
+++ b/app/feature/feature-claim-chat/build.gradle.kts
@@ -55,12 +55,19 @@ kotlin {
       implementation(projects.uiForceUpgrade)
       implementation(projects.partnersDeflect)
     }
+    commonTest.dependencies {
+      implementation(libs.assertK)
+      implementation(libs.coroutines.test)
+      implementation(libs.kotlin.test)
+      implementation(libs.turbine)
+    }
     androidMain.dependencies {
       implementation(libs.accompanist.permissions)
       implementation(libs.androidx.activity.compose)
       implementation(libs.bundles.kmpPreviewBugWorkaround)
       implementation(libs.rive.android)
       implementation(projects.composeUi)
+      implementation(projects.coreDemoMode)
       implementation(projects.coreRive)
       implementation(projects.navigationCommon)
       implementation(projects.navigationCompose)

--- a/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/android/feature/claim/chat/di/ClaimChatDemoSwitchers.kt
+++ b/app/feature/feature-claim-chat/src/androidMain/kotlin/com/hedvig/android/feature/claim/chat/di/ClaimChatDemoSwitchers.kt
@@ -1,0 +1,177 @@
+package com.hedvig.android.feature.claim.chat.di
+
+import arrow.core.Either
+import com.hedvig.android.core.common.di.AppScope
+import com.hedvig.android.core.demomode.DemoManager
+import com.hedvig.android.core.demomode.DemoSwitcher
+import com.hedvig.android.core.fileupload.CommonFile
+import com.hedvig.android.feature.claim.chat.data.ClaimChatErrorMessage
+import com.hedvig.android.feature.claim.chat.data.ClaimIntent
+import com.hedvig.android.feature.claim.chat.data.ClaimIntentId
+import com.hedvig.android.feature.claim.chat.data.FormSubmissionData
+import com.hedvig.android.feature.claim.chat.data.GetClaimIntentUseCase
+import com.hedvig.android.feature.claim.chat.data.GetClaimIntentUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.GetClaimIntentUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.RegretStepUseCase
+import com.hedvig.android.feature.claim.chat.data.RegretStepUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.RegretStepUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.ResumeClaimUseCase
+import com.hedvig.android.feature.claim.chat.data.ResumeClaimUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.ResumeClaimUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.SkipStepUseCase
+import com.hedvig.android.feature.claim.chat.data.SkipStepUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.SkipStepUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.StartClaimIntentUseCase
+import com.hedvig.android.feature.claim.chat.data.StartClaimIntentUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.StartClaimIntentUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.StepId
+import com.hedvig.android.feature.claim.chat.data.SubmitAudioRecordingUseCase
+import com.hedvig.android.feature.claim.chat.data.SubmitAudioRecordingUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.SubmitAudioRecordingUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.SubmitFormUseCase
+import com.hedvig.android.feature.claim.chat.data.SubmitFormUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.SubmitFormUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.SubmitSelectUseCase
+import com.hedvig.android.feature.claim.chat.data.SubmitSelectUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.SubmitSelectUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.SubmitSummaryUseCase
+import com.hedvig.android.feature.claim.chat.data.SubmitSummaryUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.SubmitSummaryUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.SubmitTaskUseCase
+import com.hedvig.android.feature.claim.chat.data.SubmitTaskUseCaseDemo
+import com.hedvig.android.feature.claim.chat.data.SubmitTaskUseCaseImpl
+import com.hedvig.android.feature.claim.chat.data.TaskStepContent
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Demo-mode selection for the claim chat use cases. Each switcher implements the use case interface and forwards every
+ * member through [DemoSwitcher.pick], so the presenter injects the plain interface and never learns demo mode exists.
+ *
+ * These carry the only `@ContributesBinding` for their type. Neither the prod `Impl` nor the `Demo` implementation is
+ * bound directly, which is what keeps the graph unambiguous.
+ */
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<StartClaimIntentUseCase>())
+internal class SwitchingStartClaimIntentUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: StartClaimIntentUseCaseImpl,
+  override val demoImpl: StartClaimIntentUseCaseDemo,
+) : StartClaimIntentUseCase, DemoSwitcher<StartClaimIntentUseCase>() {
+  override suspend fun invoke(developmentFlow: Boolean): Either<ClaimChatErrorMessage, ClaimIntent> =
+    pick().invoke(developmentFlow)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<ResumeClaimUseCase>())
+internal class SwitchingResumeClaimUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: ResumeClaimUseCaseImpl,
+  override val demoImpl: ResumeClaimUseCaseDemo,
+) : ResumeClaimUseCase, DemoSwitcher<ResumeClaimUseCase>() {
+  override suspend fun invoke(): Either<ClaimChatErrorMessage, ClaimIntent?> = pick().invoke()
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<GetClaimIntentUseCase>())
+internal class SwitchingGetClaimIntentUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: GetClaimIntentUseCaseImpl,
+  override val demoImpl: GetClaimIntentUseCaseDemo,
+) : GetClaimIntentUseCase, DemoSwitcher<GetClaimIntentUseCase>() {
+  override fun invoke(claimIntentId: ClaimIntentId): Flow<Either<ClaimChatErrorMessage, TaskStepContent>> =
+    pickFlow { it.invoke(claimIntentId) }
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<SubmitTaskUseCase>())
+internal class SwitchingSubmitTaskUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: SubmitTaskUseCaseImpl,
+  override val demoImpl: SubmitTaskUseCaseDemo,
+) : SubmitTaskUseCase, DemoSwitcher<SubmitTaskUseCase>() {
+  override suspend fun invoke(stepId: String): Either<ClaimChatErrorMessage, ClaimIntent> = pick().invoke(stepId)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<SubmitAudioRecordingUseCase>())
+internal class SwitchingSubmitAudioRecordingUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: SubmitAudioRecordingUseCaseImpl,
+  override val demoImpl: SubmitAudioRecordingUseCaseDemo,
+) : SubmitAudioRecordingUseCase, DemoSwitcher<SubmitAudioRecordingUseCase>() {
+  override suspend fun invoke(stepId: StepId, freeText: String): Either<ClaimChatErrorMessage, ClaimIntent> =
+    pick().invoke(stepId, freeText)
+
+  override suspend fun invoke(
+    stepId: StepId,
+    commonFile: CommonFile,
+    uploadUrl: String,
+  ): Either<ClaimChatErrorMessage, ClaimIntent> = pick().invoke(stepId, commonFile, uploadUrl)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<SubmitFormUseCase>())
+internal class SwitchingSubmitFormUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: SubmitFormUseCaseImpl,
+  override val demoImpl: SubmitFormUseCaseDemo,
+) : SubmitFormUseCase, DemoSwitcher<SubmitFormUseCase>() {
+  override suspend fun invoke(formData: FormSubmissionData): Either<ClaimChatErrorMessage, ClaimIntent> =
+    pick().invoke(formData)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<SubmitSelectUseCase>())
+internal class SwitchingSubmitSelectUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: SubmitSelectUseCaseImpl,
+  override val demoImpl: SubmitSelectUseCaseDemo,
+) : SubmitSelectUseCase, DemoSwitcher<SubmitSelectUseCase>() {
+  override suspend fun invoke(id: StepId, selectedId: String): Either<ClaimChatErrorMessage, ClaimIntent> =
+    pick().invoke(id, selectedId)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<SubmitSummaryUseCase>())
+internal class SwitchingSubmitSummaryUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: SubmitSummaryUseCaseImpl,
+  override val demoImpl: SubmitSummaryUseCaseDemo,
+) : SubmitSummaryUseCase, DemoSwitcher<SubmitSummaryUseCase>() {
+  override suspend fun invoke(stepId: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = pick().invoke(stepId)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<SkipStepUseCase>())
+internal class SwitchingSkipStepUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: SkipStepUseCaseImpl,
+  override val demoImpl: SkipStepUseCaseDemo,
+) : SkipStepUseCase, DemoSwitcher<SkipStepUseCase>() {
+  override suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = pick().invoke(id)
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<RegretStepUseCase>())
+internal class SwitchingRegretStepUseCase(
+  override val demoManager: DemoManager,
+  override val prodImpl: RegretStepUseCaseImpl,
+  override val demoImpl: RegretStepUseCaseDemo,
+) : RegretStepUseCase, DemoSwitcher<RegretStepUseCase>() {
+  override suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = pick().invoke(id)
+}

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/ClaimChatDemoUseCases.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/ClaimChatDemoUseCases.kt
@@ -1,0 +1,126 @@
+package com.hedvig.android.feature.claim.chat.data
+
+import arrow.core.Either
+import arrow.core.right
+import com.hedvig.android.core.fileupload.CommonFile
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Demo-mode implementations of the claim chat use cases. Every one of them is a thin delegate over
+ * [DemoClaimIntentScript], which owns the canned flow and the position within it.
+ *
+ * These are selected by the `Switching*` bindings in the `di` package, so nothing outside demo mode can reach them.
+ */
+
+@Inject
+internal class StartClaimIntentUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : StartClaimIntentUseCase {
+  override suspend fun invoke(developmentFlow: Boolean): Either<ClaimChatErrorMessage, ClaimIntent> =
+    script.start().right()
+}
+
+@Inject
+internal class ResumeClaimUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : ResumeClaimUseCase {
+  /**
+   * Demo mode keeps no draft across process death, so there is nothing to genuinely resume. Returning a fresh start
+   * rather than null keeps the resume entry point usable instead of dropping the user on the failed-to-start screen.
+   */
+  override suspend fun invoke(): Either<ClaimChatErrorMessage, ClaimIntent?> = script.start().right()
+}
+
+@Inject
+internal class GetClaimIntentUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : GetClaimIntentUseCase {
+  override fun invoke(claimIntentId: ClaimIntentId): Flow<Either<ClaimChatErrorMessage, TaskStepContent>> = flow {
+    val step = ClaimIntentStep(
+      id = DemoClaimIntentScript.taskStepId,
+      text = null,
+      hint = null,
+      isRegrettable = false,
+      stepContent = incompleteTask(emptyList()),
+    )
+    for ((waitBefore, descriptions) in DemoClaimIntentScript.taskDescriptionSchedule) {
+      delay(waitBefore)
+      emit(TaskStepContent(step, incompleteTask(descriptions)).right())
+    }
+    delay(DemoClaimIntentScript.taskCompletionDelay)
+    // The caller accumulates descriptions across emissions, so the completing emission need not repeat them.
+    emit(
+      TaskStepContent(
+        step,
+        StepContent.Task(descriptions = emptyList(), isCompleted = true, failedToSubmit = false),
+      ).right(),
+    )
+  }
+
+  private fun incompleteTask(descriptions: List<String>) = StepContent.Task(
+    descriptions = descriptions,
+    isCompleted = false,
+    failedToSubmit = false,
+  )
+}
+
+@Inject
+internal class SubmitTaskUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : SubmitTaskUseCase {
+  override suspend fun invoke(stepId: String): Either<ClaimChatErrorMessage, ClaimIntent> = script.advance().right()
+}
+
+@Inject
+internal class SubmitAudioRecordingUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : SubmitAudioRecordingUseCase {
+  override suspend fun invoke(stepId: StepId, freeText: String): Either<ClaimChatErrorMessage, ClaimIntent> =
+    script.advance().right()
+
+  override suspend fun invoke(
+    stepId: StepId,
+    commonFile: CommonFile,
+    uploadUrl: String,
+  ): Either<ClaimChatErrorMessage, ClaimIntent> = script.advance().right()
+}
+
+@Inject
+internal class SubmitFormUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : SubmitFormUseCase {
+  override suspend fun invoke(formData: FormSubmissionData): Either<ClaimChatErrorMessage, ClaimIntent> =
+    script.advance().right()
+}
+
+@Inject
+internal class SubmitSelectUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : SubmitSelectUseCase {
+  override suspend fun invoke(id: StepId, selectedId: String): Either<ClaimChatErrorMessage, ClaimIntent> =
+    script.advance().right()
+}
+
+@Inject
+internal class SubmitSummaryUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : SubmitSummaryUseCase {
+  override suspend fun invoke(stepId: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = script.advance().right()
+}
+
+@Inject
+internal class SkipStepUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : SkipStepUseCase {
+  override suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = script.advance().right()
+}
+
+@Inject
+internal class RegretStepUseCaseDemo(
+  private val script: DemoClaimIntentScript,
+) : RegretStepUseCase {
+  override suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = script.current().right()
+}

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/ClaimChatDemoUseCases.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/ClaimChatDemoUseCases.kt
@@ -122,5 +122,5 @@ internal class SkipStepUseCaseDemo(
 internal class RegretStepUseCaseDemo(
   private val script: DemoClaimIntentScript,
 ) : RegretStepUseCase {
-  override suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = script.current().right()
+  override suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent> = script.regretTo(id).right()
 }

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScript.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScript.kt
@@ -1,0 +1,230 @@
+package com.hedvig.android.feature.claim.chat.data
+
+import com.hedvig.android.core.common.di.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The canned claim flow used when the app is in demo mode.
+ *
+ * Holds the position within [steps] and hands out a [ClaimIntent] pointing at whatever comes next, so every demo use
+ * case can stay a thin delegate. Answers are not recorded: submitting anything simply advances the script, which is
+ * enough to exercise the presentation of each step type.
+ *
+ * The steps are chosen to cover the cases that are awkward to get a real backend to produce on demand:
+ *
+ * - An audio recording step, for the two input modes and their overlays.
+ * - A task step whose descriptions arrive unevenly, including two at once, see [taskDescriptionSchedule].
+ * - A single-select form over several contracts, for the insurance picker.
+ * - A summary carrying a text, an audio and a file answer, for the answer hierarchy.
+ */
+@SingleIn(AppScope::class)
+@Inject
+internal class DemoClaimIntentScript {
+  private var index = 0
+
+  fun start(): ClaimIntent {
+    index = 0
+    return intentAt(0)
+  }
+
+  fun advance(): ClaimIntent {
+    index = (index + 1).coerceAtMost(steps.size)
+    return intentAt(index)
+  }
+
+  /** Re-presents the step the script is already on, for regretting an answer. */
+  fun current(): ClaimIntent = intentAt(index)
+
+  fun currentStep(): ClaimIntentStep? = steps.getOrNull(index)
+
+  private fun intentAt(position: Int): ClaimIntent {
+    val next = steps.getOrNull(position)
+      ?.let { ClaimIntent.Next.Step(it) }
+      ?: ClaimIntent.Next.Outcome(
+        ClaimIntentOutcome.Claim(
+          claimId = "demo-claim",
+          claimSubmissionDate = Clock.System.now(),
+        ),
+      )
+    return ClaimIntent(
+      id = intentId,
+      next = next,
+      progress = position.toFloat() / steps.size,
+      displayName = "Claim",
+      resumable = false,
+      previousSteps = steps.take(position),
+    )
+  }
+
+  companion object {
+    val intentId = ClaimIntentId("demo-claim-intent")
+
+    private val describeStepId = StepId("demo-describe")
+    val taskStepId = StepId("demo-task")
+    private val selectInsuranceStepId = StepId("demo-select-insurance")
+    private val travellingStepId = StepId("demo-travelling")
+    private val summaryStepId = StepId("demo-summary")
+
+    /**
+     * What the task step emits, and how long to wait before each emission. The gaps are deliberately uneven and one
+     * entry carries two descriptions at once, because a burst is exactly the case where showing only the most recent
+     * description drops the ones in between.
+     */
+    val taskDescriptionSchedule: List<Pair<Duration, List<String>>> = listOf(
+      0.milliseconds to listOf("Analyzing..."),
+      1200.milliseconds to listOf("Reading your answer..."),
+      200.milliseconds to listOf("Going through the details...", "Working out the next step..."),
+      1500.milliseconds to listOf("One moment..."),
+    )
+
+    /** How long the task sits complete before the flow moves on. */
+    val taskCompletionDelay: Duration = 1000.milliseconds
+
+    private val steps: List<ClaimIntentStep> = listOf(
+      ClaimIntentStep(
+        id = describeStepId,
+        text = "In order to help you faster we would like you to describe the situation.",
+        hint = "Please answer the following questions:\n- What happened?\n- When did it happen?\n" +
+          "- Where did it happen?",
+        isRegrettable = true,
+        stepContent = StepContent.AudioRecording(
+          uploadUri = "https://example.invalid/demo-upload",
+          isSkippable = true,
+          recordingState = AudioRecordingStepState.AudioRecording.NotRecording,
+          freeTextMinLength = 10,
+          freeTextMaxLength = 2000,
+        ),
+      ),
+      ClaimIntentStep(
+        id = taskStepId,
+        text = null,
+        hint = null,
+        isRegrettable = false,
+        stepContent = StepContent.Task(
+          descriptions = emptyList(),
+          isCompleted = false,
+          failedToSubmit = false,
+        ),
+      ),
+      ClaimIntentStep(
+        id = selectInsuranceStepId,
+        text = "Which insurance is this about?",
+        hint = null,
+        isRegrettable = true,
+        stepContent = StepContent.Form(
+          isSkippable = true,
+          fields = listOf(
+            StepContent.Form.Field(
+              id = FieldId("demo-insurance"),
+              isRequired = true,
+              suffix = null,
+              title = "Select insurance...",
+              defaultValues = emptyList(),
+              maxValue = null,
+              minValue = null,
+              type = StepContent.Form.FieldType.SINGLE_SELECT,
+              options = contractOptions,
+              // No prefill. Swap in `listOf(contractOptions.first())` to exercise the best-guess case instead.
+              selectedOptions = emptyList(),
+              datePickerUiState = null,
+              searchData = null,
+            ),
+          ),
+        ),
+      ),
+      ClaimIntentStep(
+        id = travellingStepId,
+        text = "Were you traveling at the time of the theft?",
+        hint = null,
+        isRegrettable = true,
+        stepContent = StepContent.ContentSelect(
+          options = listOf(
+            StepContent.ContentSelect.Option(id = "yes", title = "Yes"),
+            StepContent.ContentSelect.Option(id = "no", title = "No"),
+          ),
+          selectedOptionId = null,
+          style = StepContent.ContentSelectStyle.BINARY,
+          isSkippable = false,
+        ),
+      ),
+      ClaimIntentStep(
+        id = summaryStepId,
+        text = "Here is everything we have. Does it look right?",
+        hint = null,
+        isRegrettable = false,
+        stepContent = StepContent.Summary(
+          items = emptyList(),
+          audioRecordings = emptyList(),
+          fileUploads = emptyList(),
+          keyDetails = listOf(
+            StepContent.Summary.Item(title = "Type", value = "Theft"),
+            StepContent.Summary.Item(title = "Insurance", value = "Homeowners Insurance Max"),
+          ),
+          answers = listOf(
+            StepContent.Summary.Answer(
+              title = "Were you traveling at the time of the theft?",
+              value = StepContent.Summary.Answer.Value.Text("No"),
+            ),
+            StepContent.Summary.Answer(
+              title = "Have you reported the theft to the police?",
+              value = StepContent.Summary.Answer.Value.Text("No"),
+            ),
+            StepContent.Summary.Answer(
+              title = "Tell us how exactly where and when you left your phone when it got stolen?",
+              value = StepContent.Summary.Answer.Value.Audio(
+                url = "https://example.invalid/demo-recording.m4a",
+                transcript = "I left it on a bench in the park and when I came back it was gone.",
+              ),
+            ),
+            StepContent.Summary.Answer(
+              title = "Did you ever leave your phone unsupervised?",
+              value = StepContent.Summary.Answer.Value.Text(
+                "Yes I did, i left it on a bench in the park.",
+              ),
+            ),
+            StepContent.Summary.Answer(
+              title = "Receipts",
+              value = StepContent.Summary.Answer.Value.Files(
+                files = listOf(
+                  StepContent.Summary.FileUpload(
+                    url = "https://example.invalid/demo-receipt.pdf",
+                    contentType = "application/pdf",
+                    fileName = "receipt.pdf",
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    private val contractOptions: List<StepContent.Form.FieldOption>
+      get() = listOf(
+        StepContent.Form.FieldOption(
+          value = "homeowners-max",
+          text = "Homeowners Insurance Max",
+          subtitle = "Birger Jarlsgatan 57 • Only you",
+        ),
+        StepContent.Form.FieldOption(
+          value = "rent-standard",
+          text = "Home Insurance Rent Standard",
+          subtitle = "Hyrgatan 15 • Only you",
+        ),
+        StepContent.Form.FieldOption(
+          value = "villa-standard",
+          text = "Villa Insurance Standard",
+          subtitle = "Villagatan 22 • Only you",
+        ),
+        StepContent.Form.FieldOption(
+          value = "accident",
+          text = "Accident Insurance",
+          subtitle = "Only you",
+        ),
+      )
+  }
+}

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScript.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScript.kt
@@ -36,8 +36,14 @@ internal class DemoClaimIntentScript {
     return intentAt(index)
   }
 
-  /** Re-presents the step the script is already on, for regretting an answer. */
-  fun current(): ClaimIntent = intentAt(index)
+  /** Rewinds to [stepId] so it can be answered again, which is what regretting an answer means. */
+  fun regretTo(stepId: StepId): ClaimIntent {
+    val position = steps.indexOfFirst { it.id == stepId }
+    if (position >= 0) {
+      index = position
+    }
+    return intentAt(index)
+  }
 
   fun currentStep(): ClaimIntentStep? = steps.getOrNull(index)
 

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/GetClaimIntentUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/GetClaimIntentUseCase.kt
@@ -22,13 +22,17 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import octopus.ClaimIntentQuery
 
+internal interface GetClaimIntentUseCase {
+  fun invoke(claimIntentId: ClaimIntentId): Flow<Either<ClaimChatErrorMessage, TaskStepContent>>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class GetClaimIntentUseCase(
+internal class GetClaimIntentUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  fun invoke(claimIntentId: ClaimIntentId): Flow<Either<ClaimChatErrorMessage, TaskStepContent>> {
+) : GetClaimIntentUseCase {
+  override fun invoke(claimIntentId: ClaimIntentId): Flow<Either<ClaimChatErrorMessage, TaskStepContent>> {
     return flow {
       var retries = 0
       while (currentCoroutineContext().isActive) {

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/RegretStepUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/RegretStepUseCase.kt
@@ -8,7 +8,6 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.logger.logcat
-import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import octopus.ClaimIntentRegretStepMutation
@@ -17,7 +16,6 @@ internal interface RegretStepUseCase {
   suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent>
 }
 
-@ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)
 @Inject
 internal class RegretStepUseCaseImpl(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/ResumeClaimUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/ResumeClaimUseCase.kt
@@ -13,13 +13,17 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import octopus.ResumeClaimQuery
 
+internal interface ResumeClaimUseCase {
+  suspend fun invoke(): Either<ClaimChatErrorMessage, ClaimIntent?>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class ResumeClaimUseCase(
+internal class ResumeClaimUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(): Either<ClaimChatErrorMessage, ClaimIntent?> {
+) : ResumeClaimUseCase {
+  override suspend fun invoke(): Either<ClaimChatErrorMessage, ClaimIntent?> {
     return either {
       apolloClient
         .query(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SkipStepUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SkipStepUseCase.kt
@@ -9,7 +9,6 @@ import com.hedvig.android.core.common.ErrorMessage
 import com.hedvig.android.core.common.di.AppScope
 import com.hedvig.android.language.LanguageService
 import com.hedvig.android.logger.logcat
-import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import octopus.ClaimIntentSkipStepMutation
@@ -18,7 +17,6 @@ internal interface SkipStepUseCase {
   suspend fun invoke(id: StepId): Either<ClaimChatErrorMessage, ClaimIntent>
 }
 
-@ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)
 @Inject
 internal class SkipStepUseCaseImpl(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/StartClaimIntentUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/StartClaimIntentUseCase.kt
@@ -16,13 +16,17 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import octopus.ClaimIntentStartMutation
 
+internal interface StartClaimIntentUseCase {
+  suspend fun invoke(developmentFlow: Boolean): Either<ClaimChatErrorMessage, ClaimIntent>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class StartClaimIntentUseCase(
+internal class StartClaimIntentUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(developmentFlow: Boolean): Either<ClaimChatErrorMessage, ClaimIntent> {
+) : StartClaimIntentUseCase {
+  override suspend fun invoke(developmentFlow: Boolean): Either<ClaimChatErrorMessage, ClaimIntent> {
     return either {
       apolloClient
         .mutation(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitAudioRecordingUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitAudioRecordingUseCase.kt
@@ -17,18 +17,28 @@ import dev.zacsweers.metro.SingleIn
 import octopus.ClaimIntentSubmitAudioMutation
 import octopus.type.ClaimIntentSubmitAudioInput
 
+internal interface SubmitAudioRecordingUseCase {
+  suspend fun invoke(stepId: StepId, freeText: String): Either<ClaimChatErrorMessage, ClaimIntent>
+
+  suspend fun invoke(
+    stepId: StepId,
+    commonFile: CommonFile,
+    uploadUrl: String,
+  ): Either<ClaimChatErrorMessage, ClaimIntent>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class SubmitAudioRecordingUseCase(
+internal class SubmitAudioRecordingUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val uploadFileUseCase: UploadFileUseCase,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(stepId: StepId, freeText: String): Either<ClaimChatErrorMessage, ClaimIntent> {
+) : SubmitAudioRecordingUseCase {
+  override suspend fun invoke(stepId: StepId, freeText: String): Either<ClaimChatErrorMessage, ClaimIntent> {
     return either { invoke(stepId, null, freeText) }
   }
 
-  suspend fun invoke(
+  override suspend fun invoke(
     stepId: StepId,
     commonFile: CommonFile,
     uploadUrl: String,

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitFormUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitFormUseCase.kt
@@ -14,13 +14,17 @@ import octopus.ClaimIntentSubmitFormMutation
 import octopus.type.ClaimIntentFormSubmitInputField
 import octopus.type.ClaimIntentSubmitFormInput
 
+internal interface SubmitFormUseCase {
+  suspend fun invoke(formData: FormSubmissionData): Either<ClaimChatErrorMessage, ClaimIntent>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class SubmitFormUseCase(
+internal class SubmitFormUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(formData: FormSubmissionData): Either<ClaimChatErrorMessage, ClaimIntent> {
+) : SubmitFormUseCase {
+  override suspend fun invoke(formData: FormSubmissionData): Either<ClaimChatErrorMessage, ClaimIntent> {
     return either {
       apolloClient
         .mutation(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitSelectUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitSelectUseCase.kt
@@ -14,13 +14,17 @@ import dev.zacsweers.metro.SingleIn
 import octopus.ClaimIntentSubmitSelectMutation
 import octopus.type.ClaimIntentSubmitSelectInput
 
+internal interface SubmitSelectUseCase {
+  suspend fun invoke(id: StepId, selectedId: String): Either<ClaimChatErrorMessage, ClaimIntent>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class SubmitSelectUseCase(
+internal class SubmitSelectUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(id: StepId, selectedId: String): Either<ClaimChatErrorMessage, ClaimIntent> {
+) : SubmitSelectUseCase {
+  override suspend fun invoke(id: StepId, selectedId: String): Either<ClaimChatErrorMessage, ClaimIntent> {
     return either {
       apolloClient
         .mutation(

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitSummaryUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitSummaryUseCase.kt
@@ -12,13 +12,17 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import octopus.ClaimIntentSubmitSummaryMutation
 
+internal interface SubmitSummaryUseCase {
+  suspend fun invoke(stepId: StepId): Either<ClaimChatErrorMessage, ClaimIntent>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class SubmitSummaryUseCase(
+internal class SubmitSummaryUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(stepId: StepId): Either<ClaimChatErrorMessage, ClaimIntent> {
+) : SubmitSummaryUseCase {
+  override suspend fun invoke(stepId: StepId): Either<ClaimChatErrorMessage, ClaimIntent> {
     return either {
       apolloClient
         .mutation(ClaimIntentSubmitSummaryMutation(stepId = stepId.value))

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitTaskUseCase.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/data/SubmitTaskUseCase.kt
@@ -17,13 +17,17 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import octopus.ClaimIntentSubmitTaskMutation
 
+internal interface SubmitTaskUseCase {
+  suspend fun invoke(stepId: String): Either<ClaimChatErrorMessage, ClaimIntent>
+}
+
 @SingleIn(AppScope::class)
 @Inject
-internal class SubmitTaskUseCase(
+internal class SubmitTaskUseCaseImpl(
   private val apolloClient: ApolloClient,
   private val languageService: LanguageService,
-) {
-  suspend fun invoke(stepId: String): Either<ClaimChatErrorMessage, ClaimIntent> {
+) : SubmitTaskUseCase {
+  override suspend fun invoke(stepId: String): Either<ClaimChatErrorMessage, ClaimIntent> {
     val maxAttempts = 6
     repeat(maxAttempts) { attempt ->
       val result = either {

--- a/app/feature/feature-claim-chat/src/commonTest/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScriptTest.kt
+++ b/app/feature/feature-claim-chat/src/commonTest/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScriptTest.kt
@@ -1,0 +1,108 @@
+package com.hedvig.android.feature.claim.chat.data
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class DemoClaimIntentScriptTest {
+  @Test
+  fun `the script walks every step and then reaches an outcome`() {
+    val script = DemoClaimIntentScript()
+
+    val visited = mutableListOf<StepContent>()
+    var intent = script.start()
+    while (intent.next is ClaimIntent.Next.Step) {
+      visited += (intent.next as ClaimIntent.Next.Step).claimIntentStep.stepContent
+      intent = script.advance()
+    }
+
+    // The loop exits on the first non-step, which must be the outcome rather than a stall.
+    assertThat(intent.next).isInstanceOf(ClaimIntent.Next.Outcome::class)
+    assertThat(visited.map { it::class.simpleName }).isEqualTo(
+      listOf("AudioRecording", "Task", "Form", "ContentSelect", "Summary"),
+    )
+  }
+
+  @Test
+  fun `regretting re-presents the same step instead of advancing`() {
+    val script = DemoClaimIntentScript()
+    script.start()
+    script.advance()
+
+    val before = script.currentStep()
+    val regretted = script.current()
+
+    assertThat(before).isNotNull()
+    assertThat((regretted.next as ClaimIntent.Next.Step).claimIntentStep.id).isEqualTo(before!!.id)
+    assertThat(script.currentStep()!!.id).isEqualTo(before.id)
+  }
+
+  @Test
+  fun `progress increases as the script advances`() {
+    val script = DemoClaimIntentScript()
+
+    val first = script.start().progress!!
+    script.advance()
+    val second = script.advance().progress!!
+
+    assertThat(second > first).isTrue()
+  }
+
+  @Test
+  fun `the single select step offers the contract options without a prefill`() {
+    val script = DemoClaimIntentScript()
+    var intent = script.start()
+    var form: StepContent.Form? = null
+    while (intent.next is ClaimIntent.Next.Step) {
+      val content = (intent.next as ClaimIntent.Next.Step).claimIntentStep.stepContent
+      if (content is StepContent.Form) {
+        form = content
+        break
+      }
+      intent = script.advance()
+    }
+
+    val field = form!!.fields.single()
+    assertThat(field.type).isEqualTo(StepContent.Form.FieldType.SINGLE_SELECT)
+    assertThat(field.options.size).isEqualTo(4)
+    // Every option carries the secondary line the picker is meant to render.
+    assertThat(field.options.all { it.subtitle != null }).isTrue()
+    assertThat(field.selectedOptions).isEqualTo(emptyList())
+  }
+
+  @Test
+  fun `the task flow emits every scheduled description including the ones that arrive together`() = runTest {
+    val demo = GetClaimIntentUseCaseDemo(DemoClaimIntentScript())
+
+    demo.invoke(DemoClaimIntentScript.intentId).test {
+      val emitted = buildList {
+        repeat(DemoClaimIntentScript.taskDescriptionSchedule.size) {
+          addAll(awaitItem().getOrNull()!!.task.descriptions)
+        }
+      }
+
+      assertThat(emitted).isEqualTo(
+        DemoClaimIntentScript.taskDescriptionSchedule.flatMap { (_, descriptions) -> descriptions },
+      )
+
+      val completing = awaitItem().getOrNull()!!
+      assertThat(completing.task.isCompleted).isTrue()
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun `two descriptions share a single emission so the consumer has to pace them itself`() = runTest {
+    // Guards the property that makes this script worth having: if the schedule ever flattens out to one description
+    // per emission, a consumer that renders only the most recent one would look correct while still dropping
+    // messages against a real backend.
+    val burst = DemoClaimIntentScript.taskDescriptionSchedule.any { (_, descriptions) -> descriptions.size > 1 }
+
+    assertThat(burst).isTrue()
+  }
+}

--- a/app/feature/feature-claim-chat/src/commonTest/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScriptTest.kt
+++ b/app/feature/feature-claim-chat/src/commonTest/kotlin/com/hedvig/android/feature/claim/chat/data/DemoClaimIntentScriptTest.kt
@@ -29,17 +29,29 @@ class DemoClaimIntentScriptTest {
   }
 
   @Test
-  fun `regretting re-presents the same step instead of advancing`() {
+  fun `regretting rewinds to the step being edited`() {
+    val script = DemoClaimIntentScript()
+    val firstStepId = (script.start().next as ClaimIntent.Next.Step).claimIntentStep.id
+    script.advance()
+    script.advance()
+
+    val regretted = script.regretTo(firstStepId)
+
+    // Editing an answer must return to the step that gave it, not to wherever the flow had reached.
+    assertThat((regretted.next as ClaimIntent.Next.Step).claimIntentStep.id).isEqualTo(firstStepId)
+    assertThat(script.currentStep()!!.id).isEqualTo(firstStepId)
+  }
+
+  @Test
+  fun `regretting an unknown step leaves the position alone`() {
     val script = DemoClaimIntentScript()
     script.start()
     script.advance()
+    val before = script.currentStep()!!.id
 
-    val before = script.currentStep()
-    val regretted = script.current()
+    script.regretTo(StepId("not-in-this-script"))
 
-    assertThat(before).isNotNull()
-    assertThat((regretted.next as ClaimIntent.Next.Step).claimIntentStep.id).isEqualTo(before!!.id)
-    assertThat(script.currentStep()!!.id).isEqualTo(before.id)
+    assertThat(script.currentStep()!!.id).isEqualTo(before)
   }
 
   @Test


### PR DESCRIPTION
Scripted path for Demo mode, to ease development but also show the flow to demo mode users

🤖 AI description:

Lets the claim chat run without a backend, so the P2-2026 design work can exercise states that are awkward to get the real backend to produce on demand: a burst of task descriptions, a contract picker with and without a prefill, and the audio recording step.

Eight of the use cases the flow runs through were concrete `internal` classes with no interface, so interfaces are extracted here first. Each then gets a `Demo` implementation and a `Switching` binding, following the `DemoSwitcher` pattern already used by home, insurances and payments. The `Switching` class carries the only `@ContributesBinding` for its type, which is why the existing `@ContributesBinding` on `SkipStepUseCaseImpl` and `RegretStepUseCaseImpl` moves onto the switchers rather than staying put.

Two things worth a reviewer's attention:

This ships. These KMP modules use AGP's `androidLibrary {}` target, which has no build types, so there is no debug source set to hide a fake in, and the use cases are `internal` so it cannot live in `:app`. Demo mode is the sanctioned alternative, which means real demo-mode users now get the scripted claim flow. That is a product change, not just test scaffolding.

The switchers sit in `androidMain` rather than `commonMain` because `core-demo-mode` is a JVM library and `commonMain` has to stay platform-agnostic. `nativeMain` builds no graph, so nothing breaks there.

`DemoClaimIntentScript`'s task schedule is deliberately uneven and delivers two descriptions in a single emission. That is the case where rendering only the most recent description silently drops messages, and a test asserts the burst stays in the schedule so it cannot be flattened away by accident.

Verified: `:app:assembleDebug` succeeds, which is what proves the graph still resolves; `:feature-claim-chat:jvmTest` passes 6 tests; `ktlintCheck` is clean. Note `allTests` fails locally on `linkDebugTestIosSimulatorArm64` with a missing `DatadogCore` framework, unrelated to this change, and CI runs `test jvmTest` rather than `allTests`.