### PR TITLE
Invert the claim summary question and answer hierarchy

### DIFF
--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/ChatClaimSummaryStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/ChatClaimSummaryStep.kt
@@ -195,9 +195,13 @@ internal fun ClaimSummaryAnswersContent(
     )
     Spacer(Modifier.height(24.dp))
     answers.forEachIndexed { index, answer ->
-      HedvigText(text = answer.title)
+      HedvigText(
+        text = answer.title,
+        style = HedvigTheme.typography.label,
+        color = HedvigTheme.colorScheme.textSecondary,
+      )
       Spacer(Modifier.height(4.dp))
-      CompositionLocalProvider(LocalContentColor provides HedvigTheme.colorScheme.textSecondary) {
+      CompositionLocalProvider(LocalContentColor provides HedvigTheme.colorScheme.textPrimary) {
         AnswerValue(
           value = answer.value,
           imageLoader = imageLoader,


### PR DESCRIPTION


🤖 AI description:

Stacked on #3150, so the diff here is the single commit on top. Rebase onto develop once that merges.

In the "show all answers" sheet the question was rendering in the default body style at primary colour while the answer was wrapped in `textSecondary`, which puts the emphasis on the question. The design wants the opposite: question as the smaller secondary label, answer as the primary body line.

The `CompositionLocalProvider` is kept rather than setting the colour per branch, so the audio and file answers inherit the same treatment as the plain text one. The answer's text size needed no change; `bodySmall` is already `HedvigText`'s default and is the design's Body token.

Verified: `:feature-claim-chat:assemble` and `ktlintCheck` pass. `PreviewSummaryAnswersContent` in the same file covers the text and audio branches, and the demo flow's summary step carries a text, an audio and a file answer for checking all three in the running app.