### PR TITLE
Animate and pace claim chat task descriptions

### DIFF
--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/TaskDescriptionQueue.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/TaskDescriptionQueue.kt
@@ -1,0 +1,50 @@
+package com.hedvig.android.feature.claim.chat.ui.step
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Walks [descriptions] one at a time, holding each for at least [minimumDwell] before moving on.
+ *
+ * A single poll can deliver several descriptions at once. Rendering only the most recent one would skip the ones in
+ * between, so this advances through the backlog in order rather than jumping to the end.
+ *
+ * [descriptions] is expected to only grow, which is how the presenter accumulates them.
+ */
+internal fun pacedDescriptions(descriptions: Flow<List<String>>, minimumDwell: Duration): Flow<String> = channelFlow {
+  val known = MutableStateFlow(emptyList<String>())
+  launch { descriptions.collect { known.value = it } }
+  var shown = 0
+  while (true) {
+    // Suspends until something unshown exists, so an idle task step costs nothing.
+    val available = known.first { it.size > shown }
+    send(available[shown])
+    shown++
+    delay(minimumDwell)
+  }
+}
+
+/** Returns the description that should currently be on screen, or null before the first one arrives. */
+@Composable
+internal fun rememberPacedDescription(
+  descriptions: List<String>,
+  minimumDwell: Duration = defaultMinimumDwell,
+): String? {
+  val latest by rememberUpdatedState(descriptions)
+  return produceState<String?>(initialValue = null) {
+    pacedDescriptions(snapshotFlow { latest }, minimumDwell).collect { value = it }
+  }.value
+}
+
+private val defaultMinimumDwell = 900.milliseconds

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/TaskStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/TaskStep.kt
@@ -1,6 +1,14 @@
 package com.hedvig.android.feature.claim.chat.ui.step
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -72,7 +80,19 @@ internal fun TaskStepTopContent(
           AnimatedContent(showBlinkingAiDot && showPill) {
             Spacer(Modifier.width(8.dp))
           }
-          AnimatedContent(lastDescription) { description ->
+          val pacedDescription = rememberPacedDescription(taskContent.descriptions)
+          AnimatedContent(
+            targetState = pacedDescription,
+            transitionSpec = {
+              val outgoing = fadeOut(animationSpec = tween(90)) +
+                slideOutVertically(animationSpec = tween(90)) { height -> -height / 2 }
+              val incoming = fadeIn(animationSpec = tween(220, delayMillis = 90)) +
+                slideInVertically(animationSpec = tween(220, delayMillis = 90)) { height -> height / 2 }
+              // Snap the bounds rather than tweening them, so the neighbouring animation does not get
+              // pushed around as descriptions of different lengths swap in.
+              incoming togetherWith outgoing using SizeTransform(clip = false) { _, _ -> snap() }
+            },
+          ) { description ->
             if (description != null) {
               HedvigText(
                 description,

--- a/app/feature/feature-claim-chat/src/commonTest/kotlin/com/hedvig/android/feature/claim/chat/ui/step/TaskDescriptionQueueTest.kt
+++ b/app/feature/feature-claim-chat/src/commonTest/kotlin/com/hedvig/android/feature/claim/chat/ui/step/TaskDescriptionQueueTest.kt
@@ -1,0 +1,69 @@
+package com.hedvig.android.feature.claim.chat.ui.step
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+
+class TaskDescriptionQueueTest {
+  @Test
+  fun `every description is shown even when several arrive at once`() = runTest {
+    val descriptions = MutableStateFlow(listOf("one"))
+
+    pacedDescriptions(descriptions, minimumDwell = 100.milliseconds).test {
+      assertThat(awaitItem()).isEqualTo("one")
+
+      // One poll delivering two new descriptions at once, the case that showing only the latest drops.
+      descriptions.value = listOf("one", "two", "three")
+
+      assertThat(awaitItem()).isEqualTo("two")
+      assertThat(awaitItem()).isEqualTo("three")
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `a description is held for at least the minimum dwell`() = runTest {
+    val descriptions = MutableStateFlow(listOf("one", "two"))
+    // Turbine's test block swaps the receiver, so the scheduler has to be captured out here.
+    val scheduler = testScheduler
+
+    pacedDescriptions(descriptions, minimumDwell = 500.milliseconds).test {
+      assertThat(awaitItem()).isEqualTo("one")
+      val beforeSecond = scheduler.currentTime
+      assertThat(awaitItem()).isEqualTo("two")
+      assertThat(scheduler.currentTime - beforeSecond >= 500).isTrue()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `an empty list produces nothing`() = runTest {
+    val descriptions = MutableStateFlow(emptyList<String>())
+
+    pacedDescriptions(descriptions, minimumDwell = 100.milliseconds).test {
+      expectNoEvents()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `descriptions appearing later are still shown in order`() = runTest {
+    val descriptions = MutableStateFlow(emptyList<String>())
+
+    pacedDescriptions(descriptions, minimumDwell = 50.milliseconds).test {
+      expectNoEvents()
+
+      descriptions.value = listOf("first")
+      assertThat(awaitItem()).isEqualTo("first")
+
+      descriptions.value = listOf("first", "second")
+      assertThat(awaitItem()).isEqualTo("second")
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+}


### PR DESCRIPTION
Improve transition etc when we get new task steps back to back

🤖 AI description:

Stacked on #3150, so the diff here is only the two commits on top. Rebase onto develop once that merges.

Two changes to the task step's loading text.

The first is a real behaviour fix rather than styling. `TaskStepTopContent` rendered `descriptions.lastOrNull()`, and the presenter accumulates descriptions across polls, so whenever one poll carried more than one new description the intermediate ones were never shown. The design treats these as a sequence the user reads. `pacedDescriptions` now walks the backlog in order, holding each for a minimum dwell.

The second is the transition. The `AnimatedContent` had no `transitionSpec`, so it inherited the default fade plus `scaleIn` plus an animated `SizeTransform`. Since the descriptions differ a lot in length ("Analyzing..." against "Going through the details..."), animating the bounds shifted the neighbouring Rive animation on every swap. It now slides and fades vertically with a snapped size transform, so the indicator holds still.

Verified: 4 new tests pass, the 6 existing demo-flow tests still pass, `:feature-claim-chat:assemble` and `ktlintCheck` are clean.

Not yet verified by hand in demo mode. A device is connected but reaching demo mode goes through the login screen, which would log out the session on it. Worth a look in the running app before this leaves draft, particularly that the indicator really does stay put.