### PR TITLE
Open the claim chat insurance picker in a bottom sheet

### DIFF
--- a/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/HedvigBigCard.kt
+++ b/app/design-system/design-system-hedvig/src/commonMain/kotlin/com/hedvig/android/design/system/hedvig/HedvigBigCard.kt
@@ -55,6 +55,8 @@ fun HedvigBigCard(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   textStyle: TextStyle = BigCardDefaults.inputTextStyle,
+  /** A secondary line under [inputText], for when the chosen value needs qualifying. */
+  subtitleText: String? = null,
 ) {
   Surface(
     shape = HedvigTheme.shapes.cornerLarge,
@@ -68,10 +70,13 @@ fun HedvigBigCard(
   ) {
     LayoutWithoutPlacement(
       sizeAdjustingContent = {
-        // Always take up the space that the two texts would take
+        // Always take up the space that the texts would take
         Column(Modifier.padding(BigCardDefaults.padding)) {
           HedvigText(text = labelText, style = BigCardDefaults.labelTextStyle)
           HedvigText(text = "H", style = textStyle)
+          if (subtitleText != null) {
+            HedvigText(text = "H", style = BigCardDefaults.labelTextStyle)
+          }
         }
       },
     ) {
@@ -96,6 +101,13 @@ fun HedvigBigCard(
             style = textStyle,
             color = bigCardColors.inputTextColor(enabled),
           )
+          if (subtitleText != null) {
+            HedvigText(
+              text = subtitleText,
+              style = BigCardDefaults.labelTextStyle,
+              color = bigCardColors.labelTextColor(enabled),
+            )
+          }
         }
       }
     }

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/FormStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/FormStep.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -70,10 +71,10 @@ import com.hedvig.android.design.system.hedvig.HorizontalItemsWithMaximumSpaceTa
 import com.hedvig.android.design.system.hedvig.Icon
 import com.hedvig.android.design.system.hedvig.IconButton
 import com.hedvig.android.design.system.hedvig.MultiSelectDialog
+import com.hedvig.android.design.system.hedvig.RadioGroup
 import com.hedvig.android.design.system.hedvig.RadioOption
 import com.hedvig.android.design.system.hedvig.RadioOptionId
 import com.hedvig.android.design.system.hedvig.SearchField
-import com.hedvig.android.design.system.hedvig.SingleSelectDialog
 import com.hedvig.android.design.system.hedvig.icon.ChevronRight
 import com.hedvig.android.design.system.hedvig.icon.Close
 import com.hedvig.android.design.system.hedvig.icon.HedvigIcons
@@ -952,28 +953,53 @@ internal fun SingleSelectBubbleWithDialog(
   errorText: String? = null,
 ) {
   val focusManager = LocalFocusManager.current
-  var showDialog by rememberSaveable { mutableStateOf(false) }
-  if (showDialog) {
-    SingleSelectDialog(
-      title = questionLabel,
-      options = options,
-      selectedOption = selectedOptionId,
-      onRadioOptionSelected = onSelect,
-      onDismissRequest = {
-        showDialog = false
-      },
+  val sheetState = rememberHedvigBottomSheetState<RadioOptionId?>()
+  HedvigBottomSheet(sheetState) { initialSelection: RadioOptionId? ->
+    // Held locally so cancelling leaves the committed answer untouched. The dialog this replaced
+    // committed on tap, which left no way back out of a mis-tap.
+    var pendingSelection by remember { mutableStateOf(initialSelection) }
+    HedvigText(
+      questionLabel,
+      modifier = Modifier.fillMaxWidth().semantics { heading() },
+      textAlign = TextAlign.Center,
     )
+    Spacer(Modifier.height(16.dp))
+    RadioGroup(
+      options = options,
+      selectedOption = pendingSelection,
+      onRadioOptionSelected = { pendingSelection = it },
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(16.dp))
+    HedvigButton(
+      text = stringResource(Res.string.general_continue_button),
+      onClick = {
+        pendingSelection?.let(onSelect)
+        sheetState.dismiss()
+      },
+      enabled = pendingSelection != null,
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(8.dp))
+    HedvigButton(
+      text = stringResource(Res.string.general_cancel_button),
+      onClick = { sheetState.dismiss() },
+      enabled = true,
+      buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
+      modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(8.dp))
   }
   Column(modifier) {
+    val selectedOption = options.firstOrNull { it.id == selectedOptionId }
     HedvigBigCard(
       onClick = {
         focusManager.clearFocus()
-        showDialog = true
+        sheetState.show(selectedOptionId)
       },
       labelText = questionLabel,
-      inputText = options.firstOrNull {
-        it.id == selectedOptionId
-      }?.text,
+      inputText = selectedOption?.text,
+      subtitleText = selectedOption?.label,
       modifier = Modifier.fillMaxWidth(),
       enabled = true,
     )

--- a/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/FormStep.kt
+++ b/app/feature/feature-claim-chat/src/commonMain/kotlin/com/hedvig/android/feature/claim/chat/ui/step/FormStep.kt
@@ -360,7 +360,7 @@ private fun FormContent(
             onClick = onSkip,
             isLoading = skipButtonLoading,
             modifier = Modifier.fillMaxWidth(),
-            buttonStyle = ButtonDefaults.ButtonStyle.Secondary,
+            buttonStyle = ButtonDefaults.ButtonStyle.Ghost,
           )
         }
       }
@@ -953,11 +953,15 @@ internal fun SingleSelectBubbleWithDialog(
   errorText: String? = null,
 ) {
   val focusManager = LocalFocusManager.current
-  val sheetState = rememberHedvigBottomSheetState<RadioOptionId?>()
-  HedvigBottomSheet(sheetState) { initialSelection: RadioOptionId? ->
+  val sheetState = rememberHedvigBottomSheetState<String>()
+  // The payload is the selected id as a string because HedvigBottomSheet only renders its content while the
+  // payload is non-null, so a nullable one would make the unselected case silently render nothing.
+  HedvigBottomSheet(sheetState) { initialSelection: String ->
     // Held locally so cancelling leaves the committed answer untouched. The dialog this replaced
     // committed on tap, which left no way back out of a mis-tap.
-    var pendingSelection by remember { mutableStateOf(initialSelection) }
+    var pendingSelection by remember {
+      mutableStateOf(initialSelection.takeIf { it.isNotEmpty() }?.let { RadioOptionId(it) })
+    }
     HedvigText(
       questionLabel,
       modifier = Modifier.fillMaxWidth().semantics { heading() },
@@ -995,7 +999,7 @@ internal fun SingleSelectBubbleWithDialog(
     HedvigBigCard(
       onClick = {
         focusManager.clearFocus()
-        sheetState.show(selectedOptionId)
+        sheetState.show(selectedOptionId?.id.orEmpty())
       },
       labelText = questionLabel,
       inputText = selectedOption?.text,


### PR DESCRIPTION


🤖 AI description:

Stacked on #3150, so the diff here is the single commit on top. Rebase onto develop once that merges.

Replaces `SingleSelectDialog` with a `HedvigBottomSheet` carrying Continue and Cancel. Beyond matching the design, this fixes a real behaviour gap: the dialog committed the answer the instant an option was tapped, so a mis-tap could not be backed out of. The sheet keeps the selection local until Continue, and Cancel leaves the committed answer untouched.

`HedvigBigCard` gains an optional `subtitleText` so the collapsed card can show the chosen contract's address line. This is a shared component, so worth a look: the parameter is optional and no existing caller changes. I went this way rather than the content-slot overload because `BigCardDefaults`, which holds the card's padding and text styles, is private, so a local rebuild would have meant copying design-system internals into the feature module.

Two things the spec expected that turned out to be unnecessary: option rows already render subtitles, since `RadioGroup` draws `option.label` and `FormStep` already populates it from `option.subtitle`; and no new Lokalise key is needed, because the sheet title is the backend-supplied field title the dialog already used.

One deliberate omission: the design shows a chevron on the card. `HedvigBigCard` draws none today, and adding one to a shared component would change its appearance everywhere it is used, so I left it out rather than make that call unilaterally. Worth deciding separately.

Verified: `:app:assembleDebug`, `:feature-claim-chat:assemble`, `ktlintCheck` and `jvmTest` all pass. Not yet checked by hand in demo mode, where the script's select step covers both the prefilled and unprefilled cases.